### PR TITLE
[FEAT] support nix flake for both macos and linux

### DIFF
--- a/support/nix/README.md
+++ b/support/nix/README.md
@@ -54,9 +54,6 @@ cargo build --workspace $FEATURES_FLAG
 
 # Run tests
 cargo nextest run --workspace $FEATURES_FLAG
-
-# Check CUDA (Linux with cuda shell)
-nvidia-smi
 ```
 
 ## Environment Variables
@@ -73,7 +70,7 @@ nvidia-smi
 
 ## Notes
 
-- CUDA support requires Linux with NVIDIA drivers
+- [BETA] CUDA support requires Linux with NVIDIA drivers.
 - Uses LLVM 14 on Linux, latest on macOS
 - Automatically navigates to `../..` (project root) on shell entry
 - For order nix version on Linux, you can also you `nix-shell` and `nix-shell --arg withCuda true``

--- a/support/nix/README.md
+++ b/support/nix/README.md
@@ -13,6 +13,9 @@ Nix flake providing a cross-platform Rust development environment with optional 
 ## Quick Start
 
 ```bash
+# Setup experimental feature
+mkdir -p ~/.conf/nix && echo "experimental-features = nix-command flakes" >> ~/.conf/nix/nix.conf
+
 # Setup flake
 nix flake update
 

--- a/support/nix/README.md
+++ b/support/nix/README.md
@@ -1,8 +1,6 @@
-# Copper-rs NIX Development Environment
+# Copper-rs Development Environment
 
-This repository contains the Nix configuration for setting up a comprehensive nix development environment for the Copper-rs project. The environment includes all necessary dependencies and tools for building and testing the project, with optional CUDA support.
-
-This setup has been tested on Linux (x86_64).
+Nix flake providing a cross-platform Rust development environment with optional CUDA support.
 
 ## Prerequisites
 
@@ -14,91 +12,65 @@ This setup has been tested on Linux (x86_64).
 
 ## Quick Start
 
-### Basic Development Environment
+```bash
+# Setup flake
+nix flake update
 
-To enter the development environment without CUDA support:
+# Basic development environment
+nix develop
+
+# With CUDA support (Linux only)
+nix develop #cuda
+```
+
+The environment automatically:
+
+- Sets up Rust toolchain with essential components
+- Configures all dependencies (GStreamer, LLVM, OpenSSL, system libraries)
+- Navigates to project root and sets feature flags
+- Displays platform and CUDA status
+
+## Features
+
+- **Cross-platform**: Linux and macOS support
+- **CUDA support**: GPU acceleration on Linux systems
+- **Pre-configured**: Comprehensive feature flags and environment variables
+- **Complete toolchain**: Latest stable Rust with rust-analyzer, clippy, rustfmt
+
+## Dependencies
+
+**All platforms**: Rust toolchain, GStreamer, LLVM/Clang, OpenSSL, pkg-config
+**Linux**: udev, libpcap, mold, optional CUDA toolkit
+**macOS**: Apple frameworks (Security, CoreFoundation), libiconv
+
+## Usage
 
 ```bash
