### PR TITLE
Ignore real HW tests and adds test --workspace to CI/CD

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -42,7 +42,7 @@ jobs:
           cargo build --workspace --features mock
 
       - name: Run tests
-        run: cargo test
+        run: cargo test --workspace
 
       - name: Run clippy
         run: cargo clippy -- -W warnings

--- a/components/sinks/cu_rp_sn754410/tests/sn754410_tester.rs
+++ b/components/sinks/cu_rp_sn754410/tests/sn754410_tester.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 struct SN754410Tester {}
 
 #[test]
+#[ignore] // As this needs the real hardware to run.
 fn test_driver_with_hardware() {
     let logger_path = "/tmp/caterpillar.copper";
     let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), None, true, None)

--- a/components/sources/cu_ads7883/tests/ads7883_tester.rs
+++ b/components/sources/cu_ads7883/tests/ads7883_tester.rs
@@ -34,6 +34,7 @@ impl<'cl> CuSinkTask<'cl> for ADS78883TestSink {
 }
 
 #[test]
+#[ignore] // As this needs the real hardware to run.
 fn test_driver_with_hardware() {
     let logger_path = "/tmp/caterpillar.copper";
     let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), None, true, None)


### PR DESCRIPTION
This ensures we have the maximum possible test coverage on CI