### PR TITLE
[FEAT] add nextest / project generation test / typos check for CI

### DIFF
--- a/.config/_typos.toml
+++ b/.config/_typos.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+mis = "mis"
+ratatui = "ratatui"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,13 @@
+# https://nexte.st/docs/configuration/test-groups/?h=group
+[test-groups]
+# resource-limited = { max-threads = 4 }
+serial-integration = { max-threads = 1 }
+
+# [[profile.default.overrides]]
+# filter = 'test(resource_limited::)'
+# test-group = 'resource-limited'
+
+[[profile.default.overrides]]
+filter = 'package(cu-vlp16) + package(cu-hesai) + package(cu-livox)'
+#platform = 'cfg(unix)'
+test-group = 'serial-integration'

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -63,13 +63,9 @@ jobs:
         run: echo "RELEASE_FLAG=$([[ '${{ matrix.mode }}' == 'release' ]] && echo '--release' || echo '')" >> $GITHUB_ENV
 
       - name: Set Release Flag (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.mode == 'release'
         run: |
-          if "%matrix_mode%" == "release" (
-            echo RELEASE_FLAG=--release >> %GITHUB_ENV%
-          ) else (
-            echo RELEASE_FLAG= >> %GITHUB_ENV%
-          )
+          Add-Content -Path $env:GITHUB_ENV -Value "RELEASE_FLAG=--release"
 
       # Run clippy and build in debug / release
       - name: Run clippy in debug / release

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -157,3 +157,12 @@ jobs:
         run: |
           cd templates/test_project
           cargo +stable build $RELEASE_FLAG
+
+  typos:
+    name: Typos Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@master
+        with:
+          config: ./.config/_typos.toml

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -10,8 +10,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-debug:
-    name: Build Debug
+  setup:
+    name: Set Up Environment
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -56,162 +56,50 @@ jobs:
           $npcapLibDir = "$env:USERPROFILE\npcap-sdk\Lib\x64"
           Add-Content -Path $env:GITHUB_ENV -Value "LIB=$npcapLibDir"
 
-      # Run debug builds and tests
-      - name: Run clippy in debug
-        run: cargo +stable clippy --workspace --all-targets -- --deny warnings
-      - name: Run clippy in debug with mock and macro_debug
-        run: cargo +stable clippy --workspace --all-targets --features mock,macro_debug -- --deny warnings
-      - name: Run clippy in debug with perf-ui, image and kornia
-        run: cargo +stable clippy --workspace --all-targets --features perf-ui,image,kornia -- --deny warnings
-      - name: Run doctests
+  build-debug-release:
+    name: Build Debug / release
+    needs: setup
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        mode: [debug, release]
+
+    steps:
+      # Run clippy and build in debug / release
+      - name: Run clippy in debug / release
+        run: cargo +stable clippy $${ '--release' if matrix.mode == 'release' else '' } --workspace --all-targets -- --deny warnings
+      - name: Run clippy in debug / release with mock and macro_debug
+        run: cargo +stable clippy $${ '--release' if matrix.mode == 'release' else '' } --workspace --all-targets --features mock,macro_debug -- --deny warnings
+      - name: Run clippy in debug /release with perf-ui, image and kornia
+        run: cargo +stable clippy $${ '--release' if matrix.mode == 'release' else '' } --workspace --all-targets --features perf-ui,image,kornia -- --deny warnings
+      - name: Run doctests in debug
+        if: runner.mode == 'debug'
         run: cargo +stable test --doc --workspace
-      - name: Run build in debug
-        run: cargo +stable build --release --workspace --all-targets --all-features
+      - name: Run build in debug / release
+        run: cargo +stable build $${ '--release' if matrix.mode == 'release' else '' } --workspace --all-targets --all-features}
 
