### PR TITLE
make the copper app buildable from a CopperContext

### DIFF
--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -1043,6 +1043,109 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     };
 
+    let builder_name = format_ident!("{}Builder", name);
+    let (
+        builder_struct,
+        builder_new,
+        builder_impl,
+        builder_sim_callback_method,
+        builder_build_sim_callback_arg,
+    ) = if sim_mode {
+        (
+            quote! {
+                pub struct #builder_name <'a, F> {
+                    clock: Option<_RobotClock>,
+                    unified_logger: Option<_Arc<_Mutex<_UnifiedLoggerWrite>>>,
+                    sim_callback: Option<&'a mut F>
+                }
+            },
+            quote! {
+                pub fn new() -> Self {
+                    Self {
+                        clock: None,
+                        unified_logger: None,
+                        sim_callback: None,
+                    }
+                }
+            },
+            quote! {
+                impl<'a, F> #builder_name <'a, F>
+                where
+                    F: FnMut(SimStep) -> cu29::simulation::SimOverride,
+            },
+            Some(quote! {
+                fn with_sim_callback(mut self, sim_callback: &'a mut F) -> Self
+                {
+                    self.sim_callback = Some(sim_callback);
+                    self
+                }
+            }),
+            Some(quote! {
+                self.sim_callback
+                    .ok_or(_CuError::from("Sim callback missing from builder"))?,
+            }),
+        )
+    } else {
+        (
+            quote! {
+                pub struct #builder_name {
+                    clock: Option<_RobotClock>,
+                    unified_logger: Option<_Arc<_Mutex<_UnifiedLoggerWrite>>>,
+                }
+            },
+            quote! {
+                pub fn new() -> Self {
+                    Self {
+                        clock: None,
+                        unified_logger: None,
+                    }
+                }
+            },
+            quote! {
+                impl #builder_name
+            },
+            None,
+            None,
+        )
+    };
+
+    let builder = quote! {
+        #builder_struct
+
+        #builder_impl
+        {
+            #builder_new
+
+            pub fn with_clock(mut self, clock: _RobotClock) -> Self {
+                self.clock = Some(clock);
+                self
+            }
+
+            pub fn with_unified_logger(mut self, unified_logger: _Arc<_Mutex<_UnifiedLoggerWrite>>) -> Self {
+                self.unified_logger = Some(unified_logger);
+                self
+            }
+
+            pub fn with_context(mut self, copper_ctx: &_CopperContext) -> Self {
+                self.clock = Some(copper_ctx.clock.clone());
+                self.unified_logger = Some(copper_ctx.unified_logger.clone());
+                self
+            }
+
+            #builder_sim_callback_method
+
+            pub fn build(self) -> _CuResult<#name> {
+                #name::new(
+                    self.clock
+                        .ok_or(_CuError::from("Clock missing from builder"))?,
+                    self.unified_logger
+                        .ok_or(_CuError::from("Unified logger missing from builder"))?,
+                    #builder_build_sim_callback_arg
+                )
+            }
+        }
+    };
+
     #[cfg(feature = "macro_debug")]
     eprintln!("[build result]");
     // Convert the modified struct back into a TokenStream
@@ -1112,6 +1215,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
 
         #runtime_impl
 
+        #builder
     };
     let tokens: TokenStream = result.into();
 

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -845,60 +845,48 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
     eprintln!("[build the sim support]");
     let sim_support: proc_macro2::TokenStream = gen_sim_support(&runtime_plan);
 