-cd support/nix
-nix-shell
+# Build with pre-configured features
+cargo build --workspace $FEATURES_FLAG
+
+# Run tests
+cargo nextest run --workspace $FEATURES_FLAG
+
+# Check CUDA (Linux with cuda shell)
+nvidia-smi
 ```
 
-This will set up a lightweight environment with all necessary dependencies for building and testing Copper-rs.
+## Environment Variables
 
-### Development Environment with CUDA Support
-
-To enable CUDA support for GPU acceleration:
-
-```bash
-cd support/nix
-nix-shell --arg withCuda true
-```
-
-This adds CUDA libraries and configures the environment for GPU-accelerated development.
-
-## Environment Features
-
-The development environment includes:
-
-- **Rust Toolchain**: Stable Rust with components like rust-analyzer, clippy, and rustfmt
-- **LLVM Dependencies**: Version 14 with proper configuration for bindgen
-- **GStreamer**: Complete suite of GStreamer libraries and plugins
-- **System Dependencies**: Common libraries like libpcap, udev, glib, openssl
-- **Development Tools**: cargo-nextest, cargo-generate, and other useful tools
-- **Optional CUDA Support**: NVIDIA CUDA toolkit and related libraries (when enabled)
-
-## Feature Flags
-
-When the environment is activated, it sets the `FEATURES_FLAG` environment variable with the following features:
-
-```
-macro_debug,mock,perf-ui,image,kornia,python,gst,faer,nalgebra,glam,debug_pane,bincode
-```
-
-When CUDA is enabled, the `cuda` feature is also added to this list.
-
-## Working Directory
-
-The shell automatically navigates to the project root directory (two levels up from the `support/nix` directory) when started.
-
-## CUDA Configuration
-
-When CUDA support is enabled:
-
-1. CUDA toolkit and NVIDIA drivers are added to the environment
-2. Environment variables like `CUDA_PATH` are configured appropriately
-3. Library paths are set up to find CUDA libraries
-4. The shell checks for available NVIDIA GPUs and displays information about them
+- `FEATURES_FLAG`: Pre-configured feature set including `macro_debug,mock,perf-ui,image,kornia,python,gst,faer,nalgebra,glam,debug_pane,bincode` (plus `cuda` when enabled)
+- `LLVM_CONFIG`, `LIBCLANG_PATH`: LLVM/Clang configuration
+- Platform-specific library paths automatically configured
 
 ## Troubleshooting
 
-### LLVM Library Issues
+**CUDA not accessible (Linux)**: Ensure NVIDIA drivers are installed, check `/dev/nvidia*` permissions
+**macOS OpenSSL issues**: PKG_CONFIG_PATH is automatically configured
+**LLVM library issues**: Symlinks created automatically in `$HOME/.nix-llvm-libs`
 
-If you encounter issues with LLVM libraries, the environment creates a symlink in `$HOME/.nix-llvm-libs` to ensure compatibility with bindgen and other tools that require specific library versions.
+## Notes
 
-### CUDA Detection
-
-If CUDA is enabled but your GPU isn't detected, verify that:
-1. You have a compatible NVIDIA GPU
-2. The NVIDIA drivers are properly installed
-3. The `nvidia-smi` command works outside the Nix shell
-
-### Unfree Packages
-
-CUDA and NVIDIA drivers are marked as "unfree" in Nix. The shell configuration handles this automatically, but if you get permission errors, you may need to:
-
-```bash
-export NIXPKGS_ALLOW_UNFREE=1
-```
-
-before running `nix-shell`.
-
-## Customization
-
-The development environment can be customized by editing the `shell.nix` file. You can:
-
-- Add additional packages to `buildInputs`
-- Modify feature flags in the `shellHook`
-- Change LLVM or CUDA versions
-- Add new environment variables or configurations
-
+- CUDA support requires Linux with NVIDIA drivers
+- Uses LLVM 14 on Linux, latest on macOS
+- Automatically navigates to `../..` (project root) on shell entry
+- For order nix version on Linux, you can also you `nix-shell` and `nix-shell --arg withCuda true``

--- a/support/nix/flake.nix
+++ b/support/nix/flake.nix
@@ -1,153 +1,243 @@
-# flake.nix
 {
-  description = "Copper-rs development environment";
+  description = "Copper-rs development environment with cross-platform support and optional CUDA";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, rust-overlay, flake-utils, ... }:
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs {
           inherit system overlays;
+          config = { allowUnfree = true; };
         };
-        
-        # Use stable rust with the components we need
-        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+
+        # Platform detection
+        isLinux = pkgs.stdenv.isLinux;
+        isDarwin = pkgs.stdenv.isDarwin;
+
+        # Use stable rust with specific components
+        rustWithComponents = pkgs.rust-bin.stable.latest.default.override {
           extensions = [ "rust-src" "rust-analyzer" "clippy" "rustfmt" ];
         };
+        
+        # Choose LLVM version based on platform
+        # Use latest LLVM on macOS to avoid version conflicts, LLVM 14 on Linux for consistency
+        llvmPackages = if isDarwin then pkgs.llvmPackages else pkgs.llvmPackages_14;
+        
+        # Create a derivation that creates a symlink to the LLVM shared libraries (Linux only)
+        llvmLibs = if isLinux then pkgs.symlinkJoin {
+          name = "llvm-libs";
+          paths = with llvmPackages; [ libllvm libclang clang ];
+        } else null;
 
