### PR TITLE
Adds back a CuMsgs type alias

### DIFF
--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -112,6 +112,7 @@ pub fn gen_cumsgs(config_path_lit: TokenStream) -> TokenStream {
             #support
         }
         use cumsgs::CuStampedDataSet;
+        type CuMsgs=CuStampedDataSet;
     };
     with_uses.into()
 }

--- a/examples/cu_dorabench/src/logreader.rs
+++ b/examples/cu_dorabench/src/logreader.rs
@@ -5,5 +5,5 @@ use cu29_export::run_cli;
 gen_cumsgs!("copperconfig.ron");
 
 fn main() {
-    run_cli::<CuStampedDataSet>().expect("Failed to run the export CLI");
+    run_cli::<CuMsgs>().expect("Failed to run the export CLI");
 }


### PR DESCRIPTION
This is to not break backward compatibility with existing code.