### PR TITLE
[FIX] (cu-msp-lib) add bincode feature flag gate fortest

### DIFF
--- a/components/common/cu_msp_lib/src/structs.rs
+++ b/components/common/cu_msp_lib/src/structs.rs
@@ -1370,6 +1370,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "bincode")]
     fn test_command_enum_with_bincode() {
         let command = MspResponse::MspApiVersion(MspApiVersion {
             protocol_version: 1,


### PR DESCRIPTION
## Summary
This PR added `bincode` feature flag gate for `cu-msp-lib` test
## Problem
The previous packages cannot be compiled with `--no-default-features` since the test rely on `bincode` feature flag.
```
cargo check --all-targets --no-default-features -p cu-msp-lib
```

## Solution
Add `bincode` feature flag gate for the test