### PR TITLE
compilation: moves the compilation feedback from std to err

### DIFF
--- a/cu29_log_derive/src/index.rs
+++ b/cu29_log_derive/src/index.rs
@@ -14,7 +14,7 @@ const COLORED_PREFIX_BUILD_LOG: &str = "\x1b[32mCLog:\x1b[0m";
 
 macro_rules! build_log {
     ($($arg:tt)*) => {
-        println!("{} {}", COLORED_PREFIX_BUILD_LOG, format!($($arg)*));
+        eprintln!("{} {}", COLORED_PREFIX_BUILD_LOG, format!($($arg)*));
     };
 }
 


### PR DESCRIPTION
We need to do that because the compiler has a json output option that gets corrupted otherwise. This fixes #34