### PR TITLE
cargo cubuild to help debug Copper's compilation errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
     "examples/cu_standalone_structlog",
     "examples/cu_zenoh",
     "examples/cu_zenoh_ros",
+    "support/cargo_cubuild",
 ]
 
 # put only the core crates here that are not platform specific

--- a/core/cu29_derive/Cargo.toml
+++ b/core/cu29_derive/Cargo.toml
@@ -17,13 +17,13 @@ proc-macro = true
 [dependencies]
 cu29-runtime = { workspace = true }
 cu29-traits = { workspace = true }
-syn = { workspace = true }
+convert_case = "0.8.0"
+itertools = "0.14.0"
 quote = { workspace = true }
 proc-macro2 = { workspace = true }
-walkdir = "2.5.0"
+syn = { workspace = true }
 syntect = "5.2.0"
-itertools = "0.14.0"
-convert_case = "0.8.0"
+walkdir = "2.5.0"
 
 [build-dependencies]
 cu29-unifiedlog = { workspace = true }  # needed

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -20,7 +20,7 @@ use cu29_traits::CuResult;
 use proc_macro2::{Ident, Span};
 
 #[cfg(feature = "macro_debug")]
-use crate::format::{highlight_rust_code, rustfmt_generated_code};
+use crate::format::rustfmt_generated_code;
 
 mod format;
 mod utils;
@@ -1348,7 +1348,9 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
     {
         let formatted_code = rustfmt_generated_code(result.to_string());
         eprintln!("\n     ===    Gen. Runtime ===\n");
-        eprintln!("{}", highlight_rust_code(formatted_code));
+        eprintln!("{}", formatted_code);
+        // if you need colors back: eprintln!("{}", highlight_rust_code(formatted_code)); was disabled for cubuild.
+        // or simply use cargo expand
         eprintln!("\n     === === === === === ===\n");
     }
     result.into()

