### PR TITLE
[FIX] nightly clippy for format

### DIFF
--- a/components/common/cu_msp_lib/src/commands.rs
+++ b/components/common/cu_msp_lib/src/commands.rs
@@ -190,6 +190,6 @@ pub enum MspCommandCode {
 
 impl From<u16> for MspCommandCode {
     fn from(value: u16) -> Self {
-        Self::from_primitive(value).unwrap_or_else(|| panic!("Invalid MSP command code: {}", value))
+        Self::from_primitive(value).unwrap_or_else(|| panic!("Invalid MSP command code: {value}"))
     }
 }

--- a/components/common/cu_msp_lib/src/lib.rs
+++ b/components/common/cu_msp_lib/src/lib.rs
@@ -32,7 +32,7 @@ impl Debug for MspPacketData {
         }
         write!(f, "0x")?;
         for byte in data {
-            write!(f, "{:02X}", byte)?;
+            write!(f, "{byte:02X}")?;
         }
         Ok(())
     }
@@ -74,8 +74,7 @@ impl Display for MspPacketParseError {
                 calculated,
             } => write!(
                 f,
-                "CRC mismatch, expected: 0x{:02X}, calculated: 0x{:02X}",
-                expected, calculated
+                "CRC mismatch, expected: 0x{expected:02X}, calculated: 0x{calculated:02X}"
             ),
             MspPacketParseError::InvalidData => write!(f, "Invalid data"),
             MspPacketParseError::InvalidHeader1 => write!(f, "Invalid header 1"),

--- a/components/monitors/cu_consolemon/src/debug_pane.rs
+++ b/components/monitors/cu_consolemon/src/debug_pane.rs
@@ -87,7 +87,7 @@ impl LogSubscriber {
     pub fn push_logs(&self, log: String) {
         if let Err(err) = self.tx.send(log) {
             let SendError(msg) = err;
-            eprintln!("Error Sending Logs to MPSC Channel: {}", msg)
+            eprintln!("Error Sending Logs to MPSC Channel: {msg}")
         }
     }
 }

--- a/components/monitors/cu_consolemon/src/sysinfo.rs
+++ b/components/monitors/cu_consolemon/src/sysinfo.rs
@@ -143,7 +143,7 @@ fn pfetch(info: Vec<(Color, String, String)>, logo: Logo, logo_enabled: bool) ->
     let logo = if color_enabled {
         logo.to_string()
     } else {
-        format!("{:#}", logo)
+        format!("{logo:#}")
     };
     let mut logo_lines = logo.lines();
     let raw_logo_lines: Vec<_> = raw_logo.lines().collect();

--- a/components/sinks/cu_iceoryx2_sink/src/lib.rs
+++ b/components/sinks/cu_iceoryx2_sink/src/lib.rs
@@ -46,7 +46,7 @@ where
         let node: iceoryx2::prelude::Node<ipc::Service> =
             NodeBuilder::new().create::<ipc::Service>().map_err(|e| {
                 CuError::new_with_cause(
-                    format!("IceoryxSink({}): Failed to create node.", service_name_str).as_str(),
+                    format!("IceoryxSink({service_name_str}): Failed to create node.").as_str(),
                     e,
                 )
             })?;

