### PR TITLE
Exclude [workspace] from cunew-generated toml

### DIFF
--- a/templates/cu_full/Cargo.toml.template
+++ b/templates/cu_full/Cargo.toml.template
@@ -4,8 +4,6 @@ version = "0.1.0"
 edition = "2021"
 default-run = "{{project-name|kebab_case}}"
 
-[workspace]
-
 # The main executable of your application
 [[bin]]
 name = "{{project-name|kebab_case}}"

--- a/templates/cu_full/Cargo.toml.template
+++ b/templates/cu_full/Cargo.toml.template
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 default-run = "{{project-name|kebab_case}}"
 
+{% if copper_source == "local" %}
+{% comment %} We must be part of a root workspace if we're in the copper repo {% endcomment %}
+[workspace]
+{%endif %}
 # The main executable of your application
 [[bin]]
 name = "{{project-name|kebab_case}}"


### PR DESCRIPTION
I used `cunew` to generate a new project and hit a couple issues but this one is the one that makes most sense to fix.

I have a bit of an odd setup here. My user-side repo at `$HOME/Repos/scratchpad` and my Cargo workspace root is at `$HOME/Repos/scratchpad/car`. In my workspace, I just add all the crates in my project as members so I can build everything easily.

When I ran cunew, I ran it from the templates dir in my local copper repo, so this:
```bash
cd ~/Repos/copper-rs/templates
cargo cunew ~/Repos/scratchpad/car/copper
# Used 'git' as a copper source
```

When I built my code from the workspace root or the new copper project, I got this error

```bash
mike@fedora:copper $ cargo b
error: multiple workspace roots found in the same workspace:
  /home/mike/Repos/scratchpad/car/copper/car
  /home/mike/Repos/scratchpad/car
```

This is the reason this doesn't work: https://doc.rust-lang.org/cargo/reference/manifest.html#the-workspace-field

> This field cannot be specified if the manifest already has a [workspace] table defined. That is, a crate cannot both be a root crate in a workspace (contain [workspace]) and also be a member crate of another workspace (contain package.workspace).

Omitting this element from the toml should fix it. I think that if users want this as the workspace root, they could add that in. I think this would relate to https://github.com/copper-project/copper-rs/issues/142

Another issue I hit is that the `local` copper repo option only works if the generated project is in the copper repo. I hit a permission issue trying to refer to my copper repo from my new project, but I figure that might just be an intentional decision from cargo on how it manages directories/permissions anyways. Based on a skim of https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-path-dependencies, it doesn't seem like paths outside of repos are supported and I don't really blame them tbh.

Some conditional handling around new workspaces vs new projects in an existing workspace would make sense, but I think that having `[workspace]` in the toml makes the assumption that we're generating a new root workspace which isn't always true. Tell me if my understanding is wrong though.