### PR TITLE
[FIX] fix logs path for template helper bin

### DIFF
--- a/templates/cu_full/bin/cl
+++ b/templates/cu_full/bin/cl
@@ -1,3 +1,3 @@
 #!/bin/bash
 # A small shortcut be able to extract your copperlists from the application logs.
-RUST_BACKTRACE=1 cargo run --features=logreader --bin {{project-name | kebab_case}}-logreader {{project-name | kebab_case}}.copper extract-copperlist
+RUST_BACKTRACE=1 cargo run --features=logreader --bin {{project-name | kebab_case}}-logreader logs/{{project-name | kebab_case}}.copper extract-copperlist

--- a/templates/cu_full/bin/log
+++ b/templates/cu_full/bin/log
@@ -1,3 +1,3 @@
 #!/bin/bash
 # A small shortcut to be able to extract your structured log.
-RUST_BACKTRACE=1 cargo run --features=logreader --bin {{project-name | kebab_case}}-logreader {{project-name | kebab_case}}.copper extract-log target/debug/cu29_log_index
+RUST_BACKTRACE=1 cargo run --features=logreader --bin {{project-name | kebab_case}}-logreader logs/{{project-name | kebab_case}}.copper extract-log target/debug/cu29_log_index


### PR DESCRIPTION
## Problem
The current template generate log under `logs` folder, the helper bins were not updated for that.
## Solution
Update the helper bins to use the copper log under `logs` folder.