### PR TITLE
Add `iyes_perf_ui` back

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -141,11 +141,11 @@ jobs:
 
       - name: Set features (Linux)
         if: runner.os == 'Linux'
-        run: echo "FEATURES_FLAG=$([[ '${{ matrix.mode }}' == 'cuda-release' ]] && echo '--all-features' || echo '--features macro_debug,mock,image,kornia,python')" >> $GITHUB_ENV
+        run: echo "FEATURES_FLAG=$([[ '${{ matrix.mode }}' == 'cuda-release' ]] && echo '--all-features' || echo '--features macro_debug,mock,iyes_perf_ui,image,kornia,python')" >> $GITHUB_ENV
       
       - name: Set features (MacOS)
         if: runner.os == 'macOS'
-        run: echo "FEATURES_FLAG=$([[ '${{ matrix.mode }}' == 'cuda-release' ]] && echo '--all-features' || echo '--features macro_debug,mock,image,kornia')" >> $GITHUB_ENV
+        run: echo "FEATURES_FLAG=$([[ '${{ matrix.mode }}' == 'cuda-release' ]] && echo '--all-features' || echo '--features macro_debug,mock,iyes_perf_ui,image,kornia')" >> $GITHUB_ENV
 
       - name: Set features (Windows)
         if: runner.os == 'Windows'
@@ -153,7 +153,7 @@ jobs:
           $features = if ($env:matrix_mode -eq 'cuda-release') {
             '--all-features'
           } else {
-            '--features macro_debug,mock,image,kornia,python'
+            '--features macro_debug,mock,iyes_perf_ui,image,kornia,python'
           }
           Add-Content -Path $env:GITHUB_ENV -Value "FEATURES_FLAG=$features"
 

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Set features (Linux / MacOS)
         if: runner.os != 'Windows'
-        run: echo "FEATURES_FLAG=$([[ '${{ matrix.mode }}' == 'cuda-release' ]] && echo '--all-features' || echo '--features macro_debug,mock,image,kornia')" >> $GITHUB_ENV
+        run: echo "FEATURES_FLAG=$([[ '${{ matrix.mode }}' == 'cuda-release' ]] && echo '--all-features' || echo '--features macro_debug,mock,iyes_perf_ui,image,kornia')" >> $GITHUB_ENV
 
       - name: Set features (Windows)
         if: runner.os == 'Windows'
@@ -166,7 +166,7 @@ jobs:
           $features = if ($env:matrix_mode -eq 'cuda-release') {
             '--all-features'
           } else {
-            '--features macro_debug,mock,image,kornia'
+            '--features macro_debug,mock,iyes_perf_ui,image,kornia'
           }
           Add-Content -Path $env:GITHUB_ENV -Value "FEATURES_FLAG=$features"
 

--- a/examples/cu_rp_balancebot/Cargo.toml
+++ b/examples/cu_rp_balancebot/Cargo.toml
@@ -32,6 +32,7 @@ cu29-export = { workspace = true, optional = true }
 bevy = { version = "0.15.1", default-features = false, features = ["x11", "wayland", "default_font", "bevy_render", "bevy_window", "bevy_core_pipeline", "bevy_pbr", "bevy_scene", "bevy_sprite", "bevy_gltf", "animation", "bevy_picking", "bevy_mesh_picking_backend", "tonemapping_luts", "bevy_ui", "ktx2", "jpeg", "png"], optional = true }
 avian3d = { version = "0.2.0", default-features = false, features = ["bevy_scene", "collider-from-mesh", "debug-plugin", "parallel", "f32", "3d", "parry-f32"], optional = true }
 cached-path = { version = "0.6.1", optional = true }
+iyes_perf_ui = { version = "0.4", optional = true }
 
 [features]
 default = ["logreader", "sim"]
@@ -39,6 +40,7 @@ default = ["logreader", "sim"]
 logreader = ["cu29-export"]
 # dependencies to build to matrix for copper
 sim = ["bevy", "avian3d", "cached-path"]
+perf-ui = ["iyes_perf_ui"]
 
 [[bin]]
 name = "balancebot"

--- a/examples/cu_rp_balancebot/README.md
+++ b/examples/cu_rp_balancebot/README.md
@@ -16,6 +16,12 @@ $ cargo run --release
 
 See the UI help for the navigation.
 
+To debug the game engine side you can add a perf overlay with:
+
+```bash
+cargo run --release --features perf-ui
+```
+
 ## To run the resimulation
 
 (you need at least a log in `logs` for example from a simulation run).

--- a/examples/cu_rp_balancebot/src/world/mod.rs
+++ b/examples/cu_rp_balancebot/src/world/mod.rs
@@ -9,6 +9,9 @@ use bevy::pbr::{DefaultOpaqueRendererMethod, ScreenSpaceReflections};
 use bevy::prelude::*;
 use cached_path::{Cache, ProgressBar};
 
+#[cfg(feature = "perf-ui")]
+use iyes_perf_ui::prelude::{PerfUiAllEntries, PerfUiPlugin};
+
 use std::path::Path;
 use std::{fs, io};
 
@@ -82,6 +85,9 @@ pub fn build_world(app: &mut App) -> &mut App {
         .add_systems(Update, update_physics)
         .add_systems(Update, global_cart_drag_listener)
         .add_systems(PostUpdate, reset_sim);
+
+    #[cfg(feature = "perf-ui")]
+    app.add_plugins(PerfUiPlugin);
 
     app
 }
@@ -283,6 +289,9 @@ fn setup_ui(mut commands: Commands) {
                 TextColor(Color::WHITE),
             ));
         });
+
+    #[cfg(feature = "perf-ui")]
+    commands.spawn(PerfUiAllEntries::default());
 }
 
 // This needs to match an object / parent object name in the GLTF file (in blender this is the object name).


### PR DESCRIPTION
Fixes #226 

The issue was blocked because `iyes_perf_ui` isn't using `0.15.1` version of bevy in it's `Cargo.toml` but instead using `0.15.0`.
This is not a real blocker for us as mentioned in [Specifying Dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio) of Cargo Guide, the version `0.15.0` is `>=0.15.0`, and `<0.16.0`.

And since, we want to use anything `>=0.15.1`, this is not going to be any issue as Cargo will automatically select the latest version which today is `0.15.3`