### PR TITLE
[ENH] Restore the original log debug behavior

### DIFF
--- a/core/cu29_log_derive/build.rs
+++ b/core/cu29_log_derive/build.rs
@@ -1,4 +1,21 @@
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(cu29_default_log_level_debug)");
+    println!("cargo:rustc-check-cfg=cfg(cu29_default_log_level_info)");
+    let has_manual_level = std::env::vars().any(|(k, _)| {
+        k == "CARGO_FEATURE_LOG_LEVEL_DEBUG"
+            || k == "CARGO_FEATURE_LOG_LEVEL_INFO"
+            || k == "CARGO_FEATURE_LOG_LEVEL_WARNING"
+            || k == "CARGO_FEATURE_LOG_LEVEL_ERROR"
+            || k == "CARGO_FEATURE_LOG_LEVEL_CRITICAL"
+    });
+
+    if !has_manual_level {
+        match std::env::var("PROFILE").as_deref() {
+            Ok("release") => println!("cargo:rustc-cfg=cu29_default_log_level_info"),
+            _ => println!("cargo:rustc-cfg=cu29_default_log_level_debug"),
+        }
+    }
+
     if cfg!(target_os = "windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }

--- a/core/cu29_log_derive/src/lib.rs
+++ b/core/cu29_log_derive/src/lib.rs
@@ -169,7 +169,7 @@ fn create_log_entry(input: TokenStream, level: CuLogLevel) -> TokenStream {
 /// In release mode, the log will be only be written to the unified logger.
 ///
 /// This macro will be compiled out if the max log level is set to a level higher than Debug.
-#[cfg(feature = "log-level-debug")]
+#[cfg(any(feature = "log-level-debug", cu29_default_log_level_debug))]
 #[proc_macro]
 pub fn debug(input: TokenStream) -> TokenStream {
     create_log_entry(input, CuLogLevel::Debug)
@@ -239,7 +239,7 @@ pub fn critical(input: TokenStream) -> TokenStream {
 }
 
 // Provide empty implementations for macros that are compiled out
-#[cfg(not(any(feature = "log-level-debug",)))]
+#[cfg(not(any(feature = "log-level-debug", cu29_default_log_level_debug)))]
 #[proc_macro]
 pub fn debug(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     reference_unused_variables(input)

--- a/examples/cu_caterpillar/Cargo.toml
+++ b/examples/cu_caterpillar/Cargo.toml
@@ -36,7 +36,7 @@ path = "src/resim.rs"
 
 [dependencies]
 # cu29 = { workspace = true, features = ["macro_debug"] }
-cu29 = { workspace = true, features = ["log-level-debug"] }
+cu29 = { workspace = true }
 cu29-helpers = { workspace = true }
 cu29-export = { workspace = true, features = ["python"] }
 serde = { workspace = true }

--- a/examples/cu_missions/Cargo.toml
+++ b/examples/cu_missions/Cargo.toml
@@ -12,8 +12,7 @@ repository.workspace = true
 
 
 [dependencies]
-# cu29 = { workspace = true, features = ["macro_debug", "log-level-debug"] }
-cu29 = { workspace = true, features = ["log-level-debug"] }
+cu29 = { workspace = true }
 cu29-helpers = { workspace = true }
 tempfile = { workspace = true }
 serde = { workspace = true }

--- a/examples/cu_zenoh_ros/Cargo.toml
+++ b/examples/cu_zenoh_ros/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 description = "Copper example to use zenoh as a ROS 2 bridge."
 
 [dependencies]
-cu29 = { workspace = true, features = ["log-level-debug"] }
+cu29 = { workspace = true }
 cu29-helpers = { workspace = true }
 cu-zenoh-ros-sink = { path = "../../components/sinks/cu_zenoh_ros_sink", version = "0.8.0" }
 tempfile = { workspace = true }


### PR DESCRIPTION
if nothing is specified -> debug builds enable log-debug
                        -> release buids enable log-info

if anything is specified, it will repect the user's choice.

This avoids flipping them in and out and in and out in git branches while we test Copper and keeps the fine grain flexibility for our users.