### PR TITLE
struct_log: removed the need to have the index file in debug mode

### DIFF
--- a/cu29_export/src/lib.rs
+++ b/cu29_export/src/lib.rs
@@ -346,8 +346,8 @@ mod tests {
 
     use cu29_clock::RobotClock;
     use cu29_log::value::Value;
-    use cu29_log_runtime::log;
     use cu29_log_runtime::LoggerRuntime;
+    use cu29_log_runtime::{log, NullLog};
     use cu29_traits::UnifiedLogType;
     use cu29_unifiedlog::{
         stream_write, UnifiedLogger, UnifiedLoggerBuilder, UnifiedLoggerIOReader,
@@ -396,7 +396,7 @@ mod tests {
             };
             let data_logger = Arc::new(Mutex::new(logger));
             let stream = stream_write(data_logger.clone(), UnifiedLogType::StructuredLogLine, 1024);
-            let rt = LoggerRuntime::init(RobotClock::default(), stream, None);
+            let rt = LoggerRuntime::init(RobotClock::default(), stream, None::<NullLog>);
 
             let mut entry = CuLogEntry::new(4); // this is a "Just a String {}" log line
             entry.add_param(0, Value::String("Parameter for the log line".into()));

--- a/cu29_export/src/lib.rs
+++ b/cu29_export/src/lib.rs
@@ -400,10 +400,10 @@ mod tests {
 
             let mut entry = CuLogEntry::new(4); // this is a "Just a String {}" log line
             entry.add_param(0, Value::String("Parameter for the log line".into()));
-            log(entry).expect("Failed to log");
+            log(&mut entry).expect("Failed to log");
             let mut entry = CuLogEntry::new(2); // this is a "Just a String {}" log line
             entry.add_param(0, Value::String("Parameter for the log line".into()));
-            log(entry).expect("Failed to log");
+            log(&mut entry).expect("Failed to log");
 
             // everything is dropped here
             drop(rt);

--- a/cu29_intern_strs/src/lib.rs
+++ b/cu29_intern_strs/src/lib.rs
@@ -16,7 +16,7 @@ pub fn read_interned_strings(index: &Path) -> CuResult<Vec<String>> {
 
     let index_to_string = env
         .open_single("index_to_string", StoreOptions::default())
-        .expect("Failed to open index_to_string store");
+        .map_err(|e| CuError::new_with_cause("Could not open the index_to_string store", e))?;
     let db_reader = env.read().unwrap();
     let ri = index_to_string.iter_start(&db_reader);
     let mut i = ri.expect("Failed to start iterator");

--- a/cu29_log/src/lib.rs
+++ b/cu29_log/src/lib.rs
@@ -115,39 +115,56 @@ impl CuLogEntry {
     }
 }
 
+/// Text log line formatter.
+#[inline]
+pub fn format_logline(
+    time: CuTime,
+    format_str: &str,
+    params: &[String],
+    named_params: &HashMap<String, String>,
+) -> CuResult<String> {
+    let mut format_str = format_str.to_string();
+
+    for param in params.iter() {
+        format_str = format_str.replacen("{}", &param, 1);
+    }
+
+    if named_params.is_empty() {
+        return Ok(format_str);
+    }
+
+    let logline = strfmt(&format_str, &named_params).map_err(|e| {
+        CuError::new_with_cause(
+            format!(
+                "Failed to format log line: {:?} with variables [{:?}]",
+                format_str, named_params
+            )
+            .as_str(),
+            e,
+        )
+    })?;
+    Ok(format!("{}: {}", time, logline))
+}
+
 /// Rebuild a log line from the interned strings and the CuLogEntry.
 /// This basically translates the world of copper logs to text logs.
 pub fn rebuild_logline(all_interned_strings: &Vec<String>, entry: &CuLogEntry) -> CuResult<String> {
-    let mut format_string = all_interned_strings[entry.msg_index as usize].clone();
-    let mut vars = HashMap::new();
+    let format_string = &all_interned_strings[entry.msg_index as usize];
+    let mut anon_params: Vec<String> = Vec::new();
+    let mut named_params = HashMap::new();
 
     for (i, param) in entry.params.iter().enumerate() {
         let param_as_string = format!("{}", param);
         if entry.paramname_indexes[i] == 0 {
             // Anonymous parameter
-            format_string = format_string.replacen("{}", &param_as_string, 1);
+            anon_params.push(param_as_string);
         } else {
             // Named parameter
             let name = all_interned_strings[entry.paramname_indexes[i] as usize].clone();
-            vars.insert(name, param_as_string);
+            named_params.insert(name, param_as_string);
         }
     }
-
-    if vars.is_empty() {
-        return Ok(format_string);
-    }
-
-    // Use strfmt to replace named parameters
-    strfmt(&format_string, &vars).map_err(|e| {
-        CuError::new_with_cause(
-            format!(
-                "Failed to format log line: {:?} with variables [{:?}]",
-                format_string, vars
-            )
-            .as_str(),
-            e,
-        )
-    })
+    format_logline(entry.time, format_string, &anon_params, &named_params)
 }
 
 fn parent_n_times(path: &Path, n: usize) -> Option<PathBuf> {
@@ -160,7 +177,7 @@ fn parent_n_times(path: &Path, n: usize) -> Option<PathBuf> {
 
 /// Convenience function to returns the default path for the log index directory.
 pub fn default_log_index_dir() -> PathBuf {
-    let outdir = std::env::var("LOG_INDEX_DIR").expect("no LOGIN_INDEX_DIR system variable set, be sure build.rs sets it, see cu29_log/build.rs for example.");
+    let outdir = std::env::var("LOG_INDEX_DIR").expect("no LOG_INDEX_DIR system variable set, be sure build.rs sets it, see cu29_log/build.rs for example.");
     let outdir_path = Path::new(&outdir);
     let target_dir = parent_n_times(&outdir_path, 3)
         .unwrap()

--- a/examples/cu_standalone_structlog/src/structlog_perf.rs
+++ b/examples/cu_standalone_structlog/src/structlog_perf.rs
@@ -1,7 +1,7 @@
 use cu29_clock::{CuTime, RobotClock};
 use cu29_log_derive::debug;
 use cu29_log_runtime::LoggerRuntime;
-use cu29_log_runtime::SimpleFileWriter;
+use cu29_log_runtime::{NullLog, SimpleFileWriter};
 use std::path::PathBuf;
 
 const LOG_FILE: &str = "./logfile.bin";
@@ -10,7 +10,7 @@ fn main() {
     let clock = RobotClock::new();
     let bf = {
         let writer = SimpleFileWriter::new(&PathBuf::from(LOG_FILE)).unwrap();
-        let _log_runtime = LoggerRuntime::init(clock.clone(), writer, None);
+        let _log_runtime = LoggerRuntime::init(clock.clone(), writer, None::<NullLog>);
         let bf: CuTime = clock.now();
         for i in 0..1_000_000 {
             debug!(


### PR DESCRIPTION
I encountered a bug with the current implementation when you want to use the standard logger on top of the structed one in a debug build on ARM. This completely removes the need to copy the index with the executable when you just want to debug something quick. 

This fixes #31 and generally improves the user experience.