### PR TITLE
[CHORE] bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,17 +105,17 @@ cu29-value = { path = "core/cu29_value", version = "0.7.0" }
 cu-sensor-payloads = { path = "components/payloads/cu_sensor_payloads", version = "0.7.0" }
 
 # External serialization
-bincode = { version = "2.0.0", features = ["derive"] }
-serde = { version = "1.0.215", features = ["derive"] }
-serde_derive = { version = "1.0.215", features = ["default"] }
+bincode = { version = "2.0.1", features = ["derive"] }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_derive = { version = "1.0.219", features = ["default"] }
 
 # External CLI
-clap = { version = "4.5.21", features = ["derive"] }
+clap = { version = "4.5.36", features = ["derive"] }
 
 # External proc macros
-proc-macro2 = { version = "1.0.89" }
-quote = "1.0.37"                                  # proc macros
-syn = { version = "2.0.85", features = ["full"] } # proc macros
+proc-macro2 = { version = "1.0.95" }
+quote = "1.0.40"                                  # proc macros
+syn = { version = "2.0.100", features = ["full"] } # proc macros
 
 # Unit of measure to be consistent across the project
 uom = { version = "0.36.0", features = ["serde"] }
@@ -127,13 +127,13 @@ compact_str = { version = "0.9.0", features = ["serde"] }
 derive_more = { version = "2.0.1", features = ["full"] }
 
 # used across testing
-tempfile = "3.18.0"
+tempfile = "3.19.1"
 
 # rerun
 rerun = { version = "0.22.1", default-features = false, features = ["sdk", "server", "log"] }
 
 # smallvec to avoid heap allocations
-smallvec = { version = "1.14.0", features = ["serde"] }
+smallvec = { version = "1.15.0", features = ["serde"] }
 
 # [profile.release]
 # lto = true

--- a/components/monitors/cu_consolemon/Cargo.toml
+++ b/components/monitors/cu_consolemon/Cargo.toml
@@ -23,11 +23,11 @@ ratatui = "0.29"
 pfetch-logo-parser = "0.1.1"
 pfetch = "2.11.1"
 dotenvy = "0.15.7"
-libmacchina = "8.0.0"
+libmacchina = "8.1.0"
 ansi-to-tui = "7.0.0"
 tui-nodes = "0.8.0"
 tui-widgets = "0.4.1"
 color-eyre = "0.6.3"
 gag = "1.0.0"
-log = { version = "0.4.26", features = ["std"], optional = true }
+log = { version = "0.4.27", features = ["std"], optional = true }
 chrono = { version = "0.4.40", optional = true }

--- a/components/payloads/cu_sensor_payloads/Cargo.toml
+++ b/components/payloads/cu_sensor_payloads/Cargo.toml
@@ -17,7 +17,7 @@ cu29-clock = { workspace = true }
 cu29 = { workspace = true }
 uom = { workspace = true }
 derive_more = { workspace = true }
-image = { version = "0.25.5", optional = true }
+image = { version = "0.25.6", optional = true }
 kornia = { version = "0.1.8", optional = true }
 
 [features]

--- a/components/payloads/cu_spatial_payloads/Cargo.toml
+++ b/components/payloads/cu_spatial_payloads/Cargo.toml
@@ -15,9 +15,9 @@ bincode = { workspace = true }
 uom = { workspace = true }
 serde = { workspace = true }
 
-faer = { version = "0.21.7", optional = true }
+faer = { version = "0.21.9", optional = true }
 nalgebra = { version = "0.33.2", optional = true }
-glam = { version = "0.30.0", optional = true }
+glam = { version = "0.30.2", optional = true }
 
 [features]
 default = []

--- a/components/sinks/cu_lewansoul/Cargo.toml
+++ b/components/sinks/cu_lewansoul/Cargo.toml
@@ -15,4 +15,4 @@ repository.workspace = true
 uom = { workspace = true }
 cu29 = { workspace = true }
 bincode = { workspace = true }
-serialport = "4.7.0"
+serialport = "4.7.1"

--- a/components/sinks/cu_msp_sink/Cargo.toml
+++ b/components/sinks/cu_msp_sink/Cargo.toml
@@ -16,6 +16,6 @@ cu29 = { workspace = true }
 smallvec = { workspace = true }
 bincode = { workspace = true }
 serde = { workspace = true }
-serialport = "4.7.0"
+serialport = "4.7.1"
 cu-msp-lib = { path = "../../common/cu_msp_lib", version = "0.7.0" }
 cu-msp-src = { path = "../../sources/cu_msp_src", version = "0.7.0" }  # Keep

