### PR TITLE
[FIX] add link advapi32 in cu29_log_derive for beta toolchain

### DIFF
--- a/core/cu29_derive/build.rs
+++ b/core/cu29_derive/build.rs
@@ -2,9 +2,6 @@ use std::path::{Path, PathBuf};
 use std::{fs, io};
 
 fn main() {
-    if cfg!(target_os = "windows") {
-        println!("cargo:rustc-link-lib=advapi32");
-    }
     println!("cargo::rerun-if-changed=tests/config");
     let trybuild_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap())
         .ancestors()

--- a/core/cu29_derive/build.rs
+++ b/core/cu29_derive/build.rs
@@ -2,6 +2,9 @@ use std::path::{Path, PathBuf};
 use std::{fs, io};
 
 fn main() {
+    if cfg!(target_os = "windows") {
+        println!("cargo:rustc-link-lib=advapi32");
+    }
     println!("cargo::rerun-if-changed=tests/config");
     let trybuild_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap())
         .ancestors()

--- a/core/cu29_log_derive/build.rs
+++ b/core/cu29_log_derive/build.rs
@@ -1,4 +1,7 @@
 fn main() {
+    if cfg!(target_os = "windows") {
+        println!("cargo:rustc-link-lib=advapi32");
+    }
     println!(
         "cargo:rustc-env=LOG_INDEX_DIR={}",
         std::env::var("OUT_DIR").unwrap()


### PR DESCRIPTION
## Problem
The beta test failed
https://github.com/copper-project/copper-rs/actions/runs/14458010901/job/40575044210

## Issue
```
  = note:    Creating library D:\a\copper-rs\copper-rs\target\tests\trybuild\debug\deps\cu29_log_derive-16eb8fc691887d16.dll.lib and object D:\a\copper-rs\copper-rs\target\tests\trybuild\debug\deps\cu29_log_derive-16eb8fc691887d16.dll.exp␍
          liblmdb_sys-702af18a9ef60260.rlib(535b1ff7273e4654-mdb.o) : error LNK2019: unresolved external symbol __imp_InitializeSecurityDescriptor referenced in function mdb_env_setup_locks␍
          liblmdb_sys-702af18a9ef60260.rlib(535b1ff7273e4654-mdb.o) : error LNK2019: unresolved external symbol __imp_SetSecurityDescriptorDacl referenced in function mdb_env_setup_locks␍
          D:\a\copper-rs\copper-rs\target\tests\trybuild\debug\deps\cu29_log_derive-16eb8fc691887d16.dll : fatal error LNK1120: 2 unresolved externals␍
          

error: could not compile `cu29-log-derive` (lib) due to 1 previous error
```

## Analysis
This looks like a Windows-specific linker issue when trying to compile a Rust program that uses the LMDB library.

The key errors are:
```
unresolved external symbol __imp_InitializeSecurityDescriptor
unresolved external symbol __imp_SetSecurityDescriptorDacl
```
These functions are part of the Windows Security API, which requires linking against the advapi32.lib library. It seems that the LMDB Rust binding isn't properly linking with this Windows system library.

## Solution
Add linking code in `build.rs` of `cu29_log_derive`.

```
if cfg!(target_os = "windows") {
        println!("cargo:rustc-link-lib=advapi32");
    }
}
```