### PR TITLE
[BUG] Adds Ctrlc handler to the default run()

### DIFF
--- a/core/cu29/Cargo.toml
+++ b/core/cu29/Cargo.toml
@@ -24,6 +24,7 @@ cu29-value = { workspace = true }
 cu29-intern-strs = { workspace = true }
 bincode = { workspace = true }
 serde = { workspace = true }
+ctrlc = "3.4.7"
 
 [features]
 macro_debug = ["cu29-derive/macro_debug", "cu29-log-derive/macro_debug"]

--- a/core/cu29/src/lib.rs
+++ b/core/cu29/src/lib.rs
@@ -17,6 +17,7 @@ pub use cu29_runtime::config::read_configuration;
 pub use cu29_traits::*;
 
 pub mod prelude {
+    pub use ctrlc;
     pub use cu29_clock::*;
     pub use cu29_derive::*;
     pub use cu29_intern_strs::*;

--- a/examples/cu_rp_balancebot/Cargo.toml
+++ b/examples/cu_rp_balancebot/Cargo.toml
@@ -25,7 +25,6 @@ cu-rp-sn754410-new = { path = "../../components/sinks/cu_rp_sn754410", version =
 cu-rp-encoder = { path = "../../components/sources/cu_rp_encoder", version = "0.8.0" }
 cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "0.8.0" } # needed
 cu-pid = { path = "../../components/tasks/cu_pid", version = "0.8.0" }
-ctrlc = "3.4.7"
 
 # Log reader depencies
 cu29-export = { workspace = true, optional = true }

--- a/examples/cu_rp_balancebot/src/main.rs
+++ b/examples/cu_rp_balancebot/src/main.rs
@@ -4,7 +4,6 @@ use cu29::prelude::*;
 use cu29_helpers::basic_copper_setup;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
 
 #[copper_runtime(config = "copperconfig.ron")]
 struct BalanceBot {}
@@ -14,7 +13,6 @@ struct BalanceBot {}
 const SLAB_SIZE: Option<usize> = Some(1 * 1024 * 1024 * 1024);
 
 fn main() {
-    static STOP_FLAG: AtomicBool = AtomicBool::new(false);
     let logger_path = "logs/balance.copper";
     if let Some(parent) = Path::new(logger_path).parent() {
         if !parent.exists() {
@@ -34,22 +32,8 @@ fn main() {
         .expect("Failed to create runtime.");
 
     let clock = copper_ctx.clock;
-    ctrlc::set_handler(move || {
-        STOP_FLAG.store(true, Ordering::SeqCst);
-    })
-    .expect("Error setting Ctrl-C handler");
 
     debug!("Running... starting clock: {}.", clock.now());
-    application
-        .start_all_tasks()
-        .expect("Failed to start all tasks.");
-    while !STOP_FLAG.load(Ordering::SeqCst) {
-        application
-            .run_one_iteration()
-            .expect("Failed to run application.");
-    }
-    application
-        .stop_all_tasks()
-        .expect("Failed to stop all tasks.");
+    application.run().expect("Failed to run application.");
     debug!("End of app: final clock: {}.", clock.now());
 }


### PR DESCRIPTION
This avoids log corruption when users don't want to implement a manual loop.