--- a/components/sources/cu_gstreamer/Cargo.toml
+++ b/components/sources/cu_gstreamer/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 [dependencies]
 cu29 = { workspace = true }
 bincode = { workspace = true }
-circular-buffer = "1.0.0"
+circular-buffer = "1.1.0"
 gstreamer = { version = "0.23.5", optional = true }
 gstreamer-app = { version = "0.23.5", optional = true }
 

--- a/components/sources/cu_hesai/Cargo.toml
+++ b/components/sources/cu_hesai/Cargo.toml
@@ -16,7 +16,7 @@ cu-sensor-payloads = { workspace = true }
 bytemuck = { version = "1.22.0", features = ["derive"] }
 uom = { workspace = true }
 chrono = { version = "0.4.40", features = ["serde"] }
-socket2 = { version = "0.5.8", features = ["all"] }
+socket2 = { version = "0.5.9", features = ["all"] }
 tempfile = { workspace = true }
 
 [dev-dependencies]

--- a/components/sources/cu_livox/Cargo.toml
+++ b/components/sources/cu_livox/Cargo.toml
@@ -16,7 +16,7 @@ cu-sensor-payloads = { workspace = true }
 bytemuck = { version = "1.22.0", features = ["derive"] }
 uom = { workspace = true }
 chrono = { version = "0.4.40", features = ["serde"] }
-socket2 = { version = "0.5.8", features = ["all"] }
+socket2 = { version = "0.5.9", features = ["all"] }
 tempfile = { workspace = true }
 
 [dev-dependencies]

--- a/components/sources/cu_msp_src/Cargo.toml
+++ b/components/sources/cu_msp_src/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 [dependencies]
 cu29 = { workspace = true }
 cu-msp-lib = { path = "../../common/cu_msp_lib", version = "0.7.0" }
-serialport = "4.7.0"
+serialport = "4.7.1"
 serde = { workspace = true }
 smallvec = { workspace = true }
 bincode = { workspace = true }

--- a/components/sources/cu_rp_encoder/Cargo.toml
+++ b/components/sources/cu_rp_encoder/Cargo.toml
@@ -20,7 +20,7 @@ bincode = { workspace = true }
 serde = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rppal = { version = "0.20.0", features = ["hal"] }
+rppal = { version = "0.22.1", features = ["hal"] }
 
 [build-dependencies]
 cfg_aliases = "0.2.1"

--- a/components/sources/cu_v4l/Cargo.toml
+++ b/components/sources/cu_v4l/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 [dependencies]
 cu29 = { workspace = true }
 cu-sensor-payloads = { workspace = true }