-    let (new, new_with_context, run_one_iteration, start_all_tasks, stop_all_tasks, run) =
-        if sim_mode {
-            (
-                quote! {
-                    pub fn new<F>(clock:_RobotClock, unified_logger: _Arc<_Mutex<_UnifiedLoggerWrite>>, sim_callback: &mut F) -> _CuResult<Self>
-                    where F: FnMut(SimStep) -> cu29::simulation::SimOverride,
-                },
-                quote! {
-                    pub fn new_with_context<F>(context: &_CopperContext, sim_callback: &mut F) -> _CuResult<Self>
-                    where F: FnMut(SimStep) -> cu29::simulation::SimOverride {
-                        Self::new(context.clock.clone(), context.unified_logger.clone(), sim_callback)
-                    }
-                },
-                quote! {
-                    pub fn run_one_iteration<F>(&mut self, sim_callback: &mut F) -> _CuResult<()>
-                    where F: FnMut(SimStep) -> cu29::simulation::SimOverride,
-                },
-                quote! {
-                    pub fn start_all_tasks<F>(&mut self, sim_callback: &mut F) -> _CuResult<()>
-                    where F: FnMut(SimStep) -> cu29::simulation::SimOverride,
-                },
-                quote! {
-                    pub fn stop_all_tasks<F>(&mut self, sim_callback: &mut F) -> _CuResult<()>
-                    where F: FnMut(SimStep) -> cu29::simulation::SimOverride,
-                },
-                quote! {
-                    pub fn run<F>(&mut self, sim_callback: &mut F) -> _CuResult<()>
-                    where F: FnMut(SimStep) -> cu29::simulation::SimOverride,
-                },
-            )
-        } else {
-            (
-                quote! {
-                    pub fn new(clock:_RobotClock, unified_logger: _Arc<_Mutex<_UnifiedLoggerWrite>>) -> _CuResult<Self>
-                },
-                quote! {
-                    pub fn new_with_context(context: &_CopperContext) -> _CuResult<Self> {
-                        Self::new(context.clock.clone(), context.unified_logger.clone())
-                    }
-                },
-                quote! {
-                    pub fn run_one_iteration(&mut self) -> _CuResult<()>
-                },
-                quote! {
-                    pub fn start_all_tasks(&mut self) -> _CuResult<()>
-                },
-                quote! {
-                    pub fn stop_all_tasks(&mut self) -> _CuResult<()>
-                },
-                quote! {
-                    pub fn run(&mut self) -> _CuResult<()>
-                },
-            )
-        };
+    let (new, run_one_iteration, start_all_tasks, stop_all_tasks, run) = if sim_mode {
+        (
+            quote! {
+                pub fn new<F>(clock:_RobotClock, unified_logger: _Arc<_Mutex<_UnifiedLoggerWrite>>, sim_callback: &mut F) -> _CuResult<Self>
+                where F: FnMut(SimStep) -> cu29::simulation::SimOverride,
+            },
+            quote! {
+                pub fn run_one_iteration<F>(&mut self, sim_callback: &mut F) -> _CuResult<()>
+                where F: FnMut(SimStep) -> cu29::simulation::SimOverride,
+            },
+            quote! {
+                pub fn start_all_tasks<F>(&mut self, sim_callback: &mut F) -> _CuResult<()>
+                where F: FnMut(SimStep) -> cu29::simulation::SimOverride,
+            },
+            quote! {
+                pub fn stop_all_tasks<F>(&mut self, sim_callback: &mut F) -> _CuResult<()>
+                where F: FnMut(SimStep) -> cu29::simulation::SimOverride,
+            },
+            quote! {
+                pub fn run<F>(&mut self, sim_callback: &mut F) -> _CuResult<()>
+                where F: FnMut(SimStep) -> cu29::simulation::SimOverride,
+            },
+        )
+    } else {
+        (
+            quote! {
+                pub fn new(clock:_RobotClock, unified_logger: _Arc<_Mutex<_UnifiedLoggerWrite>>) -> _CuResult<Self>
+            },
+            quote! {
+                pub fn run_one_iteration(&mut self) -> _CuResult<()>
+            },
+            quote! {
+                pub fn start_all_tasks(&mut self) -> _CuResult<()>
+            },
+            quote! {
+                pub fn stop_all_tasks(&mut self) -> _CuResult<()>
+            },
+            quote! {
+                pub fn run(&mut self) -> _CuResult<()>
+            },
+        )
+    };
 
     let sim_callback_arg = if sim_mode {
         Some(quote!(sim_callback))
@@ -1032,8 +1020,6 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
 
                 runtime
             }
