### PR TITLE
[FIX] (cu_rp_gpio) hardware flag instead of not mock flag for Mac compabiibility

### DIFF
--- a/components/sinks/cu_rp_gpio/src/lib.rs
+++ b/components/sinks/cu_rp_gpio/src/lib.rs
@@ -74,7 +74,7 @@ impl<'cl> CuSinkTask<'cl> for RPGpio {
             .clone()
             .into();
 
-        #[cfg(not(feature = "mock"))]
+        #[cfg(hardware)]
         let pin = GPIO
             .get(pin_nb)
             .map_err(|e| CuError::new_with_cause("Could not get pin", e))?


### PR DESCRIPTION
## Problem
The previous version fail the compilation on macOS without mock feature:
```
cargo check --no-default-features -p cu-rp-gpio
```

## Solution
Use `hardware` flag instead of simple no `mock` flag to consider non-linux platform 