--- a/support/cargo_cubuild/Cargo.toml
+++ b/support/cargo_cubuild/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cargo-cubuild"
+description = "A cargo tool to help with copper macro expansion errors."
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/support/cargo_cubuild/README.md
+++ b/support/cargo_cubuild/README.md
@@ -1,0 +1,50 @@
+# cargo cubuild
+
+A small Cargo extension that expands the [`#[copper_runtime]`](https://github.com/copperhq/copper) macro in-place at the call site.
+
+It replaces the macro invocation with the actual generated code, runs `cargo check`, and reports errors directly on the expanded code. This makes debugging macro-generated compilation errors vastly easier.
+
+After the check completes (successfully or not), your original file is automatically restored.
+
+## ✨ Features
+
+- In-place macro expansion of `#[copper_runtime(...)]`
+- Line-accurate diagnostics on the generated code
+- Automatic backup and restoration of `src/main.rs`
+- Requires no changes to your copper project
+
+## 🔧 Usage
+
+```bash
+cargo install --path .
+cargo cubuild
+```
+
+## example before with a simple cargo build
+
+```
+$ cargo build
+error[E0277]: the trait bound `&[u8]: Reader` is not satisfied
+  --> examples/cu_caterpillar/src/main.rs:6:1
+   |
+6  | #[copper_runtime(config = "copperconfig.ron")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Reader` is not implemented for `&[u8]`
+   |
+note: there are multiple different versions of crate `bincode` in the dependency graph
+  --> /home/gbin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bincode-2.0.1/src/de/read.rs:17:1
+```
+
+## example after, with cargo cubuild
+```
+$ cargo cubuild
+error[E0277]: the trait bound `&[u8]: Reader` is not satisfied
+    --> examples/cu_caterpillar/src/main.rs:2629:48
+     |
+2629 |             let mut decoder = DecoderImpl::new(slice, config, ());
+     |                               ---------------- ^^^^^ the trait `Reader` is not implemented for `&[u8]`
+     |                               |
+     |                               required by a bound introduced by this call
+     |
+note: there are multiple different versions of crate `bincode` in the dependency graph
+[...]
+```

--- a/support/cargo_cubuild/src/main.rs
+++ b/support/cargo_cubuild/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
 }
 
 fn try_main(main_rs: &PathBuf, backup: &PathBuf) -> Result<(), i32> {
-    fs::copy(&main_rs, &backup).expect("Failed to backup main.rs");
+    fs::copy(main_rs, backup).expect("Failed to backup main.rs");
 
     let output = Command::new("cargo")
         .env("RUSTFLAGS", "--cfg feature=\"macro_debug\"")
@@ -43,9 +43,9 @@ fn try_main(main_rs: &PathBuf, backup: &PathBuf) -> Result<(), i32> {
         }
     };
 
-    let original = fs::read_to_string(&backup).expect("Failed to read main.rs");
+    let original = fs::read_to_string(backup).expect("Failed to read main.rs");
     let patched = inject_generated_code(&original, &expanded);
-    fs::write(&main_rs, &patched).expect("Failed to write patched main.rs");
+    fs::write(main_rs, patched).expect("Failed to write patched main.rs");
 
     let status = Command::new("cargo")
         .arg("check")

--- a/support/cargo_cubuild/src/main.rs
+++ b/support/cargo_cubuild/src/main.rs
@@ -67,6 +67,9 @@ fn cleanup_and_exit(backup: &PathBuf, main_rs: &PathBuf, code: i32) -> ! {
     std::process::exit(code);
 }
 
+const START_TAG: &str = "===    Gen. Runtime ===";
+const END_TAG: &str = "=== === === === === ===";
+
 fn extract_expansion(stderr: &str) -> Option<String> {
     let start = stderr.find(START_TAG)? + START_TAG.len();
     let end = stderr[start..].find(END_TAG)? + start;

--- a/support/cargo_cubuild/src/main.rs
+++ b/support/cargo_cubuild/src/main.rs
@@ -1,4 +1,8 @@
-use std::{fs, path::PathBuf, process::{Command, Stdio}};
+use std::{
+    fs,
+    path::PathBuf,
+    process::{Command, Stdio},
+};
 
 fn main() {
     let main_rs = PathBuf::from("src/main.rs");

--- a/support/cargo_cubuild/src/main.rs
+++ b/support/cargo_cubuild/src/main.rs
@@ -1,0 +1,94 @@
+use std::{fs, path::PathBuf, process::{Command, Stdio}};
+
+fn main() {
+    let main_rs = PathBuf::from("src/main.rs");
+    if !main_rs.exists() {
+        eprintln!("[cubuild] Error: src/main.rs not found in current directory");
+        std::process::exit(1);
+    }
+
+    let backup = main_rs.with_extension("rs.bak");
+
+    println!("[cubuild] Backing up main.rs to {}", backup.display());
+
+    if let Err(code) = try_main(&main_rs, &backup) {
+        cleanup_and_exit(&backup, &main_rs, code);
+    } else {
+        cleanup_and_exit(&backup, &main_rs, 0);
+    }
+}
+
+fn try_main(main_rs: &PathBuf, backup: &PathBuf) -> Result<(), i32> {
+    fs::copy(&main_rs, &backup).expect("Failed to backup main.rs");
+
+    let output = Command::new("cargo")
+        .env("RUSTFLAGS", "--cfg feature=\"macro_debug\"")
+        .arg("run")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("Failed to run cargo run with macro_debug");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let expanded = match extract_expansion(&stderr) {
+        Some(e) => e,
+        None => {
+            eprintln!("[cubuild] Could not extract macro expansion from output:");
+            eprintln!("{}", stderr);
+            return Err(1);
+        }
+    };
+
+    let original = fs::read_to_string(&backup).expect("Failed to read main.rs");
+    let patched = inject_generated_code(&original, &expanded);
+    fs::write(&main_rs, &patched).expect("Failed to write patched main.rs");
+
+    let status = Command::new("cargo")
+        .arg("check")
+        .status()
+        .expect("cargo check failed");
+
+    if !status.success() {
+        return Err(status.code().unwrap_or(1));
+    }
+
+    Ok(())
+}
+
+fn cleanup_and_exit(backup: &PathBuf, main_rs: &PathBuf, code: i32) -> ! {
+    if backup.exists() {
+        println!("[cubuild] Restoring original main.rs from backup");
+        let _ = fs::rename(backup, main_rs);
+    }
+    std::process::exit(code);
+}
+
+fn extract_expansion(stderr: &str) -> Option<String> {
+    let start_tag = "===    Gen. Runtime ===";
+    let end_tag = "=== === === === === ===";
+    let start = stderr.find(start_tag)? + start_tag.len();
+    let end = stderr[start..].find(end_tag)? + start;
+    stderr.get(start..end).map(|s| s.trim().to_string())
+}
+
+fn inject_generated_code(original: &str, generated: &str) -> String {
+    let mut output = String::new();
+    let mut in_macro_block = false;
+    for line in original.lines() {
+        if line.contains("#[copper_runtime") {
+            in_macro_block = true;
+            continue;
+        }
+        if in_macro_block && line.contains("struct") {
+            output.push_str(generated);
+            output.push('\n');
+            in_macro_block = false;
+            continue;
+        }
+        if !in_macro_block {
+            output.push_str(line);
+            output.push('\n');
+        }
+    }
+    output
+}

--- a/support/cargo_cubuild/src/main.rs
+++ b/support/cargo_cubuild/src/main.rs
@@ -68,10 +68,8 @@ fn cleanup_and_exit(backup: &PathBuf, main_rs: &PathBuf, code: i32) -> ! {
 }
 
 fn extract_expansion(stderr: &str) -> Option<String> {
-    let start_tag = "===    Gen. Runtime ===";
-    let end_tag = "=== === === === === ===";
-    let start = stderr.find(start_tag)? + start_tag.len();
-    let end = stderr[start..].find(end_tag)? + start;
+    let start = stderr.find(START_TAG)? + START_TAG.len();
+    let end = stderr[start..].find(END_TAG)? + start;
     stderr.get(start..end).map(|s| s.trim().to_string())
 }
 


### PR DESCRIPTION
I don't know why it took me a year to finally just implement this :)

**before**

```bash
$ cargo build
error[E0277]: the trait bound `&[u8]: Reader` is not satisfied
  --> examples/cu_caterpillar/src/main.rs:6:1
   |
6  | #[copper_runtime(config = "copperconfig.ron")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Reader` is not implemented for `&[u8]`
   |
note: there are multiple different versions of crate `bincode` in the dependency graph
  --> /home/gbin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bincode-2.0.1/src/de/read.rs:17:1
```

**after**

```bash
$ cargo cubuild
error[E0277]: the trait bound `&[u8]: Reader` is not satisfied
    --> examples/cu_caterpillar/src/main.rs:2629:48
     |
2629 |             let mut decoder = DecoderImpl::new(slice, config, ());
     |                               ---------------- ^^^^^ the trait `Reader` is not implemented for `&[u8]`
     |                               |
     |                               required by a bound introduced by this call
     |
note: there are multiple different versions of crate `bincode` in the dependency graph
[...]
```

ACTUAL error, on ACTUAL code. :exploding_head: 

Enjoy.

