### PR TITLE
[FEAT] Add ROS compatible zenoh sink

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "core/cu29_unifiedlog",
     "components/common/cu_msp_lib",
     "components/monitors/cu_consolemon",
+    "components/payloads/cu_ros_payloads",
     "components/payloads/cu_sensor_payloads",
     "components/payloads/cu_spatial_payloads",
     "components/sinks/cu_iceoryx2_sink",
@@ -24,6 +25,7 @@ members = [
     "components/sinks/cu_rp_sn754410",
     "components/sinks/cu_lewansoul",
     "components/sinks/cu_zenoh_sink",
+    "components/sinks/cu_zenoh_ros_sink",
     "components/sources/cu_ads7883",
     "components/sources/cu_gstreamer",
     "components/sources/cu_hesai",
@@ -51,6 +53,7 @@ members = [
     "examples/cu_standalone_structlog",
     "examples/cu_standalone_structlog",
     "examples/cu_zenoh",
+    "examples/cu_zenoh_ros",
 ]
 
 # put only the core crates here that are not platform specific
@@ -105,6 +108,7 @@ cu29-value = { path = "core/cu29_value", version = "0.7.0" }
 
 # Payload definitions
 cu-sensor-payloads = { path = "components/payloads/cu_sensor_payloads", version = "0.7.0" }
+cu-ros-payloads = { path = "components/payloads/cu_ros_payloads", version = "0.7.0" }
 
 # External serialization
 bincode = { version = "2.0.1", features = ["derive"] }

--- a/components/payloads/cu_ros_payloads/Cargo.toml
+++ b/components/payloads/cu_ros_payloads/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "cu-ros-payloads"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Sepcial copper payloads designed to be ROS compatible"
+
+[dependencies]
+compact_str = { workspace = true }
+serde = { workspace = true }
+cu29-value = { workspace = true }
+cu-sensor-payloads = { workspace = true }

--- a/components/payloads/cu_ros_payloads/src/builtin.rs
+++ b/components/payloads/cu_ros_payloads/src/builtin.rs
@@ -1,0 +1,14 @@
+use compact_str::CompactString;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Header {
+    pub stamp: Time,
+    pub frame_id: CompactString,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Time {
+    pub sec: i32,
+    pub nanosec: u32,
+}

--- a/components/payloads/cu_ros_payloads/src/lib.rs
+++ b/components/payloads/cu_ros_payloads/src/lib.rs
@@ -1,0 +1,30 @@
+pub mod builtin;
+pub mod sensor_msgs;
+pub mod std_msgs;
+
+use serde::Serialize;
+use std::convert::From;
+
+// By default use Rust type as ROS type
+#[macro_export]
+macro_rules! ros_type_name {
+    ($t:ty) => {{
+        std::any::type_name::<$t>().rsplit("::").next().unwrap()
+    }};
+}
+
+/// ROS adaptation trait to convert payload data to ROS compatible message.
+/// The output type must match the structure of the related "msg" file.
+/// The namespace relates to the ROS namespace (such as "std_msgs")
+/// and the type name is the same as the message filename.
+pub trait RosMsgAdapter<'a>: std::marker::Sized {
+    type Output: Serialize + for<'b> From<&'b Self>;
+
+    fn namespace() -> &'a str;
+    fn type_name() -> &'a str {
+        ros_type_name!(Self::Output)
+    }
+    fn convert(&self) -> Self::Output {
+        self.into()
+    }
+}

--- a/components/payloads/cu_ros_payloads/src/sensor_msgs.rs
+++ b/components/payloads/cu_ros_payloads/src/sensor_msgs.rs
@@ -1,0 +1,57 @@
+use compact_str::CompactString;
+use cu_sensor_payloads::PointCloudSoa;
+use serde::{Deserialize, Serialize};
+
+use crate::{builtin::Header, RosMsgAdapter};
+
+// sensor_msgs/PointField
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PointField {
+    pub name: CompactString,
+    pub offset: u32,
+    pub datatype: u8,
+    pub count: u32,
+}
+
+// sensor_msgs/PointCloud2 like struct
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PointCloud2 {
+    pub header: Header,
+    pub height: u32, //
+    pub width: u32,  // Length of the point cloud
+    pub pointfields: Vec<PointField>,
+    pub is_bigendian: bool,
+    pub point_step: u32, // Length of a point in bytes
+    pub row_step: u32,   // Length of a row in bytes
+    pub data: Vec<u8>,   // size is (row_step*height)
+    pub is_dense: bool,  // True if there are no invalid points
+}
+
+impl<const N: usize> RosMsgAdapter<'static> for PointCloudSoa<N> {
+    type Output = PointCloud2;
+
+    fn namespace() -> &'static str {
+        "sensor_msgs"
+    }
+
+    fn type_name() -> &'static str {
+        "PointCloud2"
+    }
+}
+
+impl<const N: usize> From<&PointCloudSoa<N>> for PointCloud2 {
+    #[allow(unreachable_code)]
+    fn from(_: &PointCloudSoa<N>) -> Self {
+        PointCloud2 {
+            header: todo!(),
+            height: 1,
+            width: todo!(),
+            pointfields: todo!(),
+            is_bigendian: true,
+            point_step: todo!(),
+            row_step: todo!(),
+            data: todo!(),
+            is_dense: todo!(),
+        }
+    }
+}

