### PR TITLE
Embed the default config to Copper's executable.

### DIFF
--- a/components/monitors/cu_consolemon/src/lib.rs
+++ b/components/monitors/cu_consolemon/src/lib.rs
@@ -4,10 +4,10 @@ use ansi_to_tui::IntoText;
 use color_eyre::config::HookBuilder;
 use compact_str::{CompactString, ToCompactString};
 use cu29::clock::{CuDuration, RobotClock};
-use cu29::config::{ComponentConfig, CuConfig, Node};
+use cu29::config::{CuConfig, Node};
 use cu29::cutask::CuMsgMetadata;
 use cu29::monitoring::{CuDurationStatistics, CuMonitor, CuTaskState, Decision};
-use cu29::{read_configuration, CuError, CuResult};
+use cu29::{CuError, CuResult};
 use libc::{close, dup, dup2};
 use ratatui::backend::CrosstermBackend;
 use ratatui::buffer::Buffer;
@@ -536,29 +536,17 @@ impl UI {
 }
 
 impl CuMonitor for CuConsoleMon {
-    fn new(config: Option<&ComponentConfig>, taskids: &'static [&'static str]) -> CuResult<Self>
+    fn new(config: &CuConfig, taskids: &'static [&'static str]) -> CuResult<Self>
     where
         Self: Sized,
     {
-        let config_file: String = if let Some(config) = config {
-            config
-                .0
-                .get("file")
-                .expect("You need to passs the path to the copper config file to use")
-                .to_string()
-        } else {
-            panic!("You need to passs the path to the copper config file to use");
-        };
-
-        let config =
-            read_configuration(config_file.as_str()).expect("Could not read configuration");
         let task_stats = Arc::new(Mutex::new(TaskStats::new(
             taskids.len(),
             CuDuration::from(Duration::from_secs(5)),
         )));
 
         Ok(Self {
-            config,
+            config: config.clone(),
             taskids,
             task_stats,
             task_statuses: Arc::new(Mutex::new(vec![TaskStatus::default(); taskids.len()])),

--- a/core/cu29/src/config.rs
+++ b/core/cu29/src/config.rs
@@ -625,6 +625,11 @@ pub fn read_configuration(config_filename: &str) -> CuResult<CuConfig> {
         ))
         .add_cause(e.to_string().as_str())
     })?;
+    read_configuration_str(config_content)
+}
+
+/// Read a copper configuration from a file.
+pub fn read_configuration_str(config_content: String) -> CuResult<CuConfig> {
     Ok(CuConfig::deserialize_ron(&config_content))
 }
 

--- a/core/cu29/src/curuntime.rs
+++ b/core/cu29/src/curuntime.rs
@@ -46,7 +46,7 @@ impl<CT, P: CopperListTuple + 'static, M: CuMonitor, const NBCL: usize> CuRuntim
         clock: RobotClock,
         config: &CuConfig,
         tasks_instanciator: impl Fn(Vec<Option<&ComponentConfig>>) -> CuResult<CT>,
-        monitor_instanciator: impl Fn(Option<&ComponentConfig>) -> M,
+        monitor_instanciator: impl Fn(&CuConfig) -> M,
         logger: impl WriteStream<CopperList<P>> + 'static,
     ) -> CuResult<Self> {
         let all_instances_configs: Vec<Option<&ComponentConfig>> = config
@@ -56,11 +56,7 @@ impl<CT, P: CopperListTuple + 'static, M: CuMonitor, const NBCL: usize> CuRuntim
             .collect();
         let tasks = tasks_instanciator(all_instances_configs)?;
 
-        let monitor = if let Some(monitor_section) = config.get_monitor_config() {
-            monitor_instanciator(monitor_section.get_config())
-        } else {
-            monitor_instanciator(None)
-        };
+        let monitor = monitor_instanciator(config);
 
         let runtime = Self {
             tasks,

--- a/core/cu29/src/curuntime.rs
+++ b/core/cu29/src/curuntime.rs
@@ -426,7 +426,7 @@ mod tests {
         ))
     }
 
