### PR TITLE
Refactoring: Generalize CuMsg to CuStampedData

### DIFF
--- a/components/sinks/cu_iceoryx2_sink/src/lib.rs
+++ b/components/sinks/cu_iceoryx2_sink/src/lib.rs
@@ -7,7 +7,7 @@ use iceoryx2::prelude::*;
 use iceoryx2::service::port_factory::publish_subscribe::PortFactory;
 
 #[derive(Clone, Debug, Default, Decode, Encode)]
-pub struct IceorixCuMsg<P: CuMsgPayload>(CuMsg<P>);
+pub struct IceorixCuMsg<P: CuMsgPayload>(CuStampedData<P>);
 
 unsafe impl<P: CuMsgPayload> ZeroCopySend for IceorixCuMsg<P> {}
 /// This is a sink task that sends messages to an iceoryx2 service.

--- a/components/sinks/cu_lewansoul/src/lib.rs
+++ b/components/sinks/cu_lewansoul/src/lib.rs
@@ -2,10 +2,7 @@ use bincode::de::Decoder;
 use bincode::enc::Encoder;
 use bincode::error::{DecodeError, EncodeError};
 use bincode::{Decode, Encode};
-use cu29::clock::RobotClock;
-use cu29::config::ComponentConfig;
-use cu29::cutask::{CuMsg, CuSinkTask, Freezable};
-use cu29::{input_msg, CuError, CuResult};
+use cu29::prelude::*;
 use serde::Serialize;
 use serialport::{DataBits, FlowControl, Parity, SerialPort, StopBits};
 use std::io::{self, Read, Write};
@@ -187,7 +184,7 @@ pub struct ServoPositionsPayload {
 impl Encode for ServoPositionsPayload {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
         let angles: [f32; MAX_SERVOS] = self.positions.map(|a| a.value);
-        angles.encode(encoder)
+        bincode::Encode::encode(&angles, encoder)
     }
 }
 

