### PR TITLE
Docker: Add Dockerfile + scripts to run and build it

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:22.04
+
+# Install necessary system apt libs
+RUN apt update \
+	&& apt install -y --no-install-recommends \ 
+	git \
+	curl \ 
+	build-essential \
+	pkg-config \
+	libudev-dev
+
+# Install cargo
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+
+# Set up entry environment
+ENV PATH="/root/.cargo/bin:${PATH}"
+CMD ["/bin/bash"]
+WORKDIR /home/copper-rs

--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -1,0 +1,3 @@
+# Build the cooper-rs-env container
+# Must be run from within the "docker" directory
+docker build -f Dockerfile -t copper-rs-env .

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Run the cooper-rs-env container and mount this directory in the container
+# Should make this a volume mount eventually
+# Should be run from within the "docker" directory for the mounting to work properly
+docker run -it -entrypoint="" --mount type=bind,source="$(pwd)"/..,target=/home/copper-rs copper-rs-env 


### PR DESCRIPTION
I wanted to get the ball rolling on making an easily reproducible environment sooner rather than later. Motivated by me not being able to build out of the box on my machine

You can use the `build_docker.sh` file to build a docker image that you can run with `run_docker.sh`. That will drop you in a container that has access to the `copper-rs` directory and contains all the necessary dependencies to build it. 