-    fn monitor_instanciator(_config: Option<&ComponentConfig>) -> NoMonitor {
+    fn monitor_instanciator(_config: &CuConfig) -> NoMonitor {
         NoMonitor {}
     }
 

--- a/core/cu29/src/monitoring.rs
+++ b/core/cu29/src/monitoring.rs
@@ -1,7 +1,7 @@
 //! Some basic internal monitoring tooling Copper uses to monitor itself and the tasks it is running.
 //!
 
-use crate::config::ComponentConfig;
+use crate::config::CuConfig;
 use crate::cutask::CuMsgMetadata;
 use cu29_clock::{CuDuration, RobotClock};
 use cu29_traits::{CuError, CuResult};
@@ -28,7 +28,7 @@ pub enum Decision {
 
 /// Trait to implement a monitoring task.
 pub trait CuMonitor: Sized {
-    fn new(config: Option<&ComponentConfig>, taskids: &'static [&'static str]) -> CuResult<Self>
+    fn new(config: &CuConfig, taskids: &'static [&'static str]) -> CuResult<Self>
     where
         Self: Sized;
 
@@ -52,7 +52,7 @@ pub trait CuMonitor: Sized {
 /// This is basically defining the default behavior of Copper in case of error.
 pub struct NoMonitor {}
 impl CuMonitor for NoMonitor {
-    fn new(_config: Option<&ComponentConfig>, _taskids: &'static [&'static str]) -> CuResult<Self> {
+    fn new(_config: &CuConfig, _taskids: &'static [&'static str]) -> CuResult<Self> {
         Ok(NoMonitor {})
     }
 

--- a/examples/cu_monitoring/src/main.rs
+++ b/examples/cu_monitoring/src/main.rs
@@ -1,4 +1,4 @@
-use cu29::config::ComponentConfig;
+use cu29::config::CuConfig;
 use cu29::cutask::CuMsgMetadata;
 use cu29::monitoring::{CuMonitor, CuTaskState, Decision};
 use cu29_derive::copper_runtime;
@@ -94,7 +94,7 @@ struct ExampleMonitor {
 struct App {}
 
 impl CuMonitor for ExampleMonitor {
-    fn new(_config: Option<&ComponentConfig>, taskids: &'static [&str]) -> CuResult<Self> {
+    fn new(_config: &CuConfig, taskids: &'static [&str]) -> CuResult<Self> {
         debug!("Monitoring: created: {}", taskids);
         Ok(ExampleMonitor { tasks: taskids })
     }

--- a/examples/cu_rp_balancebot/copperconfig.ron
+++ b/examples/cu_rp_balancebot/copperconfig.ron
@@ -20,11 +20,10 @@
             type: "tasks::BalPID",
             config: {
                 "kp": 0.015, // 0.02 1 / 168 ticks = .00593
-                 "kd": 0.01,
-                 // "ki": 0.00005,
-                 // "setpoint": 3176.0,
-                 "setpoint": 3072.0, // the perfect sim
-                 "cutoff": 170.0, // cut off if the measured value is outside of +/- 170 ticks around the setpoint
+                "kd": 0.01,
+                "ki": 0.0,
+                "setpoint": 3072.0, // the perfect sim
+                "cutoff": 170.0, // cut off if the measured value is outside of +/- 170 ticks around the setpoint
             },
         ),
 
@@ -33,11 +32,11 @@
             type: "tasks::PosPID",
             config: {
                 "kp": 0.0005, // 0.02 1 / 168 ticks = .00593
-                 "kd": 0.5,
-                 // "ki": 0.000001,
-                 "setpoint": 0.0,
-                 "cutoff": 1000.0, // cut off if the it is about to hit the side of the rail
-                 "sampling_ms": 100,
+                "kd": 0.5,
+                "ki": 0.0,
+                "setpoint": 0.0,
+                "cutoff": 1000.0, // cut off if the it is about to hit the side of the rail
+                "sampling_ms": 100,
             },
         ),
 
@@ -62,9 +61,8 @@
         (src: "railpos_pid", dst: "merge_pids", msg:"cu_pid::PIDControlOutputPayload"),
         (src: "merge_pids", dst: "motor", msg:"cu_rp_sn754410_new::MotorPayload"),
     ],
-    // monitor: (
-    //     type: "cu_consolemon::CuConsoleMon",
-    //     config: {"file": "copperconfig.ron"},
-    // )
+    monitor: (
+        type: "cu_consolemon::CuConsoleMon",
+    )
 )
 

--- a/examples/cu_rp_balancebot/src/sim.rs
+++ b/examples/cu_rp_balancebot/src/sim.rs
@@ -5,7 +5,6 @@ use crate::world::{Cart, Rod};
 use avian3d::math::Vector;
 use avian3d::prelude::{ExternalForce, Physics};
 use bevy::prelude::*;
-use cached_path::{Cache, ProgressBar};
 use cu29::clock::{RobotClock, RobotClockMock};
 use cu29::simulation::{CuTaskCallbackState, SimOverride};
 use cu29_derive::copper_runtime;
@@ -14,7 +13,6 @@ use cu29_log_derive::debug;
 use cu_ads7883_new::ADSReadingPayload;
 use cu_rp_encoder::EncoderPayload;
 use std::path::PathBuf;
-use std::{fs, io};
 
 // To enable sim, it is just your regular macro with sim_mode true
 #[copper_runtime(config = "copperconfig.ron", sim_mode = true)]
@@ -71,6 +69,7 @@ fn setup_copper(mut commands: Commands) {
         &mut default_callback,
     )
     .expect("Failed to create runtime.");
+
     copper_app
         .start_all_tasks(&mut default_callback)
         .expect("Failed to start all tasks.");
@@ -174,27 +173,7 @@ fn stop_copper_on_exit(mut exit_events: EventReader<AppExit>, mut copper_ctx: Re
     }
 }
 
