### PR TITLE
log: Simplified and optimized the structlog

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ members = [
     "drivers/cu_wt901_tester",
     "drivers/cu_lewansoul",
     "examples/cu_caterpillar",
-    "examples/cu_config_gen", "examples/cu_standalone_structlog",
+    "examples/cu_config_gen",
+    "examples/cu_standalone_structlog",
     ]
 resolver = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
     "drivers/cu_wt901_tester",
     "drivers/cu_lewansoul",
     "examples/cu_caterpillar",
-    "examples/cu_config_gen",
+    "examples/cu_config_gen", "examples/cu_standalone_structlog",
     ]
 resolver = "2"
 

--- a/cu29/src/curuntime.rs
+++ b/cu29/src/curuntime.rs
@@ -285,6 +285,7 @@ mod tests {
         ))
     }
 
+    #[derive(Debug)]
     struct FakeWriter {}
 
     impl<E: Encode> WriteStream<E> for FakeWriter {

--- a/cu29_export/Cargo.toml
+++ b/cu29_export/Cargo.toml
@@ -11,6 +11,10 @@ categories.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+# This is a python binding
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 cu29 = { workspace = true }
 cu29-traits = { workspace = true }
@@ -20,6 +24,8 @@ cu29-unifiedlog = { workspace = true }
 cu29-intern-strs = { workspace = true }
 clap = { version = "4.5.11", features = ["derive"] }
 bincode = { workspace = true }
+pyo3 = { version = "0.22.2", features = ["extension-module"] }
+
 
 [dev-dependencies]
 cu29-log-runtime = { workspace = true }

--- a/cu29_export/Cargo.toml
+++ b/cu29_export/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 
 # This is a python binding
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 cu29 = { workspace = true }

--- a/cu29_export/build.rs
+++ b/cu29_export/build.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 fn main() {
 

--- a/cu29_export/build.rs
+++ b/cu29_export/build.rs
@@ -1,0 +1,19 @@
+use std::env;
+use std::path::{Path, PathBuf};
+
+fn main() {
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    let target_dir =  out_dir.join("../../..");
+    let lib_name = "libcu29_export.so";
+    let new_name = "cu29_export.so";
+
+    let lib_path = target_dir.join(lib_name);
+    let new_path = target_dir.join(new_name);
+
+    if !new_path.exists() {
+        std::os::unix::fs::symlink(&lib_path, &new_path).expect("Failed to create symlink");
+    }
+}
+

--- a/cu29_export/src/lib.rs
+++ b/cu29_export/src/lib.rs
@@ -17,6 +17,7 @@ use cu29_unifiedlog::{UnifiedLogger, UnifiedLoggerBuilder, UnifiedLoggerIOReader
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 use cu29_log::value::Value;
+use pyo3::types::PyDelta;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum ExportFormat {
@@ -228,9 +229,16 @@ pub struct PyCuLogEntry {
 #[pymethods]
 impl PyCuLogEntry {
 
-    /// Returns the time of the log entry in nanoseconds.
-    pub fn time_ns(&self) -> u64 {
-        self.inner.time.0
+    /// Returns the timestamp of the log entry.
+    pub fn ts<'a>(&self, py: Python<'a>) -> Bound<'a, PyDelta> {
+        let nanoseconds = self.inner.time.0;
+
+        // Convert nanoseconds to seconds and microseconds
+        let days = (nanoseconds / 86_400_000_000_000) as i32;
+        let seconds = (nanoseconds / 1_000_000_000) as i32;
+        let microseconds = ((nanoseconds % 1_000_000_000) / 1_000) as i32;
+
+        PyDelta::new_bound(py, days, seconds, microseconds, false).unwrap()
     }
 
     /// Returns the index of the message in the vector of interned strings.

--- a/cu29_log/Cargo.toml
+++ b/cu29_log/Cargo.toml
@@ -18,3 +18,4 @@ cu29-value = { workspace = true }
 cu29-traits = { workspace = true }
 cu29-clock = { workspace = true }
 strfmt = "0.2.4"
+smallvec = { version = "1.13.2", features = ["serde"] }

--- a/cu29_log/src/lib.rs
+++ b/cu29_log/src/lib.rs
@@ -16,7 +16,7 @@ const INDEX_DIR_NAME: &str = "cu29_log_index";
 #[allow(dead_code)]
 pub const ANONYMOUS: u32 = 0;
 
-pub const MAX_PARAMS: usize = 10;
+pub const MAX_LOG_PARAMS_ON_STACK: usize = 10;
 
 /// This is the basic structure for a log entry in Copper.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -28,10 +28,10 @@ pub struct CuLogEntry {
     pub msg_index: u32,
     
     // interned indexes of the parameter names
-    pub paramname_indexes: SmallVec<[u32; MAX_PARAMS]>,
+    pub paramname_indexes: SmallVec<[u32; MAX_LOG_PARAMS_ON_STACK]>,
     
     // Serializable values for the parameters (Values are acting like an Any Value).
-    pub params: SmallVec<[Value; MAX_PARAMS]>,
+    pub params: SmallVec<[Value; MAX_LOG_PARAMS_ON_STACK]>,
 }
 
 impl Encode for CuLogEntry {

--- a/cu29_log_runtime/Cargo.toml
+++ b/cu29_log_runtime/Cargo.toml
@@ -32,3 +32,4 @@ cu29-log-derive = { workspace = true }
 cu29-helpers = { workspace = true }
 serde = { workspace = true }
 tempdir = "0.3.7"
+smallvec = "1.13.2"

--- a/cu29_log_runtime/Cargo.toml
+++ b/cu29_log_runtime/Cargo.toml
@@ -21,7 +21,6 @@ cu29-clock = { workspace = true }
 cu29-intern-strs = { workspace = true }
 serde = { workspace = true }
 bincode = { workspace = true }
-kanal = { version = "0.1.0-pre8" }
 once_cell = "1.19.0"
 simplelog = "0.12.2"
 log = "0.4.22"

--- a/cu29_log_runtime/src/lib.rs
+++ b/cu29_log_runtime/src/lib.rs
@@ -1,10 +1,11 @@
+use std::fmt::{Debug, Formatter};
 use std::fs::File;
 use std::sync::{Mutex, OnceLock};
 use std::io::{BufWriter, Write};
 use cu29_clock::RobotClock;
 use cu29_log::CuLogEntry;
 use cu29_traits::{CuResult, WriteStream};
-use log::Log;
+use log::{Log, Record};
 use std::path::PathBuf;
 use std::sync::Arc;
 use bincode::config::Configuration;
@@ -12,14 +13,13 @@ use bincode::enc::{Encoder, EncoderImpl};
 use bincode::error::EncodeError;
 use bincode::enc::write::Writer;
 use bincode::enc::Encode;
+use cu29_intern_strs::read_interned_strings;
 
-static WRITER: OnceLock<(Arc<Mutex<dyn WriteStream<CuLogEntry>>>, RobotClock)> = OnceLock::new();
+static WRITER: OnceLock<(Mutex<Box<dyn WriteStream<CuLogEntry>>>, RobotClock)> = OnceLock::new();
+static EXTRA_TEXT_LOGGER: OnceLock<Option<ExtraTextLogger>> = OnceLock::new();
 
 /// The lifetime of this struct is the lifetime of the logger.
-pub struct LoggerRuntime {
-    #[allow(dead_code)]
-    extra_text_logger: Option<ExtraTextLogger>,
-}
+pub struct LoggerRuntime {}
 
 impl LoggerRuntime {
     /// destination is the binary stream in which we will log the structured log.
@@ -30,56 +30,57 @@ impl LoggerRuntime {
         extra_text_logger: Option<ExtraTextLogger>,
     ) -> Self {
         if (!cfg!(debug_assertions)) && extra_text_logger.is_some() {
-            eprintln!("Extra text logger is only available in debug builds. Ignoring the extra text logger.");
+            eprintln!("cu29_log: Extra text logger is only available in debug builds. Extra text logger will be disabled for this release build.");
         };
 
-        let runtime = LoggerRuntime {
-            extra_text_logger,
-        };
-        if let Ok(_) = WRITER.set((Arc::new(Mutex::new(destination)), clock)) { panic!("Logger already initialized."); };
+        let runtime = LoggerRuntime {};
+
+        // If WRITER is already initialized, update the inner value.
+        // This should only be useful for unit testing.
+        if let Some((writer, _)) = WRITER.get() {
+            let mut writer_guard = writer.lock().unwrap();
+            *writer_guard = Box::new(destination);
+        } else {
+            WRITER.set((Mutex::new(Box::new(destination)), clock)).unwrap();
+        }
+
         runtime
     }
 
-
     pub fn flush(&self) {
-        let d = WRITER.get().map(|(writer, clock)| (Arc::clone(writer), clock));
-        if d.is_none() {
-            return;
+        if let Some((writer, _clock)) = WRITER.get() {
+            if let Ok(mut writer) = writer.lock() {
+                if let Err(err) = writer.flush() {
+                    eprintln!("cu29_log: Failed to flush writer: {}", err);
+                }
+            } else {
+                eprintln!("cu29_log: Failed to lock writer.");
+            }
+        } else {
+            eprintln!("cu29_log: Logger not initialized.");
         }
-        let (writer, _clock) = d.unwrap();
-        writer.lock().unwrap().flush().unwrap();
-    }
-
-    pub fn close(&mut self) {
-        let d = WRITER.get().map(|(writer, clock)| (Arc::clone(writer), clock));
-        if d.is_none() {
-            return;
-        }
-        let (writer, _clock) = d.unwrap();
-        writer.lock().unwrap().flush().unwrap();
     }
 }
 
 impl Drop for LoggerRuntime {
     fn drop(&mut self) {
-        self.close();
+        self.flush();
     }
 }
 
 /// This is to basically be able to see the logs in text format in real time.
-/// THIS WILL SLOW DOWN THE LOGGING SYSTEM by an order of magnitude.
 /// This will only be active for debug builds.
 pub struct ExtraTextLogger {
-    #[allow(dead_code)] 
-    path_to_index: PathBuf,
-    #[allow(dead_code)]
-    logger: Arc<dyn Log>,
+    // We reload the entire index in memory.
+    all_strings: Vec<String>,
+    inner: Arc<dyn Log>,
 }
 impl ExtraTextLogger {
     pub fn new(path_to_index: PathBuf, logger: Box<dyn Log>) -> Self {
+        let all_strings = read_interned_strings(&path_to_index).unwrap();
         ExtraTextLogger {
-            path_to_index,
-            logger: Arc::new(logger),
+            all_strings,
+            inner: Arc::new(logger),
         }
     }
 }
@@ -88,56 +89,47 @@ impl ExtraTextLogger {
 /// It moves entry by design, it will be absorbed in the queue.
 #[inline(always)]
 pub fn log(mut entry: CuLogEntry) -> CuResult<()> {
-    let d = WRITER.get().map(|(writer, clock)| (Arc::clone(writer), clock));
+    let d = WRITER.get().map(|(writer, clock)| (writer, clock));
     if d.is_none() {
         return Err("Logger not initialized.".into());
     }
     let (writer, clock) = d.unwrap();
     entry.time = clock.now();
-
     if let Err(err) = writer.lock().unwrap().log(&entry) {
         eprintln!("Failed to log data: {}", err);
     }
     // TODO(gbin): Put that back
     // This is only for debug builds with standard textual logging implemented.
-    // #[cfg(debug_assertions)]
-    // let index = entry.msg_index;
-    // if let Some(index) = &index {
-    //     if let Some(ref logger) = self.extra_text_logger {
-    //         let stringified = cu29_log::rebuild_logline(index, &cu_log_entry);
-    //         match stringified {
-    //             Ok(s) => {
-    //                 let s = format!("[{}] {}", cu_log_entry.time, s);
-    //                 logger.log(
-    //                     &Record::builder()
-    //                         // TODO: forward this info in the CuLogEntry
-    //                         .level(log::Level::Debug)
-    //                         // .target("copper")
-    //                         //.module_path_static(Some("cu29_log"))
-    //                         //.file_static(Some("cu29_log"))
-    //                         //.line(Some(0))
-    //                         .args(format_args!("{}", s))
-    //                         .build(),
-    //                 ); // DO NOT TRY to split off this statement.
-    //                 // format_args! has to be in the same statement per structure and scoping.
-    //             }
-    //             Err(e) => {
-    //                 eprintln!("Failed to rebuild log line: {}", e);
-    //             }
-    //         }
-    //     }
-    // }
+    #[cfg(debug_assertions)]
+    // if we have not passed a text logger in debug mode, it is ok just move along.
+    if EXTRA_TEXT_LOGGER.get().is_none() {
+        return Ok(());
+    }
+    if let Some(logger) = EXTRA_TEXT_LOGGER.get().unwrap() {
+        let stringified = cu29_log::rebuild_logline(&logger.all_strings, &entry);
+        match stringified {
+            Ok(s) => {
+                let s = format!("[{}] {}", entry.time, s);
+                logger.inner.log(
+                    &Record::builder()
+                        // TODO: forward this info in the CuLogEntry
+                        .level(log::Level::Debug)
+                        // .target("copper")
+                        //.module_path_static(Some("cu29_log"))
+                        //.file_static(Some("cu29_log"))
+                        //.line(Some(0))
+                        .args(format_args!("{}", s))
+                        .build(),
+                ); // DO NOT TRY to split off this statement.
+                // format_args! has to be in the same statement per structure and scoping.
+            }
+            Err(e) => {
+                eprintln!("Failed to rebuild log line: {}", e);
+            }
+        }
+    }
 
     Ok(())
-    // if let Some((queue, clock)) = QUEUE_CLOCK.get() {
-    //     entry.time = clock.now();
-    //     let err = queue
-    //         .send(entry)
-    //         .map_err(|e| format!("Failed to send data to the logger, did you hold the reference to the logger long enough? {:?}", e).into());
-    //     err
-    // } else {
-    //     Err("Logger not initialized.".into())
-    // }
 }
 
 // This is an adaptation of the Iowriter from bincode.
@@ -184,6 +176,7 @@ impl<W: Write> Writer for OwningIoWriter<W> {
 
 /// This allows this crate to be used outside of Copper (ie. decoupling it from the unifiedlog.
 pub struct SimpleFileWriter {
+    path: PathBuf,
     encoder: EncoderImpl<OwningIoWriter<File>, Configuration>,
 }
 
@@ -198,7 +191,13 @@ impl SimpleFileWriter {
         let writer = OwningIoWriter::new(file);
         let encoder = EncoderImpl::new(writer, bincode::config::standard());
 
-        Ok(SimpleFileWriter { encoder})
+        Ok(SimpleFileWriter { path: path.clone(), encoder})
+    }
+}
+
+impl Debug for SimpleFileWriter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SimpleFileWriter for path {:?}", self.path)
     }
 }
 

--- a/cu29_log_runtime/src/lib.rs
+++ b/cu29_log_runtime/src/lib.rs
@@ -1,31 +1,23 @@
 use std::fs::File;
-use std::sync::OnceLock;
-use std::io::Write;
-use cu29_clock::{ClockProvider, RobotClock};
-use cu29_intern_strs::read_interned_strings;
+use std::sync::{Mutex, OnceLock};
+use std::io::{BufWriter, Write};
+use cu29_clock::RobotClock;
 use cu29_log::CuLogEntry;
 use cu29_traits::{CuResult, WriteStream};
-use kanal::{bounded, Sender};
-use log::{warn, Log, Record};
+use log::Log;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::thread;
-use std::sync::Once;
-use std::thread::{sleep, JoinHandle};
-use std::time::Duration;
 use bincode::config::Configuration;
-use bincode::enc;
 use bincode::enc::{Encoder, EncoderImpl};
 use bincode::error::EncodeError;
-use bincode::enc::write::{SliceWriter, Writer};
+use bincode::enc::write::Writer;
 use bincode::enc::Encode;
 
-// The logging system is basically a global queue.
-static QUEUE_CLOCK: OnceLock<(Sender<CuLogEntry>, RobotClock)> = OnceLock::new();
+static WRITER: OnceLock<(Arc<Mutex<dyn WriteStream<CuLogEntry>>>, RobotClock)> = OnceLock::new();
 
 /// The lifetime of this struct is the lifetime of the logger.
 pub struct LoggerRuntime {
-    handle: Option<JoinHandle<()>>,
+    #[allow(dead_code)]
     extra_text_logger: Option<ExtraTextLogger>,
 }
 
@@ -41,108 +33,30 @@ impl LoggerRuntime {
             eprintln!("Extra text logger is only available in debug builds. Ignoring the extra text logger.");
         };
 
-        let mut runtime = LoggerRuntime {
+        let runtime = LoggerRuntime {
             extra_text_logger,
-            handle: None,
         };
-        let (s, handle) = runtime.initialize_queue(destination);
-        QUEUE_CLOCK
-            .set((s, clock))
-            .expect("Failed to initialize the logger queue.");
-        runtime.handle = Some(handle);
+        if let Ok(_) = WRITER.set((Arc::new(Mutex::new(destination)), clock)) { panic!("Logger already initialized."); };
         runtime
     }
 
-    fn initialize_queue(
-        &self,
-        mut destination: impl WriteStream<CuLogEntry> + 'static,
-    ) -> (Sender<CuLogEntry>, JoinHandle<()>) {
-        let (sender, receiver) = bounded::<CuLogEntry>(10000);
-
-        #[cfg(debug_assertions)]
-        let (index, extra_text_logger) = if let Some(extra) = &self.extra_text_logger {
-            let index = Some(
-                read_interned_strings(extra.path_to_index.as_path())
-                    .expect("Failed to read the interned strings"),
-            );
-            let logger = Some(extra.logger.clone());
-            (index, logger)
-        } else {
-            (None, None)
-        };
-
-        let handle = thread::spawn(move || {
-            let receiver = receiver.clone();
-            loop {
-                if let Ok(cu_log_entry) = receiver.recv() {
-                    // If the user wants to really log a clock they should add it as a structured field.
-                    if let Err(err) = destination.log(&cu_log_entry) {
-                        eprintln!("Failed to log data: {}", err);
-                    }
-
-                    // This is only for debug builds with standard textual logging implemented.
-                    #[cfg(debug_assertions)]
-                    if let Some(index) = &index {
-                        if let Some(ref logger) = extra_text_logger {
-                            let stringified = cu29_log::rebuild_logline(index, &cu_log_entry);
-                            match stringified {
-                                Ok(s) => {
-                                    let s = format!("[{}] {}", cu_log_entry.time, s);
-                                    logger.log(
-                                        &Record::builder()
-                                            // TODO: forward this info in the CuLogEntry
-                                            .level(log::Level::Debug)
-                                            // .target("copper")
-                                            //.module_path_static(Some("cu29_log"))
-                                            //.file_static(Some("cu29_log"))
-                                            //.line(Some(0))
-                                            .args(format_args!("{}", s))
-                                            .build(),
-                                    ); // DO NOT TRY to split off this statement.
-                                       // format_args! has to be in the same statement per structure and scoping.
-                                }
-                                Err(e) => {
-                                    eprintln!("Failed to rebuild log line: {}", e);
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    // means that the sender has disconnected, we can stop the thread.
-                    break;
-                }
-            }
-        });
-        (sender, handle)
-    }
-    pub fn is_alive(&self) -> bool {
-        QUEUE_CLOCK.get().is_some()
-    }
 
     pub fn flush(&self) {
-        if let Some((queue, _)) = QUEUE_CLOCK.get() {
-            loop {
-                if queue.is_empty() {
-                    break;
-                }
-                println!("Waiting for the queue to empty.");
-                sleep(Duration::from_millis(1));
-            }
+        let d = WRITER.get().map(|(writer, clock)| (Arc::clone(writer), clock));
+        if d.is_none() {
+            return;
         }
+        let (writer, _clock) = d.unwrap();
+        writer.lock().unwrap().flush().unwrap();
     }
 
     pub fn close(&mut self) {
-        let queue = QUEUE_CLOCK.get();
-        if queue.is_none() {
-            eprintln!("Logger closed before it was initialized.");
+        let d = WRITER.get().map(|(writer, clock)| (Arc::clone(writer), clock));
+        if d.is_none() {
             return;
         }
-        self.flush();
-        queue.unwrap().0.close();
-        if let Some(handle) = self.handle.take() {
-            handle.join().expect("Failed to join the logger thread.");
-            self.handle = None;
-        }
+        let (writer, _clock) = d.unwrap();
+        writer.lock().unwrap().flush().unwrap();
     }
 }
 
@@ -156,7 +70,9 @@ impl Drop for LoggerRuntime {
 /// THIS WILL SLOW DOWN THE LOGGING SYSTEM by an order of magnitude.
 /// This will only be active for debug builds.
 pub struct ExtraTextLogger {
+    #[allow(dead_code)] 
     path_to_index: PathBuf,
+    #[allow(dead_code)]
     logger: Arc<dyn Log>,
 }
 impl ExtraTextLogger {
@@ -172,33 +88,82 @@ impl ExtraTextLogger {
 /// It moves entry by design, it will be absorbed in the queue.
 #[inline(always)]
 pub fn log(mut entry: CuLogEntry) -> CuResult<()> {
-    if let Some((queue, clock)) = QUEUE_CLOCK.get() {
-        entry.time = clock.now();
-        let err = queue
-            .send(entry)
-            .map_err(|e| format!("Failed to send data to the logger, did you hold the reference to the logger long enough? {:?}", e).into());
-        err
-    } else {
-        Err("Logger not initialized.".into())
+    let d = WRITER.get().map(|(writer, clock)| (Arc::clone(writer), clock));
+    if d.is_none() {
+        return Err("Logger not initialized.".into());
     }
+    let (writer, clock) = d.unwrap();
+    entry.time = clock.now();
+
+    if let Err(err) = writer.lock().unwrap().log(&entry) {
+        eprintln!("Failed to log data: {}", err);
+    }
+    // TODO(gbin): Put that back
+    // This is only for debug builds with standard textual logging implemented.
+    // #[cfg(debug_assertions)]
+    // let index = entry.msg_index;
+    // if let Some(index) = &index {
+    //     if let Some(ref logger) = self.extra_text_logger {
+    //         let stringified = cu29_log::rebuild_logline(index, &cu_log_entry);
+    //         match stringified {
+    //             Ok(s) => {
+    //                 let s = format!("[{}] {}", cu_log_entry.time, s);
+    //                 logger.log(
+    //                     &Record::builder()
+    //                         // TODO: forward this info in the CuLogEntry
+    //                         .level(log::Level::Debug)
+    //                         // .target("copper")
+    //                         //.module_path_static(Some("cu29_log"))
+    //                         //.file_static(Some("cu29_log"))
+    //                         //.line(Some(0))
+    //                         .args(format_args!("{}", s))
+    //                         .build(),
+    //                 ); // DO NOT TRY to split off this statement.
+    //                 // format_args! has to be in the same statement per structure and scoping.
+    //             }
+    //             Err(e) => {
+    //                 eprintln!("Failed to rebuild log line: {}", e);
+    //             }
+    //         }
+    //     }
+    // }
+
+    Ok(())
+    // if let Some((queue, clock)) = QUEUE_CLOCK.get() {
+    //     entry.time = clock.now();
+    //     let err = queue
+    //         .send(entry)
+    //         .map_err(|e| format!("Failed to send data to the logger, did you hold the reference to the logger long enough? {:?}", e).into());
+    //     err
+    // } else {
+    //     Err("Logger not initialized.".into())
+    // }
 }
 
 // This is an adaptation of the Iowriter from bincode.
 pub struct OwningIoWriter<W: Write> {
-    writer: W,
+    writer: BufWriter<W>,
     bytes_written: usize,
 }
 
 impl<'a, W: Write> OwningIoWriter<W> {
     pub fn new(writer: W) -> Self {
+
         Self {
-            writer,
+            writer: BufWriter::new(writer),
             bytes_written: 0,
         }
     }
 
     pub fn bytes_written(&self) -> usize {
         self.bytes_written
+    }
+
+    pub fn flush(&mut self) -> Result<(), EncodeError> {
+        self.writer.flush().map_err(|inner| EncodeError::Io {
+            inner,
+            index: self.bytes_written,
+        })
     }
 }
 
@@ -243,26 +208,31 @@ impl WriteStream<CuLogEntry> for SimpleFileWriter {
         obj.encode(&mut self.encoder).map_err(|e| format!("Failed to write to file: {:?}", e))?;
         Ok(())
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use crate::CuLogEntry;
-    use bincode::config::standard;
-    use cu29_log::value::Value;
-
-    #[test]
-    fn test_encode_decode_structured_log() {
-        let log_entry = CuLogEntry {
-            time: 0.into(),
-            msg_index: 1,
-            paramname_indexes: vec![2, 3],
-            params: vec![Value::String("test".to_string())],
-        };
-        let encoded = bincode::encode_to_vec(&log_entry, standard()).unwrap();
-        println!("{:?}", encoded);
-        let decoded_tuple: (CuLogEntry, usize) =
-            bincode::decode_from_slice(&encoded, standard()).unwrap();
-        assert_eq!(log_entry, decoded_tuple.0);
+    fn flush(&mut self) -> CuResult<()> {
+        self.encoder.writer().flush().map_err(|e| format!("Failed to flush file: {:?}", e))?;
+        Ok(())
     }
 }
+
+// #[cfg(test)]
+// mod tests {
+//     use crate::CuLogEntry;
+//     use bincode::config::standard;
+//     use cu29_log::value::Value;
+//
+//     #[test]
+//     fn test_encode_decode_structured_log() {
+//         let log_entry = CuLogEntry {
+//             time: 0.into(),
+//             msg_index: 1,
+//             paramname_indexes: vec![2, 3],
+//             params: vec![Value::String("test".to_string())],
+//         };
+//         let encoded = bincode::encode_to_vec(&log_entry, standard()).unwrap();
+//         println!("{:?}", encoded);
+//         let decoded_tuple: (CuLogEntry, usize) =
+//             bincode::decode_from_slice(&encoded, standard()).unwrap();
+//         assert_eq!(log_entry, decoded_tuple.0);
+//     }
+// }

--- a/cu29_log_runtime/src/lib.rs
+++ b/cu29_log_runtime/src/lib.rs
@@ -2,9 +2,6 @@ use std::fmt::{Debug, Formatter};
 use std::fs::File;
 use std::sync::{Mutex, OnceLock};
 use std::io::{BufWriter, Write};
-use cu29_clock::RobotClock;
-use cu29_log::CuLogEntry;
-use cu29_traits::{CuResult, WriteStream};
 #[cfg(debug_assertions)]
 use log::{Log, Record};
 use std::path::PathBuf;
@@ -17,6 +14,9 @@ use bincode::enc::write::Writer;
 use bincode::enc::Encode;
 #[cfg(debug_assertions)]
 use cu29_intern_strs::read_interned_strings;
+use cu29_clock::RobotClock;
+use cu29_log::CuLogEntry;
+use cu29_traits::{CuResult, WriteStream};
 
 static WRITER: OnceLock<(Mutex<Box<dyn WriteStream<CuLogEntry>>>, RobotClock)> = OnceLock::new();
 
@@ -225,24 +225,25 @@ impl WriteStream<CuLogEntry> for SimpleFileWriter {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use crate::CuLogEntry;
-//     use bincode::config::standard;
-//     use cu29_log::value::Value;
-//
-//     #[test]
-//     fn test_encode_decode_structured_log() {
-//         let log_entry = CuLogEntry {
-//             time: 0.into(),
-//             msg_index: 1,
-//             paramname_indexes: vec![2, 3],
-//             params: vec![Value::String("test".to_string())],
-//         };
-//         let encoded = bincode::encode_to_vec(&log_entry, standard()).unwrap();
-//         println!("{:?}", encoded);
-//         let decoded_tuple: (CuLogEntry, usize) =
-//             bincode::decode_from_slice(&encoded, standard()).unwrap();
-//         assert_eq!(log_entry, decoded_tuple.0);
-//     }
-// }
+#[cfg(test)]
+mod tests {
+    use crate::CuLogEntry;
+    use bincode::config::standard;
+    use cu29_log::value::Value;
+    use smallvec::smallvec;
+
+    #[test]
+    fn test_encode_decode_structured_log() {
+        let log_entry = CuLogEntry {
+            time: 0.into(),
+            msg_index: 1,
+            paramname_indexes: smallvec![2, 3],
+            params: smallvec![Value::String("test".to_string())],
+        };
+        let encoded = bincode::encode_to_vec(&log_entry, standard()).unwrap();
+        println!("{:?}", encoded);
+        let decoded_tuple: (CuLogEntry, usize) =
+            bincode::decode_from_slice(&encoded, standard()).unwrap();
+        assert_eq!(log_entry, decoded_tuple.0);
+    }
+}

--- a/cu29_traits/src/lib.rs
+++ b/cu29_traits/src/lib.rs
@@ -61,6 +61,9 @@ pub type CuResult<T> = Result<T, CuError>;
 /// Defines a basic write, append only stream trait to be able to log or send serializable objects.
 pub trait WriteStream<E: Encode>: Sync + Send {
     fn log(&mut self, obj: &E) -> CuResult<()>;
+    fn flush(&mut self) -> CuResult<()> {
+        Ok(())
+    }
 }
 
 /// Defines the types of what can be logged in the unified logger.

--- a/cu29_traits/src/lib.rs
+++ b/cu29_traits/src/lib.rs
@@ -59,7 +59,7 @@ impl CuError {
 pub type CuResult<T> = Result<T, CuError>;
 
 /// Defines a basic write, append only stream trait to be able to log or send serializable objects.
-pub trait WriteStream<E: Encode>: Sync + Send {
+pub trait WriteStream<E: Encode>: Sync + Send + Debug {
     fn log(&mut self, obj: &E) -> CuResult<()>;
     fn flush(&mut self) -> CuResult<()> {
         Ok(())

--- a/cu29_unifiedlog/src/lib.rs
+++ b/cu29_unifiedlog/src/lib.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::slice::from_raw_parts_mut;
 use std::sync::{Arc, Mutex};
 use std::{io, mem};
-
+use std::fmt::{Debug, Formatter};
 use memmap2::{Mmap, MmapMut, RemapOptions};
 
 use bincode::config::standard;
@@ -81,6 +81,12 @@ impl MmapStream {
     }
 }
 
+impl Debug for MmapStream {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MmapStream {{ entry_type: {:?}, current_position: {}, minimum_allocation_amount: {} }}", self.entry_type, self.current_position, self.minimum_allocation_amount)
+    }
+}
+
 impl<E: Encode> WriteStream<E> for MmapStream {
     fn log(&mut self, obj: &E) -> CuResult<()> {
         let dst = self.current_section.get_user_buffer();
@@ -133,7 +139,7 @@ pub fn stream_write<E: Encode>(
     entry_type: UnifiedLogType,
     minimum_allocation_amount: usize,
 ) -> impl WriteStream<E> {
-    return MmapStream::new(entry_type, logger.clone(), minimum_allocation_amount);
+    MmapStream::new(entry_type, logger.clone(), minimum_allocation_amount)
 }
 
 const DEFAULT_LOGGER_SIZE: usize = 1024 * 1024 * 1024; // 1GB

--- a/examples/cu_standalone_structlog/Cargo.toml
+++ b/examples/cu_standalone_structlog/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "cu_standalone_structlog"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "structlog_perf"
+path = "src/structlog_perf.rs"
+
+[[bin]]
+name = "standardlog_perf"
+path = "src/standardlog_perf.rs"
+
+[dependencies]
+cu29-traits = { workspace = true }
+cu29-log = { workspace = true }
+cu29-log-derive = { workspace = true }
+cu29-log-runtime = { workspace = true }
+cu29-clock = { workspace = true }
+log = "0.4.22"
+simplelog = "0.12.2"

--- a/examples/cu_standalone_structlog/build.rs
+++ b/examples/cu_standalone_structlog/build.rs
@@ -1,0 +1,5 @@
+use std::env;
+fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    println!("cargo:rustc-env=OUT_DIR={}", out_dir);
+}

--- a/examples/cu_standalone_structlog/profile_cu.sh
+++ b/examples/cu_standalone_structlog/profile_cu.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+CARGO_PROFILE_RELEASE_DEBUG=true cargo flamegraph --bin structlog_perf 

--- a/examples/cu_standalone_structlog/profile_st.sh
+++ b/examples/cu_standalone_structlog/profile_st.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+CARGO_PROFILE_RELEASE_DEBUG=true cargo flamegraph --bin standardlog_perf 

--- a/examples/cu_standalone_structlog/readlog.py
+++ b/examples/cu_standalone_structlog/readlog.py
@@ -14,8 +14,7 @@ from datetime import datetime, timedelta
 log_file_path = "logfile.bin"
 index_file_path = target_dir / "cu29_log_index"
 
-log_iterator = cu29_export.PyLogIterator(str(log_file_path), str(index_file_path))
-all_strings = log_iterator.all_strings()
+log_iterator, all_strings = cu29_export.struct_log_iterator_bare(log_file_path, str(index_file_path))
 
 
 for log_entry in log_iterator:

--- a/examples/cu_standalone_structlog/readlog.py
+++ b/examples/cu_standalone_structlog/readlog.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# This is an example script using the python bindings for the Copper log file format.
+from pathlib import Path
+import sys
+
+crate_dir = Path(__file__).resolve().parent
+target_dir = crate_dir.parent.parent / "target" / "debug"  # Use "release" if you did a release build
+sys.path.append(str(target_dir))
+
+
+import cu29_export
+from datetime import datetime, timedelta
+
+log_file_path = "logfile.bin"
+index_file_path = target_dir / "cu29_log_index"
+
+log_iterator = cu29_export.PyLogIterator(str(log_file_path), str(index_file_path))
+all_strings = log_iterator.all_strings()
+
+
+for log_entry in log_iterator:
+
+    message = all_strings[log_entry.msg_index()]
+
+    try:
+        formatted_message = message.format(*log_entry.params())
+    except IndexError as e:
+        formatted_message = f"Error formatting message: {e}"
+
+    nanoseconds = log_entry.time_ns()
+    elapsed_time = timedelta(seconds=nanoseconds // 1_000_000_000, microseconds=(nanoseconds % 1_000_000_000) // 1_000)
+
+    print(f"{elapsed_time}: {formatted_message}")

--- a/examples/cu_standalone_structlog/readlog.py
+++ b/examples/cu_standalone_structlog/readlog.py
@@ -9,7 +9,6 @@ sys.path.append(str(target_dir))
 
 
 import cu29_export
-from datetime import datetime, timedelta
 
 log_file_path = "logfile.bin"
 index_file_path = target_dir / "cu29_log_index"
@@ -18,15 +17,12 @@ log_iterator, all_strings = cu29_export.struct_log_iterator_bare(log_file_path, 
 
 
 for log_entry in log_iterator:
-
     message = all_strings[log_entry.msg_index()]
+    parameters = log_entry.params()
 
     try:
-        formatted_message = message.format(*log_entry.params())
+        formatted_message = message.format(*parameters)
     except IndexError as e:
         formatted_message = f"Error formatting message: {e}"
 
-    nanoseconds = log_entry.time_ns()
-    elapsed_time = timedelta(seconds=nanoseconds // 1_000_000_000, microseconds=(nanoseconds % 1_000_000_000) // 1_000)
-
-    print(f"{elapsed_time}: {formatted_message}")
+    print(f"{log_entry.ts()}: {formatted_message}")

--- a/examples/cu_standalone_structlog/src/standardlog_perf.rs
+++ b/examples/cu_standalone_structlog/src/standardlog_perf.rs
@@ -1,0 +1,24 @@
+use std::fs::File;
+use std::path::Path;
+use log::{info, LevelFilter, Log};
+use simplelog::{Config, WriteLogger};
+use cu29_clock::RobotClock;
+
+const LOG_FILE: &str = "/tmp/logfile.txt";
+
+pub fn main() {
+    let clock = RobotClock::new();
+
+    WriteLogger::init(
+        LevelFilter::Info,  // Set the desired log level
+        Config::default(),
+        File::create(Path::new(LOG_FILE)).unwrap()).unwrap();
+
+    let bf = clock.now();
+    for i in 0..1_000_000 {
+        info!("This is the logline associated with the log Logging an int = {}", i)
+    }
+    log::logger().flush();
+    let af = clock.now();
+    println!("Total time: {} in {}", af - bf, LOG_FILE);
+}

--- a/examples/cu_standalone_structlog/src/standardlog_perf.rs
+++ b/examples/cu_standalone_structlog/src/standardlog_perf.rs
@@ -4,7 +4,7 @@ use log::{info, LevelFilter, Log};
 use simplelog::{Config, WriteLogger};
 use cu29_clock::RobotClock;
 
-const LOG_FILE: &str = "/tmp/logfile.txt";
+const LOG_FILE: &str = "./logfile.txt";
 
 pub fn main() {
     let clock = RobotClock::new();
@@ -16,7 +16,7 @@ pub fn main() {
 
     let bf = clock.now();
     for i in 0..1_000_000 {
-        info!("This is the logline associated with the log Logging an int = {}", i)
+        info!("This is the logline {} associated with the log Logging and some more = {}, {}", i , i+2, i+3);
     }
     log::logger().flush();
     let af = clock.now();

--- a/examples/cu_standalone_structlog/src/standardlog_perf.rs
+++ b/examples/cu_standalone_structlog/src/standardlog_perf.rs
@@ -6,6 +6,8 @@ use cu29_clock::RobotClock;
 
 const LOG_FILE: &str = "./logfile.txt";
 
+
+
 pub fn main() {
     let clock = RobotClock::new();
 
@@ -16,7 +18,7 @@ pub fn main() {
 
     let bf = clock.now();
     for i in 0..1_000_000 {
-        info!("This is the logline {} associated with the log Logging and some more = {}, {}", i , i+2, i+3);
+        info!("This is the logline {} associated with the log logging and some more = {}, {}", i , i+2, i+3);
     }
     log::logger().flush();
     let af = clock.now();

--- a/examples/cu_standalone_structlog/src/standardlog_perf.rs
+++ b/examples/cu_standalone_structlog/src/standardlog_perf.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::path::Path;
-use log::{info, LevelFilter, Log};
+use log::{info, LevelFilter};
 use simplelog::{Config, WriteLogger};
 use cu29_clock::RobotClock;
 

--- a/examples/cu_standalone_structlog/src/structlog_perf.rs
+++ b/examples/cu_standalone_structlog/src/structlog_perf.rs
@@ -1,0 +1,23 @@
+use std::path::PathBuf;
+use cu29_clock::{CuTime, RobotClock};
+use cu29_log_derive::debug;
+use cu29_log_runtime::SimpleFileWriter;
+use cu29_log_runtime::LoggerRuntime;
+
+const LOG_FILE: &str = "/tmp/logfile.bin";
+
+fn main() {
+    let clock = RobotClock::new();
+    let bf = {
+        let writer  = SimpleFileWriter::new(&PathBuf::from(LOG_FILE)).unwrap();
+        let log_runtime = LoggerRuntime::init(clock.clone(), writer, None);
+        let bf : CuTime = clock.now();
+        for i in 0..1_000_000 {
+            debug!("Logging an int = {}", i)
+        }
+        bf
+    };
+    // This will force the flush here for fairness.
+    let af = clock.now();
+    println!("Total time: {} in {}", af - bf, LOG_FILE);
+}

--- a/examples/cu_standalone_structlog/src/structlog_perf.rs
+++ b/examples/cu_standalone_structlog/src/structlog_perf.rs
@@ -4,7 +4,7 @@ use cu29_log_derive::debug;
 use cu29_log_runtime::SimpleFileWriter;
 use cu29_log_runtime::LoggerRuntime;
 
-const LOG_FILE: &str = "/tmp/logfile.bin";
+const LOG_FILE: &str = "./logfile.bin";
 
 fn main() {
     let clock = RobotClock::new();
@@ -13,7 +13,7 @@ fn main() {
         let log_runtime = LoggerRuntime::init(clock.clone(), writer, None);
         let bf : CuTime = clock.now();
         for i in 0..1_000_000 {
-            debug!("Logging an int = {}", i)
+            debug!("This is the logline {} associated with the log Logging and some more = {}, {}", i , i+2, i+3);
         }
         bf
     };

--- a/examples/cu_standalone_structlog/src/structlog_perf.rs
+++ b/examples/cu_standalone_structlog/src/structlog_perf.rs
@@ -10,7 +10,7 @@ fn main() {
     let clock = RobotClock::new();
     let bf = {
         let writer  = SimpleFileWriter::new(&PathBuf::from(LOG_FILE)).unwrap();
-        let log_runtime = LoggerRuntime::init(clock.clone(), writer, None);
+        let _log_runtime = LoggerRuntime::init(clock.clone(), writer, None);
         let bf : CuTime = clock.now();
         for i in 0..1_000_000 {
             debug!("This is the logline {} associated with the log Logging and some more = {}, {}", i , i+2, i+3);


### PR DESCRIPTION
Notable change: I completely removed the queue in the runtime as the overhead was larger than a simple unbuffered mutex. 

I also build a quick benchmark to compare the speed with the more traditional Rust text logging.

```
sal ➜  cu_standalone_structlog (gbin/structlog_optim) ✗ source back2back.sh
   Compiling cu_standalone_structlog v0.2.1 (/home/gbin/projects/copper/copper-rs/examples/cu_standalone_structlog)
    Finished `release` profile [optimized] target(s) in 1.92s
     Running `/home/gbin/projects/copper/copper-rs/target/release/standardlog_perf`
Total time: 34.220 s in ./logfile.txt
.rw-r--r-- gbin gbin 101 MB Sat Aug 10 10:45:55 2024  logfile.txt
   Compiling cu_standalone_structlog v0.2.1 (/home/gbin/projects/copper/copper-rs/examples/cu_standalone_structlog)
CLog: ==================================================================================
CLog: Interned strings are stored in: "/home/gbin/projects/copper/copper-rs/target/release/cu29_log_index"
CLog:    [r] is reused index and [n] is new index.
CLog: ==================================================================================
CLog: #001 [r] -> This is the logline {} associated with the log Logging and some more = {}, {}.
    Finished `release` profile [optimized] target(s) in 1.84s
     Running `/home/gbin/projects/copper/copper-rs/target/release/structlog_perf`
Total time: 70.342 ms in ./logfile.bin
.rw-r--r-- gbin gbin 28 MB Sat Aug 10 10:45:57 2024  logfile.bin
```

60% reduction in logged size and 486x faster walltime