-libc = "0.2.171"
+libc = "0.2.172"
 nix = { version = "0.29.0", features = ["time"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/components/tasks/cu_aligner/Cargo.toml
+++ b/components/tasks/cu_aligner/Cargo.toml
@@ -13,5 +13,5 @@ repository.workspace = true
 [dependencies]
 cu29 = { workspace = true }
 cu29-clock = { workspace = true }
-circular-buffer = "1.0.0"
+circular-buffer = "1.1.0"
 paste = "1.0.15"

--- a/components/tasks/cu_apriltag/Cargo.toml
+++ b/components/tasks/cu_apriltag/Cargo.toml
@@ -23,5 +23,5 @@ apriltag = { version = "0.4.0" }
 apriltag-sys = { version = "0.3.0" }
 
 [dev-dependencies]
-image = "0.25.5"
-anyhow = "1.0.97"
+image = "0.25.6"
+anyhow = "1.0.98"

--- a/core/cu29_log/Cargo.toml
+++ b/core/cu29_log/Cargo.toml
@@ -18,4 +18,4 @@ cu29-value = { workspace = true }
 cu29-traits = { workspace = true }
 cu29-clock = { workspace = true }
 strfmt = "0.2.4"
-smallvec = { version = "1.14.0", features = ["serde"] }
+smallvec = { workspace = true }

--- a/core/cu29_log_runtime/Cargo.toml
+++ b/core/cu29_log_runtime/Cargo.toml
@@ -20,7 +20,7 @@ cu29-traits = { workspace = true }
 cu29-clock = { workspace = true }
 bincode = { workspace = true }
 smallvec = { workspace = true }
-log = "0.4.26"
+log = "0.4.27"
 
 [dev-dependencies]
 cu29-value = { workspace = true }

--- a/core/cu29_runtime/Cargo.toml
+++ b/core/cu29_runtime/Cargo.toml
@@ -39,7 +39,7 @@ object-pool = "0.6.0"
 html-escape = "0.2"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-cudarc = { version = "0.15.0", optional = true, features = ["cuda-version-from-build-system"] }
+cudarc = { version = "0.16.0", optional = true, features = ["cuda-version-from-build-system"] }
 
 [features]
 default = []

--- a/core/cu29_value/Cargo.toml
+++ b/core/cu29_value/Cargo.toml
@@ -19,7 +19,7 @@ documentation = "https://docs.rs/cu29-value"
 bincode = { workspace = true }
 serde = { workspace = true }
 cu29-clock = { workspace = true }
-ordered-float = "4.5.0"
+ordered-float = "5.0.0"
 
 [dev-dependencies]
 serde_derive = { workspace = true }

--- a/examples/cu_caterpillar/Cargo.toml
+++ b/examples/cu_caterpillar/Cargo.toml
@@ -38,7 +38,7 @@ bincode = { workspace = true }
 # cu-consolemon = { path = "../../components/monitors/cu_consolemon", default-features = false, version = "0.6" }  # needed
 cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "0.7.0" } # needed
 cu-rp-gpio = { path = "../../components/sinks/cu_rp_gpio", version = "0.7.0" }
-tempfile = "3.18.0"
+tempfile = { workspace = true }
 
 
 [features]

--- a/examples/cu_pointclouds/Cargo.toml
+++ b/examples/cu_pointclouds/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 [dependencies]
 cu29 = { workspace = true }
 cu29-helpers = { workspace = true }
-tempfile = "3.14.0"
+tempfile = { workspace = true }
 cu-hesai = { path = "../../components/sources/cu_hesai", version = "0.7.0" }
 cu-udp-inject = { path = "../../components/testing/cu_udp_inject", version = "0.7.0" }
 cu-sensor-payloads = { path = "../../components/payloads/cu_sensor_payloads", version = "0.7.0" }

--- a/examples/cu_rp_balancebot/Cargo.toml
+++ b/examples/cu_rp_balancebot/Cargo.toml
@@ -23,7 +23,7 @@ cu-rp-sn754410-new = { path = "../../components/sinks/cu_rp_sn754410", version =
 cu-rp-encoder = { path = "../../components/sources/cu_rp_encoder", version = "0.7.0" }
 cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "0.7.0" } # needed
 cu-pid = { path = "../../components/tasks/cu_pid", version = "0.7.0" }
-ctrlc = "3.4.5"
+ctrlc = "3.4.6"
 
 # Log reader depencies
 cu29-export = { workspace = true, optional = true }

--- a/examples/cu_standalone_structlog/Cargo.toml
+++ b/examples/cu_standalone_structlog/Cargo.toml
@@ -21,5 +21,5 @@ path = "src/standardlog_perf.rs"
 [dependencies]
 cu29 = { workspace = true }  # needed
 cu29-clock = { workspace = true }
-log = "0.4.26"
+log = "0.4.27"
 simplelog = "0.12.2"

--- a/templates/cu_full/Cargo.toml.template
+++ b/templates/cu_full/Cargo.toml.template
@@ -25,7 +25,7 @@ logreader = ["dep:cu29-export"]
 
 [dependencies]
 cu29 = { {%if copper_source == "crates.io" %} version = "*" {%elsif copper_source == "git" %} git = "https://github.com/copper-project/copper-rs.git" {%elsif copper_source == "local" %}path = "../../core/cu29" {%endif %} }
-bincode = { version = "2.0.0", features = ["derive"] }
+bincode = { version = "2.0.1", features = ["derive"] }
 cu29-helpers = { {%if copper_source == "crates.io" %}version = "*" {%elsif copper_source == "git" %} git = "https://github.com/copper-project/copper-rs.git" {%elsif copper_source == "local" %}path = "../../core/cu29_helpers" {%endif %} }
 cu29-export = { {%if copper_source == "crates.io" %}version = "*" {%elsif copper_source == "git" %} git = "https://github.com/copper-project/copper-rs.git" {%elsif copper_source == "local" %}path = "../../core/cu29_export" {%endif %}, optional = true }
 


### PR DESCRIPTION
1. bump cudarc from 0.15.0 to 0.16.0 https://github.com/coreylowman/cudarc/compare/v0.15.0...v0.16.0
2. bump libmacchina from 8.0.0 to 8.1.0 https://github.com/Macchina-CLI/libmacchina/compare/8.0.0...v8.1.0
3. bump circular-buffer from 1.0.0 to 1.1.0 https://github.com/andreacorbellini/rust-circular-buffer/compare/v1.0.0...v1.1.0
4. bump ordered-float from 4.5.0 to 5.0.0 https://github.com/reem/rust-ordered-float/compare/v4.5.0...v5.0.0