### PR TITLE
fix: index into array with node_id instead of output_position

### DIFF
--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -823,7 +823,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                             }
                                         }
                                     }, {  // logging preprocess
-                                        if !task_specs.logging_enabled[*output_index as usize] {
+                                        if !task_specs.logging_enabled[step.node_id as usize] {
 
                                             #[cfg(feature = "macro_debug")]
                                             eprintln!(
@@ -1037,7 +1037,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                         }
                                     }, {
 
-                                    if !task_specs.logging_enabled[*output_index as usize] {
+                                    if !task_specs.logging_enabled[step.node_id as usize] {
                                         #[cfg(feature = "macro_debug")]
                                         eprintln!(
                                             "{} -> Logging Disabled",


### PR DESCRIPTION
The logging_enabled array should be indexed into by step.node_id not output_index.

Found this bug because I finally got resim working for my project and noticed things were getting logged out that that I thought I had disabled.