### PR TITLE
[FIX] (CI) rust-cache key and fix audit

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -37,7 +37,7 @@ jobs:
         if: runner.os == 'Windows'
         uses: Cyberboss/install-winget@v1
 
-      - name: Cargo fmt check
+      - name: Check formatting
         run: cargo +stable fmt --all -- --check
 
       ## System dependencies
@@ -55,49 +55,48 @@ jobs:
       - name: Set Library and Include Paths (Windows)
         if: runner.os == 'Windows'
         run: |
-          $npcapLibDir = "$env:USERPROFILE\npcap-sdk\Lib\x64"
-          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$npcapLibDir"
+          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$env:ProgramFiles (x86)\Win10Pcap\x64"
 
-      - name: Set Release Flag (Linux / MacOS)
+      - name: Set build mode (Linux / MacOS)
         if: runner.os != 'Windows'
         run: echo "RELEASE_FLAG=$([[ '${{ matrix.mode }}' == 'release' ]] && echo '--release' || echo '')" >> $GITHUB_ENV
 
-      - name: Set Release Flag (Windows)
+      - name: Set build mode (Windows)
         if: runner.os == 'Windows' && matrix.mode == 'release'
         run: |
           Add-Content -Path $env:GITHUB_ENV -Value "RELEASE_FLAG=--release"
 
       # Run Clippy and build
-      - name: Run clippy on ${{ matrix.os }} with ${{matrix.mode}}
+      - name: Run clippy on (${{ matrix.os }} | ${{matrix.mode}})
         run: cargo +stable clippy $RELEASE_FLAG --workspace --all-targets -- --deny warnings
-      - name: Run clippy with all features on ${{ matrix.os }} with ${{matrix.mode}}
+      - name: Run clippy with all features on (${{ matrix.os }} | ${{matrix.mode}})
         run: cargo +stable clippy $RELEASE_FLAG --workspace --all-targets --all-features -- --deny warnings
 
-      - name: Run build with all features on ${{ matrix.os }} with ${{matrix.mode}}
+      - name: Run build with all features on $(${{ matrix.os }} | ${{matrix.mode}})
         run: cargo +stable build $RELEASE_FLAG --workspace --all-targets --all-features
 
-      - name: Run doctests on ${{ matrix.os }} with debug
+      - name: Run doctests on (${{ matrix.os }} | debug)
         if: matrix.mode == 'debug'
         run: cargo +stable test --doc --workspace
 
       # Run Unit Tests
-      - name: Run Unit Tests on ${{ matrix.os }} with ${{matrix.mode}}
+      - name: Run Unit Tests on (${{ matrix.os }} | ${{matrix.mode}})
         run: cargo +stable nextest run $RELEASE_FLAG --all-targets --workspace
-      - name: Run Unit Tests with all features on ${{ matrix.os }} with ${{matrix.mode}}
+      - name: Run Unit Tests with all features on (${{ matrix.os }} | ${{matrix.mode}})
         run: cargo +stable nextest run $RELEASE_FLAG --all-targets --workspace --all-features
 
       # Run Project Generation Tests
-      - name: Install cargo-generate on ${{ matrix.os }} with debug
+      - name: Install cargo-generate on (${{ matrix.os }} | debug)
         if: matrix.mode == 'debug'
         run: cargo +stable install cargo-generate
 
-      - name: Generate new project on ${{ matrix.os }} with debug
+      - name: Generate new project on (${{ matrix.os }} | debug)
         if: matrix.mode == 'debug'
         run: |
           cd templates
           cargo +stable generate -p cu_full --name test_project --destination . -d copper_source=local --silent
 
-      - name: Build generated project on ${{ matrix.os }} with debug
+      - name: Build generated project on (${{ matrix.os }} | debug)
         if: matrix.mode == 'debug'
         run: |
           cd templates/test_project

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -51,18 +51,13 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           winget install DaiyuuNobori.Win10Pcap --accept-source-agreements --accept-package-agreements
-          dir "C:\Program Files"
-          dir "C:\Program Files (x86)"
-          dir "C:\Program Files\Win10Pcap"
           dir "C:\Program Files (x86)\Win10Pcap"
-          dir "C:\Program Files\Win10Pcap\x64"
           dir "C:\Program Files (x86)\Win10Pcap\x64"
 
       - name: Set Library and Include Paths (Windows)
         if: runner.os == 'Windows'
         run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$env:ProgramFiles\Win10Pcap\x64"