--- a/components/payloads/cu_ros_payloads/src/std_msgs.rs
+++ b/components/payloads/cu_ros_payloads/src/std_msgs.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+
+use crate::RosMsgAdapter;
+
+// std_msgs/Int8 like struct
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Int8 {
+    pub data: i8,
+}
+
+impl RosMsgAdapter<'static> for i8 {
+    type Output = Int8;
+
+    fn namespace() -> &'static str {
+        "std_msgs"
+    }
+}
+
+impl From<&i8> for Int8 {
+    fn from(value: &i8) -> Self {
+        Self { data: *value }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_adapter_type_info() {
+        let x: i8 = 42;
+        let msg = x.convert();
+        assert_eq!(msg.data, 42);
+        assert_eq!(<i8 as RosMsgAdapter>::namespace(), "std_msgs");
+        assert_eq!(<i8 as RosMsgAdapter>::type_name(), "Int8");
+    }
+}

--- a/components/sinks/cu_zenoh_ros_sink/Cargo.toml
+++ b/components/sinks/cu_zenoh_ros_sink/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "cu-zenoh-ros-sink"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Copper sink task for ROS-compatible Zenoh messages."
+
+[dependencies]
+cu29 = { workspace = true }
+cu-ros-payloads = { workspace = true }
+serde = { workspace = true }
+zenoh = { version = "1.3.4" }
+zenoh-ext = { version = "1.3.4" }
+cdr = { version = "0.2.4" }

--- a/components/sinks/cu_zenoh_ros_sink/README.md
+++ b/components/sinks/cu_zenoh_ros_sink/README.md
@@ -1,0 +1,65 @@
+# cu-zenoh-ros-sink
+
+This is a Copper sink task that publishes messages to ROS 2 via Zenoh middleware.
+It allows seamless integration between Copper applications and ROS 2 nodes by using the [RMW zenoh implementation](https://github.com/ros2/rmw_zenoh).
+
+## Configuration
+
+The sink requires the following configuration parameters:
+
+- zenoh_config_json: Zenoh config [as json string](https://github.com/ros2/rmw_zenoh/blob/rolling/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5) (optional).
+- domain_id: ROS domain ID (optional, defaults to "0"),
+- namespace: The ROS namespace (optional, defaults to "copper").
+- node: The ROS node name (optional, defaults to "node").
+- topic: The ROS topic name to publish to (optional, defaults to "copper").
+
+Example configuration in a Copper application:
+
+```ron
+(
+    tasks: [
+        (
+            id: "publisher",
+            config: {
+                "domain_id": 0,
+                "namespace": "copper",
+                "node": "sink_node",
+                "topic": "output",
+            }
+        ),
+    ],
+    // ... rest of the configuration
+)
+```
+
+## Integration with ROS 2
+
+To receive messages in ROS 2:
+
+1. Install "rmw_zenoh":
+
+```bash
+sudo apt install ros-$ROS_DISTRO-rmw-zenoh
+```
+
+2. Set the RMW implementation to Zenoh:
+
+```bash
+export RMW_IMPLEMENTATION=rmw_zenoh
+```
+
+3. Run your ROS 2 nodes as usual - they will automatically receive messages published by this sink.
+
+## Limitations
+
+- Payload has to implement `RosMsgAdapter` trait (see `cu_ros_payloads`).
+- QoS is not implemented (default QoS).
+- Only works with Humble distribution (hash type not implemented).
+- No service implemented.
+
+## Caveats
+
+- Add an extra serialization step to CDR format that could impact performance.
+
+
+See the crate [cu29](https://crates.io/crates/cu29) for more information about the Copper project.

--- a/components/sinks/cu_zenoh_ros_sink/build.rs
+++ b/components/sinks/cu_zenoh_ros_sink/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=LOG_INDEX_DIR={}",
+        std::env::var("OUT_DIR").unwrap()
+    );
+}

--- a/components/sinks/cu_zenoh_ros_sink/src/attachment.rs
+++ b/components/sinks/cu_zenoh_ros_sink/src/attachment.rs
@@ -1,0 +1,14 @@
+use cu29::clock::RobotClock;
+use zenoh::{bytes::ZBytes, config::ZenohId};
+use zenoh_ext::ZSerializer;
+
+pub fn encode_attachment(sequence_number: u64, clock: &RobotClock, zid: &ZenohId) -> ZBytes {
+    let mut serializer = ZSerializer::new();
+    serializer.serialize("sequence_number".to_string());
+    serializer.serialize(sequence_number);
+    serializer.serialize("source_timestamp".to_string());
+    serializer.serialize(clock.now().as_nanos());
+    serializer.serialize("source_gid");
+    serializer.serialize(zid.to_le_bytes());
+    serializer.finish()
+}

--- a/components/sinks/cu_zenoh_ros_sink/src/error.rs
+++ b/components/sinks/cu_zenoh_ros_sink/src/error.rs
@@ -1,0 +1,10 @@
+use cu29::CuError;
+use zenoh::Error as ZenohError;
+
+pub fn cu_error(msg: &str, error: ZenohError) -> CuError {
+    CuError::new_with_cause(msg, error.as_ref())
+}
+
+pub fn cu_error_map(msg: &str) -> impl FnOnce(ZenohError) -> CuError + '_ {
+    |e| cu_error(msg, e)
+}

--- a/components/sinks/cu_zenoh_ros_sink/src/keyexpr.rs
+++ b/components/sinks/cu_zenoh_ros_sink/src/keyexpr.rs
@@ -1,0 +1,94 @@
+#[macro_export]
+macro_rules! format_keyexpr_raw {
+    ($first:expr, $($arg:expr),*) => {{
+        use $crate::error::cu_error_map;
+
+        let mut result = KeyExpr::new($first.to_string());
+        $(
+            if let Ok(r) = result {
+              result = r.join(&$arg.to_string());
+            }
+        )*
+        result.map_err(cu_error_map("Bad keyexpr argument"))
+    }};
+}
+
+pub use format_keyexpr_raw;
+
+#[macro_export]
+macro_rules! format_keyexpr {
+    ($first:expr, $($arg:expr),*) => {{
+
+        use $crate::keyexpr::normalize_chunk;
+        use $crate::keyexpr::format_keyexpr_raw;
+        format_keyexpr_raw!(normalize_chunk($first), $(normalize_chunk($arg)), *)
+    }};
+}
+
+/// Liveliness keyexpr mangles key parts in order to escape slashes
+#[macro_export]
+macro_rules! format_liveliness_keyexpr {
+    ($first:expr, $($arg:expr),*) => {{
+
+        use $crate::keyexpr::mangle_chunk;
+        use $crate::keyexpr::format_keyexpr_raw;
+        format_keyexpr_raw!(mangle_chunk($first), $(mangle_chunk($arg)), *)
+    }};
+}
+
+pub(crate) fn normalize_chunk<T>(arg: T) -> String
+where
+    T: ToString,
+{
+    let str = arg.to_string();
+    let str_trimmed = str.trim_matches('/');
+    // Empty chunks are forbidden
+    if str_trimmed.is_empty() {
+        return "_".into();
+    }
+
+    str_trimmed.into()
+}
+
+pub(crate) fn mangle_chunk<T>(arg: T) -> String
+where
+    T: ToString,
+{
+    let str = arg.to_string();
+    // Empty chunks are forbidden
+    if str.is_empty() {
+        return "%".into();
+    }
+
+    str.replace("/", "%")
+}
+
+#[cfg(test)]
+mod tests {
+    use zenoh::key_expr::KeyExpr;
+
+    #[test]
+    fn test_basic_keyexpr() {
+        {
+            let keyexpr = format_keyexpr!("test", "copper").unwrap();
+            assert_eq!(keyexpr.to_string(), "test/copper")
+        }
+        {
+            let keyexpr = format_liveliness_keyexpr!("test", "copper").unwrap();
+            assert_eq!(keyexpr.to_string(), "test/copper")
+        }
+    }
+
+    #[test]
+    fn test_special_keyexpr() {
+        {
+            let keyexpr = format_keyexpr!("@prefix", "/topic/a/", 1).unwrap();
+            assert_eq!(keyexpr.to_string(), "@prefix/topic/a/1")
+        }
+
+        {
+            let keyexpr = format_liveliness_keyexpr!("@prefix", "", "/topic/a", 1).unwrap();
+            assert_eq!(keyexpr.to_string(), "@prefix/%/%topic%a/1")
+        }
+    }
+}

--- a/components/sinks/cu_zenoh_ros_sink/src/lib.rs
+++ b/components/sinks/cu_zenoh_ros_sink/src/lib.rs
@@ -1,0 +1,190 @@
+mod attachment;
+mod error;
+mod keyexpr;
+mod liveliness;
+mod node;
+mod topic;
+
+use attachment::encode_attachment;
+use cdr::{CdrBe, Infinite};
+use cu29::clock::RobotClock;
+use cu29::prelude::*;
+use cu_ros_payloads::RosMsgAdapter;
+use error::cu_error_map;
+use liveliness::{node_liveliness, publisher_liveliness};
+use node::Node;
+use topic::Topic;
+use zenoh::bytes::Encoding;
+use zenoh::Config;
+
+use std::marker::PhantomData;
+
+// Only one node per session
+const NODE_ID: u32 = 0;
+
+// Only one publisher per session
+const PUBLISHER_ID: u32 = NODE_ID + 1;
+
+/// This is a sink task that sends ROS-compatible messages to a Zenoh topic.
+/// P is the payload type of the messages, which must be convertible to ROS format.
+/// Hence the payload type must implement the `RosMsgAdapter` trait.
+pub struct ZenohRosSink<P>
+where
+    P: CuMsgPayload + RosMsgAdapter<'static>,
+{
+    _marker: PhantomData<P>,
+    config: ZenohRosConfig,
+    ctx: Option<ZenohRosContext>,
+}
+
+pub struct ZenohRosConfig {
+    session: zenoh::Config,
+    domain_id: u32,
+    namespace: String,
+    node: String,
+    topic: String,
+}
+
+pub struct ZenohRosContext {
+    session: zenoh::Session,
+    publisher: zenoh::pubsub::Publisher<'static>,
+    // Token have to be kept alive (undeclared on drop)
+    #[allow(dead_code)]
+    node_token: zenoh::liveliness::LivelinessToken,
+    #[allow(dead_code)]
+    publisher_token: zenoh::liveliness::LivelinessToken,
+    sequence_number: u64,
+}
+
+impl<P> Freezable for ZenohRosSink<P> where P: CuMsgPayload + RosMsgAdapter<'static> {}
+
+impl<'cl, P> CuSinkTask<'cl> for ZenohRosSink<P>
+where
+    P: CuMsgPayload + RosMsgAdapter<'static> + 'cl,
+{
+    type Input = input_msg!('cl, P);
+
+    fn new(config: Option<&ComponentConfig>) -> CuResult<Self>
+    where
+        Self: Sized,
+    {
+        let config = config.ok_or(CuError::from("ZenohRosSink: Missing configuration"))?;
+
+        // Get json zenoh config
+        let session_config = config.get::<String>("zenoh_config_json").map_or(
+            // Or default zenoh config otherwise
+            CuResult::Ok(Config::default()),
+            |s| -> CuResult<zenoh::Config> {
+                Config::from_json5(&s)
+                    .map_err(cu_error_map("ZenohRosSink: Failed to create zenoh config"))
+            },
+        )?;
+
+        Ok(Self {
+            _marker: Default::default(),
+            config: ZenohRosConfig {
+                session: session_config,
+                domain_id: config.get::<u32>("domain_id").unwrap_or(0),
+                namespace: config.get::<String>("namespace").unwrap_or("node".into()),
+                node: config.get::<String>("node").unwrap_or("node".into()),
+                topic: config.get::<String>("topic").unwrap_or("copper".into()),
+            },
+            ctx: None,
+        })
+    }
+
+    fn start(&mut self, _clock: &RobotClock) -> CuResult<()> {
+        let session = zenoh::Wait::wait(zenoh::open(self.config.session.clone()))
+            .map_err(cu_error_map("ZenohRosSink: Failed to open session"))?;
+
+        debug!("Zenoh session open");
+
+        let zid = session.zid();
+
+        let node = Node {
+            domain_id: self.config.domain_id,
+            zid,
+            id: NODE_ID,
+            namespace: self.config.namespace.as_ref(),
+            name: self.config.node.as_ref(),
+        };
+
+        let topic = Topic::new::<P>(self.config.topic.as_ref());
+
+        let node_token =
+            zenoh::Wait::wait(session.liveliness().declare_token(node_liveliness(&node)?))
+                .map_err(cu_error_map(
+                    "ZenohRosSink: Failed to declare node liveliness token",
+                ))?;
+
+        let publisher_token = zenoh::Wait::wait(
+            session
+                .liveliness()
+                .declare_token(publisher_liveliness(&node, &topic, PUBLISHER_ID)?),
+        )
+        .map_err(cu_error_map(
+            "ZenohRosSink: Failed to declare topic liveliness token",
+        ))?;
+
+        // Format the key expression according to ROS 2 conventions
+        let publisher = zenoh::Wait::wait(session.declare_publisher(topic.pubsub_keyexpr(&node)?))
+            .map_err(cu_error_map("ZenohRosSink: Failed to create publisher"))?;
+
+        self.ctx = Some(ZenohRosContext {
+            session,
+            publisher,
+            node_token,
+            publisher_token,
+            sequence_number: 0,
+        });
+        Ok(())
+    }
+
+    fn process(&mut self, clock: &RobotClock, input: Self::Input) -> CuResult<()> {
+        let ctx = self
+            .ctx
+            .as_mut()
+            .ok_or(CuError::from("ZenohRosSink: Context not found"))?;
+
+        // Convert the payload to ROS-compatible CDR format
+        let payload = input.payload().ok_or(CuError::from(
+            "ZenohRosSink: Cannot send empty payload through ROS bridge",
+        ))?;
+
+        let ros_payload = payload.convert();
+        let serial_ros_payload = cdr::serialize::<_, _, CdrBe>(&ros_payload, Infinite)
+            .map_err(|e| CuError::new_with_cause("ZenohRosSink: Failed to serialize payload", e))?;
+
+        let serial_metadata = encode_attachment(ctx.sequence_number, clock, &ctx.session.zid());
+
+        ctx.sequence_number += 1;
+
+        zenoh::Wait::wait(
+            ctx.publisher
+                .put(serial_ros_payload)
+                .encoding(Encoding::APPLICATION_CDR)
+                .attachment(serial_metadata),
+        )
+        .map_err(cu_error_map("ZenohRosSink: Failed to put value"))?;
+
+        Ok(())
+    }
+
+    fn stop(&mut self, _clock: &RobotClock) -> CuResult<()> {
+        if let Some(ZenohRosContext {
+            session,
+            publisher,
+            node_token: _,
+            publisher_token: _,
+            sequence_number: _,
+        }) = self.ctx.take()
+        {
+            zenoh::Wait::wait(publisher.undeclare())
+                .map_err(cu_error_map("ZenohRosSink: Failed to undeclare publisher"))?;
+            zenoh::Wait::wait(session.close())
+                .map_err(cu_error_map("ZenohRosSink: Failed to close session"))?;
+        }
+        debug!("ZenohRosSink: Stopped");
+        Ok(())
+    }
+}

--- a/components/sinks/cu_zenoh_ros_sink/src/liveliness.rs
+++ b/components/sinks/cu_zenoh_ros_sink/src/liveliness.rs
@@ -1,0 +1,59 @@
+use std::fmt;
+
+use cu29::CuResult;
+use zenoh::key_expr::KeyExpr;
+
+use crate::{format_liveliness_keyexpr, node::Node, topic::Topic};
+
+const ADMIN_SPACE: &str = "@ros2_lv";
+
+enum Entity {
+    Node,
+    Publisher,
+}
+
+impl fmt::Display for Entity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Entity::Node => write!(f, "NN"),
+            Entity::Publisher => write!(f, "MP"),
+        }
+    }
+}
+
+pub fn node_liveliness(node: &Node) -> CuResult<KeyExpr<'static>> {
+    liveliness_base_keyexpr(node, Entity::Node, node.id)
+}
+
+pub fn publisher_liveliness(
+    node: &Node,
+    topic: &Topic,
+    instance_id: u32,
+) -> CuResult<KeyExpr<'static>> {
+    let base_keyexpr = liveliness_base_keyexpr(node, Entity::Publisher, instance_id)?;
+    let topic_keyexpr =
+        format_liveliness_keyexpr!(topic.name(), topic.type_name(), topic.hash(), topic.qos())?;
+
+    Ok(base_keyexpr / topic_keyexpr.as_ref())
+}
+
+fn liveliness_base_keyexpr(
+    node: &Node,
+    entity: Entity,
+    entity_id: u32,
+) -> CuResult<KeyExpr<'static>> {
+    // Admin space / Domain ID / ZID /  Node ID / Entity ID / Entity type /  Enclave /
+    // Namespace / Node name
+
+    format_liveliness_keyexpr!(
+        ADMIN_SPACE,
+        node.domain_id,
+        node.zid,
+        node.id,
+        entity_id,
+        entity,
+        "", // enclave (useless?)
+        node.namespace,
+        node.name
+    )
+}

