### PR TITLE
Sink virtual output + Added wrapper around msgs instead of tuple.

### DIFF
--- a/cu29/src/copperlist.rs
+++ b/cu29/src/copperlist.rs
@@ -47,16 +47,16 @@ impl Display for CopperListState {
 pub struct CopperList<P: CopperListTuple> {
     pub id: u32,
     state: CopperListState,
-    pub payload: P, // This is generated from the runtime.
+    pub msgs: P, // This is generated from the runtime.
 }
 
 impl<P: CopperListTuple> CopperList<P> {
     // This is not the usual way to create a CopperList, this is just for testing.
-    pub fn new(id: u32, payload: P) -> Self {
+    pub fn new(id: u32, msgs: P) -> Self {
         CopperList {
             id,
             state: CopperListState::Initialized,
-            payload,
+            msgs,
         }
     }
 
@@ -253,54 +253,54 @@ mod tests {
     #[test]
     fn partially_full_queue() {
         let mut q = CuListsManager::<i32, 5>::new();
-        q.create().unwrap().payload = 1;
-        q.create().unwrap().payload = 2;
-        q.create().unwrap().payload = 3;
+        q.create().unwrap().msgs = 1;
+        q.create().unwrap().msgs = 2;
+        q.create().unwrap().msgs = 3;
 
         assert!(!q.is_empty());
         assert_eq!(q.len(), 3);
 
-        let res: Vec<i32> = q.iter().map(|x| x.payload).collect();
+        let res: Vec<i32> = q.iter().map(|x| x.msgs).collect();
         assert_eq!(res, [3, 2, 1]);
     }
 
     #[test]
     fn full_queue() {
         let mut q = CuListsManager::<i32, 5>::new();
-        q.create().unwrap().payload = 1;
-        q.create().unwrap().payload = 2;
-        q.create().unwrap().payload = 3;
-        q.create().unwrap().payload = 4;
-        q.create().unwrap().payload = 5;
+        q.create().unwrap().msgs = 1;
+        q.create().unwrap().msgs = 2;
+        q.create().unwrap().msgs = 3;
+        q.create().unwrap().msgs = 4;
+        q.create().unwrap().msgs = 5;
         assert_eq!(q.len(), 5);
 
-        let res: Vec<_> = q.iter().map(|x| x.payload).collect();
+        let res: Vec<_> = q.iter().map(|x| x.msgs).collect();
         assert_eq!(res, [5, 4, 3, 2, 1]);
     }
 
     #[test]
     fn over_full_queue() {
         let mut q = CuListsManager::<i32, 5>::new();
-        q.create().unwrap().payload = 1;
-        q.create().unwrap().payload = 2;
-        q.create().unwrap().payload = 3;
-        q.create().unwrap().payload = 4;
-        q.create().unwrap().payload = 5;
+        q.create().unwrap().msgs = 1;
+        q.create().unwrap().msgs = 2;
+        q.create().unwrap().msgs = 3;
+        q.create().unwrap().msgs = 4;
+        q.create().unwrap().msgs = 5;
         assert!(q.create().is_none());
         assert_eq!(q.len(), 5);
 
-        let res: Vec<_> = q.iter().map(|x| x.payload).collect();
+        let res: Vec<_> = q.iter().map(|x| x.msgs).collect();
         assert_eq!(res, [5, 4, 3, 2, 1]);
     }
 
     #[test]
     fn clear() {
         let mut q = CuListsManager::<i32, 5>::new();
-        q.create().unwrap().payload = 1;
-        q.create().unwrap().payload = 2;
-        q.create().unwrap().payload = 3;
-        q.create().unwrap().payload = 4;
-        q.create().unwrap().payload = 5;
+        q.create().unwrap().msgs = 1;
+        q.create().unwrap().msgs = 2;
+        q.create().unwrap().msgs = 3;
+        q.create().unwrap().msgs = 4;
+        q.create().unwrap().msgs = 5;
         assert!(q.create().is_none());
         assert_eq!(q.len(), 5);
 
@@ -309,30 +309,30 @@ mod tests {
         assert_eq!(q.len(), 0);
         assert!(q.iter().next().is_none());
 
-        q.create().unwrap().payload = 1;
-        q.create().unwrap().payload = 2;
-        q.create().unwrap().payload = 3;
+        q.create().unwrap().msgs = 1;
+        q.create().unwrap().msgs = 2;
+        q.create().unwrap().msgs = 3;
 
         assert_eq!(q.len(), 3);
 
-        let res: Vec<_> = q.iter().map(|x| x.payload).collect();
+        let res: Vec<_> = q.iter().map(|x| x.msgs).collect();
         assert_eq!(res, [3, 2, 1]);
     }
 
     #[test]
     fn mutable_iterator() {
         let mut q = CuListsManager::<i32, 5>::new();
-        q.create().unwrap().payload = 1;
-        q.create().unwrap().payload = 2;
-        q.create().unwrap().payload = 3;
-        q.create().unwrap().payload = 4;
-        q.create().unwrap().payload = 5;
+        q.create().unwrap().msgs = 1;
+        q.create().unwrap().msgs = 2;
+        q.create().unwrap().msgs = 3;
+        q.create().unwrap().msgs = 4;
+        q.create().unwrap().msgs = 5;
 
         for x in q.iter_mut() {
-            x.payload *= 2;
+            x.msgs *= 2;
         }
 
-        let res: Vec<_> = q.iter().map(|x| x.payload).collect();
+        let res: Vec<_> = q.iter().map(|x| x.msgs).collect();
         assert_eq!(res, [10, 8, 6, 4, 2]);
     }
 
@@ -346,9 +346,9 @@ mod tests {
         assert_eq!(q.len(), 3);
 
         let mut iter = q.iter();
-        assert_eq!(iter.next().unwrap().payload, ());
-        assert_eq!(iter.next().unwrap().payload, ());
-        assert_eq!(iter.next().unwrap().payload, ());
+        assert_eq!(iter.next().unwrap().msgs, ());
+        assert_eq!(iter.next().unwrap().msgs, ());
+        assert_eq!(iter.next().unwrap().msgs, ());
         assert!(iter.next().is_none());
     }
 
@@ -360,53 +360,53 @@ mod tests {
     #[test]
     fn test_drop_last() {
         let mut q = CuListsManager::<i32, 5>::new();
-        q.create().unwrap().payload = 1;
-        q.create().unwrap().payload = 2;
-        q.create().unwrap().payload = 3;
-        q.create().unwrap().payload = 4;
-        q.create().unwrap().payload = 5;
+        q.create().unwrap().msgs = 1;
+        q.create().unwrap().msgs = 2;
+        q.create().unwrap().msgs = 3;
+        q.create().unwrap().msgs = 4;
+        q.create().unwrap().msgs = 5;
         assert_eq!(q.len(), 5);
 
         q.drop_last();
         assert_eq!(q.len(), 4);
 
-        let res: Vec<_> = q.iter().map(|x| x.payload).collect();
+        let res: Vec<_> = q.iter().map(|x| x.msgs).collect();
         assert_eq!(res, [4, 3, 2, 1]);
     }
 
     #[test]
     fn test_pop() {
         let mut q = CuListsManager::<i32, 5>::new();
-        q.create().unwrap().payload = 1;
-        q.create().unwrap().payload = 2;
-        q.create().unwrap().payload = 3;
-        q.create().unwrap().payload = 4;
-        q.create().unwrap().payload = 5;
+        q.create().unwrap().msgs = 1;
+        q.create().unwrap().msgs = 2;
+        q.create().unwrap().msgs = 3;
+        q.create().unwrap().msgs = 4;
+        q.create().unwrap().msgs = 5;
         assert_eq!(q.len(), 5);
 
         let last = q.pop().unwrap();
-        assert_eq!(last.payload, 5);
+        assert_eq!(last.msgs, 5);
         assert_eq!(q.len(), 4);
 
-        let res: Vec<_> = q.iter().map(|x| x.payload).collect();
+        let res: Vec<_> = q.iter().map(|x| x.msgs).collect();
         assert_eq!(res, [4, 3, 2, 1]);
     }
 
     #[test]
     fn test_peek() {
         let mut q = CuListsManager::<i32, 5>::new();
-        q.create().unwrap().payload = 1;
-        q.create().unwrap().payload = 2;
-        q.create().unwrap().payload = 3;
-        q.create().unwrap().payload = 4;
-        q.create().unwrap().payload = 5;
+        q.create().unwrap().msgs = 1;
+        q.create().unwrap().msgs = 2;
+        q.create().unwrap().msgs = 3;
+        q.create().unwrap().msgs = 4;
+        q.create().unwrap().msgs = 5;
         assert_eq!(q.len(), 5);
 
         let last = q.peek().unwrap();
-        assert_eq!(last.payload, 5);
+        assert_eq!(last.msgs, 5);
         assert_eq!(q.len(), 5);
 
-        let res: Vec<_> = q.iter().map(|x| x.payload).collect();
+        let res: Vec<_> = q.iter().map(|x| x.msgs).collect();
         assert_eq!(res, [5, 4, 3, 2, 1]);
     }
 }

--- a/cu29/src/curuntime.rs
+++ b/cu29/src/curuntime.rs
@@ -228,7 +228,7 @@ fn plan_tasks_tree_branch(
         let node = config.get_node(id).unwrap();
 
         let mut input_msg_indices_types: Vec<(u32, String)> = Vec::new();
-        let mut output_msg_index_type: Option<(u32, String)> = None;
+        let output_msg_index_type: Option<(u32, String)>;
 
         let task_type = find_task_type_for_id(&config.graph, id);
 
@@ -261,6 +261,12 @@ fn plan_tasks_tree_branch(
                         return next_culist_output_index;
                     }
                 }
+                // Here we create an artificial "end node" for this sink to record the metadata associated with it.
+                output_msg_index_type = Some((
+                    next_culist_output_index,
+                    "()".to_string(), // empty type
+                ));
+                next_culist_output_index += 1;
             }
             CuTaskType::Regular => {
                 let parents: Vec<NodeIndex> = config

--- a/cu29_derive/src/lib.rs
+++ b/cu29_derive/src/lib.rs
@@ -26,11 +26,10 @@ fn int2sliceindex(i: u32) -> syn::Index {
     syn::Index::from(i as usize)
 }
 
-#[proc_macro]
 /// Generates the CopperList content type from a config.
 /// gen_cumsgs!("path/to/config.toml")
-/// It will creates a new type called CuMsgs you can pass to the log reader for decoding:
-///
+/// It will create a new type called CuMsgs you can pass to the log reader for decoding:
+#[proc_macro]
 pub fn gen_cumsgs(config_path_lit: TokenStream) -> TokenStream {
     let config = parse_macro_input!(config_path_lit as LitStr).value();
     eprintln!("[gen culist support with {:?}]", config);

--- a/cu29_export/src/lib.rs
+++ b/cu29_export/src/lib.rs
@@ -447,9 +447,9 @@ mod tests {
         let reader = Cursor::new(data);
 
         let mut iter = copperlists_dump::<MyCuPayload>(reader);
-        assert_eq!(iter.next().unwrap().payload, (1, 2, 3.0));
-        assert_eq!(iter.next().unwrap().payload, (2, 3, 4.0));
-        assert_eq!(iter.next().unwrap().payload, (3, 4, 5.0));
-        assert_eq!(iter.next().unwrap().payload, (4, 5, 6.0));
+        assert_eq!(iter.next().unwrap().msgs, (1, 2, 3.0));
+        assert_eq!(iter.next().unwrap().msgs, (2, 3, 4.0));
+        assert_eq!(iter.next().unwrap().msgs, (3, 4, 5.0));
+        assert_eq!(iter.next().unwrap().msgs, (4, 5, 6.0));
     }
 }

--- a/examples/cu_caterpillar/src/logreader.rs
+++ b/examples/cu_caterpillar/src/logreader.rs
@@ -1,9 +1,9 @@
 use cu29::cutask::CuMsg as _CuMsg;
-use cu29_derive::gen_culist_tuple;
+use cu29_derive::gen_cumsgs;
 use cu29_export::run_cli;
 
-type CuListPayload = gen_culist_tuple!("copperconfig.ron");
+gen_cumsgs!("copperconfig.ron");
 
 fn main() {
-    run_cli::<CuListPayload>().expect("Failed to run the export CLI");
+    run_cli::<CuMsgs>().expect("Failed to run the export CLI");
 }

--- a/examples/cu_monitoring/src/main.rs
+++ b/examples/cu_monitoring/src/main.rs
@@ -126,7 +126,6 @@ impl CuMonitor for ExampleMonitor {
         Ok(())
     }
 }
-
 const SLAB_SIZE: Option<usize> = Some(1024 * 1024 * 1);
 fn main() {
     let logger_path = "monitor.copper";

--- a/examples/cu_rp_balancebot/src/logreader.rs
+++ b/examples/cu_rp_balancebot/src/logreader.rs
@@ -2,17 +2,17 @@ use bincode::config::standard;
 use bincode::decode_from_std_read;
 use bincode::error::DecodeError;
 use cu29::cutask::CuMsg as _CuMsg;
-use cu29_derive::gen_culist_tuple;
+use cu29_derive::gen_cumsgs;
 use cu29_intern_strs::read_interned_strings;
 use cu29_log::CuLogEntry;
 use cu29_traits::UnifiedLogType;
 use cu29_unifiedlog::{UnifiedLogger, UnifiedLoggerBuilder, UnifiedLoggerIOReader};
 use std::path::Path;
 
-type CuListPayload = gen_culist_tuple!("copperconfig.ron");
+gen_cumsgs!("copperconfig.ron");
 
 fn main() {
-    // run_cli::<CuListPayload>().expect("Failed to run the export CLI");
+    // run_cli::<CuMsgs>().expect("Failed to run the export CLI");
 
     // extract PID values
     let UnifiedLogger::Read(dl) = UnifiedLoggerBuilder::new()

--- a/templates/cu_full/src/logreader.rs
+++ b/templates/cu_full/src/logreader.rs
@@ -1,11 +1,13 @@
 pub mod tasks;
 
 use cu29::cutask::CuMsg as _CuMsg;
-use cu29_derive::gen_culist_tuple;
+use cu29_derive::gen_cumsgs;
 use cu29_export::run_cli;
 
-type CuListTuple = gen_culist_tuple!("copperconfig.ron");
+/// This will create the CuMsgs that is specific to your copper project.
+/// It is used to instruct the log reader how to decode the logs.
+gen_cumsgs!("copperconfig.ron");
 
 fn main() {
-    run_cli::<CuListTuple>().expect("Failed to run the export CLI");
+    run_cli::<CuMsgs>().expect("Failed to run the export CLI");
 }


### PR DESCRIPTION
It solves 3 problems:
1. now we can track the latency truely end to end without the hack I implemented previously forcing me to have the input for the sinks as writeable. Now it generates a virtual end msg that is just the metadata for the sink.
2. it allows monitoring to work with sinks
3. doing that I hit a serious limitation with the tuple that triggered a refactoring of the CopperLists. It is 2 fold: one, all the blanket traits like Debug are implemented up to tuples of 12 elements, and the second issue, any tuple is considered a foreign type so if the trait is not in the crate I cannot implement them. The solution is to have a type wrapper.

While at it, I renames cl.payload to cl.msgs so it makes the hierarcy crystal clear:
CL - Msg - Payload
 