### PR TITLE
[CHORE] (cu29_runtime) bump ron to 0.10.1 and petgraph to 0.9.1

### DIFF
--- a/core/cu29_runtime/Cargo.toml
+++ b/core/cu29_runtime/Cargo.toml
@@ -35,9 +35,9 @@ clap = { workspace = true }
 tempfile = { workspace = true }
 arrayvec = "0.7.6"
 smallvec = { workspace = true }
-ron = "0.9"
+ron = "0.10.1"
 hdrhistogram = "7.5.4"
-petgraph = { version = "0.7.1", features = ["serde", "serde-1", "serde_derive"] }
+petgraph = { version = "0.8.1", features = ["serde", "serde-1", "serde_derive"] }
 object-pool = "0.6.0"
 gstreamer = { version = "0.23.5", optional = true }
 gstreamer-app = { version = "0.23.5", optional = true }

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -184,6 +184,7 @@ impl Display for Value {
                     Number::U64(n) => n.to_string(),
                     Number::F32(n) => n.0.to_string(),
                     Number::F64(n) => n.0.to_string(),
+                    _ => panic!("Expected a Number variant but got {value:?}"),
                 };
                 write!(f, "{s}")
             }


### PR DESCRIPTION
fix bug with ron@0.10.1
```
error[E0004]: non-exhaustive patterns: `&ron::Number::__NonExhaustive(_)` not covered
   --> core/cu29_runtime/src/config.rs:176:31
    |
176 |                 let s = match n {
    |                               ^ pattern `&ron::Number::__NonExhaustive(_)` not covered
    |
note: `ron::Number` defined here
   --> /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ron-0.10.1/src/value/number.rs:36:1
    |
36  | pub enum Number {
    | ^^^^^^^^^^^^^^^
...
53  |     __NonExhaustive(private::Never),
    |     --------------- not covered
    = note: the matched value is of type `&ron::Number`
    = note: `ron::value::number::private::Never` is uninhabited but is not being matched by value, so a wildcard `_` is required
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
186 ~                     Number::F64(n) => n.0.to_string(),
187 ~                     &ron::Number::__NonExhaustive(_) => todo!(),
    |
```