--- a/components/sinks/cu_zenoh_ros_sink/src/node.rs
+++ b/components/sinks/cu_zenoh_ros_sink/src/node.rs
@@ -1,0 +1,9 @@
+use zenoh::config::ZenohId;
+
+pub struct Node<'a> {
+    pub domain_id: u32,
+    pub zid: ZenohId,
+    pub id: u32,
+    pub namespace: &'a str,
+    pub name: &'a str,
+}

--- a/components/sinks/cu_zenoh_ros_sink/src/topic.rs
+++ b/components/sinks/cu_zenoh_ros_sink/src/topic.rs
@@ -1,0 +1,57 @@
+use cu29::CuResult;
+use cu_ros_payloads::RosMsgAdapter;
+use zenoh::key_expr::KeyExpr;
+
+use crate::{format_keyexpr, node::Node};
+
+// ROS Humble does not support hash
+const UNSUPPORTED_HASH: &str = "TypeHashNotSupported";
+
+pub struct Topic<'a> {
+    name: &'a str,
+    type_name: String,
+    hash: &'a str,
+}
+
+impl<'a> Topic<'a> {
+    pub fn new<'b, T>(name: &'a str) -> Self
+    where
+        T: RosMsgAdapter<'b>,
+    {
+        Self {
+            name,
+            type_name: get_dds_type_name::<T>(),
+            // TODO implement hash for other ROS distribution
+            hash: UNSUPPORTED_HASH,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        self.name
+    }
+
+    pub fn type_name(&self) -> &str {
+        self.type_name.as_ref()
+    }
+
+    pub fn hash(&self) -> &str {
+        self.hash
+    }
+
+    pub fn qos(&self) -> &str {
+        // TODO implement QoS
+        "::,:,:,:,,"
+    }
+
+    pub fn pubsub_keyexpr(&self, node: &Node) -> CuResult<KeyExpr<'static>> {
+        format_keyexpr!(node.domain_id, self.name(), self.type_name(), self.hash())
+    }
+}
+
+fn get_dds_type_name<'a, T>() -> String
+where
+    T: RosMsgAdapter<'a>,
+{
+    // DDS name encoding relates to https://github.com/ros2/rmw_fastrtps/blob/469624e3d483290d6f88fe4b89ee5feaa7694e61/rmw_fastrtps_cpp/src/type_support_common.hpp
+    format!("{}::msg::dds_::{}_", T::namespace(), T::type_name())
+}

