### PR TITLE
Refactor: Build all node arrays in one iteration

### DIFF
--- a/cu29_derive/Cargo.toml
+++ b/cu29_derive/Cargo.toml
@@ -22,6 +22,7 @@ quote = { workspace = true }
 proc-macro2 = { workspace = true  }
 walkdir = "2.5.0"
 syntect = "5.2.0"
+itertools = "0.13.0"
 
 [build-dependencies]
 cargo_metadata = "0.18.1"


### PR DESCRIPTION
This diff is kinda nasty to look at. It's easier to see what I changed when you look at the source by itself.

**What?** 

We were iterating over `all_tasks_types` 5 times to create all the different node arrays. While there is nothing technically wrong with that, it's not the cleanest in my opinion. So I changed it to create all the node arrays in a single iteration of `all_tasks_types`. 

This required using `itertools::multiunzip` which means I had to bring `itertools` in to the repo. But that's good. It's super powerful and we will inevitably use more from it.

**Why?**

Keeping it rusty :call_me_hand: 

**Testing:**

I did my best to verify that this change wouldn't change the output. ie that it is a pure refactor. But if you are able to check that too it would make me feel better since I am still new in this code. 