### PR TITLE
[WIP] Adding Missions and Includes

### DIFF
--- a/components/monitors/cu_consolemon/src/lib.rs
+++ b/components/monitors/cu_consolemon/src/lib.rs
@@ -148,18 +148,23 @@ impl NodesScrollableWidgetState {
     fn new(config: &CuConfig, errors: Arc<Mutex<Vec<TaskStatus>>>) -> Self {
         let mut config_nodes: Vec<Node> = Vec::new();
         let mut node_types: Vec<NodeType> = Vec::new();
-        for (_, node) in config.get_all_nodes() {
+        for (_, node) in config.get_all_nodes(None) {
+            // FIXME(gbin): Multimission
             config_nodes.push(node.clone());
             node_types.push(NodeType::Unknown);
         }
-        let mut connections: Vec<Connection> = Vec::with_capacity(config.graph.edge_count());
+        let graph = config
+            .get_graph(None)
+            .expect("Only supported for simple config");
+        let mut connections: Vec<Connection> = Vec::with_capacity(graph.edge_count()); // FIXME(gbin): Multimission
 
         // Keep track if we already used a port.
         for (dst_index, dst_node) in config_nodes.iter().enumerate() {
-            let node_incoming_edges = config.get_dst_edges(dst_index as u32);
+            let node_incoming_edges = config
+                .get_dst_edges(dst_index as u32, None)
+                .expect("Only supported for simple config"); // FIXME(gbin): Multimission
             for (dst_port, edge_id) in node_incoming_edges.iter().enumerate() {
-                if let Some((src_index, dst_index)) =
-                    config.graph.edge_endpoints((*edge_id as u32).into())
+                if let Some((src_index, dst_index)) = graph.edge_endpoints((*edge_id as u32).into())
                 {
                     let (src_index, dst_index) = (src_index.index(), dst_index.index());
                     connections.push(Connection::new(

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -1312,7 +1312,7 @@ fn extract_tasks_types(
         .iter()
         .map(|(id, _)| {
             find_task_type_for_id(
-                &copper_config
+                copper_config
                     .get_graph(None)
                     .expect("Only implemented for Simple"),
                 *id,

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -219,6 +219,7 @@ pub struct Node {
 }
 
 impl Node {
+    #[allow(dead_code)]
     pub fn new(id: &str, ptype: &str) -> Self {
         Node {
             id: id.to_string(),
@@ -250,6 +251,7 @@ impl Node {
         self.config.as_ref()
     }
 
+    #[allow(dead_code)]
     pub fn get_param<T: From<Value>>(&self, key: &str) -> Option<T> {
         let pc = self.config.as_ref()?;
         let ComponentConfig(pc) = pc;
@@ -257,6 +259,7 @@ impl Node {
         Some(T::from(v.clone()))
     }
 
+    #[allow(dead_code)]
     pub fn set_param<T: Into<Value>>(&mut self, key: &str, value: T) {
         if self.config.is_none() {
             self.config = Some(ComponentConfig(HashMap::new()));
@@ -280,11 +283,6 @@ pub struct Cnx {
 
     /// Restrict this connection for this list of missions.
     pub missions: Option<Vec<String>>,
-
-    /// Tells Copper to batch messages before sending the buffer to the next node.
-    /// If None, Copper will just send 1 message at a time.
-    /// If Some(n), Copper will batch n messages before sending the buffer.
-    pub batch: Option<u32>,
 
     /// Tells Copper if it needs to log the messages.
     pub store: Option<bool>,
@@ -387,7 +385,6 @@ impl ConfigGraphs {
         source: NodeId,
         target: NodeId,
         msg_type: &str,
-        batch: Option<u32>,
         store: Option<bool>,
         mission_id: Option<&str>,
         missions: Option<Vec<String>>,
@@ -412,7 +409,6 @@ impl ConfigGraphs {
                 dst: dst_id,
                 msg: msg_type.to_string(),
                 missions,
-                batch,
                 store,
             },
         );
@@ -669,10 +665,12 @@ pub struct MonitorConfig {
 }
 
 impl MonitorConfig {
+    #[allow(dead_code)]
     pub fn get_type(&self) -> &str {
         &self.type_
     }
 
+    #[allow(dead_code)]
     pub fn get_config(&self) -> Option<&ComponentConfig> {
         self.config.as_ref()
     }
@@ -788,7 +786,6 @@ impl<'de> Deserialize<'de> for CuConfig {
                                         src.index() as NodeId,
                                         dst.index() as NodeId,
                                         &c.msg,
-                                        c.batch,
                                         c.store,
                                         Some(mission_id),
                                         Some(cnx_missions.clone()),
@@ -824,7 +821,6 @@ impl<'de> Deserialize<'de> for CuConfig {
                                     src.index() as NodeId,
                                     dst.index() as NodeId,
                                     &c.msg,
-                                    c.batch,
                                     c.store,
                                     Some(mission_id),
                                     None,
@@ -865,7 +861,6 @@ impl<'de> Deserialize<'de> for CuConfig {
                             src.index() as NodeId,
                             dst.index() as NodeId,
                             &c.msg,
-                            c.batch,
                             c.store,
                             None,
                             None,
@@ -959,10 +954,12 @@ impl CuConfig {
     /// Add a new node to the configuration graph.
     /// If mission_id is provided, adds the node to that mission's graph.
     /// Otherwise adds it to the simple graph.
+    #[allow(dead_code)]
     pub fn add_node(&mut self, node: Node, mission_id: Option<&str>) -> CuResult<NodeId> {
         self.graphs.add_node(node, mission_id)
     }
 
+    #[allow(dead_code)]
     pub fn get_node(&self, node_id: NodeId, mission_id: Option<&str>) -> Option<&Node> {
         self.graphs.get_node(node_id, mission_id)
     }
@@ -1019,24 +1016,25 @@ impl CuConfig {
     /// msg_type is the type of message exchanged between the two nodes/tasks.
     /// batch is the number of messages to batch before sending the buffer.
     /// store tells Copper if it needs to log the messages.
+    #[allow(dead_code)]
     pub fn connect_ext(
         &mut self,
         source: NodeId,
         target: NodeId,
         msg_type: &str,
-        batch: Option<u32>,
         store: Option<bool>,
         mission_id: Option<&str>,
         missions: Option<Vec<String>>,
     ) -> CuResult<()> {
         self.graphs
-            .connect_ext(source, target, msg_type, batch, store, mission_id, missions)
+            .connect_ext(source, target, msg_type, store, mission_id, missions)
     }
 
     /// Adds an edge between two nodes/tasks in the configuration graph.
     /// msg_type is the type of message exchanged between the two nodes/tasks.
+    #[allow(dead_code)]
     pub fn connect(&mut self, source: NodeId, target: NodeId, msg_type: &str) -> CuResult<()> {
-        self.connect_ext(source, target, msg_type, None, None, None, None)
+        self.connect_ext(source, target, msg_type, None, None, None)
     }
 
     fn get_options() -> Options {
@@ -1139,6 +1137,7 @@ impl CuConfig {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub fn get_all_instances_configs(
         &self,
         mission_id: Option<&str>,
@@ -1149,10 +1148,12 @@ impl CuConfig {
             .collect()
     }
 
+    #[allow(dead_code)]
     pub fn get_graph(&self, mission_id: Option<&str>) -> CuResult<&CuGraph> {
         self.graphs.get_graph(mission_id)
     }
 
+    #[allow(dead_code)]
     pub fn get_graph_mut(&mut self, mission_id: Option<&str>) -> CuResult<&mut CuGraph> {
         self.graphs.get_graph_mut(mission_id)
     }

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -1280,7 +1280,6 @@ mod tests {
         CuConfig::deserialize_ron(txt);
     }
     #[test]
-    #[should_panic(expected = "missing field `tasks`")]
     fn test_missions() {
         let txt = r#"( missions: [ (id: "data_collection"), (id: "autonomous")])"#;
         let config = CuConfig::deserialize_ron(txt);

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -5,9 +5,10 @@
 
 use cu29_traits::{CuError, CuResult};
 use html_escape::encode_text;
-use petgraph::adj::NodeIndex;
 use petgraph::stable_graph::{EdgeIndex, StableDiGraph};
 use petgraph::visit::EdgeRef;
+pub use petgraph::Direction::Incoming;
+pub use petgraph::Direction::Outgoing;
 use ron::extensions::Extensions;
 use ron::value::Value as RonValue;
 use ron::{Number, Options};
@@ -16,6 +17,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Display;
 use std::fs::read_to_string;
+use ConfigGraphs::{Missions, Simple};
 
 /// NodeId is the unique identifier of a node in the configuration graph for petgraph
 /// and the code generation.
@@ -217,7 +219,6 @@ pub struct Node {
 }
 
 impl Node {
-    #[allow(dead_code)]
     pub fn new(id: &str, ptype: &str) -> Self {
         Node {
             id: id.to_string(),
@@ -239,6 +240,7 @@ impl Node {
         self
     }
 
+    #[allow(dead_code)]
     pub fn get_type(&self) -> &str {
         self.type_.as_ref().unwrap()
     }
@@ -248,7 +250,6 @@ impl Node {
         self.config.as_ref()
     }
 
-    #[allow(dead_code)]
     pub fn get_param<T: From<Value>>(&self, key: &str) -> Option<T> {
         let pc = self.config.as_ref()?;
         let ComponentConfig(pc) = pc;
@@ -256,7 +257,6 @@ impl Node {
         Some(T::from(v.clone()))
     }
 
-    #[allow(dead_code)]
     pub fn set_param<T: Into<Value>>(&mut self, key: &str, value: T) {
         if self.config.is_none() {
             self.config = Some(ComponentConfig(HashMap::new()));
@@ -292,15 +292,372 @@ pub struct Cnx {
 
 pub type CuGraph = StableDiGraph<Node, Cnx, NodeId>;
 
+#[derive(Debug, Clone)]
+pub enum ConfigGraphs {
+    Simple(CuGraph),
+    Missions(HashMap<String, CuGraph>),
+}
+
+impl ConfigGraphs {
+    #[allow(dead_code)]
+    pub fn get_all_nodes(&self, mission_id: Option<&str>) -> Vec<(NodeId, &Node)> {
+        match self {
+            Simple(graph) => {
+                if mission_id.is_none() {
+                    graph
+                        .node_indices()
+                        .map(|index| (index.index() as u32, &graph[index]))
+                        .collect()
+                } else {
+                    Vec::new()
+                }
+            }
+            Missions(graphs) => {
+                if let Some(id) = mission_id {
+                    if let Some(graph) = graphs.get(id) {
+                        graph
+                            .node_indices()
+                            .map(|index| (index.index() as u32, &graph[index]))
+                            .collect()
+                    } else {
+                        Vec::new()
+                    }
+                } else {
+                    Vec::new()
+                }
+            }
+        }
+    }
+
+    pub fn node_indices(&self, mission_id: Option<&str>) -> Vec<petgraph::stable_graph::NodeIndex> {
+        match self {
+            Simple(graph) => {
+                if mission_id.is_none() {
+                    graph.node_indices().collect()
+                } else {
+                    Vec::new()
+                }
+            }
+            Missions(graphs) => {
+                if let Some(id) = mission_id {
+                    graphs
+                        .get(id)
+                        .map(|graph| graph.node_indices().collect())
+                        .unwrap_or_default()
+                } else {
+                    Vec::new()
+                }
+            }
+        }
+    }
+
+    pub fn get_node_input_msg_type(
+        &self,
+        node_id: &str,
+        mission_id: Option<&str>,
+    ) -> Option<String> {
+        match self {
+            Simple(graph) => {
+                if mission_id.is_none() {
+                    ConfigGraphs::get_node_input_msg_type_from_graph(graph, node_id)
+                } else {
+                    None
+                }
+            }
+            Missions(graphs) => {
+                if let Some(id) = mission_id {
+                    if let Some(graph) = graphs.get(id) {
+                        ConfigGraphs::get_node_input_msg_type_from_graph(graph, node_id)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+        }
+    }
+    pub fn add_node(&mut self, node: Node, mission_id: Option<&str>) -> CuResult<NodeId> {
+        let graph = self.get_graph_mut(mission_id)?;
+        Ok(graph.add_node(node).index() as NodeId)
+    }
+
+    pub fn connect_ext(
+        &mut self,
+        source: NodeId,
+        target: NodeId,
+        msg_type: &str,
+        batch: Option<u32>,
+        store: Option<bool>,
+        mission_id: Option<&str>,
+        missions: Option<Vec<String>>,
+    ) -> CuResult<()> {
+        let (src_id, dst_id) = (
+            self.get_node(source, mission_id)
+                .ok_or("Source node not found")?
+                .id
+                .clone(),
+            self.get_node(target, mission_id)
+                .ok_or("Target node not found")?
+                .id
+                .clone(),
+        );
+
+        let graph = self.get_graph_mut(mission_id)?;
+        graph.add_edge(
+            source.into(),
+            target.into(),
+            Cnx {
+                src: src_id,
+                dst: dst_id,
+                msg: msg_type.to_string(),
+                missions,
+                batch,
+                store,
+            },
+        );
+        Ok(())
+    }
+
+    pub fn get_graph(&self, mission_id: Option<&str>) -> CuResult<&CuGraph> {
+        match self {
+            Simple(graph) => {
+                if mission_id.is_none() {
+                    Ok(graph)
+                } else {
+                    Err("Cannot get mission graph from simple config".into())
+                }
+            }
+            Missions(graphs) => {
+                if let Some(id) = mission_id {
+                    graphs
+                        .get(id)
+                        .ok_or_else(|| format!("Mission {id} not found").into())
+                } else {
+                    Err("Mission ID required for mission configs".into())
+                }
+            }
+        }
+    }
+
+    /// Get the node with the given id.
+    /// If mission_id is provided, get the node from that mission's graph.
+    /// Otherwise get the node from the simple graph.
+    pub fn get_node(&self, node_id: NodeId, mission_id: Option<&str>) -> Option<&Node> {
+        match self {
+            Simple(graph) => {
+                if mission_id.is_none() {
+                    graph.node_weight(node_id.into())
+                } else {
+                    None
+                }
+            }
+            Missions(graphs) => {
+                if let Some(id) = mission_id {
+                    if let Some(graph) = graphs.get(id) {
+                        graph.node_weight(node_id.into())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    pub fn get_node_mut(&mut self, node_id: NodeId, mission_id: Option<&str>) -> Option<&mut Node> {
+        match self {
+            Simple(graph) => {
+                if mission_id.is_none() {
+                    graph.node_weight_mut(node_id.into())
+                } else {
+                    None
+                }
+            }
+            Missions(graphs) => {
+                if let Some(id) = mission_id {
+                    if let Some(graph) = graphs.get_mut(id) {
+                        graph.node_weight_mut(node_id.into())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    pub fn get_node_output_msg_type(
+        &self,
+        node_id: &str,
+        mission_id: Option<&str>,
+    ) -> Option<String> {
+        match self {
+            Simple(graph) => {
+                if mission_id.is_none() {
+                    ConfigGraphs::get_node_output_msg_type_from_graph(graph, node_id)
+                } else {
+                    None
+                }
+            }
+            Missions(graphs) => {
+                if let Some(id) = mission_id {
+                    if let Some(graph) = graphs.get(id) {
+                        ConfigGraphs::get_node_output_msg_type_from_graph(graph, node_id)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    pub fn get_graph_mut(&mut self, mission_id: Option<&str>) -> CuResult<&mut CuGraph> {
+        match self {
+            Simple(graph) => {
+                if mission_id.is_none() {
+                    Ok(graph)
+                } else {
+                    Err("Cannot get mission graph from simple config".into())
+                }
+            }
+            ConfigGraphs::Missions(graphs) => {
+                if let Some(id) = mission_id {
+                    graphs
+                        .get_mut(id)
+                        .ok_or_else(|| format!("Mission {id} not found").into())
+                } else {
+                    Err("Mission ID required for mission configs".into())
+                }
+            }
+        }
+    }
+
+    pub fn get_edge_weight(&self, index: usize, mission_id: Option<&str>) -> Option<Cnx> {
+        match self {
+            Simple(graph) => {
+                if mission_id.is_none() {
+                    graph.edge_weight(EdgeIndex::new(index)).cloned()
+                } else {
+                    None
+                }
+            }
+            Missions(graphs) => {
+                if let Some(id) = mission_id {
+                    graphs.get(id)?.edge_weight(EdgeIndex::new(index)).cloned()
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    fn get_node_output_msg_type_from_graph(graph: &CuGraph, node_id: &str) -> Option<String> {
+        graph.node_indices().find_map(|node_index| {
+            if let Some(node) = graph.node_weight(node_index) {
+                if node.id != node_id {
+                    return None;
+                }
+                let edges: Vec<_> = graph
+                    .edges_directed(node_index, Outgoing)
+                    .map(|edge| edge.id().index())
+                    .collect();
+                if edges.is_empty() {
+                    panic!("A CuSrcTask is configured with no task connected to it.")
+                }
+                let cnx = graph
+                    .edge_weight(EdgeIndex::new(edges[0]))
+                    .expect("Found an cnx id but could not retrieve it back");
+                return Some(cnx.msg.clone());
+            }
+            None
+        })
+    }
+
+    fn get_node_input_msg_type_from_graph(graph: &CuGraph, node_id: &str) -> Option<String> {
+        graph.node_indices().find_map(|node_index| {
+            if let Some(node) = graph.node_weight(node_index) {
+                if node.id != node_id {
+                    return None;
+                }
+                let edges: Vec<_> = graph
+                    .edges_directed(node_index, Incoming)
+                    .map(|edge| edge.id().index())
+                    .collect();
+                if edges.is_empty() {
+                    panic!("A CuSinkTask is configured with no task connected to it.")
+                }
+                let cnx = graph
+                    .edge_weight(EdgeIndex::new(edges[0]))
+                    .expect("Found an cnx id but could not retrieve it back");
+                return Some(cnx.msg.clone());
+            }
+            None
+        })
+    }
+
+    /// Get the list of edges that are connected to the given node as a source.
+    fn get_edges_by_direction(
+        &self,
+        node_id: NodeId,
+        mission_id: Option<&str>,
+        direction: petgraph::Direction,
+    ) -> CuResult<Vec<usize>> {
+        match self {
+            Simple(graph) => {
+                if mission_id.is_none() {
+                    Ok(graph
+                        .edges_directed(node_id.into(), direction)
+                        .map(|edge| edge.id().index())
+                        .collect())
+                } else {
+                    Err(CuError::from("Cannot get mission edges from simple graph"))
+                }
+            }
+            Missions(graphs) => {
+                if let Some(id) = mission_id {
+                    if let Some(graph) = graphs.get(id) {
+                        Ok(graph
+                            .edges_directed(node_id.into(), direction)
+                            .map(|edge| edge.id().index())
+                            .collect())
+                    } else {
+                        Err(CuError::from(format!("Mission {id} not found")))
+                    }
+                } else {
+                    Err(CuError::from("Mission ID required for mission graphs"))
+                }
+            }
+        }
+    }
+
+    pub fn add_mission(&mut self, mission_id: &str) -> CuResult<()> {
+        match self {
+            Simple(_) => Err("Cannot add mission to simple config".into()),
+            Missions(graphs) => {
+                if graphs.contains_key(mission_id) {
+                    Err(format!("Mission {mission_id} already exists").into())
+                } else {
+                    graphs.insert(mission_id.to_string(), CuGraph::default());
+                    Ok(())
+                }
+            }
+        }
+    }
+}
+
 /// CuConfig is the programmatic representation of the configuration graph.
 /// It is a directed graph where nodes are tasks and edges are connections between tasks.
 #[derive(Debug, Clone)]
 pub struct CuConfig {
     // This is not what is directly serialized, see the custom serialization below.
-    pub graph: CuGraph,
     pub monitor: Option<MonitorConfig>,
     pub logging: Option<LoggingConfig>,
-    pub missions: HashMap<String, CuGraph>,
+    pub graphs: ConfigGraphs,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
@@ -312,12 +669,10 @@ pub struct MonitorConfig {
 }
 
 impl MonitorConfig {
-    #[allow(dead_code)]
     pub fn get_type(&self) -> &str {
         &self.type_
     }
 
-    #[allow(dead_code)]
     pub fn get_config(&self) -> Option<&ComponentConfig> {
         self.config.as_ref()
     }
@@ -370,48 +725,160 @@ impl<'de> Deserialize<'de> for CuConfig {
     {
         let representation =
             CuConfigRepresentation::deserialize(deserializer).map_err(serde::de::Error::custom)?;
-
         let mut cuconfig = CuConfig::default();
-        if let Some(tasks) = representation.tasks {
-            for task in tasks {
-                cuconfig.add_node(task);
-            }
-        }
 
-        if let Some(cnx) = representation.cnx {
-            for c in cnx {
-                let src = cuconfig
-                    .graph
-                    .node_indices()
-                    .find(|i| cuconfig.graph[*i].id == c.src)
-                    .expect("Source node not found");
-                let dst = cuconfig
-                    .graph
-                    .node_indices()
-                    .find(|i| cuconfig.graph[*i].id == c.dst)
-                    .unwrap_or_else(|| panic!("Destination {} node not found", c.dst));
-                cuconfig.connect_ext(
-                    src.index() as NodeId,
-                    dst.index() as NodeId,
-                    &c.msg,
-                    c.missions,
-                    c.batch,
-                    c.store,
-                );
+        if let Some(mission_configs) = &representation.missions {
+            // This is the multi-mission case
+            let mut missions = Missions(HashMap::new());
+
+            for mission_config in mission_configs {
+                let mission_id = mission_config.id.as_str();
+                missions
+                    .add_mission(mission_id)
+                    .map_err(serde::de::Error::custom)?;
+                if let Some(tasks) = &representation.tasks {
+                    for task in tasks {
+                        if let Some(task_missions) = &task.missions {
+                            // if there is a filter by mission on the task, only add the task to the mission if it matches the filter.
+                            if task_missions.contains(&mission_id.to_owned()) {
+                                missions
+                                    .add_node(task.clone(), Some(mission_id))
+                                    .map_err(serde::de::Error::custom)?;
+                            }
+                        } else {
+                            // if there is no filter by mission on the task, add the task to the mission.
+                            missions
+                                .add_node(task.clone(), Some(mission_id))
+                                .map_err(serde::de::Error::custom)?;
+                        }
+                    }
+                }
+
+                if let Some(cnx) = &representation.cnx {
+                    for c in cnx {
+                        if let Some(cnx_missions) = &c.missions {
+                            // if there is a filter by mission on the connection, only add the connection to the mission if it matches the filter.
+                            if cnx_missions.contains(&mission_id.to_owned()) {
+                                let src = missions
+                                    .node_indices(Some(mission_id))
+                                    .into_iter()
+                                    .find(|i| {
+                                        missions
+                                            .get_node(i.index() as NodeId, Some(mission_id))
+                                            .unwrap()
+                                            .id
+                                            == c.src
+                                    })
+                                    .expect("Source node not found");
+                                let dst = missions
+                                    .node_indices(Some(mission_id))
+                                    .into_iter()
+                                    .find(|i| {
+                                        missions
+                                            .get_node(i.index() as NodeId, Some(mission_id))
+                                            .unwrap()
+                                            .id
+                                            == c.dst
+                                    })
+                                    .unwrap_or_else(|| {
+                                        panic!("Destination {} node not found", c.dst)
+                                    });
+                                missions
+                                    .connect_ext(
+                                        src.index() as NodeId,
+                                        dst.index() as NodeId,
+                                        &c.msg,
+                                        c.batch,
+                                        c.store,
+                                        Some(mission_id),
+                                        Some(cnx_missions.clone()),
+                                    )
+                                    .map_err(serde::de::Error::custom)?;
+                            }
+                        } else {
+                            // if there is no filter by mission on the connection, add the connection to the mission.
+                            let src = missions
+                                .node_indices(Some(mission_id))
+                                .into_iter()
+                                .find(|i| {
+                                    missions
+                                        .get_node(i.index() as NodeId, Some(mission_id))
+                                        .unwrap()
+                                        .id
+                                        == c.src
+                                })
+                                .expect("Source node not found");
+                            let dst = missions
+                                .node_indices(Some(mission_id))
+                                .into_iter()
+                                .find(|i| {
+                                    missions
+                                        .get_node(i.index() as NodeId, Some(mission_id))
+                                        .unwrap()
+                                        .id
+                                        == c.dst
+                                })
+                                .unwrap_or_else(|| panic!("Destination {} node not found", c.dst));
+                            missions
+                                .connect_ext(
+                                    src.index() as NodeId,
+                                    dst.index() as NodeId,
+                                    &c.msg,
+                                    c.batch,
+                                    c.store,
+                                    Some(mission_id),
+                                    None,
+                                )
+                                .map_err(serde::de::Error::custom)?;
+                        }
+                    }
+                }
             }
+            cuconfig.graphs = missions;
+            // TODO: Continue
+        } else {
+            // this is the simple case
+            let mut graphs = Simple(CuGraph::default());
+
+            if let Some(tasks) = representation.tasks {
+                for task in tasks {
+                    graphs
+                        .add_node(task, None)
+                        .map_err(serde::de::Error::custom)?;
+                }
+            }
+
+            if let Some(cnx) = representation.cnx {
+                for c in cnx {
+                    let src = graphs
+                        .node_indices(None)
+                        .into_iter()
+                        .find(|i| graphs.get_node(i.index() as NodeId, None).unwrap().id == c.src)
+                        .expect("Source node not found");
+                    let dst = graphs
+                        .node_indices(None)
+                        .into_iter()
+                        .find(|i| graphs.get_node(i.index() as NodeId, None).unwrap().id == c.dst)
+                        .unwrap_or_else(|| panic!("Destination {} node not found", c.dst));
+                    graphs
+                        .connect_ext(
+                            src.index() as NodeId,
+                            dst.index() as NodeId,
+                            &c.msg,
+                            c.batch,
+                            c.store,
+                            None,
+                            None,
+                        )
+                        .map_err(serde::de::Error::custom)?;
+                }
+            }
+            cuconfig.graphs = graphs;
         }
 
         cuconfig.monitor = representation.monitor;
         cuconfig.logging = representation.logging;
 
-        // Build the missions one by one.
-        if let Some(mission_configs) = &representation.missions {
-            for mission in mission_configs {
-                let id = mission.id.clone();
-                let mission_graph = StableDiGraph::new();
-                cuconfig.missions.insert(id, mission_graph);
-            }
-        }
         Ok(cuconfig)
     }
 }
@@ -422,37 +889,51 @@ impl Serialize for CuConfig {
     where
         S: Serializer,
     {
-        let tasks: Vec<Node> = self
-            .graph
-            .node_indices()
-            .map(|idx| self.graph[idx].clone())
-            .collect();
+        match &self.graphs {
+            Simple(graph) => {
+                let tasks: Vec<Node> = graph.node_indices().map(|idx| graph[idx].clone()).collect();
 
-        let cnx: Vec<Cnx> = self
-            .graph
-            .edge_indices()
-            .map(|edge| self.graph[edge].clone())
-            .collect();
+                let cnx: Vec<Cnx> = graph
+                    .edge_indices()
+                    .map(|edge| graph[edge].clone())
+                    .collect();
 
-        CuConfigRepresentation {
-            tasks: Some(tasks),
-            cnx: Some(cnx),
-            monitor: self.monitor.clone(),
-            logging: self.logging.clone(),
-            missions: None,
-            includes: None,
+                CuConfigRepresentation {
+                    tasks: Some(tasks),
+                    cnx: Some(cnx),
+                    monitor: self.monitor.clone(),
+                    logging: self.logging.clone(),
+                    missions: None,
+                    includes: None,
+                }
+                .serialize(serializer)
+            }
+            Missions(graphs) => {
+                let missions = graphs
+                    .keys()
+                    .map(|id| MissionsConfig { id: id.clone() })
+                    .collect();
+
+                CuConfigRepresentation {
+                    tasks: None,
+                    cnx: None,
+                    monitor: self.monitor.clone(),
+                    logging: self.logging.clone(),
+                    missions: Some(missions),
+                    includes: None,
+                }
+                .serialize(serializer)
+            }
         }
-        .serialize(serializer)
     }
 }
 
 impl Default for CuConfig {
     fn default() -> Self {
         CuConfig {
-            graph: StableDiGraph::new(),
+            graphs: Simple(StableDiGraph::new()),
             monitor: None,
             logging: None,
-            missions: HashMap::new(),
         }
     }
 }
@@ -460,94 +941,78 @@ impl Default for CuConfig {
 /// The implementation has a lot of convenience methods to manipulate
 /// the configuration to give some flexibility into programmatically creating the configuration.
 impl CuConfig {
-    /// Add a new node to the configuration graph.
-    pub fn add_node(&mut self, node: Node) -> NodeId {
-        self.graph.add_node(node).index() as NodeId
+    #[allow(dead_code)]
+    pub fn new_simple_type() -> Self {
+        Self::default()
     }
 
-    /// Get the node with the given id.
-    #[allow(dead_code)] // Used in proc macro
-    pub fn get_node(&self, node_id: NodeId) -> Option<&Node> {
-        self.graph.node_weight(node_id.into())
+    #[allow(dead_code)]
+    pub fn new_mission_type() -> Self {
+        CuConfig {
+            graphs: Missions(HashMap::new()),
+            monitor: None,
+            logging: None,
+        }
+    }
+
+    /// Add a new node to the simple configuration graph.
+    /// Add a new node to the configuration graph.
+    /// If mission_id is provided, adds the node to that mission's graph.
+    /// Otherwise adds it to the simple graph.
+    pub fn add_node(&mut self, node: Node, mission_id: Option<&str>) -> CuResult<NodeId> {
+        self.graphs.add_node(node, mission_id)
+    }
+
+    pub fn get_node(&self, node_id: NodeId, mission_id: Option<&str>) -> Option<&Node> {
+        self.graphs.get_node(node_id, mission_id)
     }
 
     /// Get the node with the given id mutably.
     #[allow(dead_code)] // Used in proc macro
-    pub fn get_node_mut(&mut self, node_id: NodeId) -> Option<&mut Node> {
-        self.graph.node_weight_mut(node_id.into())
+    pub fn get_node_mut(&mut self, node_id: NodeId, mission_id: Option<&str>) -> Option<&mut Node> {
+        self.graphs.get_node_mut(node_id, mission_id)
     }
 
-    /// this is more like infer from the connections of this node.
     #[allow(dead_code)] // Used in proc macro
-    pub fn get_node_output_msg_type(&self, node_id: &str) -> Option<String> {
-        self.graph.node_indices().find_map(|node_index| {
-            if let Some(node) = self.get_node(node_index.index() as u32) {
-                if node.id != node_id {
-                    return None;
-                }
-                let edges = self.get_src_edges(node_index.index() as u32);
-                if edges.is_empty() {
-                    panic!("A CuSrcTask is configured with no task connected to it.")
-                }
-                let cnx = self
-                    .graph
-                    .edge_weight(EdgeIndex::new(edges[0]))
-                    .expect("Found an cnx id but could not retrieve it back");
-                return Some(cnx.msg.clone());
-            }
-            None
-        })
+    pub fn get_node_output_msg_type(
+        &self,
+        node_id: &str,
+        mission_id: Option<&str>,
+    ) -> Option<String> {
+        self.graphs.get_node_output_msg_type(node_id, mission_id)
     }
 
-    /// this is more like infer from the connections of this node.
     #[allow(dead_code)] // Used in proc macro
-    pub fn get_node_input_msg_type(&self, node_id: &str) -> Option<String> {
-        self.graph.node_indices().find_map(|node_index| {
-            if let Some(node) = self.get_node(node_index.index() as u32) {
-                if node.id != node_id {
-                    return None;
-                }
-                let edges = self.get_dst_edges(node_index.index() as u32);
-                if edges.is_empty() {
-                    panic!("A CuSinkTask is configured with no task connected to it.")
-                }
-                let cnx = self
-                    .graph
-                    .edge_weight(EdgeIndex::new(edges[0]))
-                    .expect("Found an cnx id but could not retrieve it back");
-                return Some(cnx.msg.clone());
-            }
-            None
-        })
+    pub fn get_node_input_msg_type(
+        &self,
+        node_id: &str,
+        mission_id: Option<&str>,
+    ) -> Option<String> {
+        self.graphs.get_node_input_msg_type(node_id, mission_id)
     }
 
-    /// Get the list of edges that are connected to the given node as a source.
-    pub fn get_src_edges(&self, node_id: NodeId) -> Vec<usize> {
-        self.graph
-            .edges_directed(node_id.into(), petgraph::Direction::Outgoing)
-            .map(|edge| edge.id().index())
-            .collect()
+    pub fn get_src_edges(&self, node_id: NodeId, mission_id: Option<&str>) -> CuResult<Vec<usize>> {
+        self.graphs
+            .get_edges_by_direction(node_id, mission_id, Outgoing)
     }
 
     /// Get the list of edges that are connected to the given node as a destination.
-    pub fn get_dst_edges(&self, node_id: NodeId) -> Vec<usize> {
-        self.graph
-            .edges_directed(node_id.into(), petgraph::Direction::Incoming)
-            .map(|edge| edge.id().index())
-            .collect()
+    pub fn get_dst_edges(&self, node_id: NodeId, mission_id: Option<&str>) -> CuResult<Vec<usize>> {
+        self.graphs
+            .get_edges_by_direction(node_id, mission_id, Incoming)
     }
 
     #[allow(dead_code)]
-    pub fn get_edge_weight(&self, index: usize) -> Option<Cnx> {
-        self.graph.edge_weight(EdgeIndex::new(index)).cloned()
+    pub fn get_edge_weight(&self, index: usize, mission_id: Option<&str>) -> Option<Cnx> {
+        self.graphs.get_edge_weight(index, mission_id)
     }
 
     /// Convenience method to get all nodes in the configuration graph.
-    pub fn get_all_nodes(&self) -> Vec<(NodeIndex, &Node)> {
-        self.graph
-            .node_indices()
-            .map(|index| (index.index() as u32, &self.graph[index]))
-            .collect()
+    /// If mission_id is provided, gets nodes from that mission's graph.
+    /// Otherwise gets nodes from the simple graph.
+    #[allow(dead_code)]
+    pub fn get_all_nodes(&self, mission_id: Option<&str>) -> Vec<(NodeId, &Node)> {
+        self.graphs.get_all_nodes(mission_id)
     }
 
     /// Adds an edge between two nodes/tasks in the configuration graph.
@@ -559,38 +1024,19 @@ impl CuConfig {
         source: NodeId,
         target: NodeId,
         msg_type: &str,
-        missions: Option<Vec<String>>,
         batch: Option<u32>,
         store: Option<bool>,
-    ) {
-        // TODO: build the mission hashmap here.
-        self.graph.add_edge(
-            source.into(),
-            target.into(),
-            Cnx {
-                src: self
-                    .get_node(source)
-                    .expect("Source node not found")
-                    .id
-                    .clone(),
-                dst: self
-                    .get_node(target)
-                    .expect("Target node not found")
-                    .id
-                    .clone(),
-                msg: msg_type.to_string(),
-                missions,
-                batch,
-                store,
-            },
-        );
+        mission_id: Option<&str>,
+        missions: Option<Vec<String>>,
+    ) -> CuResult<()> {
+        self.graphs
+            .connect_ext(source, target, msg_type, batch, store, mission_id, missions)
     }
 
     /// Adds an edge between two nodes/tasks in the configuration graph.
     /// msg_type is the type of message exchanged between the two nodes/tasks.
-    #[allow(dead_code)]
-    pub fn connect(&mut self, source: NodeId, target: NodeId, msg_type: &str) {
-        self.connect_ext(source, target, msg_type, None, None, None);
+    pub fn connect(&mut self, source: NodeId, target: NodeId, msg_type: &str) -> CuResult<()> {
+        self.connect_ext(source, target, msg_type, None, None, None, None)
     }
 
     fn get_options() -> Options {
@@ -618,11 +1064,17 @@ impl CuConfig {
     }
 
     /// Render the configuration graph in the dot format.
-    pub fn render(&self, output: &mut dyn std::io::Write) {
+    pub fn render(
+        &self,
+        output: &mut dyn std::io::Write,
+        mission_id: Option<&str>,
+    ) -> CuResult<()> {
         writeln!(output, "digraph G {{").unwrap();
 
-        for index in self.graph.node_indices() {
-            let node = &self.graph[index];
+        let graph = self.graphs.get_graph(mission_id)?;
+
+        for index in graph.node_indices() {
+            let node = &graph[index];
             let config_str = match &node.config {
                 Some(config) => {
                     let config_str = config
@@ -640,8 +1092,14 @@ impl CuConfig {
             writeln!(output, "style=\"rounded, filled\",").unwrap();
             writeln!(output, "fontname=\"Noto Sans\"").unwrap();
 
-            let is_src = self.get_dst_edges(index.index() as NodeId).is_empty();
-            let is_sink = self.get_src_edges(index.index() as NodeId).is_empty();
+            let is_src = self
+                .get_dst_edges(index.index() as NodeId, mission_id)
+                .unwrap_or_default()
+                .is_empty();
+            let is_sink = self
+                .get_src_edges(index.index() as NodeId, mission_id)
+                .unwrap_or_default()
+                .is_empty();
             if is_src {
                 writeln!(output, "fillcolor=lightgreen,").unwrap();
             } else if is_sink {
@@ -663,10 +1121,10 @@ impl CuConfig {
 
             writeln!(output, "];").unwrap();
         }
-        for edge in self.graph.edge_indices() {
-            let (src, dst) = self.graph.edge_endpoints(edge).unwrap();
+        for edge in graph.edge_indices() {
+            let (src, dst) = graph.edge_endpoints(edge).unwrap();
 
-            let cnx = &self.graph[edge];
+            let cnx = &graph[edge];
             let msg = encode_text(&cnx.msg);
             writeln!(
                 output,
@@ -678,14 +1136,25 @@ impl CuConfig {
             .unwrap();
         }
         writeln!(output, "}}").unwrap();
+        Ok(())
     }
 
-    #[allow(dead_code)]
-    pub fn get_all_instances_configs(&self) -> Vec<Option<&ComponentConfig>> {
-        self.get_all_nodes()
+    pub fn get_all_instances_configs(
+        &self,
+        mission_id: Option<&str>,
+    ) -> Vec<Option<&ComponentConfig>> {
+        self.get_all_nodes(mission_id)
             .iter()
             .map(|(_, node)| node.get_instance_config())
             .collect()
+    }
+
+    pub fn get_graph(&self, mission_id: Option<&str>) -> CuResult<&CuGraph> {
+        self.graphs.get_graph(mission_id)
+    }
+
+    pub fn get_graph_mut(&mut self, mission_id: Option<&str>) -> CuResult<&mut CuGraph> {
+        self.graphs.get_graph_mut(mission_id)
     }
 
     #[allow(dead_code)]
@@ -746,13 +1215,19 @@ mod tests {
     #[test]
     fn test_plain_serialize() {
         let mut config = CuConfig::default();
-        let n1 = config.add_node(Node::new("test1", "package::Plugin1"));
-        let n2 = config.add_node(Node::new("test2", "package::Plugin2"));
-        config.connect(n1, n2, "msgpkg::MsgType");
+        let n1 = config
+            .add_node(Node::new("test1", "package::Plugin1"), None)
+            .unwrap();
+        let n2 = config
+            .add_node(Node::new("test2", "package::Plugin2"), None)
+            .unwrap();
+        config.connect(n1, n2, "msgpkg::MsgType").unwrap();
         let serialized = config.serialize_ron();
         let deserialized = CuConfig::deserialize_ron(&serialized);
-        assert_eq!(config.graph.node_count(), deserialized.graph.node_count());
-        assert_eq!(config.graph.edge_count(), deserialized.graph.edge_count());
+        let graph = config.graphs.get_graph(None).unwrap();
+        let deserialized_graph = deserialized.graphs.get_graph(None).unwrap();
+        assert_eq!(graph.node_count(), deserialized_graph.node_count());
+        assert_eq!(graph.edge_count(), deserialized_graph.edge_count());
     }
 
     #[test]
@@ -760,12 +1235,12 @@ mod tests {
         let mut config = CuConfig::default();
         let mut camera = Node::new("copper-camera", "camerapkg::Camera");
         camera.set_param::<Value>("resolution-height", 1080.into());
-        config.add_node(camera);
+        config.add_node(camera, None).unwrap();
         let serialized = config.serialize_ron();
         let deserialized = CuConfig::deserialize_ron(&serialized);
         assert_eq!(
             deserialized
-                .get_node(0)
+                .get_node(0, None)
                 .unwrap()
                 .get_param::<i32>("resolution-height")
                 .unwrap(),
@@ -781,11 +1256,14 @@ mod tests {
         CuConfig::deserialize_ron(txt);
     }
     #[test]
+    #[should_panic(expected = "missing field `tasks`")]
     fn test_missions() {
         let txt = r#"( missions: [ (id: "data_collection"), (id: "autonomous")])"#;
         let config = CuConfig::deserialize_ron(txt);
-        assert!(config.missions.contains_key("data_collection"));
-        assert!(config.missions.contains_key("autonomous"));
+        let graph = config.graphs.get_graph(Some("data_collection")).unwrap();
+        assert!(graph.node_count() == 0);
+        let graph = config.graphs.get_graph(Some("autonomous")).unwrap();
+        assert!(graph.node_count() == 0);
     }
 
     #[test]
@@ -855,15 +1333,54 @@ mod tests {
 
         // the node id depends on the order in which the tasks are added
         let src1_id = 0;
-        assert_eq!(config.get_node(src1_id).unwrap().id, "src1");
+        assert_eq!(config.get_node(src1_id, None).unwrap().id, "src1");
         let src2_id = 1;
-        assert_eq!(config.get_node(src2_id).unwrap().id, "src2");
+        assert_eq!(config.get_node(src2_id, None).unwrap().id, "src2");
 
         // the edge id depends on the order the connection is created
         // the src2 was added second in the tasks, but the connection was added first
-        let src1_edge_id = *config.get_src_edges(src1_id).first().unwrap();
+        let src1_edge_id = *config
+            .get_src_edges(src1_id, None)
+            .unwrap()
+            .first()
+            .unwrap();
         assert_eq!(src1_edge_id, 1);
-        let src2_edge_id = *config.get_src_edges(src2_id).first().unwrap();
+        let src2_edge_id = *config
+            .get_src_edges(src2_id, None)
+            .unwrap()
+            .first()
+            .unwrap();
         assert_eq!(src2_edge_id, 0);
+    }
+
+    #[test]
+    fn test_simple_missions() {
+        // A simple config that selection a source depending on the mission it is in.
+        let txt = r#"(
+                    missions: [ (id: "m1"),
+                                (id: "m2"),
+                                ],
+                    tasks: [(id: "src1", type: "a", missions: ["m1"]),
+                            (id: "src2", type: "b", missions: ["m2"]),
+                            (id: "sink", type: "c")],
+
+                    cnx: [
+                            (src: "src1", dst: "sink", msg: "u32", missions: ["m1"]),
+                            (src: "src2", dst: "sink", msg: "u32", missions: ["m2"]),
+                         ],
+              )
+              "#;
+
+        let config = CuConfig::deserialize_ron(txt);
+        let m1_graph = config.graphs.get_graph(Some("m1")).unwrap();
+        assert_eq!(m1_graph.edge_count(), 1);
+        assert_eq!(m1_graph.node_count(), 2);
+        let index = EdgeIndex::new(0);
+        let cnx = m1_graph.edge_weight(index).unwrap();
+
+        assert_eq!(cnx.src, "src1");
+        assert_eq!(cnx.dst, "sink");
+        assert_eq!(cnx.msg, "u32");
+        assert_eq!(cnx.missions, Some(vec!["m1".to_string()]));
     }
 }

--- a/core/cu29_runtime/src/curuntime.rs
+++ b/core/cu29_runtime/src/curuntime.rs
@@ -300,7 +300,7 @@ fn plan_tasks_tree_branch(
 
         let mut input_msg_indices_types: Vec<(u32, String)> = Vec::new();
         let output_msg_index_type: Option<(u32, String)>;
-        let task_type = find_task_type_for_id(&graph, id);
+        let task_type = find_task_type_for_id(graph, id);
 
         match task_type {
             CuTaskType::Source => {
@@ -655,7 +655,7 @@ mod tests {
         // note that the source2 connection is before the source1
         let src1_type = "src1_type";
         let src2_type = "src2_type";
-        config.connect(src2_id, sink_id.into(), src2_type).unwrap();
+        config.connect(src2_id, sink_id, src2_type).unwrap();
         config.connect(src1_id, sink_id, src1_type).unwrap();
 
         let src1_edge_id = *config

--- a/core/cu29_runtime/src/rendercfg.rs
+++ b/core/cu29_runtime/src/rendercfg.rs
@@ -29,7 +29,7 @@ fn main() -> std::io::Result<()> {
     let mut content = Vec::<u8>::new();
     {
         let mut cursor = Cursor::new(&mut content);
-        config.render(&mut cursor);
+        config.render(&mut cursor, None).unwrap();
     }
 
     // Generate SVG from DOT

--- a/examples/cu_config_gen/src/main.rs
+++ b/examples/cu_config_gen/src/main.rs
@@ -11,11 +11,11 @@ fn main() {
     camera.set_param::<Value>("resolution-height", 1080.into());
     let isp = Node::new("copper-isp", "isppkg::Isp");
     let algo = Node::new("copper-algo", "algopkg::Algo");
-    let n1 = copperconfig.add_node(isp);
-    let n2 = copperconfig.add_node(camera);
-    let n3 = copperconfig.add_node(algo);
+    let n1 = copperconfig.add_node(isp, None).unwrap();
+    let n2 = copperconfig.add_node(camera, None).unwrap();
+    let n3 = copperconfig.add_node(algo, None).unwrap();
 
-    copperconfig.connect(n2, n1, "imgmsgpkg::Image");
-    copperconfig.connect(n1, n3, "imgmsgpkg::Image");
+    copperconfig.connect(n2, n1, "imgmsgpkg::Image").unwrap();
+    copperconfig.connect(n1, n3, "imgmsgpkg::Image").unwrap();
     println!("{}", copperconfig.serialize_ron());
 }

--- a/examples/cu_config_variation/src/main.rs
+++ b/examples/cu_config_variation/src/main.rs
@@ -35,10 +35,14 @@ fn main() {
 
     // restart with a variation of the configuration
     {
-        let node_indices = copperconfig.graph.node_indices().collect::<Vec<_>>();
+        let node_indices = copperconfig
+            .get_graph(None)
+            .unwrap()
+            .node_indices()
+            .collect::<Vec<_>>();
         node_indices.iter().for_each(|node_index| {
             let node = copperconfig
-                .get_node_mut(node_index.index() as NodeId)
+                .get_node_mut(node_index.index() as NodeId, None)
                 .unwrap();
             if node.get_id() == "dst" {
                 node.set_param("pin", 42);


### PR DESCRIPTION
Adds a more flexible way to compose copper configurations sub graphs and build missions (or think about modes) to have several graphs configured and a way to switch from one to another.

This is an intermediate PR maintaining backward compatibility but adding the notion of mission to the serialization / deserialization of the config + building of the dag. 