### PR TITLE
Logging parameters in the Ron file. Fixes #183

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "examples/cu_caterpillar",
     "examples/cu_config_gen",
     "examples/cu_iceoryx2",
+    "examples/cu_logging_size",
     "examples/cu_monitoring",
     "examples/cu_multisources",
     "examples/cu_pointclouds",

--- a/core/cu29_unifiedlog/src/lib.rs
+++ b/core/cu29_unifiedlog/src/lib.rs
@@ -539,6 +539,14 @@ impl UnifiedLoggerWrite {
             AllocatedSection::Section(section) => section,
         }
     }
+
+    pub fn stats(&self) -> (usize, Vec<usize>, usize) {
+        (
+            self.front_slab.current_global_position,
+            self.front_slab.sections_offsets_in_flight.clone(),
+            self.back_slabs.len(),
+        )
+    }
 }
 
 impl Drop for UnifiedLoggerWrite {

--- a/examples/cu_logging_size/Cargo.toml
+++ b/examples/cu_logging_size/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "cu-logging-size"
+description = "This is an example for the Copper project to show how to set custom logging parameters."
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+cu29 = { workspace = true }
+cu29-helpers = { workspace = true }
+tempfile = { workspace = true }

--- a/examples/cu_logging_size/build.rs
+++ b/examples/cu_logging_size/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=LOG_INDEX_DIR={}",
+        std::env::var("OUT_DIR").unwrap()
+    );
+}

--- a/examples/cu_logging_size/copperconfig.ron
+++ b/examples/cu_logging_size/copperconfig.ron
@@ -1,0 +1,25 @@
+(
+    tasks: [
+        (
+            id: "task0",
+            type: "tasks::ExampleSrc",
+        ),
+        (
+            id: "task1",
+            type: "tasks::ExampleTask",
+        ),
+        (
+            id: "task2",
+            type: "tasks::ExampleSink",
+        ),
+     ],
+    cnx: [
+        (src: "task0", dst: "task1", msg: "i32"),
+        (src: "task1", dst: "task2", msg: "i32"),
+    ],
+
+    logging: (
+        slab_size_mib: 1024, // Preallocates 1GiB of memory map file at a time
+        section_size_mib: 100, // Preallocates 100MiB of memory map per section for the main logger.
+    ),
+)

--- a/examples/cu_logging_size/src/main.rs
+++ b/examples/cu_logging_size/src/main.rs
@@ -1,0 +1,120 @@
+use cu29::prelude::*;
+use cu29_helpers::basic_copper_setup;
+use std::fs::metadata;
+use tempfile::tempdir;
+
+pub mod tasks {
+    use cu29::prelude::*;
+
+    pub struct ExampleSrc {}
+
+    impl Freezable for ExampleSrc {}
+
+    impl<'cl> CuSrcTask<'cl> for ExampleSrc {
+        type Output = output_msg!('cl, i32);
+
+        fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
+        where
+            Self: Sized,
+        {
+            Ok(Self {})
+        }
+
+        fn process(&mut self, _clock: &RobotClock, new_msg: Self::Output) -> CuResult<()> {
+            new_msg.set_payload(42);
+            Ok(())
+        }
+    }
+
+    pub struct ExampleTask {}
+
+    impl Freezable for ExampleTask {}
+
+    impl<'cl> CuTask<'cl> for ExampleTask {
+        type Input = input_msg!('cl, i32);
+        type Output = output_msg!('cl, i32);
+
+        fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
+        where
+            Self: Sized,
+        {
+            Ok(Self {})
+        }
+
+        fn process(
+            &mut self,
+            _clock: &RobotClock,
+            input: Self::Input,
+            output: Self::Output,
+        ) -> CuResult<()> {
+            output.set_payload(input.payload().unwrap() + 1);
+            Ok(())
+        }
+    }
+
+    pub struct ExampleSink {}
+
+    impl Freezable for ExampleSink {}
+
+    impl<'cl> CuSinkTask<'cl> for ExampleSink {
+        type Input = input_msg!('cl, i32);
+
+        fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
+        where
+            Self: Sized,
+        {
+            Ok(Self {})
+        }
+
+        fn process(&mut self, _clock: &RobotClock, _input: Self::Input) -> CuResult<()> {
+            Ok(())
+        }
+    }
+}
+
+#[copper_runtime(config = "copperconfig.ron")]
+struct App {}
+
+const SLAB_SIZE: Option<usize> = Some(150 * 1024 * 1024);
+fn main() {
+    let logger_path = "logger.copper";
+    // get a temporary directory
+    let dir = tempdir().expect("Could not get a temporary directory");
+    // construct dir/logger_path
+    let logger_path = dir.path().join(logger_path);
+    let copper_ctx =
+        basic_copper_setup(&logger_path, SLAB_SIZE, true, None).expect("Failed to setup logger.");
+    debug!("Logger created at {}.", path = &logger_path);
+    let clock = copper_ctx.clock;
+    debug!("Creating application... ");
+    let mut application = App::new(clock.clone(), copper_ctx.unified_logger.clone())
+        .expect("Failed to create runtime.");
+    debug!("Running... starting clock: {}.", clock.now());
+    application
+        .start_all_tasks()
+        .expect("Failed to start application.");
+    application
+        .run_one_iteration()
+        .expect("Failed to run application.");
+    application
+        .stop_all_tasks()
+        .expect("Failed to stop application.");
+    debug!("End of program: {}.", clock.now());
+    // check if the logger file is at least 1 section in length
+
+    // change the end of the logger_path from copper to _0.copper
+    let logger_first_path = dir.path().join("logger_0.copper"); // get the first slab
+
+    match metadata(&logger_first_path) {
+        Ok(meta) => {
+            let file_size = meta.len();
+            assert!(file_size >= SLAB_SIZE.unwrap() as u64);
+        }
+        Err(e) => {
+            eprintln!("Failed to get file metadata: {}", e);
+        }
+    }
+    let (current_slab_used, _current_slab_offsets, _back_slab_in_flight) =
+        copper_ctx.unified_logger.lock().unwrap().stats();
+    assert!(current_slab_used > 100 * 1024 * 1024); // in the ron file we said:  section_size_mib: 100 so at least that amount should be used before it the logger is closed and trimmed
+}


### PR DESCRIPTION
One for to override the section size (if the copperlist references allocated stuff outside of it) and one for the slab size (that will be hooked up after the construction from the copper_ctx is merged)