### PR TITLE
[FEAT] run-time log-level macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ Cargo.lock
 
 # Test generation project
 /templates/test_project
+
+**/CLAUDE.md
+**/CLAUDE.local.md
+**/justfile

--- a/components/monitors/cu_consolemon/src/debug_pane.rs
+++ b/components/monitors/cu_consolemon/src/debug_pane.rs
@@ -1,4 +1,5 @@
 use crate::UI;
+use cu29::prelude::CuLogLevel;
 use ratatui::layout::Rect;
 use ratatui::prelude::Stylize;
 use ratatui::widgets::{Block, Borders, Paragraph};
@@ -13,7 +14,6 @@ use {
     std::sync::atomic::AtomicU16,
     std::sync::mpsc::{Receiver, SyncSender},
 };
-use cu29::prelude::CuLogLevel;
 
 #[derive(Debug)]
 pub struct DebugLog {

--- a/components/monitors/cu_consolemon/src/debug_pane.rs
+++ b/components/monitors/cu_consolemon/src/debug_pane.rs
@@ -13,6 +13,7 @@ use {
     std::sync::atomic::AtomicU16,
     std::sync::mpsc::{Receiver, SyncSender},
 };
+use cu29::prelude::CuLogLevel;
 
 #[derive(Debug)]
 pub struct DebugLog {
@@ -75,12 +76,18 @@ pub struct LogSubscriber {
 
 impl LogSubscriber {
     #[allow(dead_code)]
-    pub fn new(tx: SyncSender<String>) -> Self {
+    pub fn new(tx: SyncSender<String>, level: CuLogLevel) -> Self {
         let log_subscriber = Self { tx };
         if log::set_boxed_logger(Box::new(log_subscriber.clone())).is_err() {
             eprintln!("Failed to set `LogSubscriber` as global log subscriber")
         }
-        log::set_max_level(LevelFilter::Debug);
+        match level {
+            CuLogLevel::Trace => log::set_max_level(LevelFilter::Trace),
+            CuLogLevel::Debug => log::set_max_level(LevelFilter::Debug),
+            CuLogLevel::Info => log::set_max_level(LevelFilter::Info),
+            CuLogLevel::Warn => log::set_max_level(LevelFilter::Warn),
+            CuLogLevel::Error => log::set_max_level(LevelFilter::Error),
+        }
         log_subscriber
     }
 

--- a/components/monitors/cu_consolemon/src/lib.rs
+++ b/components/monitors/cu_consolemon/src/lib.rs
@@ -9,10 +9,10 @@ use cu29::clock::{CuDuration, RobotClock};
 use cu29::config::{CuConfig, Node};
 use cu29::cutask::CuMsgMetadata;
 use cu29::monitoring::{CuDurationStatistics, CuMonitor, CuTaskState, Decision};
-use cu29::prelude::{pool, CuCompactString};
-use cu29::{CuError, CuResult};
 #[cfg(feature = "debug_pane")]
 use cu29::prelude::CuLogLevel;
+use cu29::prelude::{pool, CuCompactString};
+use cu29::{CuError, CuResult};
 #[cfg(feature = "debug_pane")]
 use debug_pane::UIExt;
 use ratatui::backend::CrosstermBackend;

--- a/components/monitors/cu_consolemon/src/lib.rs
+++ b/components/monitors/cu_consolemon/src/lib.rs
@@ -9,8 +9,10 @@ use cu29::clock::{CuDuration, RobotClock};
 use cu29::config::{CuConfig, Node};
 use cu29::cutask::CuMsgMetadata;
 use cu29::monitoring::{CuDurationStatistics, CuMonitor, CuTaskState, Decision};
-use cu29::prelude::{pool, CuCompactString, CuLogLevel};
+use cu29::prelude::{pool, CuCompactString};
 use cu29::{CuError, CuResult};
+#[cfg(feature = "debug_pane")]
+use cu29::prelude::CuLogLevel;
 #[cfg(feature = "debug_pane")]
 use debug_pane::UIExt;
 use ratatui::backend::CrosstermBackend;

--- a/components/monitors/cu_consolemon/src/lib.rs
+++ b/components/monitors/cu_consolemon/src/lib.rs
@@ -9,7 +9,7 @@ use cu29::clock::{CuDuration, RobotClock};
 use cu29::config::{CuConfig, Node};
 use cu29::cutask::CuMsgMetadata;
 use cu29::monitoring::{CuDurationStatistics, CuMonitor, CuTaskState, Decision};
-use cu29::prelude::{pool, CuCompactString};
+use cu29::prelude::{pool, CuCompactString, CuLogLevel};
 use cu29::{CuError, CuResult};
 #[cfg(feature = "debug_pane")]
 use debug_pane::UIExt;
@@ -800,8 +800,8 @@ impl CuMonitor for CuConsoleMon {
                 {
                     let max_lines = terminal.size().unwrap().height - 5;
                     let (debug_log, tx) = debug_pane::DebugLog::new(max_lines);
-
-                    let log_subscriber = debug_pane::LogSubscriber::new(tx);
+                    let log_level = CuLogLevel::Debug;
+                    let log_subscriber = debug_pane::LogSubscriber::new(tx, log_level);
 
                     *cu29_log_runtime::EXTRA_TEXT_LOGGER.write().unwrap() =
                         Some(Box::new(log_subscriber) as Box<dyn log::Log>);

--- a/components/monitors/cu_consolemon/src/lib.rs
+++ b/components/monitors/cu_consolemon/src/lib.rs
@@ -9,7 +9,7 @@ use cu29::clock::{CuDuration, RobotClock};
 use cu29::config::{CuConfig, Node};
 use cu29::cutask::CuMsgMetadata;
 use cu29::monitoring::{CuDurationStatistics, CuMonitor, CuTaskState, Decision};
-#[cfg(feature = "debug_pane")]
+#[cfg(debug_assertions)]
 use cu29::prelude::CuLogLevel;
 use cu29::prelude::{pool, CuCompactString};
 use cu29::{CuError, CuResult};

--- a/components/sinks/cu_rp_sn754410/tests/sn754410_tester.rs
+++ b/components/sinks/cu_rp_sn754410/tests/sn754410_tester.rs
@@ -9,7 +9,7 @@ struct SN754410Tester {}
 #[ignore] // As this needs the real hardware to run.
 fn test_driver_with_hardware() {
     let logger_path = "/tmp/caterpillar.copper";
-    let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), None, true, None)
+    let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), None, true, None, None)
         .expect("Failed to setup logger.");
     debug!("Logger created at {}.", logger_path);
     let clock = copper_ctx.clock;

--- a/components/sources/cu_ads7883/tests/ads7883_tester.rs
+++ b/components/sources/cu_ads7883/tests/ads7883_tester.rs
@@ -29,7 +29,7 @@ impl<'cl> CuSinkTask<'cl> for ADS78883TestSink {
 #[ignore] // As this needs the real hardware to run.
 fn test_driver_with_hardware() {
     let logger_path = "/tmp/caterpillar.copper";
-    let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), None, true, None)
+    let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), None, true, None, None)
         .expect("Failed to setup logger.");
     debug!("Logger created at {}.", logger_path);
     let clock = copper_ctx.clock;

--- a/components/sources/cu_gstreamer/tests/gstreamer_tester.rs
+++ b/components/sources/cu_gstreamer/tests/gstreamer_tester.rs
@@ -59,7 +59,7 @@ mod tests {
     #[ignore]
     fn end_2_end() {
         let logger_path = "/tmp/caterpillar.copper";
-        let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), None, true, None)
+        let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), None, true, None, None)
             .expect("Failed to setup logger.");
         debug!("Logger created at {}.", logger_path);
         debug!("Creating application... ");

