### PR TITLE
Make cu-consolemon debug pane only active if `text_log` is true

### DIFF
--- a/components/monitors/cu_consolemon/src/debug_pane.rs
+++ b/components/monitors/cu_consolemon/src/debug_pane.rs
@@ -20,6 +20,7 @@ pub struct DebugLog {
 }
 
 impl DebugLog {
+    #[allow(dead_code)]
     pub fn new(max_lines: u16) -> (Self, SyncSender<String>) {
         let (tx, rx) = std::sync::mpsc::sync_channel(1000);
         (
@@ -70,6 +71,7 @@ pub struct LogSubscriber {
 }
 
 impl LogSubscriber {
+    #[allow(dead_code)]
     pub fn new(tx: SyncSender<String>) -> Self {
         let log_subscriber = Self { tx };
         log::set_boxed_logger(Box::new(log_subscriber.clone())).unwrap();

--- a/components/monitors/cu_consolemon/src/debug_pane.rs
+++ b/components/monitors/cu_consolemon/src/debug_pane.rs
@@ -91,7 +91,12 @@ impl Log for LogSubscriber {
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            let message = format!("[{}] - {}\n", record.level(), record.args());
+            let message = format!(
+                "{} [{}] - {}\n",
+                chrono::Local::now().time().format("%H:%M:%S"),
+                record.level(),
+                record.args()
+            );
 
             self.push_logs(message);
         }

--- a/components/monitors/cu_consolemon/src/debug_pane.rs
+++ b/components/monitors/cu_consolemon/src/debug_pane.rs
@@ -13,6 +13,7 @@ use {
     std::sync::mpsc::{Receiver, SyncSender},
 };
 
+#[derive(Debug)]
 pub struct DebugLog {
     debug_log: VecDeque<String>,
     pub(crate) max_rows: AtomicU16,
@@ -74,8 +75,10 @@ impl LogSubscriber {
     #[allow(dead_code)]
     pub fn new(tx: SyncSender<String>) -> Self {
         let log_subscriber = Self { tx };
-        log::set_boxed_logger(Box::new(log_subscriber.clone())).unwrap();
-        log::set_max_level(LevelFilter::Info);
+        if log::set_boxed_logger(Box::new(log_subscriber.clone())).is_err() {
+            eprintln!("Failed to set `LogSubscriber` as global log subscriber")
+        }
+        log::set_max_level(LevelFilter::Debug);
         log_subscriber
     }
 

--- a/components/monitors/cu_consolemon/src/lib.rs
+++ b/components/monitors/cu_consolemon/src/lib.rs
@@ -651,7 +651,6 @@ impl CuMonitor for CuConsoleMon {
                     let max_lines = terminal.size().unwrap().height - 5;
                     let (debug_log, tx) = debug_pane::DebugLog::new(max_lines);
 
-                    #[allow(unused_variables)]
                     let log_subscriber = debug_pane::LogSubscriber::new(tx);
 
                     *cu29_log_runtime::EXTRA_TEXT_LOGGER.write().unwrap() =
@@ -661,8 +660,9 @@ impl CuMonitor for CuConsoleMon {
                     setup_terminal();
 
                     ui.debug_output = Some(debug_log);
+                } else {
+                    println!("EXTRA_TEXT_LOGGER is none");
                 }
-
                 ui.run_app(&mut terminal).expect("Failed to run app");
             }
 

--- a/examples/cu_caterpillar/src/main.rs
+++ b/examples/cu_caterpillar/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
     let logger_path = tmp_dir.path().join("caterpillar.copper");
 
     let copper_ctx =
-        basic_copper_setup(&logger_path, SLAB_SIZE, false, None).expect("Failed to setup logger.");
+        basic_copper_setup(&logger_path, SLAB_SIZE, true, None).expect("Failed to setup logger.");
     let mut application = CaterpillarApplicationBuilder::new()
         .with_context(&copper_ctx)
         .build()

--- a/examples/cu_rp_balancebot/src/main.rs
+++ b/examples/cu_rp_balancebot/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
         }
     }
 
-    let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), SLAB_SIZE, false, None)
+    let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), SLAB_SIZE, true, None)
         .expect("Failed to setup logger.");
     debug!("Logger created at {}.", path = logger_path);
 

--- a/examples/cu_rp_balancebot/src/resim.rs
+++ b/examples/cu_rp_balancebot/src/resim.rs
@@ -82,7 +82,7 @@ fn main() {
     let copper_ctx = basic_copper_setup(
         &PathBuf::from(logger_path),
         LOG_SLAB_SIZE,
-        false,
+        true,
         Some(robot_clock.clone()),
     )
     .expect("Failed to setup logger.");

--- a/examples/cu_rp_balancebot/src/sim.rs
+++ b/examples/cu_rp_balancebot/src/sim.rs
@@ -62,7 +62,7 @@ fn setup_copper(mut commands: Commands) {
     let copper_ctx = basic_copper_setup(
         &PathBuf::from(logger_path),
         LOG_SLAB_SIZE,
-        false,
+        true,
         Some(robot_clock.clone()),
     )
     .expect("Failed to setup logger.");


### PR DESCRIPTION
This PR makes the following behaviour work:

```txt
text_log = True with no cu-consolemon -> dumping in the console like it was doing before
text_log = False -> ONLY structured logging in the main log no text is constructed ever.
text_log = True with cu-consolemon  -> redirect that to the Pane
text_log = False with cu-consolemon  -> by order of preference: message in the Pane, no pane or empty Pane it there is no way to know
compilation in release mode -> text_log = False is forced, I would even compile out the support like I did for the standard console version
```
_As discussed on discord_

as well as also add time to the log shown in cu-consolemon