-        # Define common dependencies
-        commonDeps = with pkgs; [
-          # System dependencies
-          pkg-config
-          udev
-          libpcap
-          glib
-          openssl
-          clang
+        # Function to create shell with optional CUDA support
+        mkDevShell = withCuda: let
+          # CUDA is only available on Linux
+          effectiveCuda = withCuda && isLinux;
           
-          # GStreamer dependencies
-          gst_all_1.gstreamer
-          gst_all_1.gst-plugins-base
-          gst_all_1.gst-plugins-good
-          gst_all_1.gst-plugins-bad
-          gst_all_1.gst-plugins-ugly
-          gst_all_1.gst-devtools
-        ];
+          # Platform-specific packages
+          linuxOnlyPackages = with pkgs; pkgs.lib.optionals isLinux [
+            # Linux-specific system dependencies
+            udev
+            libpcap
+            mold
+            
+            # NVIDIA/CUDA packages (only if CUDA enabled)
+          ] ++ (pkgs.lib.optionals effectiveCuda [
+            cudatoolkit
+            linuxPackages.nvidia_x11
+            libGL
+            libGLU
+          ]);
 
-        # Define platform-specific dependencies
-        linuxDeps = with pkgs; lib.optionals pkgs.stdenv.isLinux [
-          # Linux-specific dependencies
-        ];
-        
-        macDeps = with pkgs; lib.optionals pkgs.stdenv.isDarwin [
-          # macOS-specific dependencies
-          darwin.apple_sdk.frameworks.CoreServices
-          darwin.apple_sdk.frameworks.CoreFoundation
-        ];
-        
-        # Environment variables
-        commonEnv = {
-          CARGO_TERM_COLOR = "always";
-          FEATURES_FLAG = "--features macro_debug,mock,perf-ui,image,kornia,python,gst,faer,nalgebra,glam,debug_pane,bincode";
-        };
-        
-        # CI-specific environment settings
-        ciEnv = commonEnv // {
-          # CI-specific environment variables
+          # macOS-specific packages
+          darwinOnlyPackages = with pkgs; pkgs.lib.optionals isDarwin [
+            # macOS-specific dependencies
+            darwin.apple_sdk.frameworks.Security
+            darwin.apple_sdk.frameworks.CoreFoundation
+            darwin.apple_sdk.frameworks.SystemConfiguration
+            libiconv
+            
+            # Network capture library (macOS version)
+            libpcap
+          ];
+          
+          # Cross-platform packages
+          commonPackages = with pkgs; [
+            # System dependencies (available on both platforms)
+            pkg-config
+            glib
+            openssl
+
+            # LLVM dependencies (version varies by platform)
+            llvmPackages.clang
+            llvmPackages.libclang
+            llvmPackages.libllvm
+
+            # GStreamer dependencies (available on both platforms)
+            gst_all_1.gstreamer
+            gst_all_1.gst-plugins-base
+            gst_all_1.gst-plugins-good
+            gst_all_1.gst-plugins-bad
+            gst_all_1.gst-plugins-ugly
+            gst_all_1.gst-devtools
+            
+            # Rust and tooling
+            rustWithComponents
+            cargo-nextest
+            cargo-generate
+          ];
+
+          # Define feature flag string based on CUDA availability
+          cudaFeatureFlag = if effectiveCuda then ",cuda" else "";
+          
+          # Platform-specific library paths
+          linuxLibraryPaths = with pkgs; pkgs.lib.optionals isLinux ([
+            # Linux-specific libraries
+            libpcap
+            udev
+            glib
+            openssl
+            
+            # GStreamer libraries
+            gst_all_1.gstreamer
+            gst_all_1.gst-plugins-base
+            
+            # LLVM libraries (LLVM 14 on Linux)
+            llvmPackages.libllvm
+            llvmPackages.libclang
+            llvmPackages.clang
+            "${llvmPackages.libllvm}/lib"
+            "${llvmPackages.clang}/lib"
+          ] ++ (if llvmLibs != null then [ "${llvmLibs}/lib" ] else [])
+            ++ (pkgs.lib.optionals effectiveCuda [
+              cudatoolkit
+              linuxPackages.nvidia_x11
+              libGL
+            ]));
+
+          # macOS library paths
+          darwinLibraryPaths = with pkgs; pkgs.lib.optionals isDarwin [
+            # macOS-specific libraries
+            glib
+            openssl
+            libiconv
+            libpcap
+            
+            # GStreamer libraries
+            gst_all_1.gstreamer
+            gst_all_1.gst-plugins-base
+            
+            # LLVM libraries (latest LLVM on macOS)
+            llvmPackages.libllvm
+            llvmPackages.libclang
+            llvmPackages.clang
+          ];
+          
+          # Combine all library paths
+          allLibraryPaths = linuxLibraryPaths ++ darwinLibraryPaths;
+
+          # Platform-specific shell hooks
+          linuxShellHook = if isLinux then ''
+            # Linux-specific LLVM library symlink setup
+            mkdir -p $HOME/.nix-llvm-libs
+            ln -sf ${llvmPackages.libllvm}/lib/libLLVM-14.so $HOME/.nix-llvm-libs/libLLVM-14.so.1 || true
+            export LD_LIBRARY_PATH=$HOME/.nix-llvm-libs:${pkgs.lib.makeLibraryPath allLibraryPaths}:$LD_LIBRARY_PATH
+            
+            ${if effectiveCuda then ''
+              # CUDA configuration (Linux only)
+              export CUDA_PATH=${pkgs.cudatoolkit}
+              export EXTRA_LDFLAGS="-L/lib -L${pkgs.linuxPackages.nvidia_x11}/lib"
+              export EXTRA_CCFLAGS="-I/usr/include"
+              
+              # Check if device files exist but have permission issues
+              if [ -e /dev/nvidia0 ]; then
+                echo "NVIDIA devices exist but may have permission issues."
+                echo "Please use sudo nvidia-smi to check if GPU is detected"
+
+                # Attempt to fix permissions if user has sudo access
+                if command -v sudo &> /dev/null && sudo -n true 2>/dev/null; then
+                  sudo nvidia-smi --query-gpu=name,driver_version --format=csv,noheader
+                fi
+              else
+                echo "Warning: No NVIDIA GPU devices detected (/dev/nvidia*)."
+                echo "Make sure NVIDIA drivers are properly installed on your system."
+              fi
+            '' else ""}
+          '' else "";
+
+          darwinShellHook = if isDarwin then ''
+            # macOS-specific library path setup
+            export DYLD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath allLibraryPaths}:$DYLD_LIBRARY_PATH
+            
+            # macOS-specific OpenSSL configuration
+            export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig:$PKG_CONFIG_PATH"
+            
+            # Ensure consistent LLVM/Clang usage on macOS
+            export CC="${llvmPackages.clang}/bin/clang"
+            export CXX="${llvmPackages.clang}/bin/clang++"
+            
+            # macOS-specific pcap library path
+            export LIBPCAP_LIBDIR="${pkgs.libpcap}/lib"
+            export PKG_CONFIG_PATH="${pkgs.libpcap}/lib/pkgconfig:$PKG_CONFIG_PATH"
+          '' else "";
+
+          # Platform name for display
+          platformName = if isDarwin then "macOS" else "Linux";
+          cudaStatus = if effectiveCuda then " with CUDA support" else 
+                      if withCuda && isDarwin then " (CUDA not available on macOS)" else "";
+        in
+        pkgs.mkShell {
+          name = "copper-rs-dev-${platformName}${if effectiveCuda then "-cuda" else ""}-env";
+          
+          buildInputs = commonPackages ++ linuxOnlyPackages ++ darwinOnlyPackages;
+
+          # Environment variables and shell hook
+          shellHook = ''
+            # Change to parent directory (../..): Navigate up two levels
+            cd ../..
+            
+            # Cargo configuration
+            export CARGO_TERM_COLOR=always
+            export FEATURES_FLAG="--features macro_debug,mock,perf-ui,image,kornia,python,gst,faer,nalgebra,glam,debug_pane,bincode${cudaFeatureFlag}"
+            
+            # LLVM configuration (platform-specific versions)
+            export LLVM_CONFIG=${llvmPackages.llvm}/bin/llvm-config
+            export LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib"
+            
+            # Platform-specific configurations
+            ${linuxShellHook}
+            ${darwinShellHook}
+            
+            # Bindgen configuration (platform-specific LLVM versions)
+            export BINDGEN_EXTRA_CLANG_ARGS="-I${llvmPackages.libclang.lib}/lib/clang/${llvmPackages.libclang.version}/include -I${pkgs.glib.dev}/include/glib-2.0 -I${pkgs.glib.out}/lib/glib-2.0/include"
+            
+            # Display current directory and environment status
+            echo "Copper-rs development environment activated on ${platformName}${cudaStatus}!"
+            echo "Working directory: $(pwd)"
+            ${if withCuda && isDarwin then ''
+              echo "Note: CUDA support is only available on Linux systems."
+            '' else ""}
+          '';
         };
       in
       {
-        devShells.default = pkgs.mkShell {
-          buildInputs = [
-            # Rust and tooling
-            rustToolchain
-            pkgs.cargo-nextest
-            pkgs.cargo-generate
-          ] ++ commonDeps ++ linuxDeps ++ macDeps;
-          
-          inherit (commonEnv) CARGO_TERM_COLOR FEATURES_FLAG;
-          
-          # Ensure libraries are discoverable
-          LD_LIBRARY_PATH = with pkgs; lib.makeLibraryPath [
-            libpcap
-            udev
-            glib
-            openssl
-            gst_all_1.gstreamer
-            gst_all_1.gst-plugins-base
-          ];
-          
-          # Additional shell hook for setup
-          shellHook = ''
-            echo "Copper-rs development environment activated!"
-          '';
-        };
+        # Default development shell (without CUDA)
+        devShells.default = mkDevShell false;
         
-        # Define a CI shell specifically for GitHub Actions
-        devShells.ci = pkgs.mkShell {
-          buildInputs = [
-            # Rust and tooling for CI
-            rustToolchain
-            pkgs.cargo-nextest
-            pkgs.cargo-generate
-          ] ++ commonDeps ++ linuxDeps;
-          
-          inherit (ciEnv) CARGO_TERM_COLOR FEATURES_FLAG;
-          
-          # Ensure libraries are discoverable
-          LD_LIBRARY_PATH = with pkgs; lib.makeLibraryPath [
-            libpcap
-            udev
-            glib
-            openssl
-            gst_all_1.gstreamer
-            gst_all_1.gst-plugins-base
-          ];
-        };
+        # CUDA-enabled development shell (Linux only)
+        devShells.cuda = mkDevShell true;
         
-        # CUDA-enabled development shell
-        devShells.cuda = pkgs.mkShell {
-          buildInputs = [
-            # Rust and tooling
-            rustToolchain
-            pkgs.cargo-nextest
-            pkgs.cargo-generate
-            
-            # CUDA toolkit
-            pkgs.cudaPackages.cudatoolkit
-          ] ++ commonDeps ++ linuxDeps;
-          
-          # Enable all features including CUDA
-          CARGO_TERM_COLOR = "always";
-          FEATURES_FLAG = "--all-features";
-          
-          # CUDA-specific environment variables
-          CUDA_PATH = "${pkgs.cudaPackages.cudatoolkit}";
-          
-          # Ensure libraries are discoverable
-          LD_LIBRARY_PATH = with pkgs; lib.makeLibraryPath ([
-            libpcap
-            udev
-            glib
-            openssl
-            gst_all_1.gstreamer
-            gst_all_1.gst-plugins-base
-            cudaPackages.cudatoolkit
-          ]);
-          
-          shellHook = ''
-            echo "Copper-rs CUDA development environment activated!"
-          '';
-        };
+        # Legacy compatibility
+        devShell = mkDevShell false;
       }
     );
 }


### PR DESCRIPTION
## Summary
This PR enables the nix flake to be compatible with macos and Linux. We can compile the `copper-rs` with `CUDA`, but the mismatched driver between nix environment and host system cause runtime error when we test `copper-rs`.

## Actions

- [ ] investigate nvidia driver mismatch issue