--- a/components/sources/cu_hesai/tests/hesai_tester.rs
+++ b/components/sources/cu_hesai/tests/hesai_tester.rs
@@ -72,7 +72,7 @@ fn main() {
     let tmp_dir = tempfile::TempDir::new().expect("could not create a tmp dir");
     let logger_path = tmp_dir.path().join("hesai_tester.copper");
 
-    let copper_ctx = basic_copper_setup(&PathBuf::from(&logger_path), None, true, None)
+    let copper_ctx = basic_copper_setup(&PathBuf::from(&logger_path), None, true, None, None)
         .expect("Failed to setup logger.");
     debug!("Logger created at {}.", logger_path);
 

--- a/components/sources/cu_livox/tests/livox_tester.rs
+++ b/components/sources/cu_livox/tests/livox_tester.rs
@@ -70,8 +70,14 @@ struct LivoxTester {}
 fn main() {
     let tmp_dir = tempfile::TempDir::new().expect("could not create a tmp dir");
     let logger_path = tmp_dir.path().join("livox_tester.copper");
-    let copper_ctx = basic_copper_setup(&PathBuf::from(&logger_path), None, true, None)
-        .expect("Failed to setup logger.");
+    let copper_ctx = basic_copper_setup(
+        &PathBuf::from(&logger_path),
+        None,
+        true,
+        None,
+        Some("tests/copperconfig.ron"),
+    )
+    .expect("Failed to setup logger.");
     debug!("Logger created at {}.", logger_path);
 
     thread::spawn(|| {

--- a/components/sources/cu_v4l/src/lib.rs
+++ b/components/sources/cu_v4l/src/lib.rs
@@ -290,7 +290,7 @@ mod linux_impl {
                 TerminalMode::Mixed,
                 ColorChoice::Auto,
             );
-            let _logger = LoggerRuntime::init(clock.clone(), NullLog {}, Some(*term_logger));
+            let _logger = LoggerRuntime::init(clock.clone(), NullLog {}, Some(*term_logger), None);
 
             let rec = RecordingStreamBuilder::new("Camera Viz")
                 .spawn()

--- a/components/sources/cu_wt901/tests/wt901_tester.rs
+++ b/components/sources/cu_wt901/tests/wt901_tester.rs
@@ -30,8 +30,14 @@ struct WT910Tester {}
 
 fn main() {
     let logger_path = "/tmp/caterpillar.copper";
-    let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), None, true, None)
-        .expect("Failed to setup logger.");
+    let copper_ctx = basic_copper_setup(
+        &PathBuf::from(logger_path),
+        None,
+        true,
+        None,
+        Some("tests/copperconfig.ron"),
+    )
+    .expect("Failed to setup logger.");
     debug!("Logger created at {}.", logger_path);
     let clock = copper_ctx.clock;
     debug!("Creating application... ");

--- a/core/cu29_export/src/lib.rs
+++ b/core/cu29_export/src/lib.rs
@@ -377,7 +377,7 @@ mod tests {
             };
             let data_logger = Arc::new(Mutex::new(logger));
             let stream = stream_write(data_logger.clone(), UnifiedLogType::StructuredLogLine, 1024);
-            let rt = LoggerRuntime::init(RobotClock::default(), stream, None::<NullLog>);
+            let rt = LoggerRuntime::init(RobotClock::default(), stream, None::<NullLog>, None);
 
             let mut entry = CuLogEntry::new(4); // this is a "Just a String {}" log line
             entry.add_param(0, Value::String("Parameter for the log line".into()));

--- a/core/cu29_helpers/tests/end2end.rs
+++ b/core/cu29_helpers/tests/end2end.rs
@@ -1,7 +1,7 @@
 use cu29_helpers::basic_copper_setup;
-use cu29_log::CuLogEntry;
 use cu29_log::ANONYMOUS;
-use cu29_log_derive::debug;
+use cu29_log::{CuLogEntry, CuLogLevel};
+use cu29_log_derive::{debug, error, info, trace, warn};
 use cu29_value::to_value;
 
 #[cfg(not(debug_assertions))]
@@ -20,7 +20,7 @@ fn log_derive_end2end() {
     let tmp_dir = TempDir::new().expect("Failed to create temp dir");
     let log_path = tmp_dir.path().join("teststructlog.copper");
 
-    let _ = basic_copper_setup(&log_path, None, true, None).expect("Failed to setup logger.");
+    let _ = basic_copper_setup(&log_path, None, true, None, None).expect("Failed to setup logger.");
     debug!("Logger created at {}.", log_path);
 
     #[derive(Serialize)]
@@ -31,7 +31,18 @@ fn log_derive_end2end() {
     let mytuple = (1, "toto", 3.34f64, true, 'a');
     {
         let _gigantic_vec = vec![0u8; 1_000_000];
-        debug!("Just a string {}", "zarma");
+
+        // Test all log levels
+        trace!("Trace level message with param {}", "detailed info");
+        debug!("Debug level message: Just a string {}", "zarma");
+        info!("Info level: Important information for users");
+        warn!(
+            "Warning level: Something might be wrong {}",
+            issue = "config missing"
+        );
+        error!("Error level: Something bad happened {}", error_code = 500);
+
+        // Continue with existing tests
         debug!("anonymous param constants {} {}", 42u16, 43u8);
         debug!("named param constants {} {}", a = 3, b = 2);
         debug!("mixed named param constants, {} {} {}", a = 3, 54, b = 2);

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -688,6 +688,8 @@ pub struct LoggingConfig {
     pub section_size_mib: Option<u64>,
     #[serde(default = "default_as_true", skip_serializing_if = "Clone::clone")]
     pub enable_task_logging: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_level: Option<cu29_log::CuLogLevel>,
 }
 
 /// Missions are used to generate alternative DAGs within the same configuration.

--- a/core/cu29_runtime/src/monitoring.rs
+++ b/core/cu29_runtime/src/monitoring.rs
@@ -5,6 +5,7 @@ use crate::config::CuConfig;
 use crate::cutask::CuMsgMetadata;
 use crate::log::*;
 use cu29_clock::{CuDuration, RobotClock};
+use cu29_log::CuLogLevel;
 use cu29_traits::{CuError, CuResult};
 use hdrhistogram::Histogram;
 use serde_derive::{Deserialize, Serialize};

--- a/examples/cu_caterpillar/src/main.rs
+++ b/examples/cu_caterpillar/src/main.rs
@@ -12,8 +12,14 @@ fn main() {
     let tmp_dir = tempfile::TempDir::new().expect("could not create a tmp dir");
     let logger_path = tmp_dir.path().join("caterpillar.copper");
 
-    let copper_ctx =
-        basic_copper_setup(&logger_path, SLAB_SIZE, true, None).expect("Failed to setup logger.");
+    let copper_ctx = basic_copper_setup(
+        &logger_path,
+        SLAB_SIZE,
+        true,
+        None,
+        Some("copperconfig.ron"),
+    )
+    .expect("Failed to setup logger.");
     let mut application = CaterpillarApplicationBuilder::new()
         .with_context(&copper_ctx)
         .build()

--- a/examples/cu_config_variation/src/main.rs
+++ b/examples/cu_config_variation/src/main.rs
@@ -7,8 +7,14 @@ struct MyApp {}
 
 fn main() {
     let mut copperconfig: CuConfig = read_configuration("copperconfig.ron").unwrap();
-    let copper_ctx = basic_copper_setup(Path::new("/tmp/test.copper"), None, true, None)
-        .expect("Failed to setup logger.");
+    let copper_ctx = basic_copper_setup(
+        Path::new("/tmp/test.copper"),
+        None,
+        true,
+        None,
+        Some("copperconfig.ron"),
+    )
+    .expect("Failed to setup logger.");
 
     // First run with the base configuration
     {

--- a/examples/cu_iceoryx2/src/bin/downstream.rs
+++ b/examples/cu_iceoryx2/src/bin/downstream.rs
@@ -12,8 +12,14 @@ fn main() {
     // the iceoryx logger does break if you attach a debugger to it.
     set_log_level(LogLevel::Fatal);
     let logger_path = "/tmp/downstream.copper";
-    let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), SLAB_SIZE, false, None)
-        .expect("Failed to setup logger.");
+    let copper_ctx = basic_copper_setup(
+        &PathBuf::from(logger_path),
+        SLAB_SIZE,
+        false,
+        None,
+        Some("downstream.ron"),
+    )
+    .expect("Failed to setup logger.");
     let mut application = DownstreamApplicationBuilder::new()
         .with_context(&copper_ctx)
         .build()

--- a/examples/cu_iceoryx2/src/bin/upstream.rs
+++ b/examples/cu_iceoryx2/src/bin/upstream.rs
@@ -9,8 +9,14 @@ const SLAB_SIZE: Option<usize> = Some(100 * 1024 * 1024);
 
 fn main() {
     let logger_path = "/tmp/upstream.copper";
-    let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), SLAB_SIZE, false, None)
-        .expect("Failed to setup logger.");
+    let copper_ctx = basic_copper_setup(
+        &PathBuf::from(logger_path),
+        SLAB_SIZE,
+        false,
+        None,
+        Some("upstream.ron"),
+    )
+    .expect("Failed to setup logger.");
     let mut application = UpstreamApplicationBuilder::new()
         .with_context(&copper_ctx)
         .build()

--- a/examples/cu_logging_size/src/main.rs
+++ b/examples/cu_logging_size/src/main.rs
@@ -82,8 +82,14 @@ fn main() {
     let dir = tempdir().expect("Could not get a temporary directory");
     // construct dir/logger_path
     let logger_path = dir.path().join(logger_path);
-    let copper_ctx =
-        basic_copper_setup(&logger_path, SLAB_SIZE, true, None).expect("Failed to setup logger.");
+    let copper_ctx = basic_copper_setup(
+        &logger_path,
+        SLAB_SIZE,
+        true,
+        None,
+        Some("copperconfig.ron"),
+    )
+    .expect("Failed to setup logger.");
     debug!("Logger created at {}.", path = &logger_path);
     let clock = copper_ctx.clock;
     debug!("Creating application... ");

--- a/examples/cu_monitoring/src/main.rs
+++ b/examples/cu_monitoring/src/main.rs
@@ -115,8 +115,14 @@ const SLAB_SIZE: Option<usize> = Some(1024 * 1024);
 fn main() {
     let logger_path = "monitor.copper";
 
-    let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), SLAB_SIZE, true, None)
-        .expect("Failed to setup logger.");
+    let copper_ctx = basic_copper_setup(
+        &PathBuf::from(logger_path),
+        SLAB_SIZE,
+        true,
+        None,
+        Some("copperconfig.ron"),
+    )
+    .expect("Failed to setup logger.");
     debug!("Logger created at {}.", path = logger_path);
     debug!("Creating application... ");
     let mut application = AppBuilder::new()

--- a/examples/cu_multisources/src/main.rs
+++ b/examples/cu_multisources/src/main.rs
@@ -13,8 +13,14 @@ const SLAB_SIZE: Option<usize> = Some(1024 * 1024);
 
 fn main() {
     let logger_path = "/tmp/caterpillar.copper";
-    let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), SLAB_SIZE, true, None)
-        .expect("Failed to setup logger.");
+    let copper_ctx = basic_copper_setup(
+        &PathBuf::from(logger_path),
+        SLAB_SIZE,
+        true,
+        None,
+        Some("copperconfig.ron"),
+    )
+    .expect("Failed to setup logger.");
     debug!("Logger created at {}.", path = logger_path);
     debug!("Creating application... ");
     let mut application = MultiSourceAppBuilder::new()

--- a/examples/cu_pointclouds/src/main.rs
+++ b/examples/cu_pointclouds/src/main.rs
@@ -59,8 +59,8 @@ fn main() {
     const PACKET_SIZE: usize = size_of::<Packet>();
     let tmp_dir = tempfile::TempDir::new().expect("could not create a tmp dir");
     let logger_path = tmp_dir.path().join("ptclouds.copper");
-    let copper_ctx =
-        basic_copper_setup(&logger_path, SLAB_SIZE, false, None).expect("Failed to setup copper.");
+    let copper_ctx = basic_copper_setup(&logger_path, SLAB_SIZE, false, None, Some("ptclouds.ron"))
+        .expect("Failed to setup copper.");
     let mut application = PtCloudsApplicationBuilder::new()
         .with_context(&copper_ctx)
         .build()

--- a/examples/cu_rp_balancebot/copperconfig.ron
+++ b/examples/cu_rp_balancebot/copperconfig.ron
@@ -1,4 +1,10 @@
 (
+    logging: (
+        slab_size_mib: 20,
+        section_size_mib: 2,
+        enable_task_logging: false,
+        max_level: Debug,
+    ),
     tasks: [
         (
             id: "balpos",

--- a/examples/cu_rp_balancebot/src/main.rs
+++ b/examples/cu_rp_balancebot/src/main.rs
@@ -21,9 +21,14 @@ fn main() {
             fs::create_dir_all(parent).expect("Failed to create logs directory");
         }
     }
-
-    let copper_ctx = basic_copper_setup(&PathBuf::from(logger_path), SLAB_SIZE, true, None)
-        .expect("Failed to setup logger.");
+    let copper_ctx = basic_copper_setup(
+        &PathBuf::from(logger_path),
+        SLAB_SIZE,
+        true,
+        None,
+        Some("copperconfig.ron"),
+    )
+    .expect("Failed to setup logger.");
     debug!("Logger created at {}.", path = logger_path);
 
     debug!("Creating application... ");

--- a/examples/cu_rp_balancebot/src/resim.rs
+++ b/examples/cu_rp_balancebot/src/resim.rs
@@ -83,6 +83,7 @@ fn main() {
         LOG_SLAB_SIZE,
         true,
         Some(robot_clock.clone()),
+        Some("copperconfig.ron"),
     )
     .expect("Failed to setup logger.");
 

--- a/examples/cu_rp_balancebot/src/sim.rs
+++ b/examples/cu_rp_balancebot/src/sim.rs
@@ -64,6 +64,7 @@ fn setup_copper(mut commands: Commands) {
         LOG_SLAB_SIZE,
         true,
         Some(robot_clock.clone()),
+        Some("copperconfig.ron"),
     )
     .expect("Failed to setup logger.");
     debug!(

--- a/examples/cu_standalone_structlog/src/structlog_perf.rs
+++ b/examples/cu_standalone_structlog/src/structlog_perf.rs
@@ -8,7 +8,7 @@ fn main() {
     let clock = RobotClock::new();
     let bf = {
         let writer = SimpleFileWriter::new(&PathBuf::from(LOG_FILE)).unwrap();
-        let _log_runtime = LoggerRuntime::init(clock.clone(), writer, None::<NullLog>);
+        let _log_runtime = LoggerRuntime::init(clock.clone(), writer, None::<NullLog>, None);
         let bf: CuTime = clock.now();
         for i in 0..1_000_000 {
             debug!(

--- a/examples/cu_zenoh/src/main.rs
+++ b/examples/cu_zenoh/src/main.rs
@@ -42,8 +42,14 @@ const SLAB_SIZE: Option<usize> = Some(150 * 1024 * 1024);
 fn main() {
     let tmp_dir = tempfile::TempDir::new().expect("could not create a tmp dir");
     let logger_path = tmp_dir.path().join("zenoh.copper");
-    let copper_ctx =
-        basic_copper_setup(&logger_path, SLAB_SIZE, true, None).expect("Failed to setup logger.");
+    let copper_ctx = basic_copper_setup(
+        &logger_path,
+        SLAB_SIZE,
+        true,
+        None,
+        Some("copperconfig.ron"),
+    )
+    .expect("Failed to setup logger.");
     debug!("Logger created at {}.", path = &logger_path);
     let clock = copper_ctx.clock;
     debug!("Creating application... ");

--- a/templates/cu_full/src/main.rs
+++ b/templates/cu_full/src/main.rs
@@ -14,7 +14,7 @@ struct {{project-name | upper_camel_case}}Application {}
 fn main() {
     let logger_path = "{{project-name | kebab_case}}.copper";
     let copper_ctx =
-        basic_copper_setup(&PathBuf::from(logger_path), PREALLOCATED_STORAGE_SIZE, true, None).expect("Failed to setup logger.");
+        basic_copper_setup(&PathBuf::from(logger_path), PREALLOCATED_STORAGE_SIZE, true, None, Some("copperconfig.ron")).expect("Failed to setup logger.");
     debug!("Logger created at {}.", logger_path);
     debug!("Creating application... ");
     let mut application = {{project-name | upper_camel_case}}ApplicationBuilder::new()


### PR DESCRIPTION
This PR adds support for configurable log levels to the logging system by introducing a new CuLogLevel enum, propagating max_level configuration through LoggerRuntime, and updating various modules and test cases to pass an optional configuration file path for logging settings.

- Introduces a new CuLogLevel type with explicit ordering and default settings.
- Adjusts LoggerRuntime and basic_copper_setup to accept and utilize a max_level parameter derived from configuration files.
- Updates tests and client code to pass the additional configuration parameter where needed.