-fn copy_to_current_dir_if_not_exist(file_path: &PathBuf, name: &str) -> io::Result<()> {
-    let current_dir = std::env::current_dir()?;
-    let destination = current_dir.join(name);
-    if !destination.exists() {
-        fs::copy(&file_path, &destination)?;
-    }
-    Ok(())
-}
-
 fn main() {
-    let cache = Cache::builder()
-        .progress_bar(Some(ProgressBar::Full))
-        .build()
-        .expect("Failed to create the file cache.");
-
-    let destination = cache
-        .cached_path("https://raw.githubusercontent.com/copper-project/copper-rs/refs/heads/master/examples/cu_rp_balancebot/copperconfig.ron").expect("Failed to download copperconfig.ron.");
-
-    copy_to_current_dir_if_not_exist(&destination, "copperconfig.ron")
-        .expect("Failed to copy copperconfig.ron to the current directory.");
-
     let mut world = App::new();
 
     // minimal setup to load the assets

--- a/examples/cu_rp_balancebot/src/world/mod.rs
+++ b/examples/cu_rp_balancebot/src/world/mod.rs
@@ -67,7 +67,7 @@ pub fn build_world(app: &mut App) -> &mut App {
             // EditorPlugin::default(),
         ))
         .insert_resource(DefaultOpaqueRendererMethod::deferred())
-        .insert_resource(SimulationState::Paused)
+        .insert_resource(SimulationState::Running)
         .insert_resource(CameraControl {
             rotate_sensitivity: 0.05,
             zoom_sensitivity: 3.5,
@@ -456,7 +456,6 @@ fn toggle_simulation_state(
         if *state == SimulationState::Running {
             *state = SimulationState::Paused;
         } else {
-            println!("Starting simulation");
             *state = SimulationState::Running;
         }
     }


### PR DESCRIPTION
Other changes:
Now the monitoring gets the full config.
This solves #77 