### PR TITLE
Reput the CuMsg type alias instead of explicit CuStampData

### DIFF
--- a/components/sinks/cu_iceoryx2_sink/src/lib.rs
+++ b/components/sinks/cu_iceoryx2_sink/src/lib.rs
@@ -7,7 +7,7 @@ use iceoryx2::prelude::*;
 use iceoryx2::service::port_factory::publish_subscribe::PortFactory;
 
 #[derive(Clone, Debug, Default, Decode, Encode)]
-pub struct IceorixCuMsg<P: CuMsgPayload>(CuStampedData<P, CuMsgMetadata>);
+pub struct IceorixCuMsg<P: CuMsgPayload>(CuMsg<P>);
 
 unsafe impl<P: CuMsgPayload> ZeroCopySend for IceorixCuMsg<P> {}
 /// This is a sink task that sends messages to an iceoryx2 service.

--- a/components/sources/cu_hesai/src/lib.rs
+++ b/components/sources/cu_hesai/src/lib.rs
@@ -145,7 +145,7 @@ mod tests {
     use super::*;
     use crate::parser::Packet;
     use chrono::DateTime;
-    use cu29::cutask::CuStampedData;
+    use cu29::cutask::CuMsg;
     use cu_udp_inject::PcapStreamer;
 
     #[test]
@@ -157,7 +157,7 @@ mod tests {
         let mut xt32 = Xt32::new(Some(&config)).unwrap();
 
         let new_payload = LidarCuMsgPayload::default();
-        let mut new_msg = CuStampedData::<LidarCuMsgPayload, CuMsgMetadata>::new(Some(new_payload));
+        let mut new_msg = CuMsg::<LidarCuMsgPayload>::new(Some(new_payload));
 
         // Picking a timestamp from the beginning of the pcap file to align the robot clock with the capture + 1s buffer in the past because ref times are negative.
         let datetime = DateTime::parse_from_rfc3339("2024-09-17T15:47:11.684855Z")

--- a/components/sources/cu_iceoryx2_src/src/lib.rs
+++ b/components/sources/cu_iceoryx2_src/src/lib.rs
@@ -6,7 +6,7 @@ use iceoryx2::prelude::*;
 use iceoryx2::service::port_factory::publish_subscribe::PortFactory;
 
 #[derive(Clone, Debug, Default, Decode, Encode)]
-pub struct IceorixCuMsg<P: CuMsgPayload>(CuStampedData<P, CuMsgMetadata>);
+pub struct IceorixCuMsg<P: CuMsgPayload>(CuMsg<P>);
 
 unsafe impl<P: CuMsgPayload> ZeroCopySend for IceorixCuMsg<P> {}
 

--- a/components/sources/cu_livox/src/lib.rs
+++ b/components/sources/cu_livox/src/lib.rs
@@ -92,7 +92,7 @@ mod tests {
     use super::*;
     use crate::parser::LidarFrame;
     use chrono::DateTime;
-    use cu29::cutask::CuStampedData;
+    use cu29::cutask::CuMsg;
     use cu_udp_inject::PcapStreamer;
 
     #[test]
@@ -104,7 +104,7 @@ mod tests {
         let mut tele15 = Tele15::new(Some(&config)).unwrap();
 
         let new_payload = LidarCuMsgPayload::default();
-        let mut new_msg = CuStampedData::<LidarCuMsgPayload, CuMsgMetadata>::new(Some(new_payload));
+        let mut new_msg = CuMsg::<LidarCuMsgPayload>::new(Some(new_payload));
 
         // Picking a timestamp from the beginning of the pcap file to align the robot clock with the capture + 1s buffer in the past because ref times are negative.
         let datetime = DateTime::parse_from_rfc3339("2024-09-17T15:47:11.684855Z")

--- a/components/sources/cu_v4l/src/lib.rs
+++ b/components/sources/cu_v4l/src/lib.rs
@@ -309,7 +309,7 @@ mod linux_impl {
             let mut v4l = V4l::new(Some(&config)).unwrap();
             v4l.start(&clock).unwrap();
 
-            let mut msg = CuStampedData::new(None);
+            let mut msg = CuMsg::new(None);
             // Define the image format
             let format = rerun::components::ImageFormat(ImageFormat {
                 width: IMG_WIDTH as u32,

--- a/components/sources/cu_vlp16/src/lib.rs
+++ b/components/sources/cu_vlp16/src/lib.rs
@@ -113,7 +113,7 @@ mod tests {
             .send_next::<PACKET_SIZE>()
             .expect("Failed to send packet")
         {
-            let mut msg = CuStampedData::new(Some(PointCloudSoa::<10000>::default()));
+            let mut msg = CuMsg::new(Some(PointCloudSoa::<10000>::default()));
             drv.process(&clk, &mut msg).unwrap();
             assert_eq!(-0.05115497, msg.payload().unwrap().x[0].value);
         }

--- a/components/tasks/cu_aligner/src/lib.rs
+++ b/components/tasks/cu_aligner/src/lib.rs
@@ -86,6 +86,7 @@ macro_rules! define_task {
 mod tests {
     use super::define_task;
     use cu29::config::ComponentConfig;
+    use cu29::cutask::CuMsg;
     use cu29::cutask::CuTask;
     use cu29::cutask::Freezable;
     use cu29::cutask::{CuMsgMetadata, CuStampedData};

--- a/components/tasks/cu_apriltag/src/lib.rs
+++ b/components/tasks/cu_apriltag/src/lib.rs
@@ -326,8 +326,8 @@ mod tests {
         config.set("family", "tag16h5".to_string());
 
         let mut task = AprilTags::new(Some(&config))?;
-        let input = CuStampedData::<CuImage<Vec<u8>>, CuMsgMetadata>::new(Some(cuimage));
-        let mut output = CuStampedData::<AprilTagDetections, CuMsgMetadata>::default();
+        let input = CuMsg::<CuImage<Vec<u8>>>::new(Some(cuimage));
+        let mut output = CuMsg::<AprilTagDetections>::default();
 
         let clock = RobotClock::new();
         let result = task.process(&clock, &input, &mut output);

--- a/components/tasks/cu_dynthreshold/src/cu_dynthreshold_impl.rs
+++ b/components/tasks/cu_dynthreshold/src/cu_dynthreshold_impl.rs
@@ -237,8 +237,8 @@ mod tests {
         // Create a new GStreamer buffer and fill it with input data
         let gstreamer_buffer = Buffer::from_mut_slice(input_data.clone());
         let cu_gst_buffer = CuGstBuffer(gstreamer_buffer);
-        let input_msg = CuStampedData::new(Some(cu_gst_buffer));
-        let mut output_image_msg = CuStampedData::<CuImage<Vec<u8>>, CuMsgMetadata>::default();
+        let input_msg = CuMsg::new(Some(cu_gst_buffer));
+        let mut output_image_msg = CuMsg::<CuImage<Vec<u8>>>::default();
         let output: <DynThreshold as CuTask>::Output = &mut output_image_msg;
 
         let clock = cu29::clock::RobotClock::new();

--- a/components/tasks/cu_ratelimit/src/lib.rs
+++ b/components/tasks/cu_ratelimit/src/lib.rs
@@ -92,8 +92,8 @@ mod tests {
     fn test_rate_limiting() {
         let (clock, _) = RobotClock::mock();
         let mut limiter = create_test_ratelimiter(10.0); // 10 Hz = 100ms interval
-        let mut input = CuStampedData::<i32, CuMsgMetadata>::new(Some(42));
-        let mut output = CuStampedData::<i32, CuMsgMetadata>::new(None);
+        let mut input = CuMsg::<i32>::new(Some(42));
+        let mut output = CuMsg::<i32>::new(None);
 
         // First message should pass
         input.tov = Tov::Time(CuTime::from(0));
@@ -115,8 +115,8 @@ mod tests {
     fn test_payload_propagation() {
         let (clock, _) = RobotClock::mock();
         let mut limiter = create_test_ratelimiter(10.0);
-        let mut input = CuStampedData::<i32, CuMsgMetadata>::new(None);
-        let mut output = CuStampedData::<i32, CuMsgMetadata>::new(None);
+        let mut input = CuMsg::<i32>::new(None);
+        let mut output = CuMsg::<i32>::new(None);
 
         // Test payload propagation
         input.set_payload(123);

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -103,12 +103,12 @@ pub fn gen_cumsgs(config_path_lit: TokenStream) -> TokenStream {
             use cu29::bincode::de::Decoder;
             use cu29::bincode::error::DecodeError;
             use cu29::copperlist::CopperList;
-            use cu29::cutask::CuMsgMetadata;
-            use cu29::cutask::CuStampedData;
             use cu29::prelude::ErasedCuStampedData;
             use cu29::prelude::ErasedCuStampedDataSet;
             use cu29::prelude::MatchingTasks;
             use cu29::prelude::Serialize;
+            use cu29::prelude::CuMsg;
+            use cu29::prelude::CuMsgMetadata;
             #support
         }
         use cumsgs::CuStampedDataSet;
@@ -165,7 +165,7 @@ fn gen_culist_support(
             let index = syn::Index::from(*output_position);
             quote! {
                 #[allow(dead_code)]
-                pub fn #fn_name(&self) -> &CuStampedData<#payload_type, CuMsgMetadata> {
+                pub fn #fn_name(&self) -> &CuMsg<#payload_type> {
                     &self.0.#index
                 }
             }
@@ -229,13 +229,13 @@ fn gen_sim_support(runtime_plan: &CuExecutionLoop) -> proc_macro2::TokenStream {
                 let inputs: Vec<Type> = step
                     .input_msg_indices_types
                     .iter()
-                    .map(|(_, t)| parse_str::<Type>(format!("CuStampedData<{t}, CuMsgMetadata>").as_str()).unwrap())
+                    .map(|(_, t)| parse_str::<Type>(format!("CuMsg<{t}>").as_str()).unwrap())
                     .collect();
                 let output: Option<Type> = step
                     .output_msg_index_type
                     .as_ref()
-                    .map(|(_, t)| parse_str::<Type>(format!("CuStampedData<{t}, CuMsgMetadata>").as_str()).unwrap());
-                let no_output = parse_str::<Type>("CuStampedData<(), CuMsgMetadata>").unwrap();
+                    .map(|(_, t)| parse_str::<Type>(format!("CuMsg<{t}>").as_str()).unwrap());
+                let no_output = parse_str::<Type>("CuMsg<()>").unwrap();
                 let output = output.as_ref().unwrap_or(&no_output);
 
                 let inputs_type = if inputs.len() == 1 {
@@ -1378,7 +1378,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 use cu29::cutask::CuSrcTask;
                 use cu29::cutask::CuSinkTask;
                 use cu29::cutask::CuTask;
-                use cu29::cutask::CuStampedData;
+                use cu29::cutask::CuMsg;
                 use cu29::cutask::CuMsgMetadata;
                 use cu29::copperlist::CopperList;
                 use cu29::monitoring::CuMonitor; // Trait import.
@@ -1550,7 +1550,7 @@ fn build_culist_tuple(all_msgs_types_in_culist_order: &[Type]) -> TypeTuple {
         parse_quote! { () }
     } else {
         parse_quote! {
-            ( #( CuStampedData<#all_msgs_types_in_culist_order, CuMsgMetadata> ),* )
+            ( #( CuMsg<#all_msgs_types_in_culist_order> ),* )
         }
     }
 }
@@ -1587,7 +1587,7 @@ fn build_culist_tuple_decode(all_msgs_types_in_culist_order: &[Type]) -> ItemImp
         .iter()
         .map(|i| {
             let t = &all_msgs_types_in_culist_order[*i];
-            quote! { CuStampedData::<#t, CuMsgMetadata>::decode(decoder)? }
+            quote! { CuMsg::<#t>::decode(decoder)? }
         })
         .collect();
 

--- a/core/cu29_runtime/Cargo.toml
+++ b/core/cu29_runtime/Cargo.toml
@@ -38,6 +38,8 @@ hdrhistogram = "7.5.4"
 petgraph = { version = "0.8.1", features = ["serde", "serde-1", "serde_derive"] }
 object-pool = "0.6.0"
 html-escape = "0.2"
+threadpool = "1.8.1"
+crossbeam = "0.8.4"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 cudarc = { version = "0.16.4", optional = true, features = ["cuda-version-from-build-system"] }

--- a/core/cu29_runtime/src/cutask.rs
+++ b/core/cu29_runtime/src/cutask.rs
@@ -52,11 +52,11 @@ impl_cu_msg_pack! {
 #[macro_export]
 macro_rules! input_msg {
     ($lifetime:lifetime, $ty:ty) => {
-        &$lifetime CuStampedData<$ty, CuMsgMetadata>
+        &$lifetime CuMsg<$ty>
     };
     ($lifetime:lifetime, $($ty:ty),*) => {
         (
-            $( &$lifetime CuStampedData<$ty, CuMsgMetadata>, )*
+            $( &$lifetime CuMsg<$ty>, )*
         )
     };
 }
@@ -65,7 +65,7 @@ macro_rules! input_msg {
 #[macro_export]
 macro_rules! output_msg {
     ($lifetime:lifetime, $ty:ty) => {
-        &$lifetime mut CuStampedData<$ty, CuMsgMetadata>
+        &$lifetime mut CuMsg<$ty>
     };
 }
 

--- a/core/cu29_runtime/src/simulation.rs
+++ b/core/cu29_runtime/src/simulation.rs
@@ -109,7 +109,7 @@
 
 use crate::config::ComponentConfig;
 
-use crate::cutask::{CuMsgMetadata, CuMsgPayload, CuSinkTask, CuSrcTask, CuStampedData, Freezable};
+use crate::cutask::{CuMsg, CuMsgPayload, CuSinkTask, CuSrcTask, Freezable};
 use crate::{input_msg, output_msg};
 use cu29_clock::RobotClock;
 use cu29_traits::CuResult;

--- a/examples/cu_caterpillar/src/logreader.rs
+++ b/examples/cu_caterpillar/src/logreader.rs
@@ -4,5 +4,5 @@ use cu29_export::run_cli;
 gen_cumsgs!("copperconfig.ron");
 
 fn main() {
-    run_cli::<CuStampedDataSet>().expect("Failed to run the export CLI");
+    run_cli::<CuMsgs>().expect("Failed to run the export CLI");
 }

--- a/examples/cu_multisources/src/tasks.rs
+++ b/examples/cu_multisources/src/tasks.rs
@@ -87,10 +87,7 @@ impl<'cl> CuTask<'cl> for MergerTask {
         output: Self::Output,
     ) -> CuResult<()> {
         // Put the types explicitly here show the actual underlying type of Self::Input
-        let (i, f): (
-            &CuStampedData<i32, CuMsgMetadata>,
-            &CuStampedData<f32, CuMsgMetadata>,
-        ) = input;
+        let (i, f): (&CuMsg<i32>, &CuMsg<f32>) = input;
         let (i, f) = (i.payload().unwrap(), f.payload().unwrap());
         output.set_payload((*i, *f)); // output is a &mut CuMsg<(i32, f32)>
         Ok(())


### PR DESCRIPTION
1. this avoids some unwarranted regression in the user codebase
2. it avoids weird specilization issues I ran into trying to add long running tasks