### PR TITLE
Add `*.copper` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /Cargo.lock
 /cu29_export.so
 
+*.copper
+
 # ROS stuff
 /examples/ros_caterpillar/build
 /examples/ros_caterpillar/log


### PR DESCRIPTION
It seems that `.copper` extension is reserved for the logger. In this PR, we add it to the gitignore list to prevent annoying mistakes when committing. 