--- a/components/sinks/cu_lewansoul/src/lib.rs
+++ b/components/sinks/cu_lewansoul/src/lib.rs
@@ -218,7 +218,7 @@ impl<'cl> CuSinkTask<'cl> for Lewansoul {
 
         let mut ids = [0u8; 8];
         for (i, id) in ids.iter_mut().enumerate() {
-            let servo = kv.get(format!("servo{}", i).as_str());
+            let servo = kv.get(format!("servo{i}").as_str());
             if servo.is_none() {
                 if i == 0 {
                     return Err(
@@ -238,7 +238,7 @@ impl<'cl> CuSinkTask<'cl> for Lewansoul {
             .stop_bits(StopBits::One)
             .timeout(TIMEOUT)
             .open()
-            .map_err(|e| format!("Error opening serial port: {:?}", e))?;
+            .map_err(|e| format!("Error opening serial port: {e:?}"))?;
 
         Ok(Lewansoul { port, ids })
     }

--- a/components/sources/cu_hesai/src/lib.rs
+++ b/components/sources/cu_hesai/src/lib.rs
@@ -174,11 +174,11 @@ mod tests {
         {
             let err = xt32.process(&clock, &mut new_msg);
             if let Err(e) = err {
-                println!("Error: {:?}", e);
+                println!("Error: {e:?}");
                 continue;
             }
             if let Some(payload) = new_msg.payload() {
-                println!("Lidar Payload: {:?}", payload);
+                println!("Lidar Payload: {payload:?}");
             }
             break;
         }

--- a/components/sources/cu_hesai/src/parser.rs
+++ b/components/sources/cu_hesai/src/parser.rs
@@ -25,8 +25,8 @@ pub enum HesaiError {
 impl fmt::Display for HesaiError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            HesaiError::InvalidPacket(msg) => write!(f, "Invalid packet: {}", msg),
-            HesaiError::InvalidTimestamp(msg) => write!(f, "Invalid timestamp: {}", msg),
+            HesaiError::InvalidPacket(msg) => write!(f, "Invalid packet: {msg}"),
+            HesaiError::InvalidTimestamp(msg) => write!(f, "Invalid timestamp: {msg}"),
         }
     }
 }
@@ -609,7 +609,7 @@ mod tests {
             robot_clock.now(),
         );
         for (bid, ts) in packet.block_ts(&rt).unwrap().iter().enumerate() {
-            println!("Block {} tov: {}", bid, ts);
+            println!("Block {bid} tov: {ts}");
         }
     }
 }

--- a/components/sources/cu_iceoryx2_src/src/lib.rs
+++ b/components/sources/cu_iceoryx2_src/src/lib.rs
@@ -46,10 +46,7 @@ where
         let node: iceoryx2::prelude::Node<ipc::Service> =
             NodeBuilder::new().create::<ipc::Service>().map_err(|e| {
                 CuError::new_with_cause(
-                    format!(
-                        "IceoryxSource({service_name_str}): Failed to create node."
-                    )
-                    .as_str(),
+                    format!("IceoryxSource({service_name_str}): Failed to create node.").as_str(),
                     e,
                 )
             })?;

--- a/components/sources/cu_iceoryx2_src/src/lib.rs
+++ b/components/sources/cu_iceoryx2_src/src/lib.rs
@@ -47,8 +47,7 @@ where
             NodeBuilder::new().create::<ipc::Service>().map_err(|e| {
                 CuError::new_with_cause(
                     format!(
-                        "IceoryxSource({}): Failed to create node.",
-                        service_name_str
+                        "IceoryxSource({service_name_str}): Failed to create node."
                     )
                     .as_str(),
                     e,

--- a/components/sources/cu_livox/src/lib.rs
+++ b/components/sources/cu_livox/src/lib.rs
@@ -119,11 +119,11 @@ mod tests {
         {
             let err = tele15.process(&clock, &mut new_msg);
             if let Err(e) = err {
-                println!("Error: {:?}", e);
+                println!("Error: {e:?}");
                 continue;
             }
             if let Some(payload) = new_msg.payload() {
-                println!("Lidar Payload: {:?}", payload);
+                println!("Lidar Payload: {payload:?}");
             }
             break;
         }

--- a/components/sources/cu_livox/src/parser.rs
+++ b/components/sources/cu_livox/src/parser.rs
@@ -263,8 +263,8 @@ pub struct LidarFrame {
 impl fmt::Display for LivoxError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            LivoxError::InvalidFrame(msg) => write!(f, "Invalid frame: {}", msg),
-            LivoxError::InvalidTimestamp(msg) => write!(f, "Invalid timestamp: {}", msg),
+            LivoxError::InvalidFrame(msg) => write!(f, "Invalid frame: {msg}"),
+            LivoxError::InvalidTimestamp(msg) => write!(f, "Invalid timestamp: {msg}"),
         }
     }
 }
@@ -429,6 +429,6 @@ mod tests {
         let datetime = Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap();
         let _rt: RefTime = (datetime, robot_clock.now());
         let timestamp = packet.header.timestamp;
-        println!("Tov: {}", timestamp);
+        println!("Tov: {timestamp}");
     }
 }

--- a/components/sources/cu_v4l/src/lib.rs
+++ b/components/sources/cu_v4l/src/lib.rs
@@ -173,8 +173,7 @@ mod linux_impl {
                 actual_fmt
             } else {
                 return Err(format!(
-                    "The V4l device {} does not provide a format with the FourCC {}.",
-                    v4l_device, fourcc
+                    "The V4l device {v4l_device} does not provide a format with the FourCC {fourcc}."
                 )
                 .into());
             };
@@ -188,7 +187,7 @@ mod linux_impl {
                 Type::VideoCapture,
                 req_buffers,
                 CuHostMemoryPool::new(
-                    format!("V4L Host Pool {}", v4l_device).as_str(),
+                    format!("V4L Host Pool {v4l_device}").as_str(),
                     req_buffers as usize + 1,
                     || vec![0; actual_fmt.size as usize],
                 )

--- a/components/sources/cu_v4l/src/v4lstream.rs
+++ b/components/sources/cu_v4l/src/v4lstream.rs
@@ -27,7 +27,7 @@ use std::os::fd::RawFd;
 use std::path::PathBuf;
 
 fn get_original_dev_path(fd: RawFd) -> Option<PathBuf> {
-    let link_path = format!("/proc/self/fd/{}", fd);
+    let link_path = format!("/proc/self/fd/{fd}");
 
     if let Ok(path) = fs::read_link(link_path) {
         if path.to_string_lossy().starts_with("/dev/video") {
@@ -167,7 +167,7 @@ impl Drop for CuV4LStream {
                 }
             }
 
-            panic!("{:?}", e)
+            panic!("{e:?}")
         }
     }
 }

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -48,19 +48,18 @@ pub fn gen_cumsgs(config_path_lit: TokenStream) -> TokenStream {
     let config = parse_macro_input!(config_path_lit as LitStr).value();
     if !std::path::Path::new(&config_full_path(&config)).exists() {
         return return_error(format!(
-            "The configuration file `{}` does not exist. Please provide a valid path.",
-            config
+            "The configuration file `{config}` does not exist. Please provide a valid path."
         ));
     }
     #[cfg(feature = "macro_debug")]
-    eprintln!("[gen culist support with {:?}]", config);
+    eprintln!("[gen culist support with {config:?}]");
     let cuconfig = match read_config(&config) {
         Ok(cuconfig) => cuconfig,
         Err(e) => return return_error(e.to_string()),
     };
     let runtime_plan: CuExecutionLoop = match compute_runtime_plan(&cuconfig) {
         Ok(plan) => plan,
-        Err(e) => return return_error(format!("Could not compute runtime plan: {}", e)),
+        Err(e) => return return_error(format!("Could not compute runtime plan: {e}")),
     };
 
     // Give a name compatible with a struct to match the task ids to their output in the CuMsgs tuple.
@@ -275,8 +274,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
 
     if !std::path::Path::new(&config_full_path(&config_file)).exists() {
         return return_error(format!(
-            "The configuration file `{}` does not exist. Please provide a valid path.",
-            config_file
+            "The configuration file `{config_file}` does not exist. Please provide a valid path."
         ));
     }
 
@@ -286,7 +284,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
     };
     let copper_config_content = match read_to_string(config_full_path(config_file.as_str())) {
         Ok(ok) => ok,
-        Err(e) => return return_error(format!("Could not read the config file (should not happen because we just succeeded just before). {}", e))
+        Err(e) => return return_error(format!("Could not read the config file (should not happen because we just succeeded just before). {e}"))
     };
 
     let mission = "default"; // FIXME(gbin) generate all the missions from the config.
@@ -294,13 +292,13 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
         parse_str::<Ident>(mission).expect("Could not make an identifier of the mission name");
 
     #[cfg(feature = "macro_debug")]
-    eprintln!("[runtime plan for mission {}]", mission);
+    eprintln!("[runtime plan for mission {mission}]");
     let runtime_plan: CuExecutionLoop = match compute_runtime_plan(&copper_config) {
         Ok(plan) => plan,
-        Err(e) => return return_error(format!("Could not compute runtime plan: {}", e)),
+        Err(e) => return return_error(format!("Could not compute runtime plan: {e}")),
     };
     #[cfg(feature = "macro_debug")]
-    eprintln!("{:?}", runtime_plan);
+    eprintln!("{runtime_plan:?}");
 
     #[cfg(feature = "macro_debug")]
     eprintln!("[extract tasks ids & types]");
@@ -875,7 +873,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
             }
         }).collect();
     #[cfg(feature = "macro_debug")]