-          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$env:ProgramFiles (x86)\Win10Pcap\x64"
+          Add-Content -Path $env:GITHUB_ENV -Value "LIB=C:\Program Files (x86)\Win10Pcap\x64"
 
       - name: Set build mode (Linux / MacOS)
         if: runner.os != 'Windows'

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -51,10 +51,17 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           winget install DaiyuuNobori.Win10Pcap --accept-source-agreements --accept-package-agreements
+          dir "C:\Program Files"
+          dir "C:\Program Files (x86)"
+          dir "C:\Program Files\Win10Pcap"
+          dir "C:\Program Files (x86)\Win10Pcap"
+          dir "C:\Program Files\Win10Pcap\x64"
+          dir "C:\Program Files (x86)\Win10Pcap\x64"
 
       - name: Set Library and Include Paths (Windows)
         if: runner.os == 'Windows'
         run: |
+          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$env:ProgramFiles\Win10Pcap\x64"
           Add-Content -Path $env:GITHUB_ENV -Value "LIB=$env:ProgramFiles (x86)\Win10Pcap\x64"
 
       - name: Set build mode (Linux / MacOS)

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -10,8 +10,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-debug-release:
-    name: Build
+  Unit-Tests:
+    name: Unit Tests
 
     runs-on: ${{ matrix.os }}
 
@@ -30,12 +30,13 @@ jobs:
       - name: Setup rust-cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ runner.os }}-${{ matrix.mode }}-${{ github.ref_name}}
+          key: ${{ matrix.mode }}
+      - name: Install latest nextest
+        uses: taiki-e/install-action@nextest
       - name: Install winget
         if: runner.os == 'Windows'
         uses: Cyberboss/install-winget@v1
 
-      # Fail cheaply and early if the code is not even formatted correctly.
       - name: Cargo fmt check
         run: cargo +stable fmt --all -- --check
 
@@ -45,14 +46,11 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libudev-dev libpcap-dev
 
-      # Those are needed for the integration tests on Windows
+      # Install dependencies only on Windows
       - name: Download Npcap SDK (Windows)
         if: runner.os == 'Windows'
         run: |
-          Invoke-WebRequest -Uri https://npcap.com/dist/npcap-sdk-1.13.zip -OutFile npcap-sdk.zip
-          Expand-Archive -Path npcap-sdk.zip -DestinationPath $env:USERPROFILE\npcap-sdk
-          Remove-Item npcap-sdk.zip
-          winget install --id DaiyuuNobori.Win10Pcap --disable-interactivity --accept-source-agreements --accept-package-agreements
+          winget install DaiyuuNobori.Win10Pcap --accept-source-agreements --accept-package-agreements
 
       - name: Set Library and Include Paths (Windows)
         if: runner.os == 'Windows'
@@ -69,99 +67,41 @@ jobs:
         run: |
           Add-Content -Path $env:GITHUB_ENV -Value "RELEASE_FLAG=--release"
 
-      # Run clippy and build in debug / release
-      - name: Run clippy in debug / release
+      # Run Clippy and build
+      - name: Run clippy on ${{ matrix.os }} with ${{matrix.mode}}
         run: cargo +stable clippy $RELEASE_FLAG --workspace --all-targets -- --deny warnings
-      - name: Run clippy in debug / release with mock and macro_debug
-        run: cargo +stable clippy $RELEASE_FLAG --workspace --all-targets --features mock,macro_debug -- --deny warnings
-      - name: Run clippy in debug /release with perf-ui, image and kornia
-        run: cargo +stable clippy $RELEASE_FLAG --workspace --all-targets --features perf-ui,image,kornia -- --deny warnings
-      - name: Run doctests in debug
-        if: matrix.mode == 'debug'
-        run: cargo +stable test --doc --workspace
-      - name: Run build in debug / release
+      - name: Run clippy with all features on ${{ matrix.os }} with ${{matrix.mode}}
+        run: cargo +stable clippy $RELEASE_FLAG --workspace --all-targets --all-features -- --deny warnings
+
+      - name: Run build with all features on ${{ matrix.os }} with ${{matrix.mode}}
         run: cargo +stable build $RELEASE_FLAG --workspace --all-targets --all-features
 