-
-            #new_with_context
 
             pub fn get_original_config() -> String {
                 #copper_config_content.to_string()

--- a/core/cu29_helpers/Cargo.toml
+++ b/core/cu29_helpers/Cargo.toml
@@ -16,6 +16,7 @@ cu29-traits = { workspace = true }
 cu29-unifiedlog = { workspace = true }
 cu29-log = { workspace = true }
 cu29-log-runtime = { workspace = true }
+cu29-runtime = { workspace = true }
 cu29-clock = { workspace = true }
 simplelog = "0.12.2"
 

--- a/core/cu29_helpers/src/lib.rs
+++ b/core/cu29_helpers/src/lib.rs
@@ -1,19 +1,13 @@
 use cu29_clock::RobotClock;
 use cu29_log_runtime::LoggerRuntime;
+use cu29_runtime::curuntime::CopperContext;
 use cu29_traits::{CuResult, UnifiedLogType};
-use cu29_unifiedlog::{stream_write, UnifiedLogger, UnifiedLoggerBuilder, UnifiedLoggerWrite};
+use cu29_unifiedlog::{stream_write, UnifiedLogger, UnifiedLoggerBuilder};
 use simplelog::TermLogger;
 #[cfg(debug_assertions)]
 use simplelog::{ColorChoice, Config, LevelFilter, TerminalMode};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-
-/// Just a simple struct to hold the various bits needed to run a Copper application.
-pub struct CopperContext {
-    pub unified_logger: Arc<Mutex<UnifiedLoggerWrite>>,
-    pub logger_runtime: LoggerRuntime,
-    pub clock: RobotClock,
-}
 
 /// This is a basic setup for a copper application to get you started.
 /// Duplicate and customize as needed when your needs grow.

--- a/core/cu29_runtime/Cargo.toml
+++ b/core/cu29_runtime/Cargo.toml
@@ -28,6 +28,7 @@ cu29-traits = { workspace = true }
 cu29-log = { workspace = true }
 cu29-log-derive = { workspace = true }
 cu29-log-runtime = { workspace = true }  # needed
+cu29-unifiedlog = { workspace = true }
 cu29-value = { workspace = true }
 cu29-clock = { workspace = true }
 clap = { workspace = true }

--- a/core/cu29_runtime/src/curuntime.rs
+++ b/core/cu29_runtime/src/curuntime.rs
@@ -7,11 +7,22 @@ use crate::config::{ComponentConfig, Node};
 use crate::copperlist::{CopperList, CopperListState, CuListsManager};
 use crate::monitoring::CuMonitor;
 use cu29_clock::{ClockProvider, RobotClock};
+use cu29_log_runtime::LoggerRuntime;
 use cu29_traits::CopperListTuple;
 use cu29_traits::CuResult;
 use cu29_traits::WriteStream;
+use cu29_unifiedlog::UnifiedLoggerWrite;
+use std::sync::{Arc, Mutex};
+
 use petgraph::prelude::*;
 use std::fmt::Debug;
+
+/// Just a simple struct to hold the various bits needed to run a Copper application.
+pub struct CopperContext {
+    pub unified_logger: Arc<Mutex<UnifiedLoggerWrite>>,
+    pub logger_runtime: LoggerRuntime,
+    pub clock: RobotClock,
+}
 
 /// This is the main structure that will be injected as a member of the Application struct.
 /// CT is the tuple of all the tasks in order of execution.

--- a/examples/cu_caterpillar/src/main.rs
+++ b/examples/cu_caterpillar/src/main.rs
@@ -14,10 +14,10 @@ fn main() {
 
     let copper_ctx =
         basic_copper_setup(&logger_path, SLAB_SIZE, false, None).expect("Failed to setup logger.");
-    let clock = copper_ctx.clock.clone();
-    let ulclone = copper_ctx.unified_logger.clone();
-    let mut application =
-        CaterpillarApplication::new(clock.clone(), ulclone).expect("Failed to create application.");
+    let mut application = CaterpillarApplicationBuilder::new()
+        .with_context(&copper_ctx)
+        .build()
+        .expect("Failed to create application.");
 
     let outcome = application.run();
     match outcome {

--- a/examples/cu_iceoryx2/src/bin/downstream.rs
+++ b/examples/cu_iceoryx2/src/bin/downstream.rs
@@ -14,10 +14,10 @@ fn main() {
     let logger_path = "/tmp/downstream.copper";
     let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), SLAB_SIZE, false, None)
         .expect("Failed to setup logger.");
-    let clock = copper_ctx.clock.clone();
-    let ulclone = copper_ctx.unified_logger.clone();
-    let mut application =
-        DownstreamApplication::new(clock.clone(), ulclone).expect("Failed to create application.");
+    let mut application = DownstreamApplicationBuilder::new()
+        .with_context(&copper_ctx)
+        .build()
+        .expect("Failed to create application.");
 
     let outcome = application.run();
     match outcome {

--- a/examples/cu_iceoryx2/src/bin/upstream.rs
+++ b/examples/cu_iceoryx2/src/bin/upstream.rs
@@ -11,10 +11,10 @@ fn main() {
     let logger_path = "/tmp/upstream.copper";
     let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), SLAB_SIZE, false, None)
         .expect("Failed to setup logger.");
-    let clock = copper_ctx.clock.clone();
-    let ulclone = copper_ctx.unified_logger.clone();
-    let mut application =
-        UpstreamApplication::new(clock.clone(), ulclone).expect("Failed to create application.");
+    let mut application = UpstreamApplicationBuilder::new()
+        .with_context(&copper_ctx)
+        .build()
+        .expect("Failed to create application.");
     let outcome = application.run();
     match outcome {
         Ok(_result) => {}

--- a/examples/cu_monitoring/src/main.rs
+++ b/examples/cu_monitoring/src/main.rs
@@ -118,10 +118,13 @@ fn main() {
     let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), SLAB_SIZE, true, None)
         .expect("Failed to setup logger.");
     debug!("Logger created at {}.", path = logger_path);
-    let clock = copper_ctx.clock;
     debug!("Creating application... ");
-    let mut application = App::new(clock.clone(), copper_ctx.unified_logger.clone())
-        .expect("Failed to create runtime.");
+    let mut application = AppBuilder::new()
+        .with_context(&copper_ctx)
+        .build()
+        .expect("Failed to create runtime");
+
+    let clock = copper_ctx.clock;
     debug!("Running... starting clock: {}.", clock.now());
     application
         .start_all_tasks()

--- a/examples/cu_multisources/src/main.rs
+++ b/examples/cu_multisources/src/main.rs
@@ -16,10 +16,13 @@ fn main() {
     let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), SLAB_SIZE, true, None)
         .expect("Failed to setup logger.");
     debug!("Logger created at {}.", path = logger_path);
-    let clock = copper_ctx.clock;
     debug!("Creating application... ");
-    let mut application = MultiSourceApp::new(clock.clone(), copper_ctx.unified_logger.clone())
+    let mut application = MultiSourceAppBuilder::new()
+        .with_context(&copper_ctx)
+        .build()
         .expect("Failed to create runtime.");
+
+    let clock = copper_ctx.clock;
     debug!("Running... starting clock: {}.", clock.now());
 
     application.run().expect("Failed to run application.");

--- a/examples/cu_pointclouds/src/main.rs
+++ b/examples/cu_pointclouds/src/main.rs
@@ -55,9 +55,10 @@ fn main() {
     let logger_path = tmp_dir.path().join("ptclouds.copper");
     let copper_ctx =
         basic_copper_setup(&logger_path, SLAB_SIZE, false, None).expect("Failed to setup copper.");
-    let mut application =
-        PtCloudsApplication::new(copper_ctx.clock.clone(), copper_ctx.unified_logger.clone())
-            .expect("Failed to create application.");
+    let mut application = PtCloudsApplicationBuilder::new()
+        .with_context(&copper_ctx)
+        .build()
+        .expect("Failed to create application");
     application
         .start_all_tasks()
         .expect("Failed to start all tasks.");

--- a/examples/cu_rp_balancebot/src/main.rs
+++ b/examples/cu_rp_balancebot/src/main.rs
@@ -25,12 +25,15 @@ fn main() {
     let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), SLAB_SIZE, false, None)
         .expect("Failed to setup logger.");
     debug!("Logger created at {}.", path = logger_path);
-    let clock = copper_ctx.clock;
+
     debug!("Creating application... ");
 
-    let mut application = BalanceBot::new(clock.clone(), copper_ctx.unified_logger.clone())
+    let mut application = BalanceBotBuilder::new()
+        .with_context(&copper_ctx)
+        .build()
         .expect("Failed to create runtime.");
 
+    let clock = copper_ctx.clock;
     ctrlc::set_handler(move || {
         STOP_FLAG.store(true, Ordering::SeqCst);
     })

--- a/examples/cu_rp_balancebot/src/resim.rs
+++ b/examples/cu_rp_balancebot/src/resim.rs
@@ -87,12 +87,11 @@ fn main() {
     )
     .expect("Failed to setup logger.");
 
-    let mut copper_app = BalanceBotReSim::new(
-        robot_clock,
-        copper_ctx.unified_logger.clone(),
-        &mut default_callback,
-    )
-    .expect("Failed to create runtime.");
+    let mut copper_app = BalanceBotReSimBuilder::new()
+        .with_context(&copper_ctx)
+        .with_sim_callback(&mut default_callback)
+        .build()
+        .expect("Failed to create runtime.");
 
     copper_app
         .start_all_tasks(&mut default_callback)

--- a/examples/cu_rp_balancebot/src/sim.rs
+++ b/examples/cu_rp_balancebot/src/sim.rs
@@ -72,12 +72,11 @@ fn setup_copper(mut commands: Commands) {
         path = logger_path
     );
 
-    let mut copper_app = BalanceBotSim::new(
-        robot_clock.clone(),
-        copper_ctx.unified_logger.clone(),
-        &mut default_callback,
-    )
-    .expect("Failed to create runtime.");
+    let mut copper_app = BalanceBotSimBuilder::new()
+        .with_context(&copper_ctx)
+        .with_sim_callback(&mut default_callback)
+        .build()
+        .expect("Failed to create runtime.");
 
     copper_app
         .start_all_tasks(&mut default_callback)

--- a/examples/cu_rp_balancebot/src/sim.rs
+++ b/examples/cu_rp_balancebot/src/sim.rs
@@ -10,7 +10,7 @@ use bevy::render::RenderPlugin;
 // disembiguation as there is also a bevy::prelude::debug
 use cu29::prelude::debug;
 use cu29::prelude::*;
-use cu29_helpers::{basic_copper_setup, CopperContext};
+use cu29_helpers::basic_copper_setup;
 use cu_ads7883_new::ADSReadingPayload;
 use cu_rp_encoder::EncoderPayload;
 use std::fs;


### PR DESCRIPTION
This is the draft PR to discuss the changes in the issue #135 

I have made commits to add both the builder pattern and a "new_with_context" method. I did both because I'm not sure which one is actually better, I like the ergonomics of the builder pattern(and it was nice to write), but I like the simplicity of new_with_context 😅. When it's decided which one it's better, I will remove the other one.

I also updated the balance bot example to use the builder pattern, to show how it's used both in the sim_mode and non sim_mode.
I can update the other examples when the changes are settled.

