### PR TITLE
Removes the lifecycle trait

### DIFF
--- a/components/sinks/cu_rp_sn754410/tests/sn754410_tester.rs
+++ b/components/sinks/cu_rp_sn754410/tests/sn754410_tester.rs
@@ -1,4 +1,4 @@
-use cu29::cutask::{CuSinkTask, CuTaskLifecycle};
+use cu29::cutask::CuSinkTask;
 use cu29_derive::copper_runtime;
 use cu29_helpers::basic_copper_setup;
 use cu29_log_derive::debug;

--- a/components/sources/cu_ads7883/tests/ads7883_tester.rs
+++ b/components/sources/cu_ads7883/tests/ads7883_tester.rs
@@ -1,6 +1,6 @@
 use cu29::clock::RobotClock;
 use cu29::config::ComponentConfig;
-use cu29::cutask::{CuMsg, CuSinkTask, CuTaskLifecycle, Freezable};
+use cu29::cutask::{CuMsg, CuSinkTask, Freezable};
 use cu29::{input_msg, CuResult};
 use cu29_derive::copper_runtime;
 use cu29_helpers::basic_copper_setup;
@@ -15,17 +15,14 @@ pub struct ADS78883TestSink {}
 
 impl Freezable for ADS78883TestSink {}
 
-impl CuTaskLifecycle for ADS78883TestSink {
+impl<'cl> CuSinkTask<'cl> for ADS78883TestSink {
+    type Input = input_msg!('cl, ADSReadingPayload);
     fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
     where
         Self: Sized,
     {
         Ok(Self {})
     }
-}
-
-impl<'cl> CuSinkTask<'cl> for ADS78883TestSink {
-    type Input = input_msg!('cl, ADSReadingPayload);
 
     fn process(&mut self, _clock: &RobotClock, new_msg: Self::Input) -> CuResult<()> {
         debug!("Received: {}", &new_msg.payload());

--- a/components/sources/cu_wt901/src/lib.rs
+++ b/components/sources/cu_wt901/src/lib.rs
@@ -4,7 +4,7 @@ use bincode::error::{DecodeError, EncodeError};
 use bincode::{Decode, Encode};
 use cu29::clock::RobotClock;
 use cu29::config::ComponentConfig;
-use cu29::cutask::{CuMsg, CuSrcTask, CuTaskLifecycle, Freezable};
+use cu29::cutask::{CuMsg, CuSrcTask, Freezable};
 use cu29::{output_msg, CuResult};
 #[cfg(hardware)]
 use embedded_hal::i2c::I2c;
@@ -216,7 +216,9 @@ impl Freezable for WT901 {
     // WT901 has no internal state, we can leave the default implementation.
 }
 
-impl CuTaskLifecycle for WT901 {
+impl<'cl> CuSrcTask<'cl> for WT901 {
+    type Output = output_msg!('cl, PositionalReadingsPayload);
+
     fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
     where
         Self: Sized,
@@ -230,10 +232,6 @@ impl CuTaskLifecycle for WT901 {
             i2c: Box::new(i2cdev),
         })
     }
-}
-
-impl<'cl> CuSrcTask<'cl> for WT901 {
-    type Output = output_msg!('cl, PositionalReadingsPayload);
 
     fn process(&mut self, _clock: &RobotClock, new_msg: Self::Output) -> CuResult<()> {
         let mut pos = PositionalReadingsPayload::default();

--- a/components/sources/cu_wt901/tests/wt901_tester.rs
+++ b/components/sources/cu_wt901/tests/wt901_tester.rs
@@ -1,6 +1,6 @@
 use cu29::clock::RobotClock;
 use cu29::config::ComponentConfig;
-use cu29::cutask::{CuMsg, CuSinkTask, CuTaskLifecycle, Freezable};
+use cu29::cutask::{CuMsg, CuSinkTask, Freezable};
 use cu29::{input_msg, CuResult};
 use cu29_derive::copper_runtime;
 use cu29_helpers::basic_copper_setup;
@@ -14,17 +14,15 @@ struct WT910TestSink {}
 
 impl Freezable for WT910TestSink {}
 
-impl CuTaskLifecycle for WT910TestSink {
+impl<'cl> CuSinkTask<'cl> for WT910TestSink {
+    type Input = input_msg!('cl, PositionalReadingsPayload);
+
     fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
     where
         Self: Sized,
     {
         Ok(Self {})
     }
-}
-
-impl<'cl> CuSinkTask<'cl> for WT910TestSink {
-    type Input = input_msg!('cl, PositionalReadingsPayload);
 
     fn process(&mut self, _clock: &RobotClock, new_msg: Self::Input) -> CuResult<()> {
         debug!("Received: {}", &new_msg.payload());

--- a/components/tasks/cu_aligner/README.md
+++ b/components/tasks/cu_aligner/README.md
@@ -45,7 +45,6 @@ use cu_aligner::define_task;
 use cu29::input_msg;
 use cu29::output_msg;
 use cu29::cutask::Freezable;
-use cu29::cutask::CuTaskLifecycle;
 use cu29::config::ComponentConfig;
 use cu29::CuResult;
 use cu29::cutask::CuTask;

--- a/components/tasks/cu_aligner/src/lib.rs
+++ b/components/tasks/cu_aligner/src/lib.rs
@@ -23,7 +23,12 @@ macro_rules! define_task {
 
         impl Freezable for $name {}
 
-        impl CuTaskLifecycle for $name {
+        impl<'cl> CuTask<'cl> for $name {
+            type Input = input_msg!('cl, $($p),*);
+            type Output = output_msg!('cl, ($(
+                cu29::payload::CuArray<$p, { $mos }>
+            ),*));
+
             fn new(config: Option<&ComponentConfig>) -> CuResult<Self>
             where
                 Self: Sized,
@@ -43,13 +48,6 @@ macro_rules! define_task {
                 self.aligner.purge(clock.now());
                 Ok(())
             }
-        }
-
-        impl<'cl> CuTask<'cl> for $name {
-            type Input = input_msg!('cl, $($p),*);
-            type Output = output_msg!('cl, ($(
-                cu29::payload::CuArray<$p, { $mos }>
-            ),*));
 
             fn process(
                 &mut self,
@@ -90,7 +88,6 @@ mod tests {
     use cu29::config::ComponentConfig;
     use cu29::cutask::CuMsg;
     use cu29::cutask::CuTask;
-    use cu29::cutask::CuTaskLifecycle;
     use cu29::cutask::Freezable;
     use cu29::input_msg;
     use cu29::output_msg;

--- a/core/cu29/src/curuntime.rs
+++ b/core/cu29/src/curuntime.rs
@@ -369,7 +369,7 @@ mod tests {
     use super::*;
     use crate::clock::RobotClock;
     use crate::config::Node;
-    use crate::cutask::{CuSinkTask, CuTaskLifecycle};
+    use crate::cutask::CuSinkTask;
     use crate::cutask::{CuSrcTask, Freezable};
     use crate::monitoring::NoMonitor;
     use bincode::Encode;
@@ -378,17 +378,15 @@ mod tests {
 
     impl Freezable for TestSource {}
 
-    impl CuTaskLifecycle for TestSource {
+    impl CuSrcTask<'_> for TestSource {
+        type Output = ();
         fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
         where
             Self: Sized,
         {
             Ok(Self {})
         }
-    }
 
-    impl CuSrcTask<'_> for TestSource {
-        type Output = ();
         fn process(&mut self, _clock: &RobotClock, _empty_msg: Self::Output) -> CuResult<()> {
             Ok(())
         }
@@ -398,17 +396,15 @@ mod tests {
 
     impl Freezable for TestSink {}
 
-    impl CuTaskLifecycle for TestSink {
+    impl CuSinkTask<'_> for TestSink {
+        type Input = ();
+
         fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
         where
             Self: Sized,
         {
             Ok(Self {})
         }
-    }
-
-    impl CuSinkTask<'_> for TestSink {
-        type Input = ();
 
         fn process(&mut self, _clock: &RobotClock, _input: Self::Input) -> CuResult<()> {
             Ok(())

--- a/core/cu29/src/cutask.rs
+++ b/core/cu29/src/cutask.rs
@@ -196,12 +196,13 @@ pub trait Freezable {
 pub trait CuSrcTask<'cl>: Freezable {
     type Output: CuMsgPack<'cl>;
 
+    /// Here you need to initialize everything your task will need for the duration of its lifetime.
+    /// The config allows you to access the configuration of the task.
     fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
     where
         Self: Sized;
 
-    /// Start is called once for a long period of time.
-    /// Here you need to initialize everything your task will need for the duration of its lifetime.
+    /// Start is called between the creation of the task and the first call to pre/process.
     fn start(&mut self, _clock: &RobotClock) -> CuResult<()> {
         Ok(())
     }
@@ -220,12 +221,12 @@ pub trait CuSrcTask<'cl>: Freezable {
 
     /// This is a method called by the runtime after "process". It is best effort a chance for
     /// the task to update some state after process is out of the way.
-    /// It can be use for example to maintain statistics etc. that are not time critical for the robot.
+    /// It can be use for example to maintain statistics etc. that are not time-critical for the robot.
     fn postprocess(&mut self, _clock: &RobotClock) -> CuResult<()> {
         Ok(())
     }
 
-    /// Call at the end of the lifecycle of the task.
+    /// Called to stop the task. It signals that the *process method won't be called until start is called again.
     fn stop(&mut self, _clock: &RobotClock) -> CuResult<()> {
         Ok(())
     }
@@ -236,12 +237,13 @@ pub trait CuTask<'cl>: Freezable {
     type Input: CuMsgPack<'cl>;
     type Output: CuMsgPack<'cl>;
 
+    /// Here you need to initialize everything your task will need for the duration of its lifetime.
+    /// The config allows you to access the configuration of the task.
     fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
     where
         Self: Sized;
 
-    /// Start is called once for a long period of time.
-    /// Here you need to initialize everything your task will need for the duration of its lifetime.
+    /// Start is called between the creation of the task and the first call to pre/process.
     fn start(&mut self, _clock: &RobotClock) -> CuResult<()> {
         Ok(())
     }
@@ -265,12 +267,12 @@ pub trait CuTask<'cl>: Freezable {
 
     /// This is a method called by the runtime after "process". It is best effort a chance for
     /// the task to update some state after process is out of the way.
-    /// It can be use for example to maintain statistics etc. that are not time critical for the robot.
+    /// It can be use for example to maintain statistics etc. that are not time-critical for the robot.
     fn postprocess(&mut self, _clock: &RobotClock) -> CuResult<()> {
         Ok(())
     }
 
-    /// Call at the end of the lifecycle of the task.
+    /// Called to stop the task. It signals that the *process method won't be called until start is called again.
     fn stop(&mut self, _clock: &RobotClock) -> CuResult<()> {
         Ok(())
     }
@@ -280,12 +282,13 @@ pub trait CuTask<'cl>: Freezable {
 pub trait CuSinkTask<'cl>: Freezable {
     type Input: CuMsgPack<'cl>;
 
+    /// Here you need to initialize everything your task will need for the duration of its lifetime.
+    /// The config allows you to access the configuration of the task.
     fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
     where
         Self: Sized;
 
-    /// Start is called once for a long period of time.
-    /// Here you need to initialize everything your task will need for the duration of its lifetime.
+    /// Start is called between the creation of the task and the first call to pre/process.
     fn start(&mut self, _clock: &RobotClock) -> CuResult<()> {
         Ok(())
     }
@@ -304,12 +307,12 @@ pub trait CuSinkTask<'cl>: Freezable {
 
     /// This is a method called by the runtime after "process". It is best effort a chance for
     /// the task to update some state after process is out of the way.
-    /// It can be use for example to maintain statistics etc. that are not time critical for the robot.
+    /// It can be use for example to maintain statistics etc. that are not time-critical for the robot.
     fn postprocess(&mut self, _clock: &RobotClock) -> CuResult<()> {
         Ok(())
     }
 
-    /// Call at the end of the lifecycle of the task.
+    /// Called to stop the task. It signals that the *process method won't be called until start is called again.
     fn stop(&mut self, _clock: &RobotClock) -> CuResult<()> {
         Ok(())
     }

--- a/core/cu29/src/cutask.rs
+++ b/core/cu29/src/cutask.rs
@@ -183,18 +183,20 @@ pub trait Freezable {
 
     /// This method is called by the framework when it wants to restore the task to a specific state.
     /// Here it is similar to Decode but the framework will give you a new instance of the task (the new method will be called)
-    ///
     #[allow(unused_variables)]
     fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
         Ok(())
     }
 }
 
-/// The CuTaskLifecycle trait is the base trait for all tasks in Copper.
-/// It defines the lifecycle of a task.
-/// It provides a default empty implementation as all those execution steps are optional.
-pub trait CuTaskLifecycle: Freezable {
-    fn new(config: Option<&ComponentConfig>) -> CuResult<Self>
+/// A Src Task is a task that only produces messages. For example drivers for sensors are Src Tasks.
+/// They are in push mode from the runtime.
+/// To set the frequency of the pulls and align them to any hw, see the runtime configuration.
+/// Note: A source has the priviledge to have a clock passed to it vs a frozen clock.
+pub trait CuSrcTask<'cl>: Freezable {
+    type Output: CuMsgPack<'cl>;
+
+    fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
     where
         Self: Sized;
 
@@ -211,6 +213,11 @@ pub trait CuTaskLifecycle: Freezable {
         Ok(())
     }
 
+    /// Process is the most critical execution of the task.
+    /// The goal will be to produce the output message as soon as possible.
+    /// Use preprocess to prepare the task to make this method as short as possible.
+    fn process(&mut self, clock: &RobotClock, new_msg: Self::Output) -> CuResult<()>;
+
     /// This is a method called by the runtime after "process". It is best effort a chance for
     /// the task to update some state after process is out of the way.
     /// It can be use for example to maintain statistics etc. that are not time critical for the robot.
@@ -224,40 +231,86 @@ pub trait CuTaskLifecycle: Freezable {
     }
 }
 
-/// A Src Task is a task that only produces messages. For example drivers for sensors are Src Tasks.
-/// They are in push mode from the runtime.
-/// To set the frequency of the pulls and align them to any hw, see the runtime configuration.
-pub trait CuSrcTask<'cl>: CuTaskLifecycle {
-    type Output: CuMsgPack<'cl>;
-
-    /// Process is the most critical execution of the task.
-    /// The goal will be to produce the output message as soon as possible.
-    /// Use preprocess to prepare the task to make this method as short as possible.
-    fn process(&mut self, clock: &RobotClock, new_msg: Self::Output) -> CuResult<()>;
-}
-
 /// This is the most generic Task of copper. It is a "transform" task deriving an output from an input.
-pub trait CuTask<'cl>: CuTaskLifecycle {
+pub trait CuTask<'cl>: Freezable {
     type Input: CuMsgPack<'cl>;
     type Output: CuMsgPack<'cl>;
+
+    fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
+    where
+        Self: Sized;
+
+    /// Start is called once for a long period of time.
+    /// Here you need to initialize everything your task will need for the duration of its lifetime.
+    fn start(&mut self, _clock: &RobotClock) -> CuResult<()> {
+        Ok(())
+    }
+
+    /// This is a method called by the runtime before "process". This is a kind of best effort,
+    /// as soon as possible call to give a chance for the task to do some work before to prepare
+    /// to make "process" as short as possible.
+    fn preprocess(&mut self, _clock: &RobotClock) -> CuResult<()> {
+        Ok(())
+    }
 
     /// Process is the most critical execution of the task.
     /// The goal will be to produce the output message as soon as possible.
     /// Use preprocess to prepare the task to make this method as short as possible.
     fn process(
         &mut self,
-        clock: &RobotClock,
+        _clock: &RobotClock,
         input: Self::Input,
         output: Self::Output,
     ) -> CuResult<()>;
+
+    /// This is a method called by the runtime after "process". It is best effort a chance for
+    /// the task to update some state after process is out of the way.
+    /// It can be use for example to maintain statistics etc. that are not time critical for the robot.
+    fn postprocess(&mut self, _clock: &RobotClock) -> CuResult<()> {
+        Ok(())
+    }
+
+    /// Call at the end of the lifecycle of the task.
+    fn stop(&mut self, _clock: &RobotClock) -> CuResult<()> {
+        Ok(())
+    }
 }
 
 /// A Sink Task is a task that only consumes messages. For example drivers for actuators are Sink Tasks.
-pub trait CuSinkTask<'cl>: CuTaskLifecycle {
+pub trait CuSinkTask<'cl>: Freezable {
     type Input: CuMsgPack<'cl>;
+
+    fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
+    where
+        Self: Sized;
+
+    /// Start is called once for a long period of time.
+    /// Here you need to initialize everything your task will need for the duration of its lifetime.
+    fn start(&mut self, _clock: &RobotClock) -> CuResult<()> {
+        Ok(())
+    }
+
+    /// This is a method called by the runtime before "process". This is a kind of best effort,
+    /// as soon as possible call to give a chance for the task to do some work before to prepare
+    /// to make "process" as short as possible.
+    fn preprocess(&mut self, _clock: &RobotClock) -> CuResult<()> {
+        Ok(())
+    }
 
     /// Process is the most critical execution of the task.
     /// The goal will be to produce the output message as soon as possible.
     /// Use preprocess to prepare the task to make this method as short as possible.
-    fn process(&mut self, clock: &RobotClock, input: Self::Input) -> CuResult<()>;
+    fn process(&mut self, _clock: &RobotClock, input: Self::Input) -> CuResult<()>;
+
+    /// This is a method called by the runtime after "process". It is best effort a chance for
+    /// the task to update some state after process is out of the way.
+    /// It can be use for example to maintain statistics etc. that are not time critical for the robot.
+    fn postprocess(&mut self, _clock: &RobotClock) -> CuResult<()> {
+        Ok(())
+    }
+
+    /// Call at the end of the lifecycle of the task.
+    fn stop(&mut self, _clock: &RobotClock) -> CuResult<()> {
+        Ok(())
+    }
 }

--- a/core/cu29/src/simulation.rs
+++ b/core/cu29/src/simulation.rs
@@ -109,9 +109,7 @@
 
 use crate::config::ComponentConfig;
 
-use crate::cutask::{
-    CuMsg, CuMsgPack, CuMsgPayload, CuSinkTask, CuSrcTask, CuTaskLifecycle, Freezable,
-};
+use crate::cutask::{CuMsg, CuMsgPack, CuMsgPayload, CuSinkTask, CuSrcTask, Freezable};
 use crate::{input_msg, output_msg};
 use cu29_clock::RobotClock;
 use cu29_traits::CuResult;
@@ -163,19 +161,17 @@ pub struct CuSimSrcTask<T> {
     boo: PhantomData<T>,
 }
 
-impl<T> CuTaskLifecycle for CuSimSrcTask<T> {
+impl<T> Freezable for CuSimSrcTask<T> {}
+
+impl<'cl, T: CuMsgPayload + 'cl> CuSrcTask<'cl> for CuSimSrcTask<T> {
+    type Output = output_msg!('cl, T);
+
     fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
     where
         Self: Sized,
     {
         Ok(Self { boo: PhantomData })
     }
-}
-
-impl<T> Freezable for CuSimSrcTask<T> {}
-
-impl<'cl, T: CuMsgPayload + 'cl> CuSrcTask<'cl> for CuSimSrcTask<T> {
-    type Output = output_msg!('cl, T);
 
     fn process(&mut self, _clock: &RobotClock, _new_msg: Self::Output) -> CuResult<()> {
         unimplemented!("A placeholder for sim was called for a source, you need answer SimOverride to ExecutedBySim for the Process step.")
@@ -188,18 +184,17 @@ pub struct CuSimSinkTask<T> {
     boo: PhantomData<T>,
 }
 
-impl<T> CuTaskLifecycle for CuSimSinkTask<T> {
+impl<'cl, T: CuMsgPayload + 'cl> Freezable for CuSimSinkTask<T> {}
+
+impl<'cl, T: CuMsgPayload + 'cl> CuSinkTask<'cl> for CuSimSinkTask<T> {
+    type Input = input_msg!('cl, T);
+
     fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
     where
         Self: Sized,
     {
         Ok(Self { boo: PhantomData })
     }
-}
-impl<T> Freezable for CuSimSinkTask<T> {}
-
-impl<'cl, T: CuMsgPayload + 'cl> CuSinkTask<'cl> for CuSimSinkTask<T> {
-    type Input = input_msg!('cl, T);
 
     fn process(&mut self, _clock: &RobotClock, _input: Self::Input) -> CuResult<()> {
         unimplemented!("A placeholder for sim was called for a sink, you need answer SimOverride to ExecutedBySim for the Process step.")

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -985,7 +985,6 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
         use cu29::curuntime::CuRuntime as _CuRuntime;
         use cu29::CuResult as _CuResult;
         use cu29::CuError as _CuError;
-        use cu29::cutask::CuTaskLifecycle as _CuTaskLifecycle; // Needed for the instantiation of tasks
         use cu29::cutask::CuSrcTask as _CuSrcTask;
         use cu29::cutask::CuSinkTask as _CuSinkTask;
         use cu29::cutask::CuTask as _CuTask;

--- a/examples/cu_caterpillar/src/tasks.rs
+++ b/examples/cu_caterpillar/src/tasks.rs
@@ -4,7 +4,7 @@ use bincode::error::{DecodeError, EncodeError};
 use bincode::{Decode, Encode};
 use cu29::clock::RobotClock;
 use cu29::config::ComponentConfig;
-use cu29::cutask::{CuMsg, CuSrcTask, CuTask, CuTaskLifecycle, Freezable};
+use cu29::cutask::{CuMsg, CuSrcTask, CuTask, Freezable};
 use cu29::{input_msg, output_msg, CuResult};
 use cu_rp_gpio::RPGpioPayload;
 
@@ -24,17 +24,15 @@ impl Freezable for CaterpillarSource {
     }
 }
 
-impl CuTaskLifecycle for CaterpillarSource {
+impl<'cl> CuSrcTask<'cl> for CaterpillarSource {
+    type Output = output_msg!('cl, RPGpioPayload);
+
     fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
     where
         Self: Sized,
     {
         Ok(Self { state: true })
     }
-}
-
-impl<'cl> CuSrcTask<'cl> for CaterpillarSource {
-    type Output = output_msg!('cl, RPGpioPayload);
 
     fn process(&mut self, _clock: &RobotClock, output: Self::Output) -> CuResult<()> {
         // forward the state to the next task
@@ -49,18 +47,16 @@ pub struct CaterpillarTask {}
 
 impl Freezable for CaterpillarTask {}
 
-impl CuTaskLifecycle for CaterpillarTask {
+impl<'cl> CuTask<'cl> for CaterpillarTask {
+    type Input = input_msg!('cl, RPGpioPayload);
+    type Output = output_msg!('cl, RPGpioPayload);
+
     fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
     where
         Self: Sized,
     {
         Ok(Self {})
     }
-}
-
-impl<'cl> CuTask<'cl> for CaterpillarTask {
-    type Input = input_msg!('cl, RPGpioPayload);
-    type Output = output_msg!('cl, RPGpioPayload);
 
     fn process(
         &mut self,

--- a/examples/cu_monitoring/src/main.rs
+++ b/examples/cu_monitoring/src/main.rs
@@ -10,25 +10,23 @@ use std::path::PathBuf;
 pub mod tasks {
     use cu29::clock::RobotClock;
     use cu29::config::ComponentConfig;
-    use cu29::cutask::{CuMsg, CuSinkTask, CuSrcTask, CuTask, CuTaskLifecycle, Freezable};
+    use cu29::cutask::{CuMsg, CuSinkTask, CuSrcTask, CuTask, Freezable};
     use cu29::{input_msg, output_msg};
     use cu29_traits::CuResult;
 
     pub struct ExampleSrc {}
 
-    impl CuTaskLifecycle for ExampleSrc {
+    impl Freezable for ExampleSrc {}
+
+    impl<'cl> CuSrcTask<'cl> for ExampleSrc {
+        type Output = output_msg!('cl, i32);
+
         fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
         where
             Self: Sized,
         {
             Ok(Self {})
         }
-    }
-
-    impl Freezable for ExampleSrc {}
-
-    impl<'cl> CuSrcTask<'cl> for ExampleSrc {
-        type Output = output_msg!('cl, i32);
 
         fn process(&mut self, _clock: &RobotClock, new_msg: Self::Output) -> CuResult<()> {
             new_msg.set_payload(42);
@@ -38,20 +36,18 @@ pub mod tasks {
 
     pub struct ExampleTask {}
 
-    impl CuTaskLifecycle for ExampleTask {
+    impl Freezable for ExampleTask {}
+
+    impl<'cl> CuTask<'cl> for ExampleTask {
+        type Input = input_msg!('cl, i32);
+        type Output = output_msg!('cl, i32);
+
         fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
         where
             Self: Sized,
         {
             Ok(Self {})
         }
-    }
-
-    impl Freezable for ExampleTask {}
-
-    impl<'cl> CuTask<'cl> for ExampleTask {
-        type Input = input_msg!('cl, i32);
-        type Output = output_msg!('cl, i32);
 
         fn process(
             &mut self,
@@ -66,19 +62,17 @@ pub mod tasks {
 
     pub struct ExampleSink {}
 
-    impl CuTaskLifecycle for ExampleSink {
+    impl Freezable for ExampleSink {}
+
+    impl<'cl> CuSinkTask<'cl> for ExampleSink {
+        type Input = input_msg!('cl, i32);
+
         fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
         where
             Self: Sized,
         {
             Ok(Self {})
         }
-    }
-
-    impl Freezable for ExampleSink {}
-
-    impl<'cl> CuSinkTask<'cl> for ExampleSink {
-        type Input = input_msg!('cl, i32);
 
         fn process(&mut self, _clock: &RobotClock, _input: Self::Input) -> CuResult<()> {
             Ok(())

--- a/examples/cu_multisources/src/tasks.rs
+++ b/examples/cu_multisources/src/tasks.rs
@@ -1,6 +1,6 @@
 use cu29::clock::RobotClock;
 use cu29::config::ComponentConfig;
-use cu29::cutask::{CuSinkTask, CuTask, CuTaskLifecycle};
+use cu29::cutask::{CuSinkTask, CuTask};
 use cu29::cutask::{CuSrcTask, Freezable};
 
 use cu29::cutask::CuMsg;
@@ -14,14 +14,11 @@ pub struct IntegerSrcTask {
 
 impl Freezable for IntegerSrcTask {}
 
-impl CuTaskLifecycle for IntegerSrcTask {
+impl<'cl> CuSrcTask<'cl> for IntegerSrcTask {
+    type Output = output_msg!('cl, i32);
     fn new(_config: Option<&ComponentConfig>) -> CuResult<Self> {
         Ok(Self { value: 42 })
     }
-}
-
-impl<'cl> CuSrcTask<'cl> for IntegerSrcTask {
-    type Output = output_msg!('cl, i32);
 
     fn process(&mut self, _clock: &RobotClock, output: Self::Output) -> CuResult<()> {
         self.value += 1;
@@ -37,14 +34,11 @@ pub struct FloatSrcTask {
 
 impl Freezable for FloatSrcTask {}
 
-impl CuTaskLifecycle for FloatSrcTask {
+impl<'cl> CuSrcTask<'cl> for FloatSrcTask {
+    type Output = output_msg!('cl, f32);
     fn new(_config: Option<&ComponentConfig>) -> CuResult<Self> {
         Ok(Self { value: 24.0 })
     }
-}
-
-impl<'cl> CuSrcTask<'cl> for FloatSrcTask {
-    type Output = output_msg!('cl, f32);
 
     fn process(&mut self, _clock: &RobotClock, output: Self::Output) -> CuResult<()> {
         self.value += 1.0;
@@ -58,15 +52,13 @@ pub struct MergingSinkTask {}
 
 impl Freezable for MergingSinkTask {}
 
-impl CuTaskLifecycle for MergingSinkTask {
-    fn new(_config: Option<&ComponentConfig>) -> CuResult<Self> {
-        Ok(Self {})
-    }
-}
-
 impl<'cl> CuSinkTask<'cl> for MergingSinkTask {
     /// The input is an i32 from the IntegerSrcTask and a f32 from the FloatSrcTask.
     type Input = input_msg!('cl, i32, f32);
+
+    fn new(_config: Option<&ComponentConfig>) -> CuResult<Self> {
+        Ok(Self {})
+    }
 
     fn process(&mut self, _clock: &RobotClock, input: Self::Input) -> CuResult<()> {
         let (i, f) = input;
@@ -84,18 +76,16 @@ pub struct MergerTask {}
 
 impl Freezable for MergerTask {}
 
-impl CuTaskLifecycle for MergerTask {
-    fn new(_config: Option<&ComponentConfig>) -> CuResult<Self> {
-        Ok(Self {})
-    }
-}
-
 impl<'cl> CuTask<'cl> for MergerTask {
     /// The input is an i32 from the IntegerSrcTask and a f32 from the FloatSrcTask.
     type Input = input_msg!('cl, i32, f32);
 
     /// The output is a tuple of i32 and f32.
     type Output = output_msg!('cl, (i32, f32));
+
+    fn new(_config: Option<&ComponentConfig>) -> CuResult<Self> {
+        Ok(Self {})
+    }
 
     fn process(
         &mut self,
@@ -116,14 +106,12 @@ pub struct MergedSinkTask {}
 
 impl Freezable for MergedSinkTask {}
 
-impl CuTaskLifecycle for MergedSinkTask {
+impl<'cl> CuSinkTask<'cl> for MergedSinkTask {
+    type Input = input_msg!('cl, (i32, f32));
+
     fn new(_config: Option<&ComponentConfig>) -> CuResult<Self> {
         Ok(Self {})
     }
-}
-
-impl<'cl> CuSinkTask<'cl> for MergedSinkTask {
-    type Input = input_msg!('cl, (i32, f32));
 
     fn process(&mut self, _clock: &RobotClock, input: Self::Input) -> CuResult<()> {
         println!("SinkTask2 received: {:?}", input.payload().unwrap());

--- a/examples/cu_rp_balancebot/src/tasks.rs
+++ b/examples/cu_rp_balancebot/src/tasks.rs
@@ -1,6 +1,6 @@
 use cu29::clock::RobotClock;
 use cu29::config::ComponentConfig;
-use cu29::cutask::{CuMsg, CuTask, CuTaskLifecycle, Freezable};
+use cu29::cutask::{CuMsg, CuTask, Freezable};
 use cu29::{input_msg, output_msg, CuResult};
 use cu29_traits::CuError;
 use cu_ads7883_new::ADSReadingPayload;
@@ -13,20 +13,18 @@ pub type PosPID = GenericPIDTask<EncoderPayload>;
 
 pub struct PIDMerger {}
 
-impl CuTaskLifecycle for PIDMerger {
+impl Freezable for PIDMerger {}
+
+impl<'cl> CuTask<'cl> for PIDMerger {
+    type Input = input_msg!('cl, PIDControlOutputPayload, PIDControlOutputPayload);
+    type Output = output_msg!('cl, MotorPayload);
+
     fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
     where
         Self: Sized,
     {
         Ok(Self {})
     }
-}
-
-impl Freezable for PIDMerger {}
-
-impl<'cl> CuTask<'cl> for PIDMerger {
-    type Input = input_msg!('cl, PIDControlOutputPayload, PIDControlOutputPayload);
-    type Output = output_msg!('cl, MotorPayload);
 
     fn process(
         &mut self,

--- a/templates/cu_full/src/tasks.rs
+++ b/templates/cu_full/src/tasks.rs
@@ -2,7 +2,7 @@ use bincode::{Decode, Encode};
 
 use cu29::clock::RobotClock;
 use cu29::config::ComponentConfig;
-use cu29::cutask::{CuMsg, CuSinkTask, CuSrcTask, CuTask, CuTaskLifecycle, Freezable};
+use cu29::cutask::{CuMsg, CuSinkTask, CuSrcTask, CuTask, Freezable};
 use cu29::CuResult;
 use cu29::{input_msg, output_msg};
 

--- a/templates/cu_full/src/tasks.rs
+++ b/templates/cu_full/src/tasks.rs
@@ -21,18 +21,17 @@ pub struct MySource {}
 // Needs to be fully implemented if you want to have a stateful task.
 impl Freezable for MySource {}
 
-impl CuTaskLifecycle for MySource {
+impl<'cl> CuSrcTask<'cl> for MySource {
+    type Output = output_msg!('cl, MyPayload);
+
     fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
     where
         Self: Sized,
     {
         Ok(Self {})
     }
-    // don't forget the other lifecycle methods if you need them: start, stop, preprocess, postprocess
-}
 
-impl<'cl> CuSrcTask<'cl> for MySource {
-    type Output = output_msg!('cl, MyPayload);
+    // don't forget the other lifecycle methods if you need them: start, stop, preprocess, postprocess
 
     fn process(&mut self, _clock: &RobotClock, output: Self::Output) -> CuResult<()> {
         // Generated a 42 message.
@@ -49,7 +48,10 @@ pub struct MyTask {
 // Needs to be fully implemented if you want to have a stateful task.
 impl Freezable for MyTask {}
 
-impl CuTaskLifecycle for MyTask {
+impl<'cl> CuTask<'cl> for MyTask {
+    type Input = input_msg!('cl, MyPayload);
+    type Output = output_msg!('cl, MyPayload);
+
     fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
     where
         Self: Sized,
@@ -59,11 +61,6 @@ impl CuTaskLifecycle for MyTask {
     }
 
     // don't forget the other lifecycle methods if you need them: start, stop, preprocess, postprocess
-}
-
-impl<'cl> CuTask<'cl> for MyTask {
-    type Input = input_msg!('cl, MyPayload);
-    type Output = output_msg!('cl, MyPayload);
 
     fn process(
         &mut self,
@@ -84,7 +81,9 @@ pub struct MySink {}
 // Needs to be fully implemented if you want to have a stateful task.
 impl Freezable for MySink {}
 
-impl CuTaskLifecycle for MySink {
+impl<'cl> CuSinkTask<'cl> for MySink {
+    type Input = input_msg!('cl, MyPayload);
+
     fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
     where
         Self: Sized,
@@ -92,10 +91,6 @@ impl CuTaskLifecycle for MySink {
         Ok(Self {})
     }
     // don't forget the other lifecycle methods if you need them: start, stop, preprocess, postprocess
-}
-
-impl<'cl> CuSinkTask<'cl> for MySink {
-    type Input = input_msg!('cl, MyPayload);
 
     fn process(&mut self, _clock: &RobotClock, input: Self::Input) -> CuResult<()> {
         debug!("Sink Received message: {}", input.payload().unwrap().value);


### PR DESCRIPTION
It split artificially the implementation of tasks and couples the passed types.