### PR TITLE
Fix crates.io metadata

### DIFF
--- a/components/sources/cu_hesai/Cargo.toml
+++ b/components/sources/cu_hesai/Cargo.toml
@@ -20,7 +20,7 @@ socket2 = { version = "0.6.0", features = ["all"] }
 tempfile = { workspace = true }
 
 [dev-dependencies]
-cu-udp-inject = { path = "../../testing/cu_udp_inject" }
+cu-udp-inject = { path = "../../testing/cu_udp_inject", version = "0.9.0" }
 cu29-derive = { workspace = true }
 cu29-helpers = { workspace = true }
 serde = { workspace = true }

--- a/components/sources/cu_livox/Cargo.toml
+++ b/components/sources/cu_livox/Cargo.toml
@@ -20,7 +20,7 @@ socket2 = { version = "0.6.0", features = ["all"] }
 tempfile = { workspace = true }
 
 [dev-dependencies]
-cu-udp-inject = { path = "../../testing/cu_udp_inject" }
+cu-udp-inject = { path = "../../testing/cu_udp_inject", version = "0.9.0" }
 cu29-derive = { workspace = true }
 cu29-helpers = { workspace = true }
 serde = { workspace = true }

--- a/components/sources/cu_vlp16/Cargo.toml
+++ b/components/sources/cu_vlp16/Cargo.toml
@@ -20,4 +20,4 @@ velodyne-lidar = { version = "0.3.0", features = ["pcap", "parallel"] }
 # remove `nmea` for `velodyne-lidar` since it has conflicts for `dep:serde_with` with `dep:zenoh-config`
 
 [dev-dependencies]
-cu-udp-inject = { path = "../../testing/cu_udp_inject" }
+cu-udp-inject = { path = "../../testing/cu_udp_inject", version = "0.9.0" }

--- a/core/cu29_base_derive/Cargo.toml
+++ b/core/cu29_base_derive/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cu29-base-derive"
+description = "Procedural macros for creating CuError instances"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/core/cu29_intern_strs/Cargo.toml
+++ b/core/cu29_intern_strs/Cargo.toml
@@ -12,7 +12,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow = { version = "*" }
+anyhow = "1.0.98"
 rkv = { version = "0.19.0", features = ["lmdb"] }
 byteorder = "1.5.0"
 

--- a/core/cu29_runtime/Cargo.toml
+++ b/core/cu29_runtime/Cargo.toml
@@ -38,7 +38,7 @@ hdrhistogram = "7.5.4"
 petgraph = { version = "0.8.1", features = ["serde", "serde-1", "serde_derive"] }
 object-pool = "0.6.0"
 html-escape = "0.2"
-rayon = { version = "*" }
+rayon = "1.7.0"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 cudarc = { version = "0.16.4", optional = true, features = ["cuda-version-from-build-system"] }

--- a/examples/cu_dorabench/Cargo.toml
+++ b/examples/cu_dorabench/Cargo.toml
@@ -35,5 +35,5 @@ cu29 = { workspace = true }
 cu29-helpers = { workspace = true }
 cu29-export = { workspace = true, features = ["python"] }
 serde = { workspace = true }
-cu-consolemon = { path = "../../components/monitors/cu_consolemon" }
+cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "0.9.0" }
 

--- a/examples/cu_rp_balancebot/Cargo.toml
+++ b/examples/cu_rp_balancebot/Cargo.toml
@@ -32,7 +32,7 @@ cu29-export = { workspace = true, optional = true }
 # Sim dependencies
 bevy = { version = "0.16.0", default-features = false, features = ["x11", "wayland", "default_font", "bevy_render", "bevy_window", "bevy_core_pipeline", "bevy_pbr", "bevy_scene", "bevy_sprite", "bevy_gltf", "animation", "bevy_picking", "bevy_mesh_picking_backend", "tonemapping_luts", "bevy_ui", "ktx2", "jpeg", "png"], optional = true }
 avian3d = { version = "0.3.0", default-features = false, features = ["bevy_scene", "collider-from-mesh", "debug-plugin", "parallel", "f32", "3d", "parry-f32"], optional = true }
-cached-path = { git = "https://github.com/gbin/rust-cached-path", branch = "gbin/port-indicatif", optional = true }
+cached-path = { version = "0.8.1", optional = true }
 iyes_perf_ui = { version = "0.5.0", optional = true }
 
 [features]

--- a/support/cargo_cubuild/Cargo.toml
+++ b/support/cargo_cubuild/Cargo.toml
@@ -3,5 +3,7 @@ name = "cargo-cubuild"
 description = "A cargo tool to help with copper macro expansion errors."
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/copper-project/copper-rs"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- add missing version numbers for path dependencies
- use release `cached-path` instead of git branch
- provide description in `cu29-base-derive`
- add license and repo to `cargo-cubuild`
- replace wildcard dependencies for `anyhow` and `rayon`

## Testing
- `cargo test --workspace --all-targets --no-run` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688b79e2b1788330a80f590d42ccd8ab