### PR TITLE
Move setup_entities to Startup phase

### DIFF
--- a/examples/cu_rp_balancebot/src/world/mod.rs
+++ b/examples/cu_rp_balancebot/src/world/mod.rs
@@ -76,7 +76,7 @@ pub fn build_world(app: &mut App) -> &mut App {
         .insert_resource(Time::<Physics>::default())
         .add_systems(Startup, setup_scene)
         .add_systems(Startup, setup_ui)
-        .add_systems(Update, setup_entities)
+        .add_systems(Startup, setup_entities)
         .add_systems(Update, toggle_simulation_state)
         .add_systems(Update, camera_control_system)
         .add_systems(Update, update_physics)


### PR DESCRIPTION
Running setup_entities during the Update phase was causing major performance issues. It should only need to be called once. Otherwise the example will hit major frame rate and memory issues.

On my system, the example went from <1 fps to ~45.