-  test-debug-release:
-    name: Test
-    runs-on: ${{ matrix.os }}
+      - name: Run doctests on ${{ matrix.os }} with debug
+        if: matrix.mode == 'debug'
+        run: cargo +stable test --doc --workspace
 
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        mode: [debug, release]
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-      - name: Setup rust-cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ runner.os }}-${{ matrix.mode }}-${{ github.ref_name}}
-      - name: Install winget
-        if: runner.os == 'Windows'
-        uses: Cyberboss/install-winget@v1
-
-      ## System dependencies
-      # Install dependencies only on Linux
-      - name: Install dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libudev-dev libpcap-dev
-
-      # Those are needed for the integration tests on Windows
-      - name: Download Npcap SDK (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          Invoke-WebRequest -Uri https://npcap.com/dist/npcap-sdk-1.13.zip -OutFile npcap-sdk.zip
-          Expand-Archive -Path npcap-sdk.zip -DestinationPath $env:USERPROFILE\npcap-sdk
-          Remove-Item npcap-sdk.zip
-          winget install --id DaiyuuNobori.Win10Pcap --disable-interactivity --accept-source-agreements --accept-package-agreements
-
-      - name: Set Library and Include Paths (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          $npcapLibDir = "$env:USERPROFILE\npcap-sdk\Lib\x64"
-          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$npcapLibDir"
-
-      - name: Install latest nextest
-        uses: taiki-e/install-action@nextest
-
-      - name: Set Release Flag (Linux / MacOS)
-        if: runner.os != 'Windows'
-        run: echo "RELEASE_FLAG=$([[ '${{ matrix.mode }}' == 'release' ]] && echo '--release' || echo '')" >> $GITHUB_ENV
-
-      - name: Set Release Flag (Windows)
-        if: runner.os == 'Windows' && matrix.mode == 'release'
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "RELEASE_FLAG=--release"
-
-      # Run test in debug / release
-      - name: Run test in debug / release
+      # Run Unit Tests
+      - name: Run Unit Tests on ${{ matrix.os }} with ${{matrix.mode}}
         run: cargo +stable nextest run $RELEASE_FLAG --all-targets --workspace
-      - name: Run test in debug / release with mock and macro_debug
-        run: cargo +stable nextest run $RELEASE_FLAG --all-targets --workspace --features mock,macro_debug
-      - name: Run test in debug / release with perf-ui, image and kornia
-        run: cargo +stable nextest run $RELEASE_FLAG --all-targets --workspace --features perf-ui,image,kornia
-      - name: Run test in debug / release with all features
+      - name: Run Unit Tests with all features on ${{ matrix.os }} with ${{matrix.mode}}
         run: cargo +stable nextest run $RELEASE_FLAG --all-targets --workspace --all-features
 
-      - name: Install cargo-generate
+      # Run Project Generation Tests
+      - name: Install cargo-generate on ${{ matrix.os }} with debug
+        if: matrix.mode == 'debug'
         run: cargo +stable install cargo-generate
 
-      - name: Generate new project
+      - name: Generate new project on ${{ matrix.os }} with debug
+        if: matrix.mode == 'debug'
         run: |
           cd templates
           cargo +stable generate -p cu_full --name test_project --destination . -d copper_source=local --silent
 
-      - name: Build generated project
+      - name: Build generated project on ${{ matrix.os }} with debug
+        if: matrix.mode == 'debug'
         run: |
           cd templates/test_project
-          cargo +stable build $RELEASE_FLAG
-
+          cargo +stable build
   typos:
     name: Typos Check
     runs-on: ubuntu-latest

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -109,6 +109,8 @@ jobs:
     name: Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+      - name: Run cargo-audit
+        run: cargo audit

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -40,24 +40,17 @@ jobs:
       - name: Check formatting
         run: cargo +stable fmt --all -- --check
 
-      ## System dependencies
-      # Install dependencies only on Linux
       - name: Install dependencies (Linux)
-        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libudev-dev libpcap-dev
 
-      # Install dependencies only on Windows
-      - name: Download Npcap SDK (Windows)
+      - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
+          Invoke-WebRequest -Uri https://npcap.com/dist/npcap-sdk-1.13.zip -OutFile npcap-sdk.zip
+          Expand-Archive -Path npcap-sdk.zip -DestinationPath $env:USERPROFILE\npcap-sdk
+          Remove-Item npcap-sdk.zip
           winget install DaiyuuNobori.Win10Pcap --accept-source-agreements --accept-package-agreements
-          dir "C:\Program Files (x86)\Win10Pcap"
-          dir "C:\Program Files (x86)\Win10Pcap\x64"
-
-      - name: Set Library and Include Paths (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value "LIB=C:\Program Files (x86)\Win10Pcap\x64"
+          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$env:USERPROFILE\npcap-sdk\Lib\x64"
 
       - name: Set build mode (Linux / MacOS)
         if: runner.os != 'Windows'
@@ -73,7 +66,6 @@ jobs:
         run: cargo +stable clippy $RELEASE_FLAG --workspace --all-targets -- --deny warnings
       - name: Run clippy with all features on (${{ matrix.os }} | ${{matrix.mode}})
         run: cargo +stable clippy $RELEASE_FLAG --workspace --all-targets --all-features -- --deny warnings
-
       - name: Run build with all features on $(${{ matrix.os }} | ${{matrix.mode}})
         run: cargo +stable build $RELEASE_FLAG --workspace --all-targets --all-features
 
@@ -111,3 +103,11 @@ jobs:
       - uses: crate-ci/typos@master
         with:
           config: ./.config/_typos.toml
+
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup rust-cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ runner.os }}-${{ matrix.mode }}
+          key: ${{ runner.os }}-${{ matrix.mode }}-${{ github.ref_name}}
       - name: Install winget
         if: runner.os == 'Windows'
         uses: Cyberboss/install-winget@v1
@@ -101,7 +101,7 @@ jobs:
       - name: Setup rust-cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ runner.os }}-${{ matrix.mode }}
