### PR TITLE
[FEAT] compile-time log-level macro

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -150,11 +150,11 @@ jobs:
 
       - name: Set features (Linux)
         if: runner.os == 'Linux'
-        run: echo "FEATURES_FLAG=$([[ '${{ matrix.mode }}' == 'cuda-release' ]] && echo '--all-features' || echo '--features macro_debug,mock,perf-ui,image,kornia,python,gst,faer,nalgebra,glam,debug_pane,bincode')" >> $GITHUB_ENV
+        run: echo "FEATURES_FLAG=$([[ '${{ matrix.mode }}' == 'cuda-release' ]] && echo '--all-features' || echo '--features macro_debug,mock,perf-ui,image,kornia,python,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug')" >> $GITHUB_ENV
 
       - name: Set features (MacOS)
         if: runner.os == 'macOS'
-        run: echo "FEATURES_FLAG=$([[ '${{ matrix.mode }}' == 'cuda-release' ]] && echo '--all-features' || echo '--features macro_debug,mock,perf-ui,image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode')" >> $GITHUB_ENV
+        run: echo "FEATURES_FLAG=$([[ '${{ matrix.mode }}' == 'cuda-release' ]] && echo '--all-features' || echo '--features macro_debug,mock,perf-ui,image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug')" >> $GITHUB_ENV
 
       - name: Set features (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -166,11 +166,11 @@ jobs:
 
       - name: Set features (Linux)
         if: runner.os == 'Linux'
-        run: echo "FEATURES_FLAG=$([[ '${{ matrix.mode }}' == 'cuda-release' ]] && echo '--all-features' || echo '--features macro_debug,mock,perf-ui,image,kornia,python,gst,faer,nalgebra,glam,debug_pane,bincode')" >> $GITHUB_ENV
+        run: echo "FEATURES_FLAG=$([[ '${{ matrix.mode }}' == 'cuda-release' ]] && echo '--all-features' || echo '--features macro_debug,mock,perf-ui,image,kornia,python,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug')" >> $GITHUB_ENV
 
       - name: Set features (MacOS)
         if: runner.os == 'macOS'
-        run: echo "FEATURES_FLAG=$([[ '${{ matrix.mode }}' == 'cuda-release' ]] && echo '--all-features' || echo '--features macro_debug,mock,perf-ui,image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode')" >> $GITHUB_ENV
+        run: echo "FEATURES_FLAG=$([[ '${{ matrix.mode }}' == 'cuda-release' ]] && echo '--all-features' || echo '--features macro_debug,mock,perf-ui,image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug')" >> $GITHUB_ENV
 
       - name: Set features (Windows)
         if: runner.os == 'Windows'

--- a/components/sources/cu_v4l/src/lib.rs
+++ b/components/sources/cu_v4l/src/lib.rs
@@ -199,7 +199,8 @@ mod linux_impl {
                 })?,
             )
             .map_err(|e| CuError::new_with_cause("Could not create the V4lStream", e))?;
