### PR TITLE
[CHORE] Fix machete in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "components/testing/cu_udp_inject",
     "examples/cu_caterpillar",
     "examples/cu_config_gen",
+    "examples/cu_config_variation",
     "examples/cu_iceoryx2",
     "examples/cu_logging_size",
     "examples/cu_monitoring",
@@ -105,7 +106,7 @@ clap = { version = "4.5.21", features = ["derive"] }
 
 # External proc macros
 proc-macro2 = { version = "1.0.89" }
-quote = "1.0.37" # proc macros
+quote = "1.0.37"                                  # proc macros
 syn = { version = "2.0.85", features = ["full"] } # proc macros
 
 # Unit of measure to be consistent across the project

--- a/components/sinks/cu_rp_gpio/Cargo.toml
+++ b/components/sinks/cu_rp_gpio/Cargo.toml
@@ -17,7 +17,6 @@ ignored = ["cu29-log", "cu29-log-runtime"]  # proc macro
 cu29 = { workspace = true }
 cu29-log = { workspace = true }
 cu29-log-runtime = { workspace = true } # needed
-cu29-log-derive = { workspace = true }
 bincode = { workspace = true }
 serde = { workspace = true }
 lazy_static = "1.5.0"

--- a/components/sources/cu_v4l/Cargo.toml
+++ b/components/sources/cu_v4l/Cargo.toml
@@ -12,8 +12,6 @@ repository.workspace = true
 
 [dependencies]
 cu29 = { workspace = true }
-cu29-log-derive = { workspace = true }
-cu29-log-runtime = { workspace = true }
 cu-sensor-payloads = { workspace = true }
 libc = "0.2.168"
 page_size = "0.6.0"

--- a/core/cu29_runtime/Cargo.toml
+++ b/core/cu29_runtime/Cargo.toml
@@ -34,7 +34,6 @@ cu29-clock = { workspace = true }
 clap = { workspace = true }
 tempfile = { workspace = true }
 arrayvec = "0.7.6"
-page_size = "0.6.0"
 
 ron = "0.8.1"
 hdrhistogram = "7.5.4"

--- a/examples/cu_caterpillar/Cargo.toml
+++ b/examples/cu_caterpillar/Cargo.toml
@@ -13,7 +13,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [package.metadata.cargo-machete]
-ignored = ["cu29-log", "cu29-log-runtime", "cu29-unifiedlog", "copper-traits"]  # proc macro
+ignored = ["cu29-log", "cu29-log-runtime", "cu29-unifiedlog", "cu-consolemon", "copper-traits"]  # proc macro and console
 
 [[bin]]
 name = "cu-caterpillar"

--- a/examples/cu_config_variation/Cargo.toml
+++ b/examples/cu_config_variation/Cargo.toml
@@ -8,3 +8,6 @@ cu29 = { workspace = true }
 cu29-helpers = { workspace = true }
 cu-caterpillar = { path = "../cu_caterpillar", version = "0.5.2" }
 cu-rp-gpio = { path = "../../components/sinks/cu_rp_gpio", version = "0.5.2" }
+
+[package.metadata.cargo-machete]
+ignored = ["cu-caterpillar", "cu-rp-gpio"] # copperconfig.ron use caterpillar and rp-gpio as an example

--- a/examples/cu_rp_balancebot/Cargo.toml
+++ b/examples/cu_rp_balancebot/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 default-run = "balancebot-sim"
 
 [package.metadata.cargo-machete]
-ignored = ["cu29-log", "cu29-log-runtime", "cu29-unifiedlog", "copper-traits"]  # proc macro
+ignored = ["cu-consolemon", "cu29-log", "cu29-log-runtime", "cu29-unifiedlog", "copper-traits"]  # proc macro and console
 
 [dependencies]
 # Core dependencies
@@ -31,7 +31,6 @@ cu29-export = { workspace = true, optional = true }
 # Sim dependencies
 bevy = { version = "0.15.1", default-features = false, features = ["x11", "wayland", "default_font", "bevy_render", "bevy_window", "bevy_core_pipeline", "bevy_pbr", "bevy_scene", "bevy_sprite", "bevy_gltf", "animation", "bevy_picking", "bevy_mesh_picking_backend", "tonemapping_luts", "bevy_ui", "ktx2", "jpeg", "png"], optional = true }
 avian3d = { version = "0.2.0", default-features = false, features = ["bevy_scene", "collider-from-mesh", "debug-plugin", "parallel", "f32", "3d", "parry-f32"], optional = true }
-parry3d = { version = "0.17.4", optional = true }
 cached-path = { version = "0.6.1", optional = true }
 iyes_perf_ui = { git = "https://github.com/makeecat/iyes_perf_ui", version = "0.4.0", optional = true }
 
@@ -40,7 +39,7 @@ default = ["logreader", "sim"]
 # generates an executable to read the logs
 logreader = ["cu29-export"]
 # dependencies to build to matrix for copper
-sim = ["bevy", "avian3d", "parry3d", "cached-path"]
+sim = ["bevy", "avian3d", "cached-path"]
 perf-ui = ["iyes_perf_ui"]
 
 [[bin]]


### PR DESCRIPTION
Fix machete in the following crates and passed with this PR: https://github.com/copper-project/copper-rs/pull/224
using `cargo machete`

- cu_config_variation
- cu29_runtime
- cu_rp_gpio
- cu_v4l
- cu_caterpillar
- cu_config_variation
- cu_rp_balancebot

Since machete can cause false positive easily, I suggest we do not add machete in weekly CI.