### PR TITLE
[FIX] (cu_rp_balancebot) perf-ui feature

### DIFF
--- a/examples/cu_rp_balancebot/Cargo.toml
+++ b/examples/cu_rp_balancebot/Cargo.toml
@@ -33,7 +33,7 @@ bevy = { version = "0.15.1", default-features = false, features = ["x11", "wayla
 avian3d = { version = "0.2.0", default-features = false, features = ["bevy_scene", "collider-from-mesh", "debug-plugin", "parallel", "f32", "3d", "parry-f32"], optional = true }
 parry3d = { version = "0.17.4", optional = true }
 cached-path = { version = "0.6.1", optional = true }
-iyes_perf_ui = { version = "0.3.0", optional = true }
+iyes_perf_ui = { git = "https://github.com/makeecat/iyes_perf_ui", version = "0.4.0", optional = true }
 
 [features]
 default = ["logreader", "sim"]

--- a/examples/cu_rp_balancebot/src/world/mod.rs
+++ b/examples/cu_rp_balancebot/src/world/mod.rs
@@ -13,7 +13,7 @@ use cached_path::{Cache, ProgressBar};
 use iyes_perf_ui::PerfUiPlugin;
 
 #[cfg(feature = "perf-ui")]
-use iyes_perf_ui::entries::PerfUiCompleteBundle;
+use iyes_perf_ui::prelude::PerfUiAllEntries;
 
 use std::path::Path;
 use std::{fs, io};
@@ -293,7 +293,7 @@ fn setup_ui(mut commands: Commands) {
             ));
         });
     #[cfg(feature = "perf-ui")]
-    commands.spawn(PerfUiCompleteBundle::default());
+    commands.spawn(PerfUiAllEntries::default());
 }
 
 // This needs to match an object / parent object name in the GLTF file (in blender this is the object name).


### PR DESCRIPTION
- Created a fork in my personal account in order to support bevy 0.15.1 for iyes_perf_ui : https://github.com/IyesGames/iyes_perf_ui/compare/main...makeecat:iyes_perf_ui:main
- Use PerfUiAllEntries instead of PerfUiCompleteBundle
- Tested under cu_rp_balancebot folder:
`cargo run --bin balancebot-sim --release --features perf-ui`