-            debug!("V4L: Set timeout to {} ms", req_timeout.as_millis() as u64);
+            let req_timeout_ms = req_timeout.as_millis() as u64;
+            debug!("V4L: Set timeout to {} ms", req_timeout_ms);
             stream.set_timeout(req_timeout);
 
             let cuformat = CuImageBufferFormat {

--- a/core/cu29/Cargo.toml
+++ b/core/cu29/Cargo.toml
@@ -26,3 +26,8 @@ bincode = { workspace = true }
 
 [features]
 macro_debug = ["cu29-derive/macro_debug", "cu29-log-derive/macro_debug"]
+log-level-debug = ["cu29-log-derive/log-level-debug"]
+log-level-info = ["cu29-log-derive/log-level-info"]
+log-level-warning = ["cu29-log-derive/log-level-warning"]
+log-level-error = ["cu29-log-derive/log-level-error"]
+log-level-critical = ["cu29-log-derive/log-level-critical"]

--- a/core/cu29_export/src/lib.rs
+++ b/core/cu29_export/src/lib.rs
@@ -351,7 +351,7 @@ mod tests {
     fn test_extract_low_level_cu29_log() {
         let temp_dir = TempDir::new().unwrap();
         let temp_path = copy_stringindex_to_temp(&temp_dir);
-        let entry = CuLogEntry::new(3);
+        let entry = CuLogEntry::new(3, CuLogLevel::Info);
         let bytes = bincode::encode_to_vec(&entry, standard()).unwrap();
         let reader = Cursor::new(bytes.as_slice());
         textlog_dump(reader, temp_path.as_path()).unwrap();
@@ -379,10 +379,10 @@ mod tests {
             let stream = stream_write(data_logger.clone(), UnifiedLogType::StructuredLogLine, 1024);
             let rt = LoggerRuntime::init(RobotClock::default(), stream, None::<NullLog>);
 
-            let mut entry = CuLogEntry::new(4); // this is a "Just a String {}" log line
+            let mut entry = CuLogEntry::new(4, CuLogLevel::Info); // this is a "Just a String {}" log line
             entry.add_param(0, Value::String("Parameter for the log line".into()));
             log(&mut entry).expect("Failed to log");
-            let mut entry = CuLogEntry::new(2); // this is a "Just a String {}" log line
+            let mut entry = CuLogEntry::new(2, CuLogLevel::Info); // this is a "Just a String {}" log line
             entry.add_param(0, Value::String("Parameter for the log line".into()));
             log(&mut entry).expect("Failed to log");
 

--- a/core/cu29_helpers/tests/end2end.rs
+++ b/core/cu29_helpers/tests/end2end.rs
@@ -8,6 +8,7 @@ use cu29_log_derive::debug;
 use cu29_value::to_value;
 
 #[cfg(not(debug_assertions))]
+#[allow(unused_imports)]
 use cu29_log_runtime::log;
 
 #[cfg(debug_assertions)]

--- a/core/cu29_helpers/tests/end2end.rs
+++ b/core/cu29_helpers/tests/end2end.rs
@@ -1,13 +1,17 @@
 use cu29_helpers::basic_copper_setup;
-use cu29_log::CuLogEntry;
+#[allow(unused_imports)]
 use cu29_log::ANONYMOUS;
+#[allow(unused_imports)]
+use cu29_log::{CuLogEntry, CuLogLevel};
 use cu29_log_derive::debug;
+#[allow(unused_imports)]
 use cu29_value::to_value;
 
 #[cfg(not(debug_assertions))]
 use cu29_log_runtime::log;
 
 #[cfg(debug_assertions)]
+#[allow(unused_imports)]
 use cu29_log_runtime::log_debug_mode;
 
 use serde::Serialize;

--- a/core/cu29_log/README.md
+++ b/core/cu29_log/README.md
@@ -1,8 +1,126 @@
-## Copper Structured Logger
+# Copper Logging (cu29-log)
 
-The `cu29_log` crate provides common onboard and offboard definitions to log structured messages in the Unified Logger
-and retrieve them efficiently.
+The `cu29-log` crate provides a structured logging system for the Copper framework. It allows for efficient, compile-time optimized logging with different severity levels and structured log entry storage.
 
-For more information on how to leverage structured logging in your projects, check
-out [cu29_log_derive](https://github.com/copper-project/copper-rs/tree/master/core/cu29_log_derive).
+## Log Levels
 
+Copper logging supports five levels of severity:
+
+- **Debug**: Detailed information useful during development
+- **Info**: General information about system operation
+- **Warning**: Indication of potential issues that don't prevent normal operation
+- **Error**: Issues that might disrupt normal operation but don't cause system failure
+- **Critical**: Critical errors requiring immediate attention, usually resulting in system failure
+
+## Compile-Time Log Level Selection
+
+A key feature of Copper's logging system is the ability to select the minimum log level at compile time. This means that log messages below the selected level are completely eliminated from the compiled code, resulting in zero runtime overhead for disabled log levels.
+
+### How to Configure Log Levels
+
+To set the minimum log level for your application, add one of the following feature flags to your `Cargo.toml` dependencies:
+
+```toml
+[dependencies]
+cu29-log = { version = "0.7.0" }
+cu29-log-derive = { version = "0.7.0", features = ["log-level-info"]  }
+```
+
+or
+
+```toml
+[dependencies]
+cu29 = { version = "0.7.0", features = ["log-level-info"]}
+```
+
+Available feature flags:
+
+- `log-level-debug`: Includes all logs (Debug, Info, Warning, Error, Critical)
+- `log-level-info`: Includes Info, Warning, Error, and Critical logs
+- `log-level-warning`: Includes Warning, Error, and Critical logs
+- `log-level-error`: Includes Error and Critical logs
+- `log-level-critical`: Includes only Critical logs
+
+By default, `log-level-debug` is enabled if no feature is specified.
+
+## Using the Logging Macros
+
+The following macros are available for logging at different levels through the `cu29_log_derive` crate:
+
+```rust
+use cu29_log_derive::{debug, info, warning, error, critical};
+
+// Log examples at different levels
+debug!("Detailed debugging information: {}", value);
+info!("Normal operational information");
+warning!("Warning: {}", message);
+error!("Error occurred: {}", err);
+critical!("Critical failure: {}", critical_error);
+
+debug!("User {} performed action {}", user_id = 123, action = "login");
+```
+
+Note that these macros will be automatically compiled out when the log level is set higher than the corresponding message level, resulting in zero runtime overhead.
+
+### Parameters
+
+All logging macros support both named and unnamed parameters:
+
+- Unnamed parameters: `debug!("Value: {}", value)`
+- Named parameters: `debug!("Value: {}", name = value)`
+
+## Behavior in Debug vs Release Mode
+
+- In **debug** mode, logs are both sent to the structured log sink and printed to the console for immediate visibility.
+- In **release** mode, logs are only sent to the structured log sink, optimizing for performance.
+
+## Advanced Usage
+
+### CuLogLevel Enum
+
+You can use the `CuLogLevel` enum directly in your code if needed:
+
+```rust
+use cu29_log::CuLogLevel;
+
+let level = CuLogLevel::Warning;
+```
+
+The enum implements `PartialOrd` and `Ord`, so you can compare levels:
+
+```rust
+assert!(CuLogLevel::Error > CuLogLevel::Warning);
+```
+
+### Structured Log Entries
+
+The `CuLogEntry` struct is the core of the structured logging system:
+
+```rust
+let entry = CuLogEntry::new(msg_index, CuLogLevel::Warning);
+entry.add_param(param_name_index, param_value);
+```
+
+Each log entry contains:
+
+- A timestamp (`CuTime`)
+- Log level (`CuLogLevel`)
+- Message index (interned string reference)
+- Parameter names and values (stored efficiently using `SmallVec`)
+
+### Log Storage and Retrieval
+
+Log messages and parameter names are interned at compile time and stored in an index for efficient retrieval. The system uses the `LOG_INDEX_DIR` environment variable to locate the log index directory.
+
+```rust
+// Get the default log index directory path
+let index_dir = cu29_log::default_log_index_dir();
+```
+
+### Log Formatting
+
+The library provides utilities to format log entries into human-readable text:
+
+```rust
+let formatted = cu29_log::rebuild_logline(&interned_strings, &log_entry)?;
+```

--- a/core/cu29_log/src/lib.rs
+++ b/core/cu29_log/src/lib.rs
@@ -9,6 +9,33 @@ use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use strfmt::strfmt;
 
+/// Log levels for Copper.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum CuLogLevel {
+    /// Detailed information useful during development
+    Debug = 0,
+    /// General information about system operation
+    Info = 1,
+    /// Indication of potential issues that don't prevent normal operation
+    Warning = 2,
+    /// Issues that might disrupt normal operation but don't cause system failure
+    Error = 3,
+    /// Critical errors requiring immediate attention, usually resulting in system failure
+    Critical = 4,
+}
+
+impl CuLogLevel {
+    /// Returns true if this log level is enabled for the given max level
+    ///
+    /// The log level is enabled if it is greater than or equal to the max level.
+    /// For example, if max_level is Info, then Info, Warning, Error and Critical are enabled,
+    /// but Debug is not.
+    #[inline]
+    pub const fn enabled(self, max_level: CuLogLevel) -> bool {
+        self as u8 >= max_level as u8
+    }
+}
+
 /// The name of the directory where the log index is stored.
 const INDEX_DIR_NAME: &str = "cu29_log_index";
 
@@ -22,6 +49,9 @@ pub const MAX_LOG_PARAMS_ON_STACK: usize = 10;
 pub struct CuLogEntry {
     // Approximate time when the log entry was created.
     pub time: CuTime,
+
+    // Log level of this entry
+    pub level: CuLogLevel,
 
     // interned index of the message
     pub msg_index: u32,
@@ -39,6 +69,7 @@ impl Encode for CuLogEntry {
         encoder: &mut E,
     ) -> Result<(), bincode::error::EncodeError> {
         self.time.encode(encoder)?;
+        (self.level as u8).encode(encoder)?;
         self.msg_index.encode(encoder)?;
 
         (self.paramname_indexes.len() as u64).encode(encoder)?;
@@ -60,6 +91,15 @@ impl<Context> Decode<Context> for CuLogEntry {
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         let time = CuTime::decode(decoder)?;
+        let level_raw = u8::decode(decoder)?;
+        let level = match level_raw {
+            0 => CuLogLevel::Debug,
+            1 => CuLogLevel::Info,
+            2 => CuLogLevel::Warning,
+            3 => CuLogLevel::Error,
+            4 => CuLogLevel::Critical,
+            _ => CuLogLevel::Debug, // Default to Debug for compatibility with older logs
+        };
         let msg_index = u32::decode(decoder)?;
 
         let paramname_len = u64::decode(decoder)? as usize;
@@ -76,6 +116,7 @@ impl<Context> Decode<Context> for CuLogEntry {
 
         Ok(CuLogEntry {
             time,
+            level,
             msg_index,
             paramname_indexes,
             params,
@@ -88,18 +129,19 @@ impl Display for CuLogEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "CuLogEntry {{ msg_index: {}, paramname_indexes: {:?}, params: {:?} }}",
-            self.msg_index, self.paramname_indexes, self.params
+            "CuLogEntry {{ level: {:?}, msg_index: {}, paramname_indexes: {:?}, params: {:?} }}",
+            self.level, self.msg_index, self.paramname_indexes, self.params
         )
     }
 }
 
 impl CuLogEntry {
     /// msg_index is the interned index of the message.
-    pub fn new(msg_index: u32) -> Self {
+    pub fn new(msg_index: u32, level: CuLogLevel) -> Self {
         CuLogEntry {
             time: 0.into(), // We have no clock at that point it is called from random places
             // the clock will be set at actual log time from clock source provided
+            level,
             msg_index,
             paramname_indexes: SmallVec::new(),
             params: SmallVec::new(),
@@ -118,6 +160,7 @@ impl CuLogEntry {
 #[inline]
 pub fn format_logline(
     time: CuTime,
+    level: CuLogLevel,
     format_str: &str,
     params: &[String],
     named_params: &HashMap<String, String>,
@@ -139,7 +182,7 @@ pub fn format_logline(
             e,
         )
     })?;
-    Ok(format!("{time}: {logline}"))
+    Ok(format!("{time} [{level:?}]: {logline}"))
 }
 
 /// Rebuild a log line from the interned strings and the CuLogEntry.
@@ -160,7 +203,13 @@ pub fn rebuild_logline(all_interned_strings: &[String], entry: &CuLogEntry) -> C
             named_params.insert(name, param_as_string);
         }
     }
-    format_logline(entry.time, format_string, &anon_params, &named_params)
+    format_logline(
+        entry.time,
+        entry.level,
+        format_string,
+        &anon_params,
+        &named_params,
+    )
 }
 
 fn parent_n_times(path: &Path, n: usize) -> Option<PathBuf> {
@@ -177,4 +226,67 @@ pub fn default_log_index_dir() -> PathBuf {
     let outdir_path = Path::new(&outdir);
 
     parent_n_times(outdir_path, 3).unwrap().join(INDEX_DIR_NAME)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_log_level_ordering() {
+        assert!(CuLogLevel::Critical > CuLogLevel::Error);
+        assert!(CuLogLevel::Error > CuLogLevel::Warning);
+        assert!(CuLogLevel::Warning > CuLogLevel::Info);
+        assert!(CuLogLevel::Info > CuLogLevel::Debug);
+
+        assert!(CuLogLevel::Debug < CuLogLevel::Info);
+        assert!(CuLogLevel::Info < CuLogLevel::Warning);
+        assert!(CuLogLevel::Warning < CuLogLevel::Error);
+        assert!(CuLogLevel::Error < CuLogLevel::Critical);
+    }
+
+    #[test]
+    fn test_log_level_enabled() {
+        // When min level is Debug (0), all logs are enabled
+        assert!(CuLogLevel::Debug.enabled(CuLogLevel::Debug));
+        assert!(CuLogLevel::Info.enabled(CuLogLevel::Debug));
+        assert!(CuLogLevel::Warning.enabled(CuLogLevel::Debug));
+        assert!(CuLogLevel::Error.enabled(CuLogLevel::Debug));
+        assert!(CuLogLevel::Critical.enabled(CuLogLevel::Debug));
+
+        // When min level is Info (1), only Info and above are enabled
+        assert!(!CuLogLevel::Debug.enabled(CuLogLevel::Info));
+        assert!(CuLogLevel::Info.enabled(CuLogLevel::Info));
+        assert!(CuLogLevel::Warning.enabled(CuLogLevel::Info));
+        assert!(CuLogLevel::Error.enabled(CuLogLevel::Info));
+        assert!(CuLogLevel::Critical.enabled(CuLogLevel::Info));
+
+        // When min level is Warning (2), only Warning and above are enabled
+        assert!(!CuLogLevel::Debug.enabled(CuLogLevel::Warning));
+        assert!(!CuLogLevel::Info.enabled(CuLogLevel::Warning));
+        assert!(CuLogLevel::Warning.enabled(CuLogLevel::Warning));
+        assert!(CuLogLevel::Error.enabled(CuLogLevel::Warning));
+        assert!(CuLogLevel::Critical.enabled(CuLogLevel::Warning));
+
+        // When min level is Error (3), only Error and above are enabled
+        assert!(!CuLogLevel::Debug.enabled(CuLogLevel::Error));
+        assert!(!CuLogLevel::Info.enabled(CuLogLevel::Error));
+        assert!(!CuLogLevel::Warning.enabled(CuLogLevel::Error));
+        assert!(CuLogLevel::Error.enabled(CuLogLevel::Error));
+        assert!(CuLogLevel::Critical.enabled(CuLogLevel::Error));
+
+        // When min level is Critical (4), only Critical is enabled
+        assert!(!CuLogLevel::Debug.enabled(CuLogLevel::Critical));
+        assert!(!CuLogLevel::Info.enabled(CuLogLevel::Critical));
+        assert!(!CuLogLevel::Warning.enabled(CuLogLevel::Critical));
+        assert!(!CuLogLevel::Error.enabled(CuLogLevel::Critical));
+        assert!(CuLogLevel::Critical.enabled(CuLogLevel::Critical));
+    }
+
+    #[test]
+    fn test_cu_log_entry_with_level() {
+        let entry = CuLogEntry::new(42, CuLogLevel::Warning);
+        assert_eq!(entry.level, CuLogLevel::Warning);
+        assert_eq!(entry.msg_index, 42);
+    }
 }

--- a/core/cu29_log_derive/Cargo.toml
+++ b/core/cu29_log_derive/Cargo.toml
@@ -27,4 +27,9 @@ lazy_static = "1.5.0"
 default = []
 # enables a more verbose build log showing the index generation.
 macro_debug = []
-
+# Log level features to control compile-time log level filtering
+log-level-debug = []
+log-level-info = []
+log-level-warning = []
+log-level-error = []
+log-level-critical = []

--- a/core/cu29_log_derive/src/lib.rs
+++ b/core/cu29_log_derive/src/lib.rs
@@ -170,7 +170,6 @@ fn create_log_entry(input: TokenStream, level: CuLogLevel) -> TokenStream {
 /// In release mode, the log will be only be written to the unified logger.
 ///
 /// This macro will be compiled out if the max log level is set to a level higher than Debug.
-
 #[cfg(feature = "log-level-debug")]
 #[proc_macro]
 pub fn debug(input: TokenStream) -> TokenStream {

--- a/core/cu29_log_derive/src/lib.rs
+++ b/core/cu29_log_derive/src/lib.rs
@@ -2,6 +2,7 @@ extern crate proc_macro;
 mod index;
 
 use crate::index::intern_string;
+use cu29_log::CuLogLevel;
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse::Parser;
@@ -10,28 +11,48 @@ use syn::spanned::Spanned;
 use syn::Token;
 use syn::{Expr, ExprAssign, ExprLit, Lit};
 
-/// This macro is used to log a message with parameters.
-/// The first parameter is a string literal that represents the message to be logged.
-/// Only `{}` is supported as a placeholder for parameters.
-/// The rest of the parameters are the values to be logged.
-/// The parameters can be named or unnamed.
-/// Named parameters are specified as `name = value`.
-/// Unnamed parameters are specified as `value`.
-/// # Example
-/// ```ignore
-/// use cu29_log_derive::debug;
-/// let a = 1;
-/// let b = 2;
-/// debug!("a = {}, b = {}", my_value = a, b); // named and unnamed parameters
-/// ```
+/// Create reference of unused_variables to avoid warnings
+/// ex: let _ = &tmp;
+#[allow(unused)]
+fn reference_unused_variables(input: TokenStream) -> TokenStream {
+    // Attempt to parse the expressions to "use" them.
+    // This ensures variables passed to the macro are considered used by the compiler.
+    let parser = syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated;
+    if let Ok(exprs) = parser.parse(input.clone()) {
+        let mut var_usages = Vec::new();
+        // Skip the first expression, which is assumed to be the format string literal.
+        // We only care about "using" the subsequent variable arguments.
+        for expr in exprs.iter().skip(1) {
+            match expr {
+                // If the argument is an assignment (e.g., `foo = bar`),
+                // we need to ensure `bar` (the right-hand side) is "used".
+                syn::Expr::Assign(assign_expr) => {
+                    let value_expr = &assign_expr.right;
+                    var_usages.push(quote::quote! { let _ = &#value_expr; });
+                }
+                // Otherwise, for any other expression, ensure it's "used".
+                _ => {
+                    var_usages.push(quote::quote! { let _ = &#expr; });
+                }
+            }
+        }
+        // Return a block that contains these dummy "usages".
+        // If only a format string was passed, var_usages will be empty,
+        // resulting in an empty block `{}`, which is fine.
+        return quote::quote! { { #(#var_usages;)* } }.into();
+    }
+
+    // Fallback: if parsing fails for some reason, return an empty TokenStream.
+    // This might still lead to warnings if parsing failed but is better than panicking.
+    proc_macro::TokenStream::new()
+}
+
+/// Create a log entry at the specified log level.
 ///
-/// You can retrieve this data using the log_reader generated with your project and giving it the
-/// unified .copper log file and the string index file generated at compile time.
-///
-/// Note: In debug mode, the log will also be printed to the console. (ie slooow).
-/// In release mode, the log will be only be written to the unified logger.
-#[proc_macro]
-pub fn debug(input: TokenStream) -> TokenStream {
+/// This is the internal macro implementation used by all the logging macros.
+/// Users should use the public-facing macros: `debug!`, `info!`, `warning!`, `error!`, or `critical!`.
+#[allow(unused)]
+fn create_log_entry(input: TokenStream, level: CuLogLevel) -> TokenStream {
     let parser = syn::punctuated::Punctuated::<Expr, Token![,]>::parse_terminated;
     let exprs = parser.parse(input).expect("Failed to parse input");
 
@@ -48,8 +69,15 @@ pub fn debug(input: TokenStream) -> TokenStream {
     } else {
         panic!("The first parameter of the argument needs to be a string literal.");
     };
+    let level_str = match level {
+        CuLogLevel::Debug => quote! { Debug },
+        CuLogLevel::Info => quote! { Info },
+        CuLogLevel::Warning => quote! { Warning },
+        CuLogLevel::Error => quote! { Error },
+        CuLogLevel::Critical => quote! { Critical },
+    };
     let prefix = quote! {
-        let mut log_entry = CuLogEntry::new(#index);
+        let mut log_entry = CuLogEntry::new(#index, CuLogLevel::#level_str);
     };
 
     let mut unnamed_params = vec![];
@@ -118,4 +146,142 @@ pub fn debug(input: TokenStream) -> TokenStream {
     };
 
     expanded.into()
+}
+
+/// This macro is used to log a debug message with parameters.
+/// The first parameter is a string literal that represents the message to be logged.
+/// Only `{}` is supported as a placeholder for parameters.
+/// The rest of the parameters are the values to be logged.
+/// The parameters can be named or unnamed.
+/// Named parameters are specified as `name = value`.
+/// Unnamed parameters are specified as `value`.
+/// # Example
+/// ```ignore
+/// use cu29_log_derive::debug;
+/// let a = 1;
+/// let b = 2;
+/// debug!("a = {}, b = {}", my_value = a, b); // named and unnamed parameters
+/// ```
+///
+/// You can retrieve this data using the log_reader generated with your project and giving it the
+/// unified .copper log file and the string index file generated at compile time.
+///
+/// Note: In debug mode, the log will also be printed to the console. (ie slooow).
+/// In release mode, the log will be only be written to the unified logger.
+///
+/// This macro will be compiled out if the max log level is set to a level higher than Debug.
+
+#[cfg(feature = "log-level-debug")]
+#[proc_macro]
+pub fn debug(input: TokenStream) -> TokenStream {
+    create_log_entry(input, CuLogLevel::Debug)
+}
+
+/// This macro is used to log an info message with parameters.
+/// The first parameter is a string literal that represents the message to be logged.
+/// Only `{}` is supported as a placeholder for parameters.
+/// The rest of the parameters are the values to be logged.
+///
+/// This macro will be compiled out if the max log level is set to a level higher than Info.
+#[cfg(any(feature = "log-level-debug", feature = "log-level-info",))]
+#[proc_macro]
+pub fn info(input: TokenStream) -> TokenStream {
+    create_log_entry(input, CuLogLevel::Info)
+}
+
+/// This macro is used to log a warning message with parameters.
+/// The first parameter is a string literal that represents the message to be logged.
+/// Only `{}` is supported as a placeholder for parameters.
+/// The rest of the parameters are the values to be logged.
+///
+/// This macro will be compiled out if the max log level is set to a level higher than Warning.
+#[cfg(any(
+    feature = "log-level-debug",
+    feature = "log-level-info",
+    feature = "log-level-warning",
+))]
+#[proc_macro]
+pub fn warning(input: TokenStream) -> TokenStream {
+    create_log_entry(input, CuLogLevel::Warning)
+}
+
+/// This macro is used to log an error message with parameters.
+/// The first parameter is a string literal that represents the message to be logged.
+/// Only `{}` is supported as a placeholder for parameters.
+/// The rest of the parameters are the values to be logged.
+///
+/// This macro will be compiled out if the max log level is set to a level higher than Error.
+#[cfg(any(
+    feature = "log-level-debug",
+    feature = "log-level-info",
+    feature = "log-level-warning",
+    feature = "log-level-error",
+))]
+#[proc_macro]
+pub fn error(input: TokenStream) -> TokenStream {
+    create_log_entry(input, CuLogLevel::Error)
+}
+
+/// This macro is used to log a critical message with parameters.
+/// The first parameter is a string literal that represents the message to be logged.
+/// Only `{}` is supported as a placeholder for parameters.
+/// The rest of the parameters are the values to be logged.
+///
+/// This macro is always compiled in, regardless of the max log level setting.
+#[cfg(any(
+    feature = "log-level-debug",
+    feature = "log-level-info",
+    feature = "log-level-warning",
+    feature = "log-level-error",
+    feature = "log-level-critical",
+))]
+#[proc_macro]
+pub fn critical(input: TokenStream) -> TokenStream {
+    create_log_entry(input, CuLogLevel::Critical)
+}
+
+// Provide empty implementations for macros that are compiled out
+#[cfg(not(any(feature = "log-level-debug",)))]
+#[proc_macro]
+pub fn debug(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    reference_unused_variables(input)
+}
+
+#[cfg(not(any(feature = "log-level-debug", feature = "log-level-info",)))]
+#[proc_macro]
+pub fn info(input: TokenStream) -> TokenStream {
+    reference_unused_variables(input)
+}
+
+#[cfg(not(any(
+    feature = "log-level-debug",
+    feature = "log-level-info",
+    feature = "log-level-warning",
+)))]
+#[proc_macro]
+pub fn warning(input: TokenStream) -> TokenStream {
+    reference_unused_variables(input)
+}
+
+#[cfg(not(any(
+    feature = "log-level-debug",
+    feature = "log-level-info",
+    feature = "log-level-warning",
+    feature = "log-level-error",
+)))]
+#[proc_macro]
+pub fn error(input: TokenStream) -> TokenStream {
+    reference_unused_variables(input)
+}
+
+#[cfg(not(any(
+    feature = "log-level-debug",
+    feature = "log-level-info",
+    feature = "log-level-warning",
+    feature = "log-level-error",
+    feature = "log-level-critical",
+)))]
+#[proc_macro]
+pub fn critical(input: TokenStream) -> TokenStream {
+    reference_unused_variables(input)
 }