--- a/examples/cu_zenoh_ros/Cargo.toml
+++ b/examples/cu_zenoh_ros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "cu-zenoh-ros"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Copper example to use zenoh as a ROS 2 bridge."
+
+[dependencies]
+cu29 = { workspace = true }
+cu29-helpers = { workspace = true }
+cu-zenoh-ros-sink = { path = "../../components/sinks/cu_zenoh_ros_sink", version = "0.7.0" }
+tempfile = { workspace = true }

--- a/examples/cu_zenoh_ros/README.md
+++ b/examples/cu_zenoh_ros/README.md
@@ -1,0 +1,24 @@
+# ROS bridge using Zenoh
+
+## To run the bridge
+
+Launch a zenoh router.
+
+```bash
+$ zenohd
+```
+
+Then run this example.
+
+```bash
+$ cd cuexamples/cu_zenoh_ros
+$ cargo run --release 
+```
+
+Display the result.
+
+```bash
+export RMW_IMPLEMENTATION=rmw_zenoh_cpp
+ros2 topic echo /output
+```
+

--- a/examples/cu_zenoh_ros/build.rs
+++ b/examples/cu_zenoh_ros/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=LOG_INDEX_DIR={}",
+        std::env::var("OUT_DIR").unwrap()
+    );
+}