+          key: ${{ runner.os }}-${{ matrix.mode }}-${{ github.ref_name}}
       - name: Install winget
         if: runner.os == 'Windows'
         uses: Cyberboss/install-winget@v1

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -104,13 +104,3 @@ jobs:
       - uses: crate-ci/typos@master
         with:
           config: ./.config/_typos.toml
-
-  audit:
-    name: Audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
-      - name: Run cargo-audit
-        run: cargo audit

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -41,6 +41,7 @@ jobs:
         run: cargo +stable fmt --all -- --check
 
       - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libudev-dev libpcap-dev
 
       - name: Install dependencies (Windows)

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -29,6 +29,8 @@ jobs:
           profile: minimal
       - name: Setup rust-cache
         uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ runner.os }}-${{ matrix.mode }}
       - name: Install winget
         if: runner.os == 'Windows'
         uses: Cyberboss/install-winget@v1
@@ -98,6 +100,8 @@ jobs:
           profile: minimal
       - name: Setup rust-cache
         uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ runner.os }}-${{ matrix.mode }}
       - name: Install winget
         if: runner.os == 'Windows'
         uses: Cyberboss/install-winget@v1

--- a/core/cu29_helpers/Cargo.toml
+++ b/core/cu29_helpers/Cargo.toml
@@ -26,4 +26,4 @@ cu29-log-derive = { workspace = true }
 cu29-helpers = { workspace = true }
 cu29-value = { workspace = true }
 serde = { workspace = true }
-tempdir = "0.3.7"
+tempfile = { workspace = true }

--- a/core/cu29_helpers/tests/end2end.rs
+++ b/core/cu29_helpers/tests/end2end.rs
@@ -11,13 +11,13 @@ use cu29_log_runtime::log;
 use cu29_log_runtime::log_debug_mode;
 
 use serde::Serialize;
-use tempdir::TempDir;
+use tempfile::TempDir;
 
 // Those should be in cu29_log_runtime but got moved here to avoid circular dependencies
 
 #[test]
 fn log_derive_end2end() {
-    let tmp_dir = TempDir::new("teststructlog").expect("Failed to create temp dir");
+    let tmp_dir = TempDir::new().expect("Failed to create temp dir");
     let log_path = tmp_dir.path().join("teststructlog.copper");
 
     let _ = basic_copper_setup(&log_path, None, true, None).expect("Failed to setup logger.");


### PR DESCRIPTION
1. Add matrix.mode in cache key. Default cache key cause conflict when build/release try to save the same cache key.
2. Further simplify the CI, test all features directly.
3. Addressed dependency security issue of cu29_helpers thanks to cargo audit. Use tempfile instead of tempdir. The tempdir was merged into tempfile and became unmaintained.