### PR TITLE
[POC] Tryout starting with cu-traits for no-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,9 @@ cu29-value = { path = "core/cu29_value", version = "0.8.0" }
 cu-sensor-payloads = { path = "components/payloads/cu_sensor_payloads", version = "0.8.0" }
 cu-ros-payloads = { path = "components/payloads/cu_ros_payloads", version = "0.8.0" }
 
+# Most structures are fixed size in Copper this is our base wrapper for strings and arrays
+arrayvec = { version = "0.7.6", features = ["serde"] }
+
 # External serialization
 bincode = { version = "2.0.1", features = ["derive"] }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/components/tasks/cu_apriltag/Cargo.toml
+++ b/components/tasks/cu_apriltag/Cargo.toml
@@ -14,7 +14,7 @@ description = "AprilTag detection and pose for Copper"
 bincode = { workspace = true }
 cu29 = { workspace = true }
 serde = { workspace = true }
-arrayvec = "0.7.6"
+arrayvec = { workspace = true }
 cu-spatial-payloads = { path = "../../payloads/cu_spatial_payloads", version = "0.8.0" }
 cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "0.8.0" }
 

--- a/core/cu29_runtime/Cargo.toml
+++ b/core/cu29_runtime/Cargo.toml
@@ -30,7 +30,7 @@ cu29-value = { workspace = true }
 cu29-clock = { workspace = true }
 clap = { workspace = true }
 tempfile = { workspace = true }
-arrayvec = "0.7.6"
+arrayvec = { workspace = true }
 smallvec = { workspace = true }
 ron = "0.10.1"
 hdrhistogram = "7.5.4"

--- a/core/cu29_traits/Cargo.toml
+++ b/core/cu29_traits/Cargo.toml
@@ -14,3 +14,8 @@ repository.workspace = true
 [dependencies]
 bincode = { workspace = true }
 serde = { workspace = true }
+arrayvec = { workspace = true }
+
+[features]
+default = ["std"]
+std = []

--- a/core/cu29_traits/src/lib.rs
+++ b/core/cu29_traits/src/lib.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 pub struct CuString<const N: usize>(pub ArrayString<N>);
 
 impl<const N: usize> CuString<N> {
+    #[allow(dead_code)]
     fn new() -> Self {
         Self(ArrayString::new())
     }
@@ -29,7 +30,7 @@ impl From<&str> for CuStr64 {
     fn from(s: &str) -> Self {
         let mut out = ArrayString::new();
         out.push_str(&s[..s.len().min(64)]);
-        CuString::<64>(out.into())
+        CuString::<64>(out)
     }
 }
 
@@ -84,7 +85,7 @@ impl From<&str> for CuError {
 impl From<CuStr64> for CuError {
     fn from(s: CuStr64) -> CuError {
         CuError {
-            message: s.into(),
+            message: s,
             cause: None,
         }
     }


### PR DESCRIPTION
In order to measure the impact on the codebase, I started to experiment the port to no-std of in the order of `cargo workspaces list` (ie. the dependency tree order). 