### PR TITLE
Fix `No space left on device (os error 28)` and improve CI speed

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -10,13 +10,14 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build-debug:
+    name: Build Debug
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]  # macos tends to break more often.
-    continue-on-error: false
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up Rust
@@ -39,7 +40,6 @@ jobs:
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libudev-dev libpcap-dev
-        
 
       # Those are needed for the integration tests on Windows
       - name: Download Npcap SDK (Windows)
@@ -56,40 +56,58 @@ jobs:
           $npcapLibDir = "$env:USERPROFILE\npcap-sdk\Lib\x64"
           Add-Content -Path $env:GITHUB_ENV -Value "LIB=$npcapLibDir"
 
-      ## End of system dependencies
-      
-      # This is also relatively quick to do, so let's fail early. 
+      # Run debug builds and tests
       - name: Run clippy in debug
-        if: runner.os == 'Linux'
         run: cargo clippy --workspace --all-targets -- --deny warnings
-
-      - name: Run clippy in release
-        if: runner.os == 'Linux'
-        run: cargo clippy --release --workspace --all-targets -- --deny warnings
-
-        # - name: Install cargo-generate
-        #   run: cargo install cargo-generate
-
-      - name: Build vanilla
-        run: |
-          cargo build --workspace --features macro_debug
-
-      - name: Build with mocks
-        run: |
-          cargo build --workspace --features mock
-
+      - name: Build in debug
+        run: cargo build --workspace --features macro_debug
       - name: Run tests
-        env:
-          LIB: ${{env.LIB}}
         run: cargo test --workspace
-        
-      # Integration Test for the 1 liner generation of a project.
-      # - name: Generate a test project from the repo template
-      #   run: |
-      #     cd templates
-      #     cargo generate -p cu_full --name test_project --destination . -d copper_source=local --silent
 
-      # - name: Compile generated project
-      #   run: |
-      #     cd templates/test_project
-      #     cargo build --release
+  build-release:
+    name: Build Release
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - name: Setup rust-cache
+        uses: Swatinem/rust-cache@v2
+      - name: Install winget
+        if: runner.os == 'Windows'
+        uses: Cyberboss/install-winget@v1
+
+      # Fail cheaply and early if the code is not even formatted correctly.
+      - name: Cargo fmt check
+        run: cargo fmt --all -- --check
+
+      ## System dependencies
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev libpcap-dev
+      - name: Download Npcap SDK (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          Invoke-WebRequest -Uri https://npcap.com/dist/npcap-sdk-1.13.zip -OutFile npcap-sdk.zip
+          Expand-Archive -Path npcap-sdk.zip -DestinationPath $env:USERPROFILE\npcap-sdk
+          Remove-Item npcap-sdk.zip
+          winget install --id DaiyuuNobori.Win10Pcap --disable-interactivity --accept-source-agreements --accept-package-agreements
+      - name: Set Library and Include Paths (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          $npcapLibDir = "$env:USERPROFILE\npcap-sdk\Lib\x64"
+          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$npcapLibDir"
+
+      # Run release builds and tests
+      - name: Run clippy in release
+        run: cargo clippy --release --workspace --all-targets -- --deny warnings
+      - name: Build in release
+        run: cargo build --release --workspace --features macro_debug


### PR DESCRIPTION
This PR address the issue of `No space left on device (os error 28)` error when running CI which I posted on [Discord](https://discord.com/channels/1305916875741597826/1316747923454951425/1327636394063040634) and also improves the performace significantly as now the action take <ins>**7m 34s**</ins> as opposed to **29m 12s**.