### PR TITLE
build: split the core from the driver/examples for macos

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -33,7 +33,14 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libudev-dev libpcap-dev
 
       - name: Build
-        run: cargo build
+        run: |
+          if [ "${{ runner.os }}" == "Linux" ]; then
+            # A lot of the non default crates are linux specific or robot target specific.
+            cargo build --workspace
+          else
+            cargo build
+          fi
+
       - name: Run tests
         run: cargo test
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,30 @@ members = [
     "cu29_traits",
     "cu29_unifiedlog",
     "drivers/cu_vlp16",
+    "drivers/cu_lewansoul",
+    "drivers/cu_wt901",
     "examples/cu_config_gen",
     "examples/cu_standalone_structlog",
+    "examples/cu_caterpillar"
+
 ]
+
+# put only the core crates here that are not platform specific
+default-members = [
+    "cu29",
+    "cu29_clock",
+    "cu29_derive",
+    "cu29_export",
+    "cu29_helpers",
+    "cu29_intern_strs",
+    "cu29_log",
+    "cu29_log_derive",
+    "cu29_log_runtime",
+    "cu29_soa_derive",
+    "cu29_traits",
+    "cu29_unifiedlog",
+]
+
 resolver = "2"
 
 [workspace.package]


### PR DESCRIPTION
Like that the picky crates that are drivers etc, only gets compiled on demand.