--- a/components/sinks/cu_rp_sn754410/src/lib.rs
+++ b/components/sinks/cu_rp_sn754410/src/lib.rs
@@ -217,10 +217,7 @@ impl<'cl> CuSinkTask<'cl> for SN754410 {
 
 pub mod test_support {
     use crate::MotorPayload;
-    use cu29::clock::RobotClock;
-    use cu29::config::ComponentConfig;
-    use cu29::cutask::{CuMsg, CuSrcTask, Freezable};
-    use cu29::{output_msg, CuResult};
+    use cu29::prelude::*;
 
     pub struct SN754410TestSrc;
 

--- a/components/sources/cu_ads7883/src/lib.rs
+++ b/components/sources/cu_ads7883/src/lib.rs
@@ -148,7 +148,7 @@ impl<'cl> CuSrcTask<'cl> for ADS7883 {
         // hard to know exactly when the value was read.
         // Should be within a couple of microseconds with the ioctl opverhead.
         let af = clock.now();
-        new_msg.metadata.tov = Some((af + bf) / 2u64).into();
+        new_msg.tov = Some((af + bf) / 2u64).into();
 
         self.integrated_value = ((self.integrated_value + analog_value as u64)
             * INTEGRATION_FACTOR)
@@ -159,7 +159,7 @@ impl<'cl> CuSrcTask<'cl> for ADS7883 {
             analog_value: result,
         };
         new_msg.set_payload(output);
-        new_msg.metadata.tov = ((clock.now() + bf) / 2u64).into();
+        new_msg.tov = ((clock.now() + bf) / 2u64).into();
         new_msg.metadata.set_status(result);
         Ok(())
     }

--- a/components/sources/cu_hesai/src/lib.rs
+++ b/components/sources/cu_hesai/src/lib.rs
@@ -127,7 +127,7 @@ impl<'cl> CuSrcTask<'cl> for Xt32 {
                     start: min_tov,
                     end: max_tov,
                 };
-                new_msg.metadata.tov = Tov::Range(tov_range); // take the oldest timestamp
+                new_msg.tov = Tov::Range(tov_range); // take the oldest timestamp
             }
             Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
                 // Handle no data available (non-blocking behavior)

--- a/components/sources/cu_hesai/src/lib.rs
+++ b/components/sources/cu_hesai/src/lib.rs
@@ -145,7 +145,7 @@ mod tests {
     use super::*;
     use crate::parser::Packet;
     use chrono::DateTime;
-    use cu29::cutask::CuMsg;
+    use cu29::cutask::CuStampedData;
     use cu_udp_inject::PcapStreamer;
 
     #[test]
@@ -157,7 +157,7 @@ mod tests {
         let mut xt32 = Xt32::new(Some(&config)).unwrap();
 
         let new_payload = LidarCuMsgPayload::default();
-        let mut new_msg = CuMsg::<LidarCuMsgPayload>::new(Some(new_payload));
+        let mut new_msg = CuStampedData::<LidarCuMsgPayload>::new(Some(new_payload));
 
         // Picking a timestamp from the beginning of the pcap file to align the robot clock with the capture + 1s buffer in the past because ref times are negative.
         let datetime = DateTime::parse_from_rfc3339("2024-09-17T15:47:11.684855Z")

--- a/components/sources/cu_iceoryx2_src/src/lib.rs
+++ b/components/sources/cu_iceoryx2_src/src/lib.rs
@@ -141,7 +141,7 @@ where
                     .clone(),
             );
 
-            new_msg.metadata.tov = icemsg.payload().0.metadata.tov;
+            new_msg.tov = icemsg.payload().0.tov;
         } else {
             debug!(
                 "IceoryxSource({}): No message received.",

--- a/components/sources/cu_iceoryx2_src/src/lib.rs
+++ b/components/sources/cu_iceoryx2_src/src/lib.rs
@@ -6,7 +6,7 @@ use iceoryx2::prelude::*;
 use iceoryx2::service::port_factory::publish_subscribe::PortFactory;
 
 #[derive(Clone, Debug, Default, Decode, Encode)]
-pub struct IceorixCuMsg<P: CuMsgPayload>(CuMsg<P>);
+pub struct IceorixCuMsg<P: CuMsgPayload>(CuStampedData<P>);
 
 unsafe impl<P: CuMsgPayload> ZeroCopySend for IceorixCuMsg<P> {}
 

--- a/components/sources/cu_livox/src/lib.rs
+++ b/components/sources/cu_livox/src/lib.rs
@@ -92,7 +92,7 @@ mod tests {
     use super::*;
     use crate::parser::LidarFrame;
     use chrono::DateTime;
-    use cu29::cutask::CuMsg;
+    use cu29::cutask::CuStampedData;
     use cu_udp_inject::PcapStreamer;
 
     #[test]
@@ -104,7 +104,7 @@ mod tests {
         let mut tele15 = Tele15::new(Some(&config)).unwrap();
 
         let new_payload = LidarCuMsgPayload::default();
-        let mut new_msg = CuMsg::<LidarCuMsgPayload>::new(Some(new_payload));
+        let mut new_msg = CuStampedData::<LidarCuMsgPayload>::new(Some(new_payload));
 
         // Picking a timestamp from the beginning of the pcap file to align the robot clock with the capture + 1s buffer in the past because ref times are negative.
         let datetime = DateTime::parse_from_rfc3339("2024-09-17T15:47:11.684855Z")

--- a/components/sources/cu_rp_encoder/src/lib.rs
+++ b/components/sources/cu_rp_encoder/src/lib.rs
@@ -2,12 +2,8 @@
 mod mock;
 
 use bincode::{Decode, Encode};
-use cu29::clock::{CuDuration, RobotClock};
-use cu29::config::ComponentConfig;
-use cu29::cutask::{CuMsg, CuSrcTask, Freezable};
-use cu29::output_msg;
+use cu29::prelude::*;
 use cu29::CuResult;
-use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
 
 #[allow(unused_imports)]
@@ -17,6 +13,7 @@ use cu29_traits::CuError;
 use mock::{get_pin, InputPin};
 #[cfg(hardware)]
 use rppal::gpio::{Gpio, InputPin, Level, Trigger};
+use serde::Deserialize;
 
 #[allow(dead_code)]
 struct InterruptData {

--- a/components/sources/cu_rp_encoder/src/lib.rs
+++ b/components/sources/cu_rp_encoder/src/lib.rs
@@ -104,7 +104,7 @@ impl<'cl> CuSrcTask<'cl> for Encoder {
 
     fn process(&mut self, clock: &RobotClock, new_msg: Self::Output) -> CuResult<()> {
         let idata = self.data_from_interrupts.lock().unwrap();
-        new_msg.metadata.tov = Some(clock.now()).into();
+        new_msg.tov = Some(clock.now()).into();
         new_msg.metadata.set_status(idata.ticks);
         new_msg.set_payload(EncoderPayload { ticks: idata.ticks });
         Ok(())

--- a/components/sources/cu_v4l/src/lib.rs
+++ b/components/sources/cu_v4l/src/lib.rs
@@ -309,7 +309,7 @@ mod linux_impl {
             let mut v4l = V4l::new(Some(&config)).unwrap();
             v4l.start(&clock).unwrap();
 
-            let mut msg = CuMsg::new(None);
+            let mut msg = CuStampedData::new(None);
             // Define the image format
             let format = rerun::components::ImageFormat(ImageFormat {
                 width: IMG_WIDTH as u32,

--- a/components/sources/cu_v4l/src/lib.rs
+++ b/components/sources/cu_v4l/src/lib.rs
@@ -240,7 +240,7 @@ mod linux_impl {
                 let cutime = cutime_from_v4ltime(self.v4l_clock_time_offset_ns, meta.timestamp);
                 let image = CuImage::new(self.settled_format, handle.clone());
                 new_msg.set_payload(image);
-                new_msg.metadata.tov = Tov::Time(cutime);
+                new_msg.tov = Tov::Time(cutime);
             } else {
                 debug!("Empty frame received");
             }

--- a/components/sources/cu_vlp16/src/lib.rs
+++ b/components/sources/cu_vlp16/src/lib.rs
@@ -3,7 +3,7 @@ use velodyne_lidar::{DataPacket, Packet};
 
 use cu29::clock::RobotClock;
 use cu29::config::ComponentConfig;
-use cu29::cutask::{CuMsg, CuSrcTask, Freezable};
+use cu29::cutask::{CuSrcTask, CuStampedData, Freezable};
 use cu29::{output_msg, CuResult};
 use cu_sensor_payloads::{PointCloud, PointCloudSoa};
 use std::net::UdpSocket;
@@ -116,7 +116,7 @@ mod tests {
             .send_next::<PACKET_SIZE>()
             .expect("Failed to send packet")
         {
-            let mut msg = CuMsg::new(Some(PointCloudSoa::<10000>::default()));
+            let mut msg = CuStampedData::new(Some(PointCloudSoa::<10000>::default()));
             drv.process(&clk, &mut msg).unwrap();
             assert_eq!(-0.05115497, msg.payload().unwrap().x[0].value);
         }

--- a/components/tasks/cu_aligner/src/buffers.rs
+++ b/components/tasks/cu_aligner/src/buffers.rs
@@ -55,7 +55,7 @@ where
         start_time: CuTime,
         end_time: CuTime,
     ) -> impl Iterator<Item = &CuStampedData<P>> {
-        self.inner.iter().filter(move |msg| match msg.metadata.tov {
+        self.inner.iter().filter(move |msg| match msg.tov {
             Tov::Time(time) => time >= start_time && time <= end_time,
             Tov::Range(range) => range.start >= start_time && range.end <= end_time,
             _ => false,
@@ -68,7 +68,7 @@ where
         let drain_end = self
             .inner
             .iter()
-            .position(|msg| match msg.metadata.tov {
+            .position(|msg| match msg.tov {
                 Tov::Time(time) => time >= time_horizon,
                 Tov::Range(range) => range.end >= time_horizon,
                 _ => false,
@@ -83,7 +83,7 @@ where
     pub fn most_recent_time(&self) -> CuResult<Option<CuTime>> {
         self.inner
             .iter()
-            .map(|msg| extract_tov_time_right(&msg.metadata.tov))
+            .map(|msg| extract_tov_time_right(&msg.tov))
             .try_fold(None, |acc, time| {
                 let time = time.ok_or_else(|| {
                     CuError::from("Trying to align temporal data with no time information")
@@ -178,7 +178,7 @@ mod tests {
             AlignmentBuffers::new(Duration::from_secs(1).into(), Duration::from_secs(2).into());
 
         let mut msg1 = CuStampedData::new(Some(1));
-        msg1.metadata.tov = Tov::Time(Duration::from_secs(1).into());
+        msg1.tov = Tov::Time(Duration::from_secs(1).into());
         buffers.buffer1.inner.push_back(msg1.clone());
         buffers.buffer2.inner.push_back(msg1);
         // within the horizon
@@ -223,16 +223,16 @@ mod tests {
 
         // Insert messages with timestamps
         let mut msg1 = CuStampedData::new(Some(1));
-        msg1.metadata.tov = Tov::Time(Duration::from_secs(1).into());
+        msg1.tov = Tov::Time(Duration::from_secs(1).into());
         buffers.buffer1.inner.push_back(msg1.clone());
         buffers.buffer2.inner.push_back(msg1);
 
         let mut msg2 = CuStampedData::new(Some(3));
-        msg2.metadata.tov = Tov::Time(Duration::from_secs(3).into());
+        msg2.tov = Tov::Time(Duration::from_secs(3).into());
         buffers.buffer2.inner.push_back(msg2);
 
         let mut msg3 = CuStampedData::new(Some(4));
-        msg3.metadata.tov = Tov::Time(Duration::from_secs(4).into());
+        msg3.tov = Tov::Time(Duration::from_secs(4).into());
         buffers.buffer1.inner.push_back(msg3.clone());
         buffers.buffer2.inner.push_back(msg3);
 

--- a/components/tasks/cu_aligner/src/lib.rs
+++ b/components/tasks/cu_aligner/src/lib.rs
@@ -69,7 +69,7 @@ macro_rules! define_task {
                     return Ok(());
                 }
 
-                // this is a tuple of iterators of CuMsgs
+                // this is a tuple of iterators of CuStampedDataSet
                 let tuple_of_iters = tuple_of_iters.unwrap();
 
                 // Populate the CuArray fields in the output message
@@ -86,7 +86,7 @@ macro_rules! define_task {
 mod tests {
     use super::define_task;
     use cu29::config::ComponentConfig;
-    use cu29::cutask::CuMsg;
+    use cu29::cutask::CuStampedData;
     use cu29::cutask::CuTask;
     use cu29::cutask::Freezable;
     use cu29::input_msg;
@@ -102,10 +102,10 @@ mod tests {
         config.set("target_alignment_window_ms", 1000);
         config.set("stale_data_horizon_ms", 2000);
         let mut aligner = AlignerTask::new(Some(&config)).unwrap();
-        let m1 = CuMsg::<f32>::default();
-        let m2 = CuMsg::<i32>::default();
+        let m1 = CuStampedData::<f32>::default();
+        let m2 = CuStampedData::<i32>::default();
         let input: <AlignerTask as CuTask>::Input = (&m1, &m2);
-        let mut m3 = CuMsg::<(CuArray<f32, 5>, CuArray<i32, 10>)>::default();
+        let mut m3 = CuStampedData::<(CuArray<f32, 5>, CuArray<i32, 10>)>::default();
         let output: <AlignerTask as CuTask>::Output = &mut m3;
 
         let clock = cu29::clock::RobotClock::new();

--- a/components/tasks/cu_apriltag/src/lib.rs
+++ b/components/tasks/cu_apriltag/src/lib.rs
@@ -324,8 +324,8 @@ mod tests {
         config.set("family", "tag16h5".to_string());
 
         let mut task = AprilTags::new(Some(&config))?;
-        let input = CuMsg::<CuImage<Vec<u8>>>::new(Some(cuimage));
-        let mut output = CuMsg::<AprilTagDetections>::default();
+        let input = CuStampedData::<CuImage<Vec<u8>>>::new(Some(cuimage));
+        let mut output = CuStampedData::<AprilTagDetections>::default();
 
         let clock = RobotClock::new();
         let result = task.process(&clock, &input, &mut output);

--- a/components/tasks/cu_apriltag/src/lib.rs
+++ b/components/tasks/cu_apriltag/src/lib.rs
@@ -268,7 +268,7 @@ impl<'cl> CuTask<'cl> for AprilTags {
                 }
             }
         };
-        output.metadata.tov = input.metadata.tov;
+        output.tov = input.tov;
         output.set_payload(result);
         Ok(())
     }

--- a/components/tasks/cu_dynthreshold/src/cu_dynthreshold_impl.rs
+++ b/components/tasks/cu_dynthreshold/src/cu_dynthreshold_impl.rs
@@ -237,8 +237,8 @@ mod tests {
         // Create a new GStreamer buffer and fill it with input data
         let gstreamer_buffer = Buffer::from_mut_slice(input_data.clone());
         let cu_gst_buffer = CuGstBuffer(gstreamer_buffer);
-        let input_msg = CuMsg::new(Some(cu_gst_buffer));
-        let mut output_image_msg = CuMsg::<CuImage<Vec<u8>>>::default();
+        let input_msg = CuStampedData::new(Some(cu_gst_buffer));
+        let mut output_image_msg = CuStampedData::<CuImage<Vec<u8>>>::default();
         let output: <DynThreshold as CuTask>::Output = &mut output_image_msg;
 
         let clock = cu29::clock::RobotClock::new();

--- a/components/tasks/cu_pid/src/lib.rs
+++ b/components/tasks/cu_pid/src/lib.rs
@@ -215,7 +215,7 @@ where
     ) -> CuResult<()> {
         match input.payload() {
             Some(payload) => {
-                let tov = match input.metadata.tov {
+                let tov = match input.tov {
                     Tov::Time(single) => single,
                     _ => return Err("Unexpected variant for a TOV of PID".into()),
                 };

--- a/components/tasks/cu_ratelimit/src/lib.rs
+++ b/components/tasks/cu_ratelimit/src/lib.rs
@@ -92,8 +92,8 @@ mod tests {
     fn test_rate_limiting() {
         let (clock, _) = RobotClock::mock();
         let mut limiter = create_test_ratelimiter(10.0); // 10 Hz = 100ms interval
-        let mut input = CuMsg::<i32>::new(Some(42));
-        let mut output = CuMsg::<i32>::new(None);
+        let mut input = CuStampedData::<i32>::new(Some(42));
+        let mut output = CuStampedData::<i32>::new(None);
 
         // First message should pass
         input.metadata.tov = Tov::Time(CuTime::from(0));
@@ -115,8 +115,8 @@ mod tests {
     fn test_payload_propagation() {
         let (clock, _) = RobotClock::mock();
         let mut limiter = create_test_ratelimiter(10.0);
-        let mut input = CuMsg::<i32>::new(None);
-        let mut output = CuMsg::<i32>::new(None);
+        let mut input = CuStampedData::<i32>::new(None);
+        let mut output = CuStampedData::<i32>::new(None);
 
         // Test payload propagation
         input.set_payload(123);

--- a/components/tasks/cu_ratelimit/src/lib.rs
+++ b/components/tasks/cu_ratelimit/src/lib.rs
@@ -53,7 +53,7 @@ where
         input: Self::Input,
         output: Self::Output,
     ) -> CuResult<()> {
-        let tov = match input.metadata.tov {
+        let tov = match input.tov {
             Tov::Time(ts) => ts,
             _ => return Err("Expected single timestamp TOV".into()),
         };
@@ -96,17 +96,17 @@ mod tests {
         let mut output = CuStampedData::<i32>::new(None);
 
         // First message should pass
-        input.metadata.tov = Tov::Time(CuTime::from(0));
+        input.tov = Tov::Time(CuTime::from(0));
         limiter.process(&clock, &input, &mut output).unwrap();
         assert_eq!(output.payload(), Some(&42));
 
         // Message within the interval should be blocked
-        input.metadata.tov = Tov::Time(CuTime::from(50_000_000)); // 50ms
+        input.tov = Tov::Time(CuTime::from(50_000_000)); // 50ms
         limiter.process(&clock, &input, &mut output).unwrap();
         assert_eq!(output.payload(), None);
 
         // Message after the interval should pass
-        input.metadata.tov = Tov::Time(CuTime::from(100_000_000)); // 100ms
+        input.tov = Tov::Time(CuTime::from(100_000_000)); // 100ms
         limiter.process(&clock, &input, &mut output).unwrap();
         assert_eq!(output.payload(), Some(&42));
     }
@@ -120,13 +120,13 @@ mod tests {
 
         // Test payload propagation
         input.set_payload(123);
-        input.metadata.tov = Tov::Time(CuTime::from(0));
+        input.tov = Tov::Time(CuTime::from(0));
         limiter.process(&clock, &input, &mut output).unwrap();
         assert_eq!(output.payload(), Some(&123));
 
         // Test empty payload propagation
         input.clear_payload();
-        input.metadata.tov = Tov::Time(CuTime::from(100_000_000));
+        input.tov = Tov::Time(CuTime::from(100_000_000));
         limiter.process(&clock, &input, &mut output).unwrap();
         assert_eq!(output.payload(), None);
     }

--- a/core/cu29_export/src/lib.rs
+++ b/core/cu29_export/src/lib.rs
@@ -498,8 +498,8 @@ mod tests {
     #[derive(Debug, PartialEq, Clone, Copy, Serialize, Encode, Decode)]
     struct MyMsgs((u8, i32, f32));
 
-    impl ErasedCuMsgs for MyMsgs {
-        fn cumsgs(&self) -> Vec<&dyn ErasedCuMsg> {
+    impl ErasedCuStampedDataSet for MyMsgs {
+        fn cumsgs(&self) -> Vec<&dyn ErasedCuStampedData> {
             Vec::new()
         }
     }

--- a/core/cu29_export/src/lib.rs
+++ b/core/cu29_export/src/lib.rs
@@ -109,7 +109,7 @@ where
                                     print!("{}, ", entry.id);
                                 }
                                 let metadata = msg.metadata();
-                                print!("{}, {}, ", metadata.process_time(), metadata.tov());
+                                print!("{}, {}, ", metadata.process_time(), msg.tov());
                                 serde_json::to_writer(std::io::stdout(), payload).unwrap(); // TODO: escape for CSV
                                 first = false;
                             }

--- a/core/cu29_runtime/src/copperlist.rs
+++ b/core/cu29_runtime/src/copperlist.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 use bincode::{Decode, Encode};
 use std::fmt;
 
-use cu29_traits::{CopperListTuple, ErasedCuMsg, ErasedCuMsgs};
+use cu29_traits::{CopperListTuple, ErasedCuStampedData, ErasedCuStampedDataSet};
 use serde_derive::Serialize;
 use std::fmt::Display;
 use std::iter::{Chain, Rev};
@@ -69,8 +69,8 @@ impl<P: CopperListTuple> CopperList<P> {
     }
 }
 
-impl<P: CopperListTuple> ErasedCuMsgs for CopperList<P> {
-    fn cumsgs(&self) -> Vec<&dyn ErasedCuMsg> {
+impl<P: CopperListTuple> ErasedCuStampedDataSet for CopperList<P> {
+    fn cumsgs(&self) -> Vec<&dyn ErasedCuStampedData> {
         self.msgs.cumsgs()
     }
 }
@@ -253,19 +253,19 @@ impl<P: CopperListTuple, const N: usize> CuListsManager<P, N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cu29_traits::{ErasedCuMsg, ErasedCuMsgs, MatchingTasks};
+    use cu29_traits::{ErasedCuStampedData, ErasedCuStampedDataSet, MatchingTasks};
     use serde::{Serialize, Serializer};
 
     #[derive(Debug, Encode, Decode, PartialEq, Clone, Copy, Serialize)]
-    struct CuMsgs(i32);
+    struct CuStampedDataSet(i32);
 
-    impl ErasedCuMsgs for CuMsgs {
-        fn cumsgs(&self) -> Vec<&dyn ErasedCuMsg> {
+    impl ErasedCuStampedDataSet for CuStampedDataSet {
+        fn cumsgs(&self) -> Vec<&dyn ErasedCuStampedData> {
             Vec::new()
         }
     }
 
-    impl MatchingTasks for CuMsgs {
+    impl MatchingTasks for CuStampedDataSet {
         fn get_all_task_ids() -> &'static [&'static str] {
             &[]
         }
@@ -273,7 +273,7 @@ mod tests {
 
     #[test]
     fn empty_queue() {
-        let q = CuListsManager::<CuMsgs, 5>::new();
+        let q = CuListsManager::<CuStampedDataSet, 5>::new();
 
         assert!(q.is_empty());
         assert!(q.iter().next().is_none());
@@ -281,7 +281,7 @@ mod tests {
 
     #[test]
     fn partially_full_queue() {
-        let mut q = CuListsManager::<CuMsgs, 5>::new();
+        let mut q = CuListsManager::<CuStampedDataSet, 5>::new();
         q.create().unwrap().msgs.0 = 1;
         q.create().unwrap().msgs.0 = 2;
         q.create().unwrap().msgs.0 = 3;
@@ -295,7 +295,7 @@ mod tests {
 
     #[test]
     fn full_queue() {
-        let mut q = CuListsManager::<CuMsgs, 5>::new();
+        let mut q = CuListsManager::<CuStampedDataSet, 5>::new();
         q.create().unwrap().msgs.0 = 1;
         q.create().unwrap().msgs.0 = 2;
         q.create().unwrap().msgs.0 = 3;
@@ -309,7 +309,7 @@ mod tests {
 
     #[test]
     fn over_full_queue() {
-        let mut q = CuListsManager::<CuMsgs, 5>::new();
+        let mut q = CuListsManager::<CuStampedDataSet, 5>::new();
         q.create().unwrap().msgs.0 = 1;
         q.create().unwrap().msgs.0 = 2;
         q.create().unwrap().msgs.0 = 3;
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn clear() {
-        let mut q = CuListsManager::<CuMsgs, 5>::new();
+        let mut q = CuListsManager::<CuStampedDataSet, 5>::new();
         q.create().unwrap().msgs.0 = 1;
         q.create().unwrap().msgs.0 = 2;
         q.create().unwrap().msgs.0 = 3;
@@ -350,7 +350,7 @@ mod tests {
 
     #[test]
     fn mutable_iterator() {
-        let mut q = CuListsManager::<CuMsgs, 5>::new();
+        let mut q = CuListsManager::<CuStampedDataSet, 5>::new();
         q.create().unwrap().msgs.0 = 1;
         q.create().unwrap().msgs.0 = 2;
         q.create().unwrap().msgs.0 = 3;
@@ -367,7 +367,7 @@ mod tests {
 
     #[test]
     fn test_drop_last() {
-        let mut q = CuListsManager::<CuMsgs, 5>::new();
+        let mut q = CuListsManager::<CuStampedDataSet, 5>::new();
         q.create().unwrap().msgs.0 = 1;
         q.create().unwrap().msgs.0 = 2;
         q.create().unwrap().msgs.0 = 3;
@@ -384,7 +384,7 @@ mod tests {
 
     #[test]
     fn test_pop() {
-        let mut q = CuListsManager::<CuMsgs, 5>::new();
+        let mut q = CuListsManager::<CuStampedDataSet, 5>::new();
         q.create().unwrap().msgs.0 = 1;
         q.create().unwrap().msgs.0 = 2;
         q.create().unwrap().msgs.0 = 3;
@@ -402,7 +402,7 @@ mod tests {
 
     #[test]
     fn test_peek() {
-        let mut q = CuListsManager::<CuMsgs, 5>::new();
+        let mut q = CuListsManager::<CuStampedDataSet, 5>::new();
         q.create().unwrap().msgs.0 = 1;
         q.create().unwrap().msgs.0 = 2;
         q.create().unwrap().msgs.0 = 3;
@@ -423,8 +423,8 @@ mod tests {
         content: [u8; 10_000_000],
     }
 
-    impl ErasedCuMsgs for TestStruct {
-        fn cumsgs(&self) -> Vec<&dyn ErasedCuMsg> {
+    impl ErasedCuStampedDataSet for TestStruct {
+        fn cumsgs(&self) -> Vec<&dyn ErasedCuStampedData> {
             Vec::new()
         }
     }

--- a/core/cu29_runtime/src/curuntime.rs
+++ b/core/cu29_runtime/src/curuntime.rs
@@ -590,7 +590,7 @@ mod tests {
     use crate::cutask::{CuSrcTask, Freezable};
     use crate::monitoring::NoMonitor;
     use bincode::Encode;
-    use cu29_traits::{ErasedCuMsg, ErasedCuMsgs, MatchingTasks};
+    use cu29_traits::{ErasedCuStampedData, ErasedCuStampedDataSet, MatchingTasks};
     use serde_derive::Serialize;
 
     pub struct TestSource {}
@@ -636,8 +636,8 @@ mod tests {
     #[derive(Debug, Encode, Decode, Serialize)]
     struct Msgs(());
 
-    impl ErasedCuMsgs for Msgs {
-        fn cumsgs(&self) -> Vec<&dyn ErasedCuMsg> {
+    impl ErasedCuStampedDataSet for Msgs {
+        fn cumsgs(&self) -> Vec<&dyn ErasedCuStampedData> {
             Vec::new()
         }
     }

--- a/core/cu29_runtime/src/cutask.rs
+++ b/core/cu29_runtime/src/cutask.rs
@@ -7,7 +7,7 @@ use bincode::enc::{Encode, Encoder};
 use bincode::error::{DecodeError, EncodeError};
 use compact_str::{CompactString, ToCompactString};
 use cu29_clock::{PartialCuTimeRange, RobotClock, Tov};
-use cu29_traits::{CuCompactString, CuResult, ErasedCuMsg, COMPACT_STRING_CAPACITY};
+use cu29_traits::{CuCompactString, CuResult, ErasedCuStampedData, COMPACT_STRING_CAPACITY};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
@@ -23,15 +23,15 @@ impl<T: Default + Debug + Clone + Encode + Decode<()> + Serialize + Sized> CuMsg
 macro_rules! impl_cu_msg_pack {
     ($(($($ty:ident),*)),*) => {
         $(
-            impl<'cl, $($ty: CuMsgPayload + 'cl),*> CuMsgPack<'cl> for ( $( &'cl CuMsg<$ty>, )* ) {}
+            impl<'cl, $($ty: CuMsgPayload + 'cl),*> CuMsgPack<'cl> for ( $( &'cl CuStampedData<$ty>, )* ) {}
         )*
     };
 }
 
-impl<'cl, T: CuMsgPayload> CuMsgPack<'cl> for (&'cl CuMsg<T>,) {}
-impl<'cl, T: CuMsgPayload> CuMsgPack<'cl> for &'cl CuMsg<T> {}
-impl<'cl, T: CuMsgPayload> CuMsgPack<'cl> for (&'cl mut CuMsg<T>,) {}
-impl<'cl, T: CuMsgPayload> CuMsgPack<'cl> for &'cl mut CuMsg<T> {}
+impl<'cl, T: CuMsgPayload> CuMsgPack<'cl> for (&'cl CuStampedData<T>,) {}
+impl<'cl, T: CuMsgPayload> CuMsgPack<'cl> for &'cl CuStampedData<T> {}
+impl<'cl, T: CuMsgPayload> CuMsgPack<'cl> for (&'cl mut CuStampedData<T>,) {}
+impl<'cl, T: CuMsgPayload> CuMsgPack<'cl> for &'cl mut CuStampedData<T> {}
 impl CuMsgPack<'_> for () {}
 
 // Apply the macro to generate implementations for tuple sizes up to 5
@@ -44,11 +44,11 @@ impl_cu_msg_pack! {
 #[macro_export]
 macro_rules! input_msg {
     ($lifetime:lifetime, $ty:ty) => {
-        &$lifetime CuMsg<$ty>
+        &$lifetime CuStampedData<$ty>
     };
     ($lifetime:lifetime, $($ty:ty),*) => {
         (
-            $( &$lifetime CuMsg<$ty>, )*
+            $( &$lifetime CuStampedData<$ty>, )*
         )
     };
 }
@@ -57,11 +57,11 @@ macro_rules! input_msg {
 #[macro_export]
 macro_rules! output_msg {
     ($lifetime:lifetime, $ty:ty) => {
-        &$lifetime mut CuMsg<$ty>
+        &$lifetime mut CuStampedData<$ty>
     };
 }
 
-/// CuMsgMetadata is a structure that contains metadata common to all CuMsgs.
+/// CuMsgMetadata is a structure that contains metadata common to all CuStampedDataSet.
 #[derive(Debug, Clone, bincode::Encode, bincode::Decode, Serialize, Deserialize)]
 pub struct CuMsgMetadata {
     /// The time range used for the processing of this message
@@ -80,7 +80,7 @@ impl CuMsgMetadata {
     }
 }
 
-impl cu29_traits::CuMsgMetadataTrait for CuMsgMetadata {
+impl cu29_traits::CuMetadataTrait for CuMsgMetadata {
     fn process_time(&self) -> PartialCuTimeRange {
         self.process_time
     }
@@ -106,7 +106,7 @@ impl Display for CuMsgMetadata {
 
 /// CuMsg is the envelope holding the msg payload and the metadata between tasks.
 #[derive(Default, Debug, Clone, bincode::Encode, bincode::Decode, Serialize)]
-pub struct CuMsg<T>
+pub struct CuStampedData<T>
 where
     T: CuMsgPayload,
 {
@@ -127,12 +127,12 @@ impl Default for CuMsgMetadata {
     }
 }
 
-impl<T> CuMsg<T>
+impl<T> CuStampedData<T>
 where
     T: CuMsgPayload,
 {
     pub fn new(payload: Option<T>) -> Self {
-        CuMsg {
+        CuStampedData {
             payload,
             metadata: CuMsgMetadata::default(),
         }
@@ -154,11 +154,11 @@ where
     }
 }
 
-impl<T> ErasedCuMsg for CuMsg<T>
+impl<T> ErasedCuStampedData for CuStampedData<T>
 where
     T: CuMsgPayload,
 {
-    fn metadata(&self) -> &dyn cu29_traits::CuMsgMetadataTrait {
+    fn metadata(&self) -> &dyn cu29_traits::CuMetadataTrait {
         &self.metadata
     }
 

--- a/core/cu29_runtime/src/simulation.rs
+++ b/core/cu29_runtime/src/simulation.rs
@@ -109,7 +109,7 @@
 
 use crate::config::ComponentConfig;
 
-use crate::cutask::{CuMsg, CuMsgPayload, CuSinkTask, CuSrcTask, Freezable};
+use crate::cutask::{CuMsgPayload, CuSinkTask, CuSrcTask, CuStampedData, Freezable};
 use crate::{input_msg, output_msg};
 use cu29_clock::RobotClock;
 use cu29_traits::CuResult;

--- a/core/cu29_traits/src/lib.rs
+++ b/core/cu29_traits/src/lib.rs
@@ -86,19 +86,15 @@ pub trait CuMetadataTrait {
     /// The time range used for the processing of this message
     fn process_time(&self) -> PartialCuTimeRange;
 
-    /// The time of validity ie. matching time in the real world of this measure or
-    /// computation derived from those measures.
-    /// It can be undefined (None), one measure point or a range of measures (TimeRange).
-    fn tov(&self) -> Tov;
-
     /// Small status text for user UI to get the realtime state of task (max 24 chrs)
     fn status_txt(&self) -> &CuCompactString;
 }
 
 /// A generic trait to expose the generated CuStampedDataSet from the task graph.
 pub trait ErasedCuStampedData {
-    fn metadata(&self) -> &dyn CuMetadataTrait;
     fn payload(&self) -> Option<&dyn erased_serde::Serialize>;
+    fn tov(&self) -> Tov;
+    fn metadata(&self) -> &dyn CuMetadataTrait;
 }
 
 /// Trait to get a vector of type-erased CuStampedDataSet

--- a/core/cu29_traits/src/lib.rs
+++ b/core/cu29_traits/src/lib.rs
@@ -82,7 +82,7 @@ pub enum UnifiedLogType {
 }
 
 /// Key metadata piece attached to every message in Copper.
-pub trait CuMsgMetadataTrait {
+pub trait CuMetadataTrait {
     /// The time range used for the processing of this message
     fn process_time(&self) -> PartialCuTimeRange;
 
@@ -95,16 +95,16 @@ pub trait CuMsgMetadataTrait {
     fn status_txt(&self) -> &CuCompactString;
 }
 
-/// A generic trait to expose the generated CuMsgs from the task graph.
-pub trait ErasedCuMsg {
-    fn metadata(&self) -> &dyn CuMsgMetadataTrait;
+/// A generic trait to expose the generated CuStampedDataSet from the task graph.
+pub trait ErasedCuStampedData {
+    fn metadata(&self) -> &dyn CuMetadataTrait;
     fn payload(&self) -> Option<&dyn erased_serde::Serialize>;
 }
 
-/// Trait to get a vector of type-erased CuMsgs
+/// Trait to get a vector of type-erased CuStampedDataSet
 /// This is used for generic serialization of the copperlists
-pub trait ErasedCuMsgs {
-    fn cumsgs(&self) -> Vec<&dyn ErasedCuMsg>;
+pub trait ErasedCuStampedDataSet {
+    fn cumsgs(&self) -> Vec<&dyn ErasedCuStampedData>;
 }
 
 /// Trait to trace back from the CopperList the origin of the messages
@@ -114,13 +114,18 @@ pub trait MatchingTasks {
 
 /// A CopperListTuple needs to be encodable, decodable and fixed size in memory.
 pub trait CopperListTuple:
-    bincode::Encode + bincode::Decode<()> + Debug + Serialize + ErasedCuMsgs + MatchingTasks
+    bincode::Encode + bincode::Decode<()> + Debug + Serialize + ErasedCuStampedDataSet + MatchingTasks
 {
 } // Decode forces Sized already
 
 // Also anything that follows this contract can be a payload (blanket implementation)
 impl<T> CopperListTuple for T where
-    T: bincode::Encode + bincode::Decode<()> + Debug + Serialize + ErasedCuMsgs + MatchingTasks
+    T: bincode::Encode
+        + bincode::Decode<()>
+        + Debug
+        + Serialize
+        + ErasedCuStampedDataSet
+        + MatchingTasks
 {
 }
 

--- a/examples/cu_caterpillar/src/logreader.rs
+++ b/examples/cu_caterpillar/src/logreader.rs
@@ -4,5 +4,5 @@ use cu29_export::run_cli;
 gen_cumsgs!("copperconfig.ron");
 
 fn main() {
-    run_cli::<CuMsgs>().expect("Failed to run the export CLI");
+    run_cli::<CuStampedDataSet>().expect("Failed to run the export CLI");
 }

--- a/examples/cu_caterpillar/src/resim.rs
+++ b/examples/cu_caterpillar/src/resim.rs
@@ -19,7 +19,7 @@ fn default_callback(step: default::SimStep) -> SimOverride {
 fn run_one_copperlist(
     copper_app: &mut CaterpillarReSim,
     robot_clock: &mut RobotClockMock,
-    copper_list: CopperList<default::CuMsgs>,
+    copper_list: CopperList<default::CuStampedDataSet>,
 ) {
     // Sync the copper clock to the simulated physics clock.
     let msgs = &copper_list.msgs;
@@ -93,14 +93,14 @@ fn main() {
         };
 
         let mut copperlists = UnifiedLoggerIOReader::new(dl, UnifiedLogType::CopperList);
-        let cl_iter = copperlists_reader::<default::CuMsgs>(&mut copperlists);
+        let cl_iter = copperlists_reader::<default::CuStampedDataSet>(&mut copperlists);
         for entry in cl_iter {
             println!("{entry:#?}");
             run_one_copperlist(&mut copper_app, &mut robot_clock_mock, entry);
         }
     }
 
-    // let cl_iter = copperlists_reader::<default::CuMsgs>(&mut copperlists_reader);
+    // let cl_iter = copperlists_reader::<default::CuStampedDataSet>(&mut copperlists_reader);
     // for entry in cl_iter {
     //     println!("{entry:#?}");
     //     run_one_copperlist(&mut copper_app, &mut robot_clock_mock, entry);

--- a/examples/cu_caterpillar/src/tasks.rs
+++ b/examples/cu_caterpillar/src/tasks.rs
@@ -35,7 +35,7 @@ impl<'cl> CuSrcTask<'cl> for CaterpillarSource {
         // forward the state to the next task
         self.state = !self.state;
         output.set_payload(RPGpioPayload { on: self.state });
-        output.metadata.tov = Tov::Time(clock.now());
+        output.tov = Tov::Time(clock.now());
         output.metadata.set_status(self.state);
         Ok(())
     }
@@ -65,7 +65,7 @@ impl<'cl> CuTask<'cl> for CaterpillarTask {
         // forward the state to the next task
         let incoming = *input.payload().unwrap();
         output.set_payload(incoming);
-        output.metadata.tov = input.metadata.tov;
+        output.tov = input.tov;
         output.metadata.set_status(incoming.on);
         Ok(())
     }

--- a/examples/cu_caterpillar/src/tasks.rs
+++ b/examples/cu_caterpillar/src/tasks.rs
@@ -2,11 +2,7 @@ use cu29::bincode::de::Decoder;
 use cu29::bincode::enc::Encoder;
 use cu29::bincode::error::{DecodeError, EncodeError};
 use cu29::bincode::{Decode, Encode};
-use cu29::clock::RobotClock;
-use cu29::config::ComponentConfig;
-use cu29::cutask::{CuMsg, CuSrcTask, CuTask, Freezable};
-use cu29::prelude::Tov;
-use cu29::{input_msg, output_msg, CuResult};
+use cu29::prelude::*;
 use cu_rp_gpio::RPGpioPayload;
 
 #[derive(Default)]

--- a/examples/cu_monitoring/Cargo.toml
+++ b/examples/cu_monitoring/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cu29 = { workspace = true }
+cu29 = { workspace = true, features = ["macro_debug"] }
 cu29-helpers = { workspace = true }
 tempfile = { workspace = true }
 serde = { workspace = true }

--- a/examples/cu_multisources/src/tasks.rs
+++ b/examples/cu_multisources/src/tasks.rs
@@ -87,7 +87,7 @@ impl<'cl> CuTask<'cl> for MergerTask {
         output: Self::Output,
     ) -> CuResult<()> {
         // Put the types explicitly here show the actual underlying type of Self::Input
-        let (i, f): (&CuMsg<i32>, &CuMsg<f32>) = input;
+        let (i, f): (&CuStampedData<i32>, &CuStampedData<f32>) = input;
         let (i, f) = (i.payload().unwrap(), f.payload().unwrap());
         output.set_payload((*i, *f)); // output is a &mut CuMsg<(i32, f32)>
         Ok(())

--- a/examples/cu_rp_balancebot/src/logreader.rs
+++ b/examples/cu_rp_balancebot/src/logreader.rs
@@ -6,5 +6,5 @@ use cu29_export::run_cli;
 gen_cumsgs!("copperconfig.ron");
 
 fn main() {
-    run_cli::<CuMsgs>().expect("Failed to run the export CLI");
+    run_cli::<CuStampedDataSet>().expect("Failed to run the export CLI");
 }

--- a/examples/cu_rp_balancebot/src/resim.rs
+++ b/examples/cu_rp_balancebot/src/resim.rs
@@ -21,7 +21,7 @@ fn default_callback(step: default::SimStep) -> SimOverride {
 fn run_one_copperlist(
     copper_app: &mut BalanceBotReSim,
     robot_clock: &mut RobotClockMock,
-    copper_list: CopperList<default::CuMsgs>,
+    copper_list: CopperList<default::CuStampedDataSet>,
 ) {
     // Sync the copper clock to the simulated physics clock.
     let msgs = &copper_list.msgs;
@@ -105,7 +105,7 @@ fn main() {
         panic!("Failed to create logger");
     };
     let mut reader = UnifiedLoggerIOReader::new(dl, UnifiedLogType::CopperList);
-    let iter = copperlists_reader::<default::CuMsgs>(&mut reader);
+    let iter = copperlists_reader::<default::CuStampedDataSet>(&mut reader);
     for entry in iter {
         println!("{entry:#?}");
         run_one_copperlist(&mut copper_app, &mut robot_clock_mock, entry);

--- a/examples/cu_rp_balancebot/src/sim.rs
+++ b/examples/cu_rp_balancebot/src/sim.rs
@@ -131,7 +131,7 @@ fn run_copper_callback(
                 // Convert the angle from radians to the actual adc value from the sensor
                 let analog_value = (angle_radians / (2.0 * std::f32::consts::PI) * 4096.0) as u16;
                 output.set_payload(ADSReadingPayload { analog_value });
-                output.metadata.tov = robot_clock.clock.now().into();
+                output.tov = robot_clock.clock.now().into();
                 SimOverride::ExecutedBySim
             }
             default::SimStep::Balpos(_) => SimOverride::ExecutedBySim,
@@ -141,7 +141,7 @@ fn run_copper_callback(
                 let (cart_transform, _) = bindings.single().expect("Failed to get cart transform");
                 let ticks = (cart_transform.translation.x * 2000.0) as i32;
                 output.set_payload(EncoderPayload { ticks });
-                output.metadata.tov = robot_clock.clock.now().into();
+                output.tov = robot_clock.clock.now().into();
                 SimOverride::ExecutedBySim
             }
             default::SimStep::Railpos(_) => SimOverride::ExecutedBySim,

--- a/examples/cu_rp_balancebot/src/tasks.rs
+++ b/examples/cu_rp_balancebot/src/tasks.rs
@@ -38,7 +38,7 @@ impl<'cl> CuTask<'cl> for PIDMerger {
             None => return Err(CuError::from("Safety mode [rail].")),
         };
         // Take the fastest measure as the reference time for the merge
-        output.metadata.tov = bal_pid_msg.metadata.tov;
+        output.tov = bal_pid_msg.tov;
         let composite_output = (bal_pid.output - pos_pid.output).clamp(-1.0, 1.0);
         output.set_payload(MotorPayload {
             power: composite_output,

--- a/templates/cu_full/src/logreader.rs
+++ b/templates/cu_full/src/logreader.rs
@@ -3,11 +3,11 @@ pub mod tasks;
 use cu29::prelude::*;
 use cu29_export::run_cli;
 
-// This will create the CuMsgs that is specific to your copper project.
+// This will create the CuStampedDataSet that is specific to your copper project.
 // It is used to instruct the log reader how to decode the logs.
 gen_cumsgs!("copperconfig.ron");
 
 #[cfg(feature = "logreader")]
 fn main() {
-    run_cli::<CuMsgs>().expect("Failed to run the export CLI");
+    run_cli::<CuStampedDataSet>().expect("Failed to run the export CLI");
 }


### PR DESCRIPTION
1. CuMsg is a more generic structure than just a message and can be used to store timestamped data so got renamed to CuStampedData 
2. Moved the TOV from metadata to the struct itself: it is basically entirely part of the semantic of it so it should be first class
3. Generalized Metadata so users can extend this structure as they see fit while keeping the Copper internal metadata independent from it.