-    eprintln!("[Culist access order:  {:?}]", taskid_call_order);
+    eprintln!("[Culist access order:  {taskid_call_order:?}]");
 
     // Give a name compatible with a struct to match the task ids to their output in the CuMsgs tuple.
     let all_tasks_member_ids: Vec<String> = all_tasks_ids

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -1202,7 +1202,7 @@ impl LoggingConfig {
         if let Some(section_size_mib) = self.section_size_mib {
             if let Some(slab_size_mib) = self.slab_size_mib {
                 if section_size_mib > slab_size_mib {
-                    return Err(CuError::from(format!("Section size ({} MiB) cannot be larger than slab size ({} MiB). Adjust the parameters accordingly.", section_size_mib, slab_size_mib)));
+                    return Err(CuError::from(format!("Section size ({section_size_mib} MiB) cannot be larger than slab size ({slab_size_mib} MiB). Adjust the parameters accordingly.")));
                 }
             }
         }

--- a/core/cu29_runtime/src/curuntime.rs
+++ b/core/cu29_runtime/src/curuntime.rs
@@ -296,7 +296,7 @@ fn plan_tasks_tree_branch(
         let id = node.index() as NodeId;
         let node_ref = config.graphs.get_node(id, None).unwrap();
         #[cfg(feature = "macro_debug")]
-        eprintln!("  Visiting node: {:?}", node_ref);
+        eprintln!("  Visiting node: {node_ref:?}");
 
         let mut input_msg_indices_types: Vec<(u32, String)> = Vec::new();
         let output_msg_index_type: Option<(u32, String)>;
@@ -306,8 +306,7 @@ fn plan_tasks_tree_branch(
             CuTaskType::Source => {
                 #[cfg(feature = "macro_debug")]
                 eprintln!(
-                    "    → Source node, assign output index {}",
-                    next_culist_output_index
+                    "    → Source node, assign output index {next_culist_output_index}"
                 );
                 output_msg_index_type = Some((
                     next_culist_output_index,
@@ -323,13 +322,13 @@ fn plan_tasks_tree_branch(
                 let parents: Vec<NodeIndex> =
                     graph.neighbors_directed(id.into(), Incoming).collect();
                 #[cfg(feature = "macro_debug")]
-                eprintln!("    → Sink with parents: {:?}", parents);
+                eprintln!("    → Sink with parents: {parents:?}");
                 for parent in &parents {
                     let pid = parent.index() as NodeId;
                     let index_type = find_output_index_type_from_nodeid(pid, plan);
                     if let Some(index_type) = index_type {
                         #[cfg(feature = "macro_debug")]
-                        eprintln!("      ✓ Input from {pid} ready: {:?}", index_type);
+                        eprintln!("      ✓ Input from {pid} ready: {index_type:?}");
                         input_msg_indices_types.push(index_type);
                     } else {
                         #[cfg(feature = "macro_debug")]
@@ -344,13 +343,13 @@ fn plan_tasks_tree_branch(
                 let parents: Vec<NodeIndex> =
                     graph.neighbors_directed(id.into(), Incoming).collect();
                 #[cfg(feature = "macro_debug")]
-                eprintln!("    → Regular task with parents: {:?}", parents);
+                eprintln!("    → Regular task with parents: {parents:?}");
                 for parent in &parents {
                     let pid = parent.index() as NodeId;
                     let index_type = find_output_index_type_from_nodeid(pid, plan);
                     if let Some(index_type) = index_type {
                         #[cfg(feature = "macro_debug")]
-                        eprintln!("      ✓ Input from {pid} ready: {:?}", index_type);
+                        eprintln!("      ✓ Input from {pid} ready: {index_type:?}");
                         input_msg_indices_types.push(index_type);
                     } else {
                         #[cfg(feature = "macro_debug")]
@@ -422,7 +421,7 @@ pub fn compute_runtime_plan(config: &CuConfig) -> CuResult<CuExecutionLoop> {
         .collect();
 
     #[cfg(feature = "macro_debug")]
-    eprintln!("Initial source nodes: {:?}", queue);
+    eprintln!("Initial source nodes: {queue:?}");
 
     while let Some(start_node) = queue.pop_front() {
         if visited.is_visited(&start_node) {

--- a/core/cu29_runtime/src/curuntime.rs
+++ b/core/cu29_runtime/src/curuntime.rs
@@ -305,9 +305,7 @@ fn plan_tasks_tree_branch(
         match task_type {
             CuTaskType::Source => {
                 #[cfg(feature = "macro_debug")]
-                eprintln!(
-                    "    → Source node, assign output index {next_culist_output_index}"
-                );
+                eprintln!("    → Source node, assign output index {next_culist_output_index}");
                 output_msg_index_type = Some((
                     next_culist_output_index,
                     graph

--- a/core/cu29_runtime/src/pool.rs
+++ b/core/cu29_runtime/src/pool.rs
@@ -106,7 +106,7 @@ where
             CuHandleInner::Pooled(r) => {
                 write!(f, "Pooled: {:?}", r.deref())
             }
-            CuHandleInner::Detached(r) => write!(f, "Detached: {:?}", r),
+            CuHandleInner::Detached(r) => write!(f, "Detached: {r:?}"),
         }
     }
 }

--- a/core/cu29_runtime/src/rendercfg.rs
+++ b/core/cu29_runtime/src/rendercfg.rs
@@ -44,7 +44,7 @@ fn main() -> std::io::Result<()> {
         let stdin = child.stdin.as_mut().expect("Failed to open stdin");
         let result = stdin.write_all(&content);
         if let Err(e) = result {
-            eprintln!("Failed to write to stdin of the dot process: {}", e);
+            eprintln!("Failed to write to stdin of the dot process: {e}");
             std::process::exit(1);
         }
     }

--- a/core/cu29_value/src/bdec.rs
+++ b/core/cu29_value/src/bdec.rs
@@ -32,8 +32,7 @@ impl<Context> Decode<Context> for Value {
             18 => Ok(Value::Bytes(Vec::<u8>::decode(decoder)?)),
             32 => Ok(Value::CuTime(CuTime::decode(decoder)?)),
             r => Err(DecodeError::OtherString(format!(
-                "Unknown Value variant: {}",
-                r
+                "Unknown Value variant: {r}"
             ))),
         }
     }
@@ -64,8 +63,7 @@ impl<'de, Context> BorrowDecode<'de, Context> for Value {
             17 => Ok(Value::Option(Option::<Box<Value>>::borrow_decode(decoder)?)),
             18 => Ok(Value::Newtype(Box::<Value>::borrow_decode(decoder)?)),
             r => Err(DecodeError::OtherString(format!(
-                "Unknown Value variant: {}",
-                r
+                "Unknown Value variant: {r}"
             ))),
         }
     }

--- a/core/cu29_value/src/de.rs
+++ b/core/cu29_value/src/de.rs
@@ -156,7 +156,7 @@ impl Error for DeserializerError {
 impl fmt::Display for DeserializerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            DeserializerError::Custom(ref msg) => write!(f, "{}", msg),
+            DeserializerError::Custom(ref msg) => write!(f, "{msg}"),
             DeserializerError::InvalidType(ref unexp, ref exp) => {
                 write!(
                     f,
@@ -174,7 +174,7 @@ impl fmt::Display for DeserializerError {
                 )
             }
             DeserializerError::InvalidLength(len, ref exp) => {
-                write!(f, "Invalid length {}. Expected {}", len, exp)
+                write!(f, "Invalid length {len}. Expected {exp}")
             }
             DeserializerError::UnknownVariant(ref field, exp) => {
                 write!(
@@ -192,8 +192,8 @@ impl fmt::Display for DeserializerError {
                     exp.join(", ")
                 )
             }
-            DeserializerError::MissingField(field) => write!(f, "Missing field {}", field),
-            DeserializerError::DuplicateField(field) => write!(f, "Duplicate field {}", field),
+            DeserializerError::MissingField(field) => write!(f, "Missing field {field}"),
+            DeserializerError::DuplicateField(field) => write!(f, "Duplicate field {field}"),
         }
     }
 }

--- a/core/cu29_value/src/lib.rs
+++ b/core/cu29_value/src/lib.rs
@@ -48,32 +48,32 @@ pub enum Value {
 impl Display for Value {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Value::Bool(v) => write!(f, "{}", v),
-            Value::U8(v) => write!(f, "{}", v),
-            Value::U16(v) => write!(f, "{}", v),
-            Value::U32(v) => write!(f, "{}", v),
-            Value::U64(v) => write!(f, "{}", v),
-            Value::I8(v) => write!(f, "{}", v),
-            Value::I16(v) => write!(f, "{}", v),
-            Value::I32(v) => write!(f, "{}", v),
-            Value::I64(v) => write!(f, "{}", v),
-            Value::F32(v) => write!(f, "{}", v),
-            Value::F64(v) => write!(f, "{}", v),
-            Value::Char(v) => write!(f, "{}", v),
-            Value::String(v) => write!(f, "{}", v),
+            Value::Bool(v) => write!(f, "{v}"),
+            Value::U8(v) => write!(f, "{v}"),
+            Value::U16(v) => write!(f, "{v}"),
+            Value::U32(v) => write!(f, "{v}"),
+            Value::U64(v) => write!(f, "{v}"),
+            Value::I8(v) => write!(f, "{v}"),
+            Value::I16(v) => write!(f, "{v}"),
+            Value::I32(v) => write!(f, "{v}"),
+            Value::I64(v) => write!(f, "{v}"),
+            Value::F32(v) => write!(f, "{v}"),
+            Value::F64(v) => write!(f, "{v}"),
+            Value::Char(v) => write!(f, "{v}"),
+            Value::String(v) => write!(f, "{v}"),
             Value::Unit => write!(f, "()"),
             Value::Option(v) => match v {
-                Some(v) => write!(f, "Some({})", v),
+                Some(v) => write!(f, "Some({v})"),
                 None => write!(f, "None"),
             },
-            Value::Newtype(v) => write!(f, "{}", v),
+            Value::Newtype(v) => write!(f, "{v}"),
             Value::Seq(v) => {
                 write!(f, "[")?;
                 for (i, v) in v.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}", v)?;
+                    write!(f, "{v}")?;
                 }
                 write!(f, "]")
             }
@@ -83,7 +83,7 @@ impl Display for Value {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}: {}", k, v)?;
+                    write!(f, "{k}: {v}")?;
                 }
                 write!(f, "}}")
             }
@@ -93,11 +93,11 @@ impl Display for Value {
                     if i > 0 {
                         write!(f, " ")?;
                     }
-                    write!(f, "{:02x}", b)?;
+                    write!(f, "{b:02x}")?;
                 }
                 write!(f, "]")
             }
-            Value::CuTime(v) => write!(f, "{}", v),
+            Value::CuTime(v) => write!(f, "{v}"),
         }
     }
 }
@@ -904,7 +904,7 @@ mod tests {
         // Check we get appropriate error types
         match bool_val.deserialize_into::<String>() {
             Err(DeserializerError::InvalidType(..)) => (), // Expected
-            other => panic!("Expected InvalidType error, got: {:?}", other),
+            other => panic!("Expected InvalidType error, got: {other:?}"),
         }
     }
 

--- a/examples/cu_logging_size/src/main.rs
+++ b/examples/cu_logging_size/src/main.rs
@@ -107,7 +107,7 @@ fn main() {
             assert!(file_size >= SLAB_SIZE.unwrap() as u64);
         }
         Err(e) => {
-            eprintln!("Failed to get file metadata: {}", e);
+            eprintln!("Failed to get file metadata: {e}");
         }
     }
     let (current_slab_used, _current_slab_offsets, _back_slab_in_flight) =

--- a/examples/cu_rp_balancebot/src/resim.rs
+++ b/examples/cu_rp_balancebot/src/resim.rs
@@ -59,7 +59,7 @@ fn run_one_copperlist(
                     let force_magnitude = motor_actuation.power * 2.0;
                     output
                         .metadata
-                        .set_status(format!("Applied force: {}", force_magnitude));
+                        .set_status(format!("Applied force: {force_magnitude}"));
                 }
                 SimOverride::ExecutedBySim
             }
@@ -107,7 +107,7 @@ fn main() {
     let mut reader = UnifiedLoggerIOReader::new(dl, UnifiedLogType::CopperList);
     let iter = copperlists_dump::<default::CuMsgs>(&mut reader);
     for entry in iter {
-        println!("{:#?}", entry);
+        println!("{entry:#?}");
         run_one_copperlist(&mut copper_app, &mut robot_clock_mock, entry);
     }
     copper_app

--- a/examples/cu_rp_balancebot/src/sim.rs
+++ b/examples/cu_rp_balancebot/src/sim.rs
@@ -158,7 +158,7 @@ fn run_copper_callback(
                     cart_force.apply_force(new_force);
                     output
                         .metadata
-                        .set_status(format!("Applied force: {}", force_magnitude));
+                        .set_status(format!("Applied force: {force_magnitude}"));
                     SimOverride::ExecutedBySim
                 } else {
                     cart_force.apply_force(Vector::ZERO);

--- a/examples/cu_rp_balancebot/src/tasks.rs
+++ b/examples/cu_rp_balancebot/src/tasks.rs
@@ -45,7 +45,7 @@ impl<'cl> CuTask<'cl> for PIDMerger {
         });
         output
             .metadata
-            .set_status(format!("Comp:{:.2}", composite_output));
+            .set_status(format!("Comp:{composite_output:.2}"));
 
         Ok(())
     }

--- a/examples/cu_rp_balancebot/src/world/mod.rs
+++ b/examples/cu_rp_balancebot/src/world/mod.rs
@@ -161,7 +161,7 @@ fn setup_scene(
         .expect("Failed to create the file cache.");
 
     let balance_bot_hashed = cache
-        .cached_path(format!("{}{}", BASE_ASSETS_URL, BALANCEBOT).as_str())
+        .cached_path(format!("{BASE_ASSETS_URL}{BALANCEBOT}").as_str())
         .expect("Failed to download and cache balancebot.glb.");
     let balance_bot_path = balance_bot_hashed.parent().unwrap().join(BALANCEBOT);
 
@@ -172,7 +172,7 @@ fn setup_scene(
     .expect("Failed to create symlink to balancebot.glb.");
 
     let skybox_path_hashed = cache
-        .cached_path(format!("{}{}", BASE_ASSETS_URL, SKYBOX).as_str())
+        .cached_path(format!("{BASE_ASSETS_URL}{SKYBOX}").as_str())
         .expect("Failed download and cache skybox.ktx2.");
 
     let skybox_path = skybox_path_hashed.parent().unwrap().join(SKYBOX);
@@ -183,7 +183,7 @@ fn setup_scene(
     .expect("Failed to create symlink to skybox.ktx2.");
 
     let diffuse_map_path_hashed = cache
-        .cached_path(format!("{}{}", BASE_ASSETS_URL, DIFFUSE_MAP).as_str())
+        .cached_path(format!("{BASE_ASSETS_URL}{DIFFUSE_MAP}").as_str())
         .expect("Failed download and cache diffuse_map.");
 
     let diffuse_map_path = diffuse_map_path_hashed.parent().unwrap().join(DIFFUSE_MAP);


### PR DESCRIPTION
This PR fixes nightly clippy warnings by updating various formatting macros to use the new inline interpolation syntax. The key changes include:

- Replacing format strings using positional formatting (e.g. "{}") with inline named interpolation (e.g. "{var}").
- Updating error messages, debug prints, and panic messages across multiple modules for consistency.