### PR TITLE
Fix CuListsManager initialization stack overflow

### DIFF
--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -107,6 +107,8 @@ pub fn gen_cumsgs(config_path_lit: TokenStream) -> TokenStream {
             use cu29::prelude::Serialize;
             use cu29::prelude::CuMsg;
             use cu29::prelude::CuMsgMetadata;
+            use cu29::prelude::CuListZeroedInit;
+            use cu29::prelude::CuCompactString;
             #support
         }
         use cumsgs::CuStampedDataSet;
@@ -221,6 +223,12 @@ fn gen_culist_support(
 
         // Adds the type erased CuStampedDataSet support (to help generic serialized conversions)
         #erasedmsg_trait_impl
+
+        impl CuListZeroedInit for CuStampedDataSet {
+            fn init_zeroed(&mut self) {
+                #(self.0.#task_indices.metadata.status_txt = CuCompactString::default();)*
+            }
+        }
     }
 }
 
@@ -1170,6 +1178,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 let clid = culist.id;
                 kf_manager.reset(clid, clock); // beginning of processing, we empty the serialized frozen states of the tasks.
                 culist.change_state(cu29::copperlist::CopperListState::Processing);
+                culist.msgs.init_zeroed();
                 {
                     let msgs = &mut culist.msgs.0;
                     #(#runtime_plan_code)*

--- a/core/cu29_runtime/src/curuntime.rs
+++ b/core/cu29_runtime/src/curuntime.rs
@@ -4,7 +4,7 @@
 
 use crate::config::{ComponentConfig, Node, DEFAULT_KEYFRAME_INTERVAL};
 use crate::config::{CuConfig, CuGraph, NodeId};
-use crate::copperlist::{CopperList, CopperListState, CuListsManager};
+use crate::copperlist::{CopperList, CopperListState, CuListZeroedInit, CuListsManager};
 use crate::cutask::{BincodeAdapter, Freezable};
 use crate::monitoring::CuMonitor;
 use cu29_clock::{ClockProvider, CuTime, RobotClock};
@@ -137,8 +137,8 @@ pub struct CuRuntime<CT, P: CopperListTuple, M: CuMonitor, const NBCL: usize> {
 }
 
 /// To be able to share the clock we make the runtime a clock provider.
-impl<CT, P: CopperListTuple + Default, M: CuMonitor, const NBCL: usize> ClockProvider
-    for CuRuntime<CT, P, M, NBCL>
+impl<CT, P: CopperListTuple + CuListZeroedInit + Default, M: CuMonitor, const NBCL: usize>
+    ClockProvider for CuRuntime<CT, P, M, NBCL>
 {
     fn get_clock(&self) -> RobotClock {
         self.clock.clone()
@@ -181,8 +181,12 @@ impl KeyFrame {
     }
 }
 
-impl<CT, P: CopperListTuple + Default + 'static, M: CuMonitor, const NBCL: usize>
-    CuRuntime<CT, P, M, NBCL>
+impl<
+        CT,
+        P: CopperListTuple + CuListZeroedInit + Default + 'static,
+        M: CuMonitor,
+        const NBCL: usize,
+    > CuRuntime<CT, P, M, NBCL>
 {
     pub fn new(
         clock: RobotClock,
@@ -669,6 +673,10 @@ mod tests {
         fn get_all_task_ids() -> &'static [&'static str] {
             &[]
         }
+    }
+
+    impl CuListZeroedInit for Msgs {
+        fn init_zeroed(&mut self) {}
     }
 
     fn tasks_instanciator(


### PR DESCRIPTION
## Summary
- allocate zeroed copper list memory and initialize metadata via `CuListZeroedInit`
- implement `CuListZeroedInit` in runtime tests
- initialize copper lists in macros after creation

## Testing
- `cargo test -p cu29-runtime --no-run`
- `cargo test -p cu29-runtime --quiet`
- `cargo test -p cu29-derive --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68893e4a74a883308e1a25bfd47bd364