### PR TITLE
[FIX] resim needs cu29-export, dynthreshold needs gst flagged gstreamer

### DIFF
--- a/components/tasks/cu_dynthreshold/Cargo.toml
+++ b/components/tasks/cu_dynthreshold/Cargo.toml
@@ -18,4 +18,4 @@ cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "0.
 cu-gstreamer = { path = "../../sources/cu_gstreamer", version = "0.7.0", optional = true }
 
 [features]
-gst = [ "dep:gstreamer", "dep:cu-gstreamer" ]
+gst = [ "dep:gstreamer", "dep:cu-gstreamer", "cu-gstreamer/gst" ]

--- a/components/tasks/cu_dynthreshold/Cargo.toml
+++ b/components/tasks/cu_dynthreshold/Cargo.toml
@@ -18,4 +18,6 @@ cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "0.
 cu-gstreamer = { path = "../../sources/cu_gstreamer", version = "0.7.0", optional = true }
 
 [features]
+# The 'gst' feature includes dependencies for GStreamer support. 
+# 'cu-gstreamer/gst' is included to propagate the 'gst' flag to the cu-gstreamer crate.
 gst = [ "dep:gstreamer", "dep:cu-gstreamer", "cu-gstreamer/gst" ]

--- a/examples/cu_rp_balancebot/Cargo.toml
+++ b/examples/cu_rp_balancebot/Cargo.toml
@@ -39,7 +39,7 @@ default = ["logreader", "sim"]
 # generates an executable to read the logs
 logreader = ["dep:cu29-export"]
 # dependencies to build to matrix for copper
-sim = ["dep:bevy", "dep:avian3d", "dep:cached-path", "dep:cu29-export"]
+sim = ["dep:bevy", "dep:avian3d", "dep:cached-path", "dep:cu29-export"] # required for exporting simulation data
 perf-ui = ["dep:iyes_perf_ui"]
 
 [[bin]]

--- a/examples/cu_rp_balancebot/Cargo.toml
+++ b/examples/cu_rp_balancebot/Cargo.toml
@@ -39,7 +39,7 @@ default = ["logreader", "sim"]
 # generates an executable to read the logs
 logreader = ["dep:cu29-export"]
 # dependencies to build to matrix for copper
-sim = ["dep:bevy", "dep:avian3d", "dep:cached-path"]
+sim = ["dep:bevy", "dep:avian3d", "dep:cached-path", "dep:cu29-export"]
 perf-ui = ["dep:iyes_perf_ui"]
 
 [[bin]]


### PR DESCRIPTION
To pass test with different combination of features flag
```
cargo install cargo-hack
cargo hack check --feature-powerset --workspace
```

We found:
1. resim.rs of `cu_rp_balancebot` used `cu29_export`
2. If `cu_gstreamer` was built without the `gst` flag, and we want to build `cu_dynthreshold` with the `gst` flag, compilation failed (both require the gst flag to be enabled).

This PR fixed both issues and passed the feature-powerset test.