--- a/core/cu29_log_runtime/src/lib.rs
+++ b/core/cu29_log_runtime/src/lib.rs
@@ -157,6 +157,9 @@ pub fn log_debug_mode(
             .collect();
 
         // Convert Copper log level to the standard log level
+        // Note: CuLogLevel::Critical is mapped to log::Level::Error because the `log` crate
+        // does not have a `Critical` level. `Error` is the highest severity level available
+        // in the `log` crate, making it the closest equivalent.
         let log_level = match entry.level {
             CuLogLevel::Debug => log::Level::Debug,
             CuLogLevel::Info => log::Level::Info,

--- a/core/cu29_log_runtime/src/lib.rs
+++ b/core/cu29_log_runtime/src/lib.rs
@@ -4,7 +4,9 @@ use bincode::enc::Encode;
 use bincode::enc::{Encoder, EncoderImpl};
 use bincode::error::EncodeError;
 use cu29_clock::RobotClock;
-use cu29_log::{CuLogEntry, CuLogLevel};
+use cu29_log::CuLogEntry;
+#[allow(unused_imports)]
+use cu29_log::CuLogLevel;
 use cu29_traits::{CuResult, WriteStream};
 use log::Log;
 

--- a/core/cu29_runtime/src/log.rs
+++ b/core/cu29_runtime/src/log.rs
@@ -11,10 +11,10 @@ pub(crate) use cu29_log_runtime::log;
 pub(crate) use cu29_log_runtime::log_debug_mode;
 
 #[allow(unused_imports)]
-pub(crate) use cu29_log_derive::debug;
+pub(crate) use cu29_log_derive::{critical, debug, error, info, warning};
 
 #[allow(unused_imports)]
-pub(crate) use cu29_log::CuLogEntry;
+pub(crate) use cu29_log::{CuLogEntry, CuLogLevel};
 
 #[allow(unused_imports)]
 pub(crate) use cu29_log::ANONYMOUS;

--- a/core/cu29_runtime/src/monitoring.rs
+++ b/core/cu29_runtime/src/monitoring.rs
@@ -5,6 +5,8 @@ use crate::config::CuConfig;
 use crate::cutask::CuMsgMetadata;
 use crate::log::*;
 use cu29_clock::{CuDuration, RobotClock};
+#[allow(unused_imports)]
+use cu29_log::CuLogLevel;
 use cu29_traits::{CuError, CuResult};
 use hdrhistogram::Histogram;
 use serde_derive::{Deserialize, Serialize};


### PR DESCRIPTION
This PR introduces compile-time log level filtering into the Copper logging system. The changes update the logging macros, add a log level field into CuLogEntry, adjust serialization/deserialization, and update documentation and tests accordingly.

- Integrated compile-time log level features and updated logging macros.
- Updated CuLogEntry to include and handle log levels in its constructor, encoding/decoding, and formatting.
- Revised documentation and tests to reflect the new logging level functionalities.

We disable all log macro by default, the user should use related features when importing `cu29` to enable specific log level.

```
[dependencies]
cu29 = { version = "0.7.0", features = ["log-level-debug"] }
```

Detailed instructions are updated in `cu29_log/README.md`.