### PR TITLE
[FIX] (cu_rp_balancebot) fix drag direction for any camera view

### DIFF
--- a/examples/cu_rp_balancebot/src/world/mod.rs
+++ b/examples/cu_rp_balancebot/src/world/mod.rs
@@ -315,6 +315,7 @@ fn global_cart_drag_listener(
     mut drag_events: EventReader<Pointer<Drag>>,
     parents: Query<(&Parent, Option<&Cart>)>,
     mut transforms: Query<&mut Transform, With<Cart>>,
+    camera_query: Query<&Transform, (With<Camera>, Without<Cart>)>, // Add Without<Cart> to prevent conflicts
 ) {
     for drag in drag_events.read() {
         if drag.button != PointerButton::Primary {
@@ -329,7 +330,10 @@ fn global_cart_drag_listener(
         }
 
         if let Ok(mut root_transform) = transforms.get_mut(entity) {
-            root_transform.translation.x += drag.delta.x / 500.0;
+            let direction_multiplier = camera_query.iter().next().map_or(1.0, |camera_transform| {
+                -camera_transform.forward().z.signum()
+            });
+            root_transform.translation.x += direction_multiplier * drag.delta.x / 500.0;
         }
     }
 }


### PR DESCRIPTION
## Bug Behavior
Previously, dragging the cart from one side of the cart will cause the cart to move in opposite direction.

## Fix
Introducing the camera transform query to fix the drag direction according to the camera view.