### PR TITLE
cu29_log: use a more specific env var

### DIFF
--- a/cu29/build.rs
+++ b/cu29/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     println!(
-        "cargo:rustc-env=OUT_DIR={}",
+        "cargo:rustc-env=LOG_INDEX_DIR={}",
         std::env::var("OUT_DIR").unwrap()
     );
 }

--- a/cu29_log/src/lib.rs
+++ b/cu29_log/src/lib.rs
@@ -160,7 +160,7 @@ fn parent_n_times(path: &Path, n: usize) -> Option<PathBuf> {
 
 /// Convenience function to returns the default path for the log index directory.
 pub fn default_log_index_dir() -> PathBuf {
-    let outdir = std::env::var("OUT_DIR").expect("no OUT_DIR set, build.rs must be broken");
+    let outdir = std::env::var("LOG_INDEX_DIR").expect("no LOGIN_INDEX_DIR system variable set, be sure build.rs sets it, see cu29_log/build.rs for example.");
     let outdir_path = Path::new(&outdir);
     let target_dir = parent_n_times(&outdir_path, 3)
         .unwrap()

--- a/cu29_log_derive/build.rs
+++ b/cu29_log_derive/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     println!(
-        "cargo:rustc-env=OUT_DIR={}",
+        "cargo:rustc-env=LOG_INDEX_DIR={}",
         std::env::var("OUT_DIR").unwrap()
     );
 }

--- a/cu29_log_runtime/build.rs
+++ b/cu29_log_runtime/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     println!(
-        "cargo:rustc-env=OUT_DIR={}",
+        "cargo:rustc-env=LOG_INDEX_DIR={}",
         std::env::var("OUT_DIR").unwrap()
     );
 }

--- a/drivers/cu_rp_gpio/build.rs
+++ b/drivers/cu_rp_gpio/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     println!(
-        "cargo:rustc-env=OUT_DIR={}",
+        "cargo:rustc-env=LOG_INDEX_DIR={}",
         std::env::var("OUT_DIR").unwrap()
     );
 }

--- a/drivers/cu_vlp16/build.rs
+++ b/drivers/cu_vlp16/build.rs
@@ -1,5 +1,6 @@
-use std::env;
 fn main() {
-    let out_dir = env::var("OUT_DIR").unwrap();
-    println!("cargo:rustc-env=OUT_DIR={}", out_dir);
+    println!(
+        "cargo:rustc-env=LOG_INDEX_DIR={}",
+        std::env::var("OUT_DIR").unwrap()
+    );
 }

--- a/drivers/cu_wt901/build.rs
+++ b/drivers/cu_wt901/build.rs
@@ -1,5 +1,6 @@
-use std::env;
 fn main() {
-    let out_dir = env::var("OUT_DIR").unwrap();
-    println!("cargo:rustc-env=OUT_DIR={}", out_dir);
+    println!(
+        "cargo:rustc-env=LOG_INDEX_DIR={}",
+        std::env::var("OUT_DIR").unwrap()
+    );
 }

--- a/drivers/cu_wt901_tester/build.rs
+++ b/drivers/cu_wt901_tester/build.rs
@@ -1,5 +1,6 @@
-use std::env;
 fn main() {
-    let out_dir = env::var("OUT_DIR").unwrap();
-    println!("cargo:rustc-env=OUT_DIR={}", out_dir);
+    println!(
+        "cargo:rustc-env=LOG_INDEX_DIR={}",
+        std::env::var("OUT_DIR").unwrap()
+    );
 }

--- a/examples/cu_caterpillar/build.rs
+++ b/examples/cu_caterpillar/build.rs
@@ -1,5 +1,6 @@
-use std::env;
 fn main() {
-    let out_dir = env::var("OUT_DIR").unwrap();
-    println!("cargo:rustc-env=OUT_DIR={}", out_dir);
+    println!(
+        "cargo:rustc-env=LOG_INDEX_DIR={}",
+        std::env::var("OUT_DIR").unwrap()
+    );
 }

--- a/examples/cu_standalone_structlog/build.rs
+++ b/examples/cu_standalone_structlog/build.rs
@@ -1,5 +1,6 @@
-use std::env;
 fn main() {
-    let out_dir = env::var("OUT_DIR").unwrap();
-    println!("cargo:rustc-env=OUT_DIR={}", out_dir);
+    println!(
+        "cargo:rustc-env=LOG_INDEX_DIR={}",
+        std::env::var("OUT_DIR").unwrap()
+    );
 }

--- a/templates/cu_full/build.rs
+++ b/templates/cu_full/build.rs
@@ -1,6 +1,6 @@
-use std::env;
 fn main() {
-    // This is essential to be able to generate the structure log index within the project out directory.
-    let out_dir = env::var("OUT_DIR").unwrap();
-    println!("cargo:rustc-env=OUT_DIR={}", out_dir);
+    println!(
+        "cargo:rustc-env=LOG_INDEX_DIR={}",
+        std::env::var("OUT_DIR").unwrap()
+    );
 }


### PR DESCRIPTION
This is to be sure we can decouple the compilation from the index generation. Like this the user can drop the build.rs and directly set a directory for example compatible with a distributed compilation system on a shared drive.