### PR TITLE
[CHORE] replace lazy_static by std::sync::OnceLock

### DIFF
--- a/components/sinks/cu_rp_gpio/Cargo.toml
+++ b/components/sinks/cu_rp_gpio/Cargo.toml
@@ -19,7 +19,6 @@ cu29-log = { workspace = true }
 cu29-log-runtime = { workspace = true } # needed
 bincode = { workspace = true }
 serde = { workspace = true }
-lazy_static = "1.5.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rppal = { version = "0.22.1", features = ["hal"] }

--- a/core/cu29_log_derive/Cargo.toml
+++ b/core/cu29_log_derive/Cargo.toml
@@ -21,7 +21,6 @@ cu29-log = { workspace = true }
 syn = { workspace = true }
 quote = { workspace = true }
 rkv = { version = "0.19.0", features = ["lmdb"] }
-lazy_static = "1.5.0"
 
 [features]
 default = []

--- a/core/cu29_log_derive/src/index.rs
+++ b/core/cu29_log_derive/src/index.rs
@@ -20,10 +20,10 @@ macro_rules! build_log {
     };
 }
 
-static RKV: OnceLock<Mutex<rkv::Rkv<rkv::backend::LmdbEnvironment>>> = OnceLock::new();
+static RKV: OnceLock<Mutex<Rkv<LmdbEnvironment>>> = OnceLock::new();
 static DBS: OnceLock<Mutex<(SStore, SStore, SStore, MStore)>> = OnceLock::new();
 
-fn rkv() -> &'static Mutex<rkv::Rkv<rkv::backend::LmdbEnvironment>> {
+fn rkv() -> &'static Mutex<Rkv<LmdbEnvironment>> {
     RKV.get_or_init(|| {
         let target_dir = default_log_index_dir();
 
@@ -44,7 +44,7 @@ fn rkv() -> &'static Mutex<rkv::Rkv<rkv::backend::LmdbEnvironment>> {
             );
         }
 
-        let env = rkv::Rkv::new::<rkv::backend::Lmdb>(&target_dir).unwrap();
+        let env = Rkv::new::<Lmdb>(&target_dir).unwrap();
         Mutex::new(env)
     })
 }


### PR DESCRIPTION
This PR replaces lazy_static! with std::sync::OnceLock, related crates are `cu-rp-gpio` and `cu29-log-derive`.