### PR TITLE
Introducing CuTimeRange

### DIFF
--- a/components/monitors/cu_consolemon/src/lib.rs
+++ b/components/monitors/cu_consolemon/src/lib.rs
@@ -58,7 +58,10 @@ impl TaskStats {
 
     fn update(&mut self, msgs: &[&CuMsgMetadata]) {
         for (i, &msg) in msgs.iter().enumerate() {
-            let (before, after) = (msg.before_process.unwrap(), msg.after_process.unwrap());
+            let (before, after) = (
+                msg.process_time.start.unwrap(),
+                msg.process_time.end.unwrap(),
+            );
             self.stats[i].record(after - before);
         }
         self.end2end.record(compute_end_to_end_latency(msgs));
@@ -73,7 +76,8 @@ impl TaskStats {
 }
 
 fn compute_end_to_end_latency(msgs: &[&CuMsgMetadata]) -> CuDuration {
-    msgs.last().unwrap().after_process.unwrap() - msgs.first().unwrap().before_process.unwrap()
+    msgs.last().unwrap().process_time.end.unwrap()
+        - msgs.first().unwrap().process_time.start.unwrap()
 }
 
 // This is kind of terrible.

--- a/components/payloads/cu_sensor_payloads/src/lib.rs
+++ b/components/payloads/cu_sensor_payloads/src/lib.rs
@@ -61,9 +61,13 @@ impl<'de> BorrowDecode<'de> for LidarLength {
     }
 }
 
+/// Standardized PointCloud.
+/// note: the derive(Soa) will generate a PointCloudSoa struct that will store the data in a SoA format.
+/// The Soa format is appropriate for early pipeline operations like changing their frame of reference.
+/// important: The ToV of the points are not assumed to be sorted.
 #[derive(Default, Clone, Encode, Decode, PartialEq, Debug, Soa)]
-pub struct LidarPayload {
-    tov: CuTime, // Time of Validity
+pub struct PointCloud {
+    tov: CuTime, // Time of Validity, not sorted.
     x: LidarLength,
     y: LidarLength,
     z: LidarLength,
@@ -71,7 +75,7 @@ pub struct LidarPayload {
     return_order: u8, // 0 for first return, 1 for second return, etc.
 }
 
-impl LidarPayload {
+impl PointCloud {
     pub fn new(tov: CuTime, x: f32, y: f32, z: f32, i: f32, return_order: Option<u8>) -> Self {
         Self {
             tov,
@@ -109,7 +113,7 @@ mod tests {
 
     #[test]
     fn test_lidar_payload() {
-        let payload = LidarPayload::new(CuDuration(1), 1.0, 2.0, 3.0, 0.0, None);
+        let payload = PointCloud::new(CuDuration(1), 1.0, 2.0, 3.0, 0.0, None);
         assert_eq!(payload.x.0.value, 1.0);
         assert_eq!(payload.y.0.value, 2.0);
         assert_eq!(payload.z.0.value, 3.0);

--- a/components/payloads/cu_sensor_payloads/src/lib.rs
+++ b/components/payloads/cu_sensor_payloads/src/lib.rs
@@ -36,28 +36,28 @@ impl<'de> BorrowDecode<'de> for Reflectivity {
 }
 
 #[derive(Default, PartialEq, Debug, Copy, Clone, Add, Deref, Sub, From, Mul, Div)]
-pub struct LidarLength(Length);
+pub struct Distance(Length);
 
 /// Encode it as a f32 in m
-impl Encode for LidarLength {
+impl Encode for Distance {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
         Encode::encode(&self.0.value, encoder)
     }
 }
 
 /// Decode it as a f32 in m
-impl Decode for LidarLength {
+impl Decode for Distance {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
         let value: f32 = Decode::decode(decoder)?;
-        Ok(LidarLength(Length::new::<meter>(value)))
+        Ok(Distance(Length::new::<meter>(value)))
     }
 }
 
 /// Decode it as a f32 in m
-impl<'de> BorrowDecode<'de> for LidarLength {
+impl<'de> BorrowDecode<'de> for Distance {
     fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let value: f32 = Decode::decode(decoder)?;
-        Ok(LidarLength(Length::new::<meter>(value)))
+        Ok(Distance(Length::new::<meter>(value)))
     }
 }
 
@@ -68,9 +68,9 @@ impl<'de> BorrowDecode<'de> for LidarLength {
 #[derive(Default, Clone, Encode, Decode, PartialEq, Debug, Soa)]
 pub struct PointCloud {
     tov: CuTime, // Time of Validity, not sorted.
-    x: LidarLength,
-    y: LidarLength,
-    z: LidarLength,
+    x: Distance,
+    y: Distance,
+    z: Distance,
     i: Reflectivity,
     return_order: u8, // 0 for first return, 1 for second return, etc.
 }
@@ -79,9 +79,9 @@ impl PointCloud {
     pub fn new(tov: CuTime, x: f32, y: f32, z: f32, i: f32, return_order: Option<u8>) -> Self {
         Self {
             tov,
-            x: LidarLength(Length::new::<meter>(x)),
-            y: LidarLength(Length::new::<meter>(y)),
-            z: LidarLength(Length::new::<meter>(z)),
+            x: Distance(Length::new::<meter>(x)),
+            y: Distance(Length::new::<meter>(y)),
+            z: Distance(Length::new::<meter>(z)),
             i: Reflectivity(Ratio::new::<percent>(i)),
             return_order: return_order.unwrap_or(0),
         }
@@ -97,9 +97,9 @@ impl PointCloud {
     ) -> Self {
         Self {
             tov,
-            x: LidarLength(x),
-            y: LidarLength(y),
-            z: LidarLength(z),
+            x: Distance(x),
+            y: Distance(y),
+            z: Distance(z),
             i: Reflectivity(i),
             return_order: return_order.unwrap_or(0),
         }
@@ -112,7 +112,7 @@ mod tests {
     use cu29_clock::CuDuration;
 
     #[test]
-    fn test_lidar_payload() {
+    fn test_point_payload() {
         let payload = PointCloud::new(CuDuration(1), 1.0, 2.0, 3.0, 0.0, None);
         assert_eq!(payload.x.0.value, 1.0);
         assert_eq!(payload.y.0.value, 2.0);
@@ -121,8 +121,8 @@ mod tests {
 
     #[test]
     fn test_length_add_sub() {
-        let a = LidarLength(Length::new::<meter>(1.0));
-        let b = LidarLength(Length::new::<meter>(2.0));
+        let a = Distance(Length::new::<meter>(1.0));
+        let b = Distance(Length::new::<meter>(2.0));
         let c = a + b;
         assert_eq!(c.value, 3.0);
         let d = c - a;
@@ -131,7 +131,7 @@ mod tests {
 
     #[test]
     fn test_encoding_length() {
-        let a = LidarLength(Length::new::<meter>(1.0));
+        let a = Distance(Length::new::<meter>(1.0));
         let mut encoded = vec![0u8; 1024]; // Reserve a buffer with sufficient capacity
 
         let length =

--- a/components/sources/cu_iceoryx2_src/src/lib.rs
+++ b/components/sources/cu_iceoryx2_src/src/lib.rs
@@ -102,7 +102,7 @@ where
                     .ok_or(CuError::from("Failed to get payload."))?
                     .clone(),
             );
-            new_msg.metadata.tov = icemsg.payload().metadata.tov;
+            new_msg.metadata.tov = icemsg.payload().metadata.tov.clone();
         } else {
             debug!("No message received");
         }

--- a/components/sources/cu_vlp16/src/lib.rs
+++ b/components/sources/cu_vlp16/src/lib.rs
@@ -5,7 +5,7 @@ use cu29::clock::RobotClock;
 use cu29::config::ComponentConfig;
 use cu29::cutask::{CuMsg, CuSrcTask, CuTaskLifecycle, Freezable};
 use cu29::{output_msg, CuResult};
-use cu_sensor_payloads::{LidarPayload, LidarPayloadSoa};
+use cu_sensor_payloads::{PointCloud, PointCloudSoa};
 use std::net::UdpSocket;
 use std::time::Duration;
 use velodyne_lidar::iter::try_packet_to_frame_xyz;
@@ -64,7 +64,7 @@ impl CuTaskLifecycle for Vlp16 {
 }
 
 impl<'cl> CuSrcTask<'cl> for Vlp16 {
-    type Output = output_msg!('cl, LidarPayloadSoa<10000>);
+    type Output = output_msg!('cl, PointCloudSoa<10000>);
 
     fn process(&mut self, _clock: &RobotClock, new_msg: Self::Output) -> CuResult<()> {
         let socket = self.socket.as_ref().unwrap();
@@ -79,7 +79,7 @@ impl<'cl> CuSrcTask<'cl> for Vlp16 {
             .next()
             .unwrap()
             .unwrap();
-        let mut output = LidarPayloadSoa::<10000>::default();
+        let mut output = PointCloudSoa::<10000>::default();
 
         frame.firing_iter().for_each(|firing| {
             firing.point_iter().for_each(|point| {
@@ -89,7 +89,7 @@ impl<'cl> CuSrcTask<'cl> for Vlp16 {
                 let y = point.measurement.xyz[1].as_meters() as f32;
                 let z = point.measurement.xyz[2].as_meters() as f32;
                 let intensity = point.measurement.intensity as f32 / 255.0f32;
-                output.push(LidarPayload::new(tov.into(), x, y, z, intensity, None));
+                output.push(PointCloud::new(tov.into(), x, y, z, intensity, None));
             });
         });
         new_msg.set_payload(output);
@@ -122,7 +122,7 @@ mod tests {
             let socket = UdpSocket::bind("0.0.0.0:2367").unwrap();
             socket.send_to(data, "127.0.0.1:2368").unwrap();
             // process
-            let mut msg = CuMsg::new(Some(LidarPayloadSoa::<10000>::default()));
+            let mut msg = CuMsg::new(Some(PointCloudSoa::<10000>::default()));
             drv.process(&clk, &mut msg).unwrap();
             assert_eq!(-0.05115497, msg.payload().unwrap().x[0].value);
         }

--- a/components/tasks/cu_pid/src/lib.rs
+++ b/components/tasks/cu_pid/src/lib.rs
@@ -2,7 +2,7 @@ use bincode::de::Decoder;
 use bincode::enc::Encoder;
 use bincode::error::{DecodeError, EncodeError};
 use bincode::{Decode, Encode};
-use cu29::clock::{CuDuration, CuTime, RobotClock};
+use cu29::clock::{CuDuration, CuTime, RobotClock, Tov};
 use cu29::config::ComponentConfig;
 use cu29::cutask::{CuMsg, CuMsgPayload};
 use cu29::cutask::{CuTask, CuTaskLifecycle, Freezable};
@@ -229,7 +229,11 @@ where
     ) -> CuResult<()> {
         match input.payload() {
             Some(payload) => {
-                let tov = input.metadata.tov.unwrap();
+                let tov = match input.metadata.tov {
+                    Tov::Time(single) => single,
+                    _ => panic!("Unexpected variant"),
+                };
+
                 let measure: f32 = payload.into();
 
                 if self.first_run {

--- a/components/tasks/cu_pid/src/lib.rs
+++ b/components/tasks/cu_pid/src/lib.rs
@@ -231,7 +231,7 @@ where
             Some(payload) => {
                 let tov = match input.metadata.tov {
                     Tov::Time(single) => single,
-                    _ => panic!("Unexpected variant"),
+                    _ => return Err("Unexpected variant for a TOV of PID".into()),
                 };
 
                 let measure: f32 = payload.into();

--- a/core/cu29_clock/src/lib.rs
+++ b/core/cu29_clock/src/lib.rs
@@ -11,6 +11,7 @@ use core::ops::{Add, Sub};
 pub use quanta::Instant;
 use quanta::{Clock, Mock};
 use serde::{Deserialize, Serialize};
+use std::convert::Into;
 use std::fmt::{Display, Formatter};
 use std::ops::{AddAssign, Div, Mul};
 use std::sync::Arc;
@@ -18,8 +19,15 @@ use std::time::Duration;
 
 /// For Robot times, the underlying type is a u64 representing nanoseconds.
 /// It is always positive to simplify the reasoning on the user side.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
 pub struct CuDuration(pub u64);
+
+impl CuDuration {
+    // Lowest value a CuDuration can have.
+    pub const MIN: CuDuration = CuDuration(0u64);
+    // Highest value a CuDuration can have reserving the max value for None.
+    pub const MAX: CuDuration = CuDuration(NONE_VALUE - 1);
+}
 
 /// bridge the API with standard Durations.
 impl From<Duration> for CuDuration {
@@ -164,7 +172,7 @@ impl Display for CuDuration {
 pub type CuTime = CuDuration;
 
 /// Homebrewed `Option<CuDuration>` to avoid using 128bits just to represent an Option.
-#[derive(Clone, Copy, Debug, PartialEq, Encode, Decode, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Encode, Decode, Serialize, Deserialize)]
 pub struct OptionCuTime(CuTime);
 
 const NONE_VALUE: u64 = 0xFFFFFFFFFFFFFFFF;
@@ -234,14 +242,25 @@ impl From<CuTime> for OptionCuTime {
 }
 
 /// Represents a time range.
-#[derive(Clone, Debug, Encode, Decode, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Encode, Decode, Serialize, Deserialize)]
 pub struct CuTimeRange {
     pub start: CuTime,
     pub end: CuTime,
 }
 
+/// Builds a time range from a slice of CuTime.
+/// This is an O(n) operation.
+impl From<&[CuTime]> for CuTimeRange {
+    fn from(slice: &[CuTime]) -> Self {
+        CuTimeRange {
+            start: *slice.iter().min().expect("Empty slice"),
+            end: *slice.iter().max().expect("Empty slice"),
+        }
+    }
+}
+
 /// Represents a time range with possible undefined start or end or both.
-#[derive(Clone, Debug, Encode, Decode, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Encode, Decode, Serialize, Deserialize)]
 pub struct PartialCuTimeRange {
     pub start: OptionCuTime,
     pub end: OptionCuTime,
@@ -445,5 +464,12 @@ mod tests {
         assert_eq!(c.0, 30);
         let d = b - a;
         assert_eq!(d.0, 10);
+    }
+
+    #[test]
+    fn test_build_range_from_slice() {
+        let range = CuTimeRange::from(&[20.into(), 10.into(), 30.into()][..]);
+        assert_eq!(range.start, 10.into());
+        assert_eq!(range.end, 30.into());
     }
 }

--- a/core/cu29_clock/src/lib.rs
+++ b/core/cu29_clock/src/lib.rs
@@ -233,6 +233,44 @@ impl From<CuTime> for OptionCuTime {
     }
 }
 
+/// Represents a time range.
+#[derive(Clone, Debug, Encode, Decode, Serialize, Deserialize)]
+pub struct CuTimeRange {
+    pub start: CuTime,
+    pub end: CuTime,
+}
+
+/// Represents a time range with possible undefined start or end or both.
+#[derive(Clone, Debug, Encode, Decode, Serialize, Deserialize)]
+pub struct PartialCuTimeRange {
+    pub start: OptionCuTime,
+    pub end: OptionCuTime,
+}
+
+impl Default for PartialCuTimeRange {
+    fn default() -> Self {
+        PartialCuTimeRange {
+            start: OptionCuTime::none(),
+            end: OptionCuTime::none(),
+        }
+    }
+}
+
+/// The time of validity of a message can be more than one time but can be a time range of Tovs.
+/// For example a sub scan for a lidar, a set of images etc... can have a range of validity.
+#[derive(Clone, Debug, Encode, Decode, Serialize, Deserialize)]
+pub enum Tov {
+    None,
+    Time(CuTime),
+    Range(CuTimeRange),
+}
+
+impl Default for Tov {
+    fn default() -> Self {
+        Tov::None
+    }
+}
+
 /// A running Robot clock.
 /// The clock is a monotonic clock that starts at an arbitrary reference time.
 /// It is clone resilient, ie a clone will be the same clock, even when mocked.

--- a/core/cu29_clock/src/lib.rs
+++ b/core/cu29_clock/src/lib.rs
@@ -271,6 +271,21 @@ impl Default for Tov {
     }
 }
 
+impl From<Option<CuDuration>> for Tov {
+    fn from(duration: Option<CuDuration>) -> Self {
+        match duration {
+            Some(duration) => Tov::Time(duration),
+            None => Tov::None,
+        }
+    }
+}
+
+impl From<CuDuration> for Tov {
+    fn from(duration: CuDuration) -> Self {
+        Tov::Time(duration)
+    }
+}
+
 /// A running Robot clock.
 /// The clock is a monotonic clock that starts at an arbitrary reference time.
 /// It is clone resilient, ie a clone will be the same clock, even when mocked.

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -620,13 +620,13 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                         {
                                             let cumsg_output = &mut msgs.#output_culist_index;
                                             #call_sim_callback
-                                            cumsg_output.metadata.before_process = self.copper_runtime.clock.now().into();
+                                            cumsg_output.metadata.process_time.start = self.copper_runtime.clock.now().into();
                                             let maybe_error = if doit {
                                                 #task_instance.process(&self.copper_runtime.clock, cumsg_output)
                                             } else {
                                                 Ok(())
                                             };
-                                            cumsg_output.metadata.after_process = self.copper_runtime.clock.now().into();
+                                            cumsg_output.metadata.process_time.end = self.copper_runtime.clock.now().into();
                                             if let Err(error) = maybe_error {
                                                 #monitoring_action
                                             }
@@ -693,9 +693,9 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                         // This is the virtual output for the sink
                                         let cumsg_output = &mut msgs.#output_culist_index;
                                         #call_sim_callback
-                                        cumsg_output.metadata.before_process = self.copper_runtime.clock.now().into();
+                                        cumsg_output.metadata.process_time.start = self.copper_runtime.clock.now().into();
                                         let maybe_error = if doit {#task_instance.process(&self.copper_runtime.clock, cumsg_input)} else {Ok(())};
-                                        cumsg_output.metadata.after_process = self.copper_runtime.clock.now().into();
+                                        cumsg_output.metadata.process_time.end = self.copper_runtime.clock.now().into();
                                         if let Err(error) = maybe_error {
                                             #monitoring_action
                                         }
@@ -760,9 +760,9 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                         let cumsg_input = (#(&msgs.#indices),*);
                                         let cumsg_output = &mut msgs.#output_culist_index;
                                         #call_sim_callback
-                                        cumsg_output.metadata.before_process = self.copper_runtime.clock.now().into();
+                                        cumsg_output.metadata.process_time.start = self.copper_runtime.clock.now().into();
                                         let maybe_error = if doit {#task_instance.process(&self.copper_runtime.clock, cumsg_input, cumsg_output)} else {Ok(())};
-                                        cumsg_output.metadata.after_process = self.copper_runtime.clock.now().into();
+                                        cumsg_output.metadata.process_time.end = self.copper_runtime.clock.now().into();
                                         if let Err(error) = maybe_error {
                                             #monitoring_action
                                         }
@@ -880,7 +880,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 {
                     // End of CL monitoring
                     let md = collect_metadata(&culist);
-                    let e2e = md.last().unwrap().after_process.unwrap() - md.first().unwrap().before_process.unwrap();
+                    let e2e = md.last().unwrap().process_time.end.unwrap() - md.first().unwrap().process_time.start.unwrap();
                     let e2en: u64 = e2e.into();
                 } // drop(md);
 

--- a/examples/cu_rp_balancebot/src/tasks.rs
+++ b/examples/cu_rp_balancebot/src/tasks.rs
@@ -44,7 +44,7 @@ impl<'cl> CuTask<'cl> for PIDMerger {
             None => return Err(CuError::from("Safety mode [rail].")),
         };
         // Take the fastest measure as the reference time for the merge
-        output.metadata.tov = bal_pid_msg.metadata.tov;
+        output.metadata.tov = bal_pid_msg.metadata.tov.clone();
         let composite_output = (bal_pid.output - pos_pid.output).clamp(-1.0, 1.0);
         output.set_payload(MotorPayload {
             power: composite_output,


### PR DESCRIPTION
This is needed to represent messages that contains more than 1 Tov like several images, several IMU measures etc... We will add helpers like range merging, range intersections etc in a separate PRs.