### PR TITLE
Balancebot example integration test and miscellaneous changes

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustc,cargo,rust-std,rustfmt,clippy
       - name: Setup rust-cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/examples/cu_rp_balancebot/src/sim.rs
+++ b/examples/cu_rp_balancebot/src/sim.rs
@@ -209,6 +209,7 @@ pub fn make_world(headless: bool) -> App {
     if headless {
         // these are not added in the minimal plugins but are needed for the integration test to run
         world.insert_resource(Assets::<Mesh>::default());
+        world.insert_resource(Assets::<Font>::default());
         world.insert_resource(SceneSpawner::default());
         world.insert_resource(Assets::<StandardMaterial>::default());
 

--- a/examples/cu_rp_balancebot/src/sim.rs
+++ b/examples/cu_rp_balancebot/src/sim.rs
@@ -50,7 +50,7 @@ fn default_callback(step: default::SimStep) -> SimOverride {
     }
 }
 
-// a system callback from bevy to setup the copper part of the house.
+// a system callback from bevy to set up the copper part of the house.
 fn setup_copper(mut commands: Commands) {
     #[allow(clippy::identity_op)]
     const LOG_SLAB_SIZE: Option<usize> = Some(1 * 1024 * 1024 * 1024);
@@ -189,6 +189,7 @@ fn stop_copper_on_exit(mut exit_events: EventReader<AppExit>, mut copper_ctx: Re
     }
 }
 
+// this function creates the bevy::App used in both the integration test and the simulation
 pub fn make_world(headless: bool) -> App {
     let mut world = App::new();
     #[cfg(target_os = "macos")]
@@ -206,10 +207,12 @@ pub fn make_world(headless: bool) -> App {
     };
 
     if headless {
-        // these are not in the minimal plugins but are needed for the integration test
+        // these are not added in the minimal plugins but are needed for the integration test to run
         world.insert_resource(Assets::<Mesh>::default());
         world.insert_resource(SceneSpawner::default());
         world.insert_resource(Assets::<StandardMaterial>::default());
+
+        // add the minimal plugins as well as others needed for our simulation to run
         world.add_plugins((
             MinimalPlugins,
             AssetPlugin {
@@ -238,6 +241,7 @@ pub fn make_world(headless: bool) -> App {
     };
 
     // set up everything that is simulation specific.
+    // this adds systems on the bevy side of things to handle things like the UI, keyboard inputs, etc.
     let simulation = world::build_world(&mut world, headless);
 
     // set up all the systems related to copper and the glue logic.

--- a/examples/cu_rp_balancebot/src/sim.rs
+++ b/examples/cu_rp_balancebot/src/sim.rs
@@ -190,7 +190,6 @@ fn stop_copper_on_exit(mut exit_events: EventReader<AppExit>, mut copper_ctx: Re
 
 fn main() {
     let mut world = App::new();
-
     #[cfg(target_os = "macos")]
     let render_plugin = RenderPlugin::default(); // This let macos pick their own backend.
 
@@ -205,7 +204,7 @@ fn main() {
         ..Default::default()
     };
 
-    let default_plugin = DefaultPlugins
+    let default_plugins = DefaultPlugins
         .set(render_plugin)
         .set(WindowPlugin {
             primary_window: Some(Window {
@@ -219,14 +218,40 @@ fn main() {
             ..default()
         });
 
-    world.add_plugins(default_plugin);
+    world.add_plugins(default_plugins);
 
     // setup everything that is simulation specific.
-    let world = world::build_world(&mut world);
+    let simulation = world::build_world(&mut world);
 
     // setup all the systems related to copper and the glue logic.
-    world.add_systems(Startup, setup_copper);
-    world.add_systems(Update, run_copper_callback);
-    world.add_systems(PostUpdate, stop_copper_on_exit);
+    simulation.add_systems(Startup, setup_copper);
+    simulation.add_systems(Update, run_copper_callback);
+    simulation.add_systems(PostUpdate, stop_copper_on_exit);
     world.run();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_balancebot_runs() {
+        let mut world = App::new();
+
+        world.add_plugins((
+            AssetPlugin {
+                unapproved_path_mode: UnapprovedPathMode::Allow,
+                ..default()
+            },
+            MinimalPlugins,
+        ));
+
+        // setup everything that is simulation specific.
+        let simulation = world::build_world(&mut world);
+
+        // setup all the systems related to copper and the glue logic.
+        // simulation.add_systems(Startup, setup_copper);
+        // simulation.add_systems(Update, run_copper_callback);
+        // simulation.add_systems(PostUpdate, stop_copper_on_exit);
+        world.update();
+    }
 }

--- a/examples/cu_rp_balancebot/src/sim.rs
+++ b/examples/cu_rp_balancebot/src/sim.rs
@@ -219,7 +219,7 @@ pub fn make_world(headless: bool) -> App {
                 unapproved_path_mode: UnapprovedPathMode::Allow,
                 ..default()
             },
-            ScenePlugin::default(),
+            ScenePlugin,
             ImagePlugin::default(),
         ));
     } else {

--- a/examples/cu_rp_balancebot/src/sim.rs
+++ b/examples/cu_rp_balancebot/src/sim.rs
@@ -97,7 +97,7 @@ fn setup_copper(mut commands: Commands) {
 #[allow(clippy::type_complexity)]
 fn run_copper_callback(
     mut query_set: ParamSet<(
-        Query<(&mut Transform, &mut ExternalForce), With<Cart>>,
+        Query<(&Transform, &mut ExternalForce), With<Cart>>,
         Query<&Transform, With<Rod>>,
     )>,
     physics_time: Res<Time<Physics>>,
@@ -116,8 +116,8 @@ fn run_copper_callback(
     let mut sim_callback = move |step: default::SimStep| -> SimOverride {
         match step {
             default::SimStep::Balpos(CuTaskCallbackState::Process(_, output)) => {
-                // so here we jump when the balpos source (the adc giving the rod position) is called
-                // we get the physical state of the work and inject back to copper what would the sensor read
+                // we run this code when the balpos source (the adc giving the rod position) is called
+                // we get the physical state of the world and inject what the sensor would read back to copper
                 let bindings = query_set.p1();
                 let rod_transform = bindings.single().expect("Failed to get rod transform");
 

--- a/examples/cu_rp_balancebot/src/sim.rs
+++ b/examples/cu_rp_balancebot/src/sim.rs
@@ -205,31 +205,13 @@ pub fn make_world(headless: bool) -> App {
         ..Default::default()
     };
 
-    let default_plugins = if headless {
-        MinimalPlugins.build()
-    } else {
-        DefaultPlugins
-            .set(render_plugin)
-            .set(WindowPlugin {
-                primary_window: Some(Window {
-                    title: "Copper Simulator".into(),
-                    ..default()
-                }),
-                ..default()
-            })
-            .set(AssetPlugin {
-                unapproved_path_mode: UnapprovedPathMode::Allow,
-                ..default()
-            })
-    };
-
-    world.add_plugins(default_plugins);
-
     if headless {
+        // these are not in the minimal plugins but are needed for the integration test
         world.insert_resource(Assets::<Mesh>::default());
         world.insert_resource(SceneSpawner::default());
         world.insert_resource(Assets::<StandardMaterial>::default());
         world.add_plugins((
+            MinimalPlugins,
             AssetPlugin {
                 unapproved_path_mode: UnapprovedPathMode::Allow,
                 ..default()
@@ -237,7 +219,23 @@ pub fn make_world(headless: bool) -> App {
             ScenePlugin::default(),
             ImagePlugin::default(),
         ));
-    }
+    } else {
+        world.add_plugins(
+            DefaultPlugins
+                .set(render_plugin)
+                .set(WindowPlugin {
+                    primary_window: Some(Window {
+                        title: "Copper Simulator".into(),
+                        ..default()
+                    }),
+                    ..default()
+                })
+                .set(AssetPlugin {
+                    unapproved_path_mode: UnapprovedPathMode::Allow,
+                    ..default()
+                }),
+        );
+    };
 
     // set up everything that is simulation specific.
     let simulation = world::build_world(&mut world, headless);

--- a/examples/cu_rp_balancebot/src/world/mod.rs
+++ b/examples/cu_rp_balancebot/src/world/mod.rs
@@ -41,6 +41,11 @@ const ALUMINUM_DENSITY: f32 = 2700.0; // kg/m^3
 const ROD_VOLUME: f32 = ROD_WIDTH * ROD_HEIGHT * ROD_DEPTH;
 
 #[derive(Resource)]
+struct DragControl {
+    pixels_per_newton: f32,
+    max_force: f32, // newtons
+}
+#[derive(Resource)]
 struct CameraControl {
     rotate_sensitivity: f32,
     zoom_sensitivity: f32,
@@ -70,7 +75,11 @@ pub fn build_world(app: &mut App, headless: bool) -> &mut App {
         .insert_resource(CameraControl {
             rotate_sensitivity: 0.05,
             zoom_sensitivity: 3.5,
-            move_sensitivity: 0.01,
+            move_sensitivity: 0.05,
+        })
+        .insert_resource(DragControl {
+            pixels_per_newton: 100.,
+            max_force: 10.,
         })
         .insert_resource(Gravity::default())
         .insert_resource(Time::<Physics>::default())
@@ -79,12 +88,12 @@ pub fn build_world(app: &mut App, headless: bool) -> &mut App {
         .add_systems(Update, setup_entities) // Wait for the cart entity to be loaded
         .add_systems(Update, update_physics);
 
+    // these will make a headless app crash, so only add them if we aren't headless
     if !headless {
         app.add_plugins(MeshPickingPlugin);
         app.add_systems(Update, toggle_simulation_state)
             .add_systems(Update, camera_control_system)
-            .add_systems(PostUpdate, reset_sim)
-            .add_systems(Update, global_cart_drag_listener);
+            .add_systems(PostUpdate, reset_sim);
     }
 
     #[cfg(feature = "perf-ui")]
@@ -345,35 +354,6 @@ fn try_to_find_cart_entity(query: Query<(Entity, &Name), Without<Cart>>) -> Opti
     None
 }
 
-// This is a global drag listener that will move the cart when dragged.
-// It is a bit of a hack, but it tries to find back the cart entity parent from any of the possible clickable children
-fn global_cart_drag_listener(
-    mut drag_events: EventReader<Pointer<Drag>>,
-    parents: Query<(&ChildOf, Option<&Cart>)>,
-    mut transforms: Query<&mut Transform, With<Cart>>,
-    camera_query: Query<&Transform, (With<Camera>, Without<Cart>)>, // Add Without<Cart> to prevent conflicts
-) {
-    for drag in drag_events.read() {
-        if drag.button != PointerButton::Primary {
-            continue;
-        }
-        let mut entity = drag.target;
-        while let Ok((parent, maybe_cart)) = parents.get(entity) {
-            if maybe_cart.is_some() {
-                break;
-            }
-            entity = parent.parent();
-        }
-
-        if let Ok(mut root_transform) = transforms.get_mut(entity) {
-            let direction_multiplier = camera_query.iter().next().map_or(1.0, |camera_transform| {
-                -camera_transform.forward().z.signum()
-            });
-            root_transform.translation.x += direction_multiplier * drag.delta.x / 500.0;
-        }
-    }
-}
-
 #[derive(Resource)]
 struct SetupCompleted(bool);
 
@@ -422,6 +402,12 @@ fn setup_entities(
             .lock_rotation_z(),
     });
 
+    // let the cart be dragged too
+    commands
+        .entity(cart_entity)
+        .observe(on_drag)
+        .observe(on_drag_end);
+
     let rail_entity = commands
         .spawn((
             RigidBody::Static, // The rail doesn't move
@@ -467,7 +453,8 @@ fn setup_entities(
                 .lock_rotation_y()
                 .lock_rotation_x(),
         ))
-        .observe(on_drag_transform)
+        .observe(on_drag)
+        .observe(on_drag_end)
         .id();
     commands.spawn(
         RevoluteJoint::new(cart_entity, rod_entity)
@@ -495,13 +482,37 @@ fn setup_entities(
     setup_completed.0 = true; // Mark as completed
 }
 
-fn on_drag_transform(
+fn on_drag_end(
+    drag: Trigger<Pointer<DragEnd>>,
+    parents: Query<(&ChildOf, Option<&Cart>, Option<&Rod>)>,
+    mut external_force: Query<&mut ExternalForce>,
+) {
+    if drag.button != PointerButton::Primary {
+        return;
+    }
+
+    // get either the cart or the pole entity (the drag event may target a descendant of them)
+    let mut target_entity = drag.target;
+    while let Ok((parent, maybe_cart, maybe_pole)) = parents.get(target_entity) {
+        if maybe_cart.is_some() || maybe_pole.is_some() {
+            break;
+        }
+        target_entity = parent.parent();
+    }
+
+    if let Ok(mut external_force) = external_force.get_mut(target_entity) {
+        // the drag ended, so clear the applied forces
+        external_force.clear();
+    }
+}
+
+fn on_drag(
     drag: Trigger<Pointer<Drag>>,
     camera_query: Option<Single<&Transform, With<Camera>>>,
-    mut external_force: Query<(&mut ExternalForce, &RigidBody)>,
-    window_query_maybe: Option<Single<&Window>>,
+    parents: Query<(&ChildOf, Option<&Cart>, Option<&Rod>)>,
+    mut external_force: Query<&mut ExternalForce>,
     time: Res<Time<Physics>>,
-    mut gizmos: Gizmos,
+    drag_control: Res<DragControl>,
 ) {
     if drag.button != PointerButton::Primary {
         return;
@@ -515,27 +526,28 @@ fn on_drag_transform(
     } else {
         return;
     };
-    // only apply forces to dynamic rigid bodies (i.e. the cart and the pole, in this case)
-    if let Ok((mut external_force, RigidBody::Dynamic)) = external_force.get_mut(drag.target) {
+
+    // get either the cart or the pole entity (the drag event may target a descendant of them)
+    let mut target_entity = drag.target;
+    while let Ok((parent, maybe_cart, maybe_pole)) = parents.get(target_entity) {
+        if maybe_cart.is_some() || maybe_pole.is_some() {
+            break;
+        }
+        target_entity = parent.parent();
+    }
+
+    if let Ok(mut external_force) = external_force.get_mut(target_entity) {
+        // clear any previously applied forces (they persist by default)
+        external_force.clear();
+
         // calculate world X-direction drag from screenspace drag
         // drag.delta.y should basically never contribute (as long as camera isn't rolled), but scaling by camera_transform.right() will feel more natural when dragging from a steep visual angle
         let drag_delta_world =
             drag.distance.x * camera_transform.right() + drag.distance.y * camera_transform.down();
 
         // apply a force to that object based on the world length and direction of the mouse drag
-        let applied_force = drag_delta_world.clamp_length_max(10.0);
+        let applied_force = (drag_delta_world / drag_control.pixels_per_newton).clamp_length_max(drag_control.max_force);
         external_force.apply_force(applied_force);
-
-        let window_query = if let Some(window_query) = window_query_maybe {
-            window_query.into_inner()
-        } else {
-            return;
-        };
-        if let Some(cursor_position) = window_query.cursor_position() {
-            let start = cursor_position - drag.distance;
-            // draw a gizmo to show the force applied
-            gizmos.line_2d(start, cursor_position, RED);
-        }
     }
 }
 
@@ -593,7 +605,7 @@ fn reset_sim(
 
 /// Winged some type of orbital camera to explore around the robot.
 fn camera_control_system(
-    control: Res<CameraControl>,
+    camera_control: Res<CameraControl>,
     keys: Res<ButtonInput<KeyCode>>,
     mut scroll_evr: EventReader<MouseWheel>,
     mut mouse_motion: EventReader<MouseMotion>,
@@ -612,15 +624,15 @@ fn camera_control_system(
     // Zoom with scroll
     for ev in scroll_evr.read() {
         let forward = camera_transform.forward(); // Store forward vector in a variable
-        let zoom_amount = ev.y * control.zoom_sensitivity * time.delta_secs();
+        let zoom_amount = ev.y * camera_control.zoom_sensitivity * time.delta_secs();
         camera_transform.translation += forward * zoom_amount;
     }
 
     // Rotate camera around the focal point with right mouse button + drag
     if mouse_button_input.pressed(MouseButton::Middle) {
         for ev in mouse_motion.read() {
-            let yaw = Quat::from_rotation_y(-ev.delta.x * control.rotate_sensitivity);
-            let pitch = Quat::from_rotation_x(-ev.delta.y * control.rotate_sensitivity);
+            let yaw = Quat::from_rotation_y(-ev.delta.x * camera_control.rotate_sensitivity);
+            let pitch = Quat::from_rotation_x(-ev.delta.y * camera_control.rotate_sensitivity);
 
             // Apply the rotation to the direction vector
             let new_direction = yaw * pitch * direction;
@@ -642,36 +654,39 @@ fn camera_control_system(
         for ev in mouse_motion.read() {
             let right = camera_transform.right();
             let up = camera_transform.up();
-            camera_transform.translation += right * -ev.delta.x * control.move_sensitivity;
-            camera_transform.translation += up * ev.delta.y * control.move_sensitivity;
+            camera_transform.translation += right * -ev.delta.x * camera_control.move_sensitivity;
+            camera_transform.translation += up * ev.delta.y * camera_control.move_sensitivity;
         }
     }
 
     let forward = if keys.pressed(KeyCode::KeyW) {
-        camera_transform.forward() * control.move_sensitivity
+        camera_transform.forward() * camera_control.move_sensitivity
     } else if keys.pressed(KeyCode::KeyS) {
-        camera_transform.back() * control.move_sensitivity
+        camera_transform.back() * camera_control.move_sensitivity
     } else {
         Vec3::ZERO
     };
 
     let strafe = if keys.pressed(KeyCode::KeyA) {
-        camera_transform.left() * control.move_sensitivity
+        camera_transform.left() * camera_control.move_sensitivity
     } else if keys.pressed(KeyCode::KeyD) {
-        camera_transform.right() * control.move_sensitivity
+        camera_transform.right() * camera_control.move_sensitivity
     } else {
         Vec3::ZERO
     };
 
     let vertical = if keys.pressed(KeyCode::KeyQ) {
-        Vec3::Y * control.move_sensitivity
+        Vec3::Y * camera_control.move_sensitivity
     } else if keys.pressed(KeyCode::KeyE) {
-        Vec3::NEG_Y * control.move_sensitivity
+        Vec3::NEG_Y * camera_control.move_sensitivity
     } else {
         Vec3::ZERO
     };
 
     camera_transform.translation += forward + strafe + vertical;
+
+    // make camera look at cart again after any movement
+    camera_transform.look_at(Vec3::ZERO, Vec3::Y);
 }
 
 // Space to start / stop the simulation

--- a/examples/cu_rp_balancebot/src/world/mod.rs
+++ b/examples/cu_rp_balancebot/src/world/mod.rs
@@ -58,9 +58,8 @@ pub struct Cart;
 #[derive(Component)]
 pub struct Rod;
 
-pub fn build_world(app: &mut App) -> &mut App {
+pub fn build_world(app: &mut App, headless: bool) -> &mut App {
     let app = app
-        .add_plugins(MeshPickingPlugin)
         .add_plugins(PhysicsPlugins::default().with_length_unit(1000.0))
         // we want Bevy to measure these values for us:
         .add_plugins(bevy::diagnostic::FrameTimeDiagnosticsPlugin::default())
@@ -77,11 +76,15 @@ pub fn build_world(app: &mut App) -> &mut App {
         .add_systems(Startup, setup_scene)
         .add_systems(Startup, setup_ui)
         .add_systems(Update, setup_entities) // Wait for the cart entity to be loaded
-        .add_systems(Update, toggle_simulation_state)
-        .add_systems(Update, camera_control_system)
-        .add_systems(Update, update_physics)
-        .add_systems(Update, global_cart_drag_listener)
-        .add_systems(PostUpdate, reset_sim);
+        .add_systems(Update, update_physics);
+
+    if !headless {
+        app.add_plugins(MeshPickingPlugin);
+        app.add_systems(Update, toggle_simulation_state)
+            .add_systems(Update, camera_control_system)
+            .add_systems(PostUpdate, reset_sim)
+            .add_systems(Update, global_cart_drag_listener);
+    }
 
     #[cfg(feature = "perf-ui")]
     app.add_plugins(PerfUiPlugin);


### PR DESCRIPTION
I've been starting to learn copper recently and I really like the balancebot example! In going through it I found a few changes that I think improve the example. Broadly, here are the changes I made:

- Added an integration test that just creates the app and updates it once, running headlessly
- Miscellaneous comment changes and additions
- Consolidated the logic for dragging the cart and the rod into one place, separated into one observer for the drag and one for the drag ending. My changes seemed to make the dragging a little smoother since it lets avian handle the position updates instead of directly modifying the transform.
- A few camera control changes, making the camera use real time instead of not specifying (I think `Time` defaults to `Time<Virtual>` where it was being used, meaning e.g. zooming the camera didn't work when time was paused. Also make the camera always face the origin after a move, whereas before it would jump back to facing the origin when the middle mouse was pressed
- Added an optional gizmo to display the external forces acting on the system. I just think it's cool to see the cart and be able to see the relative magnitude of your dragging force

Feel free to ask me to remove any or all of this! I mostly made it in hopes it would be helpful and to actively learn via the example.