### PR TITLE
[FIX] end2end test of cu29_helpers

### DIFF
--- a/core/cu29_helpers/tests/end2end.rs
+++ b/core/cu29_helpers/tests/end2end.rs
@@ -2,7 +2,7 @@ use cu29_helpers::basic_copper_setup;
 use cu29_log::CuLogEntry;
 use cu29_log::ANONYMOUS;
 use cu29_log_derive::debug;
-use cu29_log_runtime::log_debug_mode;
+use cu29_log_runtime::log;
 use cu29_value::to_value;
 use serde::Serialize;
 use tempdir::TempDir;

--- a/core/cu29_helpers/tests/end2end.rs
+++ b/core/cu29_helpers/tests/end2end.rs
@@ -2,8 +2,14 @@ use cu29_helpers::basic_copper_setup;
 use cu29_log::CuLogEntry;
 use cu29_log::ANONYMOUS;
 use cu29_log_derive::debug;
-use cu29_log_runtime::log;
 use cu29_value::to_value;
+
+#[cfg(not(debug_assertions))]
+use cu29_log_runtime::log;
+
+#[cfg(debug_assertions)]
+use cu29_log_runtime::log_debug_mode;
+
 use serde::Serialize;
 use tempdir::TempDir;
 


### PR DESCRIPTION
Compilation issue with
`cargo build --release --all-targets --workspace`

fixed by importing log_debug_mode for debug mode, and importing log for release mode