-  build-release:
-    name: Build Release
+  test-debug-release:
+    name: Test Debug / Rlease
+    needs: setup
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        mode: [debug, release]
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-      - name: Setup rust-cache
-        uses: Swatinem/rust-cache@v2
-      - name: Install winget
-        if: runner.os == 'Windows'
-        uses: Cyberboss/install-winget@v1
-
-      ## System dependencies
-      - name: Install dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libudev-dev libpcap-dev
-      - name: Download Npcap SDK (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          Invoke-WebRequest -Uri https://npcap.com/dist/npcap-sdk-1.13.zip -OutFile npcap-sdk.zip
-          Expand-Archive -Path npcap-sdk.zip -DestinationPath $env:USERPROFILE\npcap-sdk
-          Remove-Item npcap-sdk.zip
-          winget install --id DaiyuuNobori.Win10Pcap --disable-interactivity --accept-source-agreements --accept-package-agreements
-      - name: Set Library and Include Paths (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          $npcapLibDir = "$env:USERPROFILE\npcap-sdk\Lib\x64"
-          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$npcapLibDir"
-
-      # Run release builds and tests
-      - name: Run clippy in release
-        run: cargo +stable clippy --release --workspace --all-targets -- --deny warnings
-      - name: Run clippy in debug with mock and macro_debug
-        run: cargo +stable clippy --release --workspace --all-targets --features mock,macro_debug -- --deny warnings
-      - name: Run clippy in debug with perf-ui, image and kornia
-        run: cargo +stable clippy --release --workspace --all-targets --features perf-ui,image,kornia -- --deny warnings
-      - name: Run build in release
-        run: cargo +stable build --release --workspace --all-targets --all-features
-
-  test-debug:
-    name: Test Debug
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-      - name: Setup rust-cache
-        uses: Swatinem/rust-cache@v2
       - name: Install latest nextest
         uses: taiki-e/install-action@nextest
-      - name: Install winget
-        if: runner.os == 'Windows'
-        uses: Cyberboss/install-winget@v1
 
-      ## System dependencies
-      - name: Install dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libudev-dev libpcap-dev
-      - name: Download Npcap SDK (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          Invoke-WebRequest -Uri https://npcap.com/dist/npcap-sdk-1.13.zip -OutFile npcap-sdk.zip
-          Expand-Archive -Path npcap-sdk.zip -DestinationPath $env:USERPROFILE\npcap-sdk
-          Remove-Item npcap-sdk.zip
-          winget install --id DaiyuuNobori.Win10Pcap --disable-interactivity --accept-source-agreements --accept-package-agreements
-      - name: Set Library and Include Paths (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          $npcapLibDir = "$env:USERPROFILE\npcap-sdk\Lib\x64"
-          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$npcapLibDir"
-
-      # Run test
-      - name: Run test in debug
-        run: cargo +stable nextest run --all-targets --workspace
-      - name: Run test in debug with mock and macro_debug
-        run: cargo +stable nextest run --all-targets --workspace --features mock,macro_debug
-      - name: Run test in debug with perf-ui, image and kornia
-        run: cargo +stable nextest run --all-targets --workspace --features perf-ui,image,kornia
-      - name: Run test in debug with all features
-        run: cargo +stable nextest run --all-targets --workspace --all-features
-
-  test-release:
-    name: Test Release
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-      - name: Setup rust-cache
-        uses: Swatinem/rust-cache@v2
-      - name: Install latest nextest
-        uses: taiki-e/install-action@nextest
-      - name: Install winget
-        if: runner.os == 'Windows'
-        uses: Cyberboss/install-winget@v1
-
-      ## System dependencies
-      - name: Install dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libudev-dev libpcap-dev
-      - name: Download Npcap SDK (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          Invoke-WebRequest -Uri https://npcap.com/dist/npcap-sdk-1.13.zip -OutFile npcap-sdk.zip
-          Expand-Archive -Path npcap-sdk.zip -DestinationPath $env:USERPROFILE\npcap-sdk
-          Remove-Item npcap-sdk.zip
-          winget install --id DaiyuuNobori.Win10Pcap --disable-interactivity --accept-source-agreements --accept-package-agreements
-      - name: Set Library and Include Paths (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          $npcapLibDir = "$env:USERPROFILE\npcap-sdk\Lib\x64"
-          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$npcapLibDir"
-
-      # Run test
-      - name: Run test in debug
-        run: cargo +stable nextest run --release --all-targets --workspace
-      - name: Run test in debug with mock and macro_debug
-        run: cargo +stable nextest run --release --all-targets --workspace --features mock,macro_debug
-      - name: Run test in debug with perf-ui, image and kornia
-        run: cargo +stable nextest run --release --all-targets --workspace --features perf-ui,image,kornia
-      - name: Run test in debug with all features
-        run: cargo +stable nextest run --release --all-targets --workspace --all-features
+      # Run test in debug / release
+      - name: Run test in debug / release
+        run: cargo +stable nextest run $${ '--release' if matrix.mode == 'release' else '' } --all-targets --workspace
+      - name: Run test in debug / release with mock and macro_debug
+        run: cargo +stable nextest run $${ '--release' if matrix.mode == 'release' else '' } --all-targets --workspace --features mock,macro_debug
+      - name: Run test in debug / release with perf-ui, image and kornia
+        run: cargo +stable nextest run $${ '--release' if matrix.mode == 'release' else '' } --all-targets --workspace --features perf-ui,image,kornia
+      - name: Run test in debug / release with all features
+        run: cargo +stable nextest run $${ '--release' if matrix.mode == 'release' else '' } --all-targets --workspace --all-features

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -10,13 +10,15 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  setup:
-    name: Set Up Environment
+  build-debug-release:
+    name: Build Debug / release
+
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        mode: [debug, release]
 
     steps:
       - uses: actions/checkout@v4
@@ -56,33 +58,24 @@ jobs:
           $npcapLibDir = "$env:USERPROFILE\npcap-sdk\Lib\x64"
           Add-Content -Path $env:GITHUB_ENV -Value "LIB=$npcapLibDir"
 
-  build-debug-release:
-    name: Build Debug / release
-    needs: setup
-    runs-on: ${{ matrix.os }}
+      - name: Set Release Flag
+        run: echo "RELEASE_FLAG=$([[ '${{ matrix.mode }}' == 'release' ]] && echo '--release' || echo '')" >> $GITHUB_ENV
 
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        mode: [debug, release]
-
-    steps:
       # Run clippy and build in debug / release
       - name: Run clippy in debug / release
-        run: cargo +stable clippy $${ '--release' if matrix.mode == 'release' else '' } --workspace --all-targets -- --deny warnings
+        run: cargo +stable clippy $RELEASE_FLAG --workspace --all-targets -- --deny warnings
       - name: Run clippy in debug / release with mock and macro_debug
-        run: cargo +stable clippy $${ '--release' if matrix.mode == 'release' else '' } --workspace --all-targets --features mock,macro_debug -- --deny warnings
+        run: cargo +stable clippy $RELEASE_FLAG --workspace --all-targets --features mock,macro_debug -- --deny warnings
       - name: Run clippy in debug /release with perf-ui, image and kornia
-        run: cargo +stable clippy $${ '--release' if matrix.mode == 'release' else '' } --workspace --all-targets --features perf-ui,image,kornia -- --deny warnings
+        run: cargo +stable clippy $RELEASE_FLAG --workspace --all-targets --features perf-ui,image,kornia -- --deny warnings
       - name: Run doctests in debug
-        if: runner.mode == 'debug'
+        if: matrix.mode == 'debug'
         run: cargo +stable test --doc --workspace
       - name: Run build in debug / release
-        run: cargo +stable build $${ '--release' if matrix.mode == 'release' else '' } --workspace --all-targets --all-features}
+        run: cargo +stable build $RELEASE_FLAG --workspace --all-targets --all-features}
 
   test-debug-release:
     name: Test Debug / Rlease
-    needs: setup
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -91,15 +84,51 @@ jobs:
         mode: [debug, release]
 
     steps:
+      - uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - name: Setup rust-cache
+        uses: Swatinem/rust-cache@v2
+      - name: Install winget
+        if: runner.os == 'Windows'
+        uses: Cyberboss/install-winget@v1
+
+      ## System dependencies
+      # Install dependencies only on Linux
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev libpcap-dev
+
+      # Those are needed for the integration tests on Windows
+      - name: Download Npcap SDK (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          Invoke-WebRequest -Uri https://npcap.com/dist/npcap-sdk-1.13.zip -OutFile npcap-sdk.zip
+          Expand-Archive -Path npcap-sdk.zip -DestinationPath $env:USERPROFILE\npcap-sdk
+          Remove-Item npcap-sdk.zip
+          winget install --id DaiyuuNobori.Win10Pcap --disable-interactivity --accept-source-agreements --accept-package-agreements
+
+      - name: Set Library and Include Paths (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          $npcapLibDir = "$env:USERPROFILE\npcap-sdk\Lib\x64"
+          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$npcapLibDir"
+
       - name: Install latest nextest
         uses: taiki-e/install-action@nextest
 
+      - name: Set Release Flag
+        run: echo "RELEASE_FLAG=$([[ '${{ matrix.mode }}' == 'release' ]] && echo '--release' || echo '')" >> $GITHUB_ENV
+
       # Run test in debug / release
       - name: Run test in debug / release
-        run: cargo +stable nextest run $${ '--release' if matrix.mode == 'release' else '' } --all-targets --workspace
+        run: cargo +stable nextest run $RELEASE_FLAG --all-targets --workspace
       - name: Run test in debug / release with mock and macro_debug
-        run: cargo +stable nextest run $${ '--release' if matrix.mode == 'release' else '' } --all-targets --workspace --features mock,macro_debug
+        run: cargo +stable nextest run $RELEASE_FLAG --all-targets --workspace --features mock,macro_debug
       - name: Run test in debug / release with perf-ui, image and kornia
-        run: cargo +stable nextest run $${ '--release' if matrix.mode == 'release' else '' } --all-targets --workspace --features perf-ui,image,kornia
+        run: cargo +stable nextest run $RELEASE_FLAG --all-targets --workspace --features perf-ui,image,kornia
       - name: Run test in debug / release with all features
-        run: cargo +stable nextest run $${ '--release' if matrix.mode == 'release' else '' } --all-targets --workspace --all-features
+        run: cargo +stable nextest run $RELEASE_FLAG --all-targets --workspace --all-features

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -78,7 +78,7 @@ jobs:
         if: matrix.mode == 'debug'
         run: cargo +stable test --doc --workspace
       - name: Run build in debug / release
-        run: cargo +stable build $RELEASE_FLAG --workspace --all-targets --all-features}
+        run: cargo +stable build $RELEASE_FLAG --workspace --all-targets --all-features
 
   test-debug-release:
     name: Test
@@ -144,3 +144,16 @@ jobs:
         run: cargo +stable nextest run $RELEASE_FLAG --all-targets --workspace --features perf-ui,image,kornia
       - name: Run test in debug / release with all features
         run: cargo +stable nextest run $RELEASE_FLAG --all-targets --workspace --all-features
+
+      - name: Install cargo-generate
+        run: cargo +stable install cargo-generate
+
+      - name: Generate new project
+        run: |
+          cd templates
+          cargo +stable generate -p cu_full --name test_project --destination . -d copper_source=local --silent
+
+      - name: Build generated project
+        run: |
+          cd templates/test_project
+          cargo +stable build $RELEASE_FLAG

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -135,13 +135,9 @@ jobs:
         run: echo "RELEASE_FLAG=$([[ '${{ matrix.mode }}' == 'release' ]] && echo '--release' || echo '')" >> $GITHUB_ENV
 
       - name: Set Release Flag (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.mode == 'release'
         run: |
-          if "%matrix_mode%" == "release" (
-            echo RELEASE_FLAG=--release >> %GITHUB_ENV%
-          ) else (
-            echo RELEASE_FLAG= >> %GITHUB_ENV%
-          )
+          Add-Content -Path $env:GITHUB_ENV -Value "RELEASE_FLAG=--release"
 
       # Run test in debug / release
       - name: Run test in debug / release

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Set Release Flag (Windows)
         if: runner.os == 'Windows'
         run: |
-          if ("%matrix_mode%" == "release") (
+          if "%matrix_mode%" == "release" (
             echo RELEASE_FLAG=--release >> %GITHUB_ENV%
           ) else (
             echo RELEASE_FLAG= >> %GITHUB_ENV%
@@ -137,7 +137,7 @@ jobs:
       - name: Set Release Flag (Windows)
         if: runner.os == 'Windows'
         run: |
-          if ("%matrix_mode%" == "release") (
+          if "%matrix_mode%" == "release" (
             echo RELEASE_FLAG=--release >> %GITHUB_ENV%
           ) else (
             echo RELEASE_FLAG= >> %GITHUB_ENV%

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -2,9 +2,9 @@ name: "CI/CD"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
 
       # Fail cheaply and early if the code is not even formatted correctly.
       - name: Cargo fmt check
-        run: cargo fmt --all -- --check
+        run: cargo +stable fmt --all -- --check
 
       ## System dependencies
       # Install dependencies only on Linux
@@ -49,7 +49,7 @@ jobs:
           Expand-Archive -Path npcap-sdk.zip -DestinationPath $env:USERPROFILE\npcap-sdk
           Remove-Item npcap-sdk.zip
           winget install --id DaiyuuNobori.Win10Pcap --disable-interactivity --accept-source-agreements --accept-package-agreements
-          
+
       - name: Set Library and Include Paths (Windows)
         if: runner.os == 'Windows'
         run: |
@@ -58,11 +58,15 @@ jobs:
 
       # Run debug builds and tests
       - name: Run clippy in debug
-        run: cargo clippy --workspace --all-targets -- --deny warnings
-      - name: Build in debug
-        run: cargo build --workspace --features macro_debug
-      - name: Run tests
-        run: cargo test --workspace
+        run: cargo +stable clippy --workspace --all-targets -- --deny warnings
+      - name: Run clippy in debug with mock and macro_debug
+        run: cargo +stable clippy --workspace --all-targets --features mock,macro_debug -- --deny warnings
+      - name: Run clippy in debug with perf-ui, image and kornia
+        run: cargo +stable clippy --workspace --all-targets --features perf-ui,image,kornia -- --deny warnings
+      - name: Run doctests
+        run: cargo +stable test --doc --workspace
+      - name: Run build in debug
+        run: cargo +stable build --release --workspace --all-targets --all-features
 
   build-release:
     name: Build Release
@@ -70,7 +74,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -84,10 +88,6 @@ jobs:
       - name: Install winget
         if: runner.os == 'Windows'
         uses: Cyberboss/install-winget@v1
-
-      # Fail cheaply and early if the code is not even formatted correctly.
-      - name: Cargo fmt check
-        run: cargo fmt --all -- --check
 
       ## System dependencies
       - name: Install dependencies (Linux)
@@ -108,6 +108,110 @@ jobs:
 
       # Run release builds and tests
       - name: Run clippy in release
-        run: cargo clippy --release --workspace --all-targets -- --deny warnings
-      - name: Build in release
-        run: cargo build --release --workspace --features macro_debug
+        run: cargo +stable clippy --release --workspace --all-targets -- --deny warnings
+      - name: Run clippy in debug with mock and macro_debug
+        run: cargo +stable clippy --release --workspace --all-targets --features mock,macro_debug -- --deny warnings
+      - name: Run clippy in debug with perf-ui, image and kornia
+        run: cargo +stable clippy --release --workspace --all-targets --features perf-ui,image,kornia -- --deny warnings
+      - name: Run build in release
+        run: cargo +stable build --release --workspace --all-targets --all-features
+
+  test-debug:
+    name: Test Debug
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - name: Setup rust-cache
+        uses: Swatinem/rust-cache@v2
+      - name: Install latest nextest
+        uses: taiki-e/install-action@nextest
+      - name: Install winget
+        if: runner.os == 'Windows'
+        uses: Cyberboss/install-winget@v1
+
+      ## System dependencies
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev libpcap-dev
+      - name: Download Npcap SDK (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          Invoke-WebRequest -Uri https://npcap.com/dist/npcap-sdk-1.13.zip -OutFile npcap-sdk.zip
+          Expand-Archive -Path npcap-sdk.zip -DestinationPath $env:USERPROFILE\npcap-sdk
+          Remove-Item npcap-sdk.zip
+          winget install --id DaiyuuNobori.Win10Pcap --disable-interactivity --accept-source-agreements --accept-package-agreements
+      - name: Set Library and Include Paths (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          $npcapLibDir = "$env:USERPROFILE\npcap-sdk\Lib\x64"
+          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$npcapLibDir"
+
+      # Run test
+      - name: Run test in debug
+        run: cargo +stable nextest run --all-targets --workspace
+      - name: Run test in debug with mock and macro_debug
+        run: cargo +stable nextest run --all-targets --workspace --features mock,macro_debug
+      - name: Run test in debug with perf-ui, image and kornia
+        run: cargo +stable nextest run --all-targets --workspace --features perf-ui,image,kornia
+      - name: Run test in debug with all features
+        run: cargo +stable nextest run --all-targets --workspace --all-features
+
+  test-release:
+    name: Test Release
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - name: Setup rust-cache
+        uses: Swatinem/rust-cache@v2
+      - name: Install latest nextest
+        uses: taiki-e/install-action@nextest
+      - name: Install winget
+        if: runner.os == 'Windows'
+        uses: Cyberboss/install-winget@v1
+
+      ## System dependencies
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev libpcap-dev
+      - name: Download Npcap SDK (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          Invoke-WebRequest -Uri https://npcap.com/dist/npcap-sdk-1.13.zip -OutFile npcap-sdk.zip
+          Expand-Archive -Path npcap-sdk.zip -DestinationPath $env:USERPROFILE\npcap-sdk
+          Remove-Item npcap-sdk.zip
+          winget install --id DaiyuuNobori.Win10Pcap --disable-interactivity --accept-source-agreements --accept-package-agreements
+      - name: Set Library and Include Paths (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          $npcapLibDir = "$env:USERPROFILE\npcap-sdk\Lib\x64"
+          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$npcapLibDir"
+
+      # Run test
+      - name: Run test in debug
+        run: cargo +stable nextest run --release --all-targets --workspace
+      - name: Run test in debug with mock and macro_debug
+        run: cargo +stable nextest run --release --all-targets --workspace --features mock,macro_debug
+      - name: Run test in debug with perf-ui, image and kornia
+        run: cargo +stable nextest run --release --all-targets --workspace --features perf-ui,image,kornia
+      - name: Run test in debug with all features
+        run: cargo +stable nextest run --release --all-targets --workspace --all-features

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-debug-release:
-    name: Build Debug / release
+    name: Build
 
     runs-on: ${{ matrix.os }}
 
@@ -58,8 +58,18 @@ jobs:
           $npcapLibDir = "$env:USERPROFILE\npcap-sdk\Lib\x64"
           Add-Content -Path $env:GITHUB_ENV -Value "LIB=$npcapLibDir"
 
-      - name: Set Release Flag
+      - name: Set Release Flag (Linux / MacOS)
+        if: runner.os != 'Windows'
         run: echo "RELEASE_FLAG=$([[ '${{ matrix.mode }}' == 'release' ]] && echo '--release' || echo '')" >> $GITHUB_ENV
+
+      - name: Set Release Flag (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          if ("%matrix_mode%" == "release") (
+            echo RELEASE_FLAG=--release >> %GITHUB_ENV%
+          ) else (
+            echo RELEASE_FLAG= >> %GITHUB_ENV%
+          )
 
       # Run clippy and build in debug / release
       - name: Run clippy in debug / release
@@ -75,7 +85,7 @@ jobs:
         run: cargo +stable build $RELEASE_FLAG --workspace --all-targets --all-features}
 
   test-debug-release:
-    name: Test Debug / Rlease
+    name: Test
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -120,8 +130,18 @@ jobs:
       - name: Install latest nextest
         uses: taiki-e/install-action@nextest
 
-      - name: Set Release Flag
+      - name: Set Release Flag (Linux / MacOS)
+        if: runner.os != 'Windows'
         run: echo "RELEASE_FLAG=$([[ '${{ matrix.mode }}' == 'release' ]] && echo '--release' || echo '')" >> $GITHUB_ENV
+
+      - name: Set Release Flag (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          if ("%matrix_mode%" == "release") (
+            echo RELEASE_FLAG=--release >> %GITHUB_ENV%
+          ) else (
+            echo RELEASE_FLAG= >> %GITHUB_ENV%
+          )
 
       # Run test in debug / release
       - name: Run test in debug / release


### PR DESCRIPTION
1. split CI into build and test, with matrix of debug and release mode
2. use nextest for parallel testing, configure three package tests that require binding to the same address with serial testing mode in .config/nextest.toml
3. add project generation test back in test matrix.
4. add typos check
5. rust-cache is effective