### PR TITLE
Fix the output type on the get_<taskname>_output() methods

### DIFF
--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -165,19 +165,27 @@ fn gen_culist_support(
         }
     };
 
-    let methods = itertools::multizip((all_tasks_as_struct_member_name, taskid_call_order)).map(
-        |(name, output_position)| {
+    let methods = all_tasks_as_struct_member_name
+        .iter()
+        .enumerate()
+        .map(|(task_id, name)| {
+            let output_position = taskid_call_order
+                .iter()
+                .position(|&id| id == task_id)
+                .unwrap_or_else(|| {
+                    panic!("Task {name} (id: {task_id}) not found in execution order")
+                });
+
             let fn_name = format_ident!("get_{}_output", name);
-            let payload_type = all_msgs_types_in_culist_order[*output_position].clone();
-            let index = syn::Index::from(*output_position);
+            let payload_type = all_msgs_types_in_culist_order[output_position].clone();
+            let index = syn::Index::from(output_position);
             quote! {
                 #[allow(dead_code)]
                 pub fn #fn_name(&self) -> &CuMsg<#payload_type> {
                     &self.0.#index
                 }
             }
-        },
-    );
+        });
 
     // This generates a way to get the metadata of every single message of a culist at low cost
     quote! {


### PR DESCRIPTION
I noticed when I was implementing resimulation for my project that the get_taskname_output() methods had the wrong return type, for example:
```rust
            default::SimStep::MotorCtrl(CuTaskCallbackState::Process(_, output)) => {
                *output = msgs.get_motor_ctrl_output().clone();
                SimOverride::ExecutedBySim
            }
```
```
    |
133 |                 *output = msgs.get_motor_ctrl_output().clone();
    |                 -------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `CuStampedData<(), CuMsgMetadata>`, found `CuStampedData<CuGstBuffer, CuMsgMetadata>`
    |                 |
    |                 expected due to the type of this binding
    |
    = note: expected struct `cu29::prelude::CuStampedData<(), _>`
               found struct `cu29::prelude::CuStampedData<cu_gstreamer::CuGstBuffer, _>`
 ```
 
 So I did some digging and found out that the ordering of taskid_call_order and all_msgs_types_in_culist_order dont match up and the mapping was incorrect.

Ill keep this a draft pull request until tomorrow when I'll go ahead and try the balance bot re simulation just to make sure this doesn't break anything. 