--- a/examples/cu_zenoh_ros/copperconfig.ron
+++ b/examples/cu_zenoh_ros/copperconfig.ron
@@ -1,0 +1,472 @@
+(
+    tasks: [
+        (
+            id: "source",
+            type: "tasks::ExampleSrc",
+        ),
+        (
+            id: "publisher",
+            type: "cu_zenoh_ros::ExamplePublisher",
+            config: {
+                "domain_id": 0,
+                "namespace": "copper",
+                "node": "sink_node",
+                "topic": "/output",
+                "zenoh_config_json": r#"
+/// This file attempts to list and document available configuration elements.
+/// For a more complete view of the configuration's structure, check out `zenoh/src/config.rs`'s `Config` structure.
+/// Note that the values here are correctly typed, but may not be sensible, so copying this file to change only the parts that matter to you is not good practice.
+{
+  /// The identifier (as unsigned 128bit integer in hexadecimal lowercase - leading zeros are not accepted)
+  /// that zenoh runtime will use.
+  /// If not set, a random unsigned 128bit integer will be used.
+  /// WARNING: this id must be unique in your zenoh network.
+  // id: "1234567890abcdef",
+
+  /// The node's mode (router, peer or client)
+  mode: "peer",
+
+  /// Which endpoints to connect to. E.g. tcp/localhost:7447.
+  /// By configuring the endpoints, it is possible to tell zenoh which router/peer to connect to at startup.
+  ///
+  /// For TCP/UDP on Linux, it is possible additionally specify the interface to be connected to:
+  /// E.g. tcp/192.168.0.1:7447#iface=eth0, for connect only if the IP address is reachable via the interface eth0
+  ///
+  /// It is also possible to specify a priority range and/or a reliability setting to be used on the link.
+  /// For example `tcp/localhost?prio=6-7;rel=0` assigns priorities "data_low" and "background" to the established link.
+  ///
+  /// For TCP and TLS links, it is possible to specify the TCP buffer sizes:
+  /// E.g. tcp/192.168.0.1:7447#so_sndbuf=65000;so_rcvbuf=65000
+  connect: {
+    /// timeout waiting for all endpoints connected (0: no retry, -1: infinite timeout)
+    /// Accepts a single value (e.g. timeout_ms: 0)
+    /// or different values for router, peer and client (e.g. timeout_ms: { router: -1, peer: -1, client: 0 }).
+    timeout_ms: { router: -1, peer: -1, client: 0 },
+
+    /// The list of endpoints to connect to.
+    /// Accepts a single list (e.g. endpoints: ["tcp/10.10.10.10:7447", "tcp/11.11.11.11:7447"])
+    /// or different lists for router, peer and client (e.g. endpoints: { router: ["tcp/10.10.10.10:7447"], peer: ["tcp/11.11.11.11:7447"] }).
+    ///
+    /// See https://docs.rs/zenoh/latest/zenoh/config/struct.EndPoint.html
+    ///
+    /// ROS setting: By default connect to the Zenoh router on localhost on port 7447.
+    endpoints: [
+      "tcp/localhost:7447"
+    ],
+
+    /// Global connect configuration,
+    /// Accepts a single value or different values for router, peer and client.
+    /// The configuration can also be specified for the separate endpoint
+    /// it will override the global one
+    /// E.g. tcp/192.168.0.1:7447#retry_period_init_ms=20000;retry_period_max_ms=10000"
+
+    /// exit from application, if timeout exceed
+    exit_on_failure: { router: false, peer: false, client: true },
+    /// connect establishing retry configuration
+    retry: {
+      /// initial wait timeout until next connect try
+      period_init_ms: 1000,
+      /// maximum wait timeout until next connect try
+      period_max_ms: 4000,
+      /// increase factor for the next timeout until nexti connect try
+      period_increase_factor: 2,
+    },
+  },
+
+  /// Which endpoints to listen on. E.g. tcp/0.0.0.0:7447.
+  /// By configuring the endpoints, it is possible to tell zenoh which are the endpoints that other routers,
+  /// peers, or client can use to establish a zenoh session.
+  ///
+  /// For TCP/UDP on Linux, it is possible additionally specify the interface to be listened to:
+  /// E.g. tcp/0.0.0.0:7447#iface=eth0, for listen connection only on eth0
+  ///
+  /// It is also possible to specify a priority range and/or a reliability setting to be used on the link.
+  /// For example `tcp/localhost?prio=6-7;rel=0` assigns priorities "data_low" and "background" to the established link.
+  ///
+  /// For TCP and TLS links, it is possible to specify the TCP buffer sizes:
+  /// E.g. tcp/192.168.0.1:7447#so_sndbuf=65000;so_rcvbuf=65000
+  listen: {
+    /// timeout waiting for all listen endpoints (0: no retry, -1: infinite timeout)
+    /// Accepts a single value (e.g. timeout_ms: 0)
+    /// or different values for router, peer and client (e.g. timeout_ms: { router: -1, peer: -1, client: 0 }).
+    timeout_ms: 0,
+
+    /// The list of endpoints to listen on.
+    /// Accepts a single list (e.g. endpoints: ["tcp/[::]:7447", "udp/[::]:7447"])
+    /// or different lists for router, peer and client (e.g. endpoints: { router: ["tcp/[::]:7447"], peer: ["tcp/[::]:0"] }).
+    ///
+    /// See https://docs.rs/zenoh/latest/zenoh/config/struct.EndPoint.html
+    ///
+    /// ROS setting: By default accept incoming connections only from localhost (i.e. from colocalized Nodes).
+    ///              All communications with other hosts are routed by the Zenoh router.
+    endpoints: [
+      "tcp/localhost:0"
+    ],
+
+    /// Global listen configuration,
+    /// Accepts a single value or different values for router, peer and client.
+    /// The configuration can also be specified for the separate endpoint
+    /// it will override the global one
+    /// E.g. tcp/192.168.0.1:7447#exit_on_failure=false;retry_period_max_ms=1000"
+
+    /// exit from application, if timeout exceed
+    exit_on_failure: true,
+    /// listen retry configuration
+    retry: {
+      /// initial wait timeout until next try
+      period_init_ms: 1000,
+      /// maximum wait timeout until next try
+      period_max_ms: 4000,
+      /// increase factor for the next timeout until next try
+      period_increase_factor: 2,
+    },
+  },
+  /// Configure the session open behavior.
+  open: {
+    /// Configure the conditions to be met before session open returns.
+    return_conditions: {
+      /// Session open waits to connect to scouted peers and routers before returning.
+      /// When set to false, first publications and queries after session open from peers may be lost.
+      connect_scouted: true,
+      /// Session open waits to receive initial declares from connected peers before returning.
+      /// Setting to false may cause extra traffic at startup from peers.
+      declares: true,
+    },
+  },
+  /// Configure the scouting mechanisms and their behaviours
+  scouting: {
+    /// In client mode, the period in milliseconds dedicated to scouting for a router before failing.
+    timeout: 3000,
+    /// In peer mode, the maximum period in milliseconds dedicated to scouting remote peers before attempting other operations.
+    delay: 500,
+    /// The multicast scouting configuration.
+    multicast: {
+      /// Whether multicast scouting is enabled or not
+      ///
+      /// ROS setting: disable multicast discovery by default
+      enabled: false,
+      /// The socket which should be used for multicast scouting
+      address: "224.0.0.224:7446",
+      /// The network interface which should be used for multicast scouting
+      interface: "auto", // If not set or set to "auto" the interface if picked automatically
+      /// The time-to-live on multicast scouting packets
+      ttl: 1,
+      /// Which type of Zenoh instances to automatically establish sessions with upon discovery on UDP multicast.
+      /// Accepts a single value (e.g. autoconnect: ["router", "peer"])
+      /// or different values for router, peer and client (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
+      /// Each value is a list of: "peer", "router" and/or "client".
+      autoconnect: { router: [], peer: ["router", "peer"], client: ["router"] },
+      /// Whether or not to listen for scout messages on UDP multicast and reply to them.
+      listen: true,
+    },
+    /// The gossip scouting configuration. Note that instances in "client" mode do not participate in gossip.
+    gossip: {
+      /// Whether gossip scouting is enabled or not
+      enabled: true,
+      /// When true, gossip scouting information are propagated multiple hops to all nodes in the local network.
+      /// When false, gossip scouting information are only propagated to the next hop.
+      /// Activating multihop gossip implies more scouting traffic and a lower scalability.
+      /// It mostly makes sense when using "linkstate" routing mode where all nodes in the subsystem don't have
+      /// direct connectivity with each other.
+      multihop: false,
+      /// Which type of Zenoh instances to send gossip messages to.
+      /// Accepts a single value (e.g. target: ["router", "peer"]) which applies whatever the configured "mode" is,
+      /// or different values for router or peer mode (e.g. target: { router: ["router", "peer"], peer: ["router"] }).
+      /// Each value is a list of "peer" and/or "router".
+      /// ROS setting: by default all peers rely on the router to discover each other. Thus configuring the peer to send gossip
+      ///               messages only to the router is sufficient and avoids unnecessary traffic between Nodes at launch time.
+      target: { router: ["router", "peer"], peer: ["router"]},
+      /// Which type of Zenoh instances to automatically establish sessions with upon discovery on gossip.
+      /// Accepts a single value (e.g. autoconnect: ["router", "peer"])
+      /// or different values for router or peer mode (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
+      /// Each value is a list of: "peer" and/or "router".
+      autoconnect: { router: [], peer: ["router", "peer"] },
+    },
+  },
+
+  /// Configuration of data messages timestamps management.
+  timestamping: {
+    /// Whether data messages should be timestamped if not already.
+    /// Accepts a single boolean value or different values for router, peer and client.
+    ///
+    /// ROS setting: PublicationCache which is required for transient_local durability
+    ///              only works when time-stamping is enabled.
+    enabled: { router: true, peer: true, client: true },
+    /// Whether data messages with timestamps in the future should be dropped or not.
+    /// If set to false (default), messages with timestamps in the future are retimestamped.
+    /// Timestamps are ignored if timestamping is disabled.
+    drop_future_timestamp: false,
+  },
+
+  /// The default timeout to apply to queries in milliseconds.
+  queries_default_timeout: 10000,
+
+  /// The routing strategy to use and it's configuration.
+  routing: {
+    /// The routing strategy to use in routers and it's configuration.
+    router: {
+      /// When set to true a router will forward data between two peers
+      /// directly connected to it if it detects that those peers are not
+      /// connected to each other.
+      /// The failover brokering only works if gossip discovery is enabled.
+      peers_failover_brokering: true,
+    },
+    /// The routing strategy to use in peers and it's configuration.
+    peer: {
+      /// The routing strategy to use in peers. ("peer_to_peer" or "linkstate").
+      mode: "peer_to_peer",
+    },
+    /// The interests-based routing configuration.
+    /// This configuration applies regardless of the mode (router, peer or client).
+    interests: {
+      /// The timeout to wait for incoming interests declarations in milliseconds.
+      /// The expiration of this timeout implies that the discovery protocol might be incomplete,
+      /// leading to potential loss of messages, queries or liveliness tokens.
+      timeout: 10000,
+    },
+  },
+
+
+  /// Configure internal transport parameters
+  transport: {
+    unicast: {
+      /// Timeout in milliseconds when opening a link
+      open_timeout: 10000,
+      /// Timeout in milliseconds when accepting a link
+      accept_timeout: 10000,
+      /// Maximum number of links in pending state while performing the handshake for accepting it
+      accept_pending: 100,
+      /// Maximum number of transports that can be simultaneously alive for a single zenoh sessions
+      max_sessions: 1000,
+      /// Maximum number of incoming links that are admitted per transport
+      max_links: 1,
+      /// Enables the LowLatency transport
+      /// This option does not make LowLatency transport mandatory, the actual implementation of transport
+      /// used will depend on Establish procedure and other party's settings
+      ///
+      /// NOTE: Currently, the LowLatency transport doesn't preserve QoS prioritization.
+      /// NOTE: Due to the note above, 'lowlatency' is incompatible with 'qos' option, so in order to
+      ///       enable 'lowlatency' you need to explicitly disable 'qos'.
+      /// NOTE: LowLatency transport does not support the fragmentation, so the message size should be
+      ///       smaller than the tx batch_size.
+      lowlatency: false,
+      /// Enables QoS on unicast communications.
+      qos: {
+        enabled: true,
+      },
+      /// Enables compression on unicast communications.
+      /// Compression capabilities are negotiated during session establishment.
+      /// If both Zenoh nodes support compression, then compression is activated.
+      compression: {
+        enabled: false,
+      },
+    },
+    /// WARNING: multicast communication does not perform any negotiation upon group joining.
+    ///   Because of that, it is important that all transport parameters are the same to make
+    ///   sure all your nodes in the system can communicate. One common parameter to configure
+    ///   is "transport/link/tx/batch_size" since its default value depends on the actual platform
+    ///   when operating on multicast.
+    ///   E.g., the batch size on Linux and Windows is 65535 bytes, on Mac OS X is 9216, and anything else is 8192.
+    multicast: {
+      /// JOIN message transmission interval in milliseconds.
+      join_interval: 2500,
+      /// Maximum number of multicast sessions.
+      max_sessions: 1000,
+      /// Enables QoS on multicast communication.
+      /// Default to false for Zenoh-to-Zenoh-Pico out-of-the-box compatibility.
+      qos: {
+        enabled: false,
+      },
+      /// Enables compression on multicast communication.
+      /// Default to false for Zenoh-to-Zenoh-Pico out-of-the-box compatibility.
+      compression: {
+        enabled: false,
+      },
+    },
+    link: {
+      /// An optional whitelist of protocols to be used for accepting and opening sessions. If not
+      /// configured, all the supported protocols are automatically whitelisted. The supported
+      /// protocols are: ["tcp" , "udp", "tls", "quic", "ws", "unixsock-stream", "vsock"] For
+      /// example, to only enable "tls" and "quic": protocols: ["tls", "quic"],
+      ///
+      /// Configure the zenoh TX parameters of a link
+      tx: {
+        /// The resolution in bits to be used for the message sequence numbers.
+        /// When establishing a session with another Zenoh instance, the lowest value of the two instances will be used.
+        /// Accepted values: 8bit, 16bit, 32bit, 64bit.
+        sequence_number_resolution: "32bit",
+        /// Link lease duration in milliseconds to announce to other zenoh nodes
+        lease: 10000,
+        /// Number of keep-alive messages in a link lease duration. If no data is sent, keep alive
+        /// messages will be sent at the configured time interval.
+        /// NOTE: In order to consider eventual packet loss and transmission latency and jitter,
+        ///       set the actual keep_alive interval to one fourth of the lease time: i.e. send
+        ///       4 keep_alive messages in a lease period. Changing the lease time will have the
+        ///       keep_alive messages sent more or less often.
+        ///       This is in-line with the ITU-T G.8013/Y.1731 specification on continuous connectivity
+        ///       check which considers a link as failed when no messages are received in 3.5 times the
+        ///       target interval.
+        keep_alive: 4,
+        /// Batch size in bytes is expressed as a 16bit unsigned integer.
+        /// Therefore, the maximum batch size is 2^16-1 (i.e. 65535).
+        /// The default batch size value is the maximum batch size: 65535.
+        batch_size: 65535,
+        /// Each zenoh link has a transmission queue that can be configured
+        queue: {
+          /// The size of each priority queue indicates the number of batches a given queue can contain.
+          /// NOTE: the number of batches in each priority must be included between 1 and 16. Different values will result in an error.
+          /// The amount of memory being allocated for each queue is then SIZE_XXX * BATCH_SIZE.
+          /// In the case of the transport link MTU being smaller than the ZN_BATCH_SIZE,
+          /// then amount of memory being allocated for each queue is SIZE_XXX * LINK_MTU.
+          /// If qos is false, then only the DATA priority will be allocated.
+          size: {
+            control: 2,
+            real_time: 2,
+            interactive_high: 2,
+            interactive_low: 2,
+            data_high: 2,
+            data: 2,
+            data_low: 2,
+            background: 2,
+          },
+          /// Congestion occurs when the queue is empty (no available batch).
+          congestion_control: {
+            /// Behavior pushing CongestionControl::Drop messages to the queue.
+            drop: {
+              /// The maximum time in microseconds to wait for an available batch before dropping a droppable message if still no batch is available.
+              wait_before_drop: 1000,
+              /// The maximum deadline limit for multi-fragment messages.
+              max_wait_before_drop_fragments: 50000,
+            },
+            /// Behavior pushing CongestionControl::Block messages to the queue.
+            block: {
+              /// The maximum time in microseconds to wait for an available batch before closing the transport session when sending a blocking message
+              /// if still no batch is available.
+              wait_before_close: 5000000,
+            },
+          },
+          /// Perform batching of messages if they are smaller of the batch_size
+          batching: {
+            /// Perform adaptive batching of messages if they are smaller of the batch_size.
+            /// When the network is detected to not be fast enough to transmit every message individually, many small messages may be
+            /// batched together and sent all at once on the wire reducing the overall network overhead. This is typically of a high-throughput
+            /// scenario mainly composed of small messages. In other words, batching is activated by the network back-pressure.
+            enabled: true,
+            /// The maximum time limit (in ms) a message should be retained for batching when back-pressure happens.
+            time_limit: 1,
+          },
+          allocation: {
+            /// Mode for memory allocation of batches in the priority queues.
+            /// - "init": batches are allocated at queue initialization time.
+            /// - "lazy": batches are allocated when needed up to the maximum number of batches configured in the size configuration parameter.
+            mode: "lazy",
+          },
+        },
+      },
+      /// Configure the zenoh RX parameters of a link
+      rx: {
+        /// Receiving buffer size in bytes for each link
+        /// The default the rx_buffer_size value is the same as the default batch size: 65535.
+        /// For very high throughput scenarios, the rx_buffer_size can be increased to accommodate
+        /// more in-flight data. This is particularly relevant when dealing with large messages.
+        /// E.g. for 16MiB rx_buffer_size set the value to: 16777216.
+        buffer_size: 65535,
+        /// Maximum size of the defragmentation buffer at receiver end.
+        /// Fragmented messages that are larger than the configured size will be dropped.
+        /// The default value is 1GiB. This would work in most scenarios.
+        /// NOTE: reduce the value if you are operating on a memory constrained device.
+        max_message_size: 1073741824,
+      },
+      /// Configure TLS specific parameters
+      tls: {
+        /// Path to the certificate of the certificate authority used to validate either the server
+        /// or the client's keys and certificates, depending on the node's mode. If not specified
+        /// on router mode then the default WebPKI certificates are used instead.
+        root_ca_certificate: null,
+        /// Path to the TLS listening side private key
+        listen_private_key: null,
+        /// Path to the TLS listening side public certificate
+        listen_certificate: null,
+        ///  Enables mTLS (mutual authentication), client authentication
+        enable_mtls: false,
+        /// Path to the TLS connecting side private key
+        connect_private_key: null,
+        /// Path to the TLS connecting side certificate
+        connect_certificate: null,
+        // Whether or not to verify the matching between hostname/dns and certificate when connecting,
+        // if set to false zenoh will disregard the common names of the certificates when verifying servers.
+        // This could be dangerous because your CA can have signed a server cert for foo.com, that's later being used to host a server at baz.com.
+        // If you want your ca to verify that the server at baz.com is actually baz.com, let this be true (default).
+        verify_name_on_connect: true,
+        // Whether or not to close links when remote certificates expires.
+        // If set to true, links that require certificates (tls/quic) will automatically disconnect when the time of expiration of the remote certificate chain is reached
+        // note that mTLS (client authentication) is required for a listener to disconnect a client on expiration
+        close_link_on_expiration: false,
+        /// Optional configuration for TCP system buffers sizes for TLS links
+        ///
+        /// Configure TCP read buffer size (bytes)
+        // so_rcvbuf: 123456,
+        /// Configure TCP write buffer size (bytes)
+        // so_sndbuf: 123456,
+      },
+    // // Configure optional TCP link specific parameters
+    // tcp: {
+    //   /// Optional configuration for TCP system buffers sizes for TCP links
+    //   ///
+    //   /// Configure TCP read buffer size (bytes)
+    //   // so_rcvbuf: 123456,
+    //   /// Configure TCP write buffer size (bytes)
+    //   // so_sndbuf: 123456,
+    // }
+    },
+    /// Shared memory configuration.
+    /// NOTE: shared memory can be used only if zenoh is compiled with "shared-memory" feature, otherwise
+    /// settings in this section have no effect.
+    shared_memory: {
+      /// A probing procedure for shared memory is performed upon session opening. To enable zenoh to operate
+      /// over shared memory (and to not fallback on network mode), shared memory needs to be enabled also on the
+      /// subscriber side. By doing so, the probing procedure will succeed and shared memory will operate as expected.
+      ///
+      /// ROS setting: disabled by default until fully tested
+      enabled: false,
+    },
+    auth: {
+      /// The configuration of authentication.
+      /// A password implies a username is required.
+      usrpwd: {
+        user: null,
+        password: null,
+        /// The path to a file containing the user password dictionary
+        dictionary_file: null,
+      },
+      pubkey: {
+        public_key_pem: null,
+        private_key_pem: null,
+        public_key_file: null,
+        private_key_file: null,
+        key_size: null,
+        known_keys_file: null,
+      },
+    },
+  },
+
+  /// Configure the Admin Space
+  /// Unstable: this configuration part works as advertised, but may change in a future release
+  adminspace: {
+    /// Enables the admin space
+    enabled: true,
+    /// read and/or write permissions on the admin space
+    permissions: {
+      read: true,
+      write: false,
+    },
+  },
+}
+                "#,
+            }
+        ),
+    ],
+    cnx: [
+        (src: "source", dst: "publisher", msg: "i8"),
+    ]
+) 

--- a/examples/cu_zenoh_ros/src/main.rs
+++ b/examples/cu_zenoh_ros/src/main.rs
@@ -1,0 +1,59 @@
+use cu29::prelude::*;
+use cu29_helpers::basic_copper_setup;
+
+pub mod cu_zenoh_ros {
+    use cu_zenoh_ros_sink::ZenohRosSink;
+
+    pub type ExamplePublisher = ZenohRosSink<i8>;
+}
+
+pub mod tasks {
+    use cu29::prelude::*;
+    use std::time::Duration;
+
+    pub struct ExampleSrc {}
+
+    impl Freezable for ExampleSrc {}
+
+    impl<'cl> CuSrcTask<'cl> for ExampleSrc {
+        type Output = output_msg!('cl, i8);
+
+        fn new(_config: Option<&ComponentConfig>) -> CuResult<Self>
+        where
+            Self: Sized,
+        {
+            Ok(Self {})
+        }
+
+        fn process(&mut self, _clock: &RobotClock, new_msg: Self::Output) -> CuResult<()> {
+            std::thread::sleep(Duration::from_secs(1));
+            debug!("Sending message to ROS");
+            new_msg.set_payload(42);
+            Ok(())
+        }
+    }
+}
+
+#[copper_runtime(config = "copperconfig.ron")]
+struct App {}
+
+fn main() {
+    let tmp_dir = tempfile::TempDir::new().expect("could not create a tmp dir");
+    let logger_path = tmp_dir.path().join("zenoh.copper");
+    let copper_ctx =
+        basic_copper_setup(&logger_path, None, true, None).expect("Failed to setup logger.");
+    debug!("Logger created at {}.", path = &logger_path);
+    let clock = copper_ctx.clock;
+    debug!("Creating application... ");
+    let mut application = App::new(clock.clone(), copper_ctx.unified_logger.clone(), None)
+        .expect("Failed to create application.");
+    debug!("Running... starting clock: {}.", clock.now());
+
+    let outcome = application.run();
+    match outcome {
+        Ok(_result) => {}
+        Err(error) => {
+            debug!("Application Ended: {}", error)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a ROS compatible Zenoh sink to forward data from Copper applications to ROS 2 via the Zenoh middleware (rmw_zenoh).

- Introduces a new sink (cu-zenoh-ros-sink) with full implementation including liveliness, key expression formatting, and configuration handling.
- Adds an example application (cu_zenoh_ros) and updates workspace members and dependencies accordingly.