### PR TITLE
Make cu29-clock no-std compliant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,8 +117,8 @@ cu-sensor-payloads = { path = "components/payloads/cu_sensor_payloads", version 
 cu-ros-payloads = { path = "components/payloads/cu_ros_payloads", version = "0.9.0" }
 
 # External serialization
-bincode = { version = "2.0.1", features = ["derive"] }
-serde = { version = "1.0.219", features = ["derive"] }
+bincode = { version = "2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_derive = { version = "1.0.219", features = ["default"] }
 
 # External CLI

--- a/core/cu29_clock/Cargo.toml
+++ b/core/cu29_clock/Cargo.toml
@@ -21,16 +21,3 @@ approx = "0.5"
 [features]
 default = ["std"]
 std = []
-
-# Target-specific dependencies for high-precision timing
-[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
-# No additional dependencies needed - use RDTSC instruction
-
-[target.'cfg(target_arch = "aarch64")'.dependencies]
-# No additional dependencies needed - use system counter
-
-[target.'cfg(target_arch = "arm")'.dependencies]
-# No additional dependencies needed - use system counter
-
-[target.'cfg(target_arch = "riscv64")'.dependencies]
-# No additional dependencies needed - use cycle counter

--- a/core/cu29_clock/Cargo.toml
+++ b/core/cu29_clock/Cargo.toml
@@ -12,13 +12,25 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-quanta = "0.12.5"
-bincode = { workspace = true }
-serde = { workspace = true }
+bincode = { workspace = true, default-features = false, features = ["alloc"] }
+serde = { workspace = true, default-features = false, features = ["derive", "alloc"] }
 
 [dev-dependencies]
-approx = "0.5.1"
+approx = "0.5"
 
 [features]
 default = ["std"]
 std = []
+
+# Target-specific dependencies for high-precision timing
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
+# No additional dependencies needed - use RDTSC instruction
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+# No additional dependencies needed - use system counter
+
+[target.'cfg(target_arch = "arm")'.dependencies]
+# No additional dependencies needed - use system counter
+
+[target.'cfg(target_arch = "riscv64")'.dependencies]
+# No additional dependencies needed - use cycle counter

--- a/core/cu29_clock/README.md
+++ b/core/cu29_clock/README.md
@@ -1,6 +1,20 @@
-## Copper monotonic clock
+## High Performance Monotonic Clock for robotics
 
-This crate is part of the Copper project.
-This crate is the clock support of copper, it provides a monotonic clock to the runtime and a mockable clock for testing and replay.
+This crate provides a monotonic clock and a mockable clock for testing and replay.
+It has a wide range of support for robots running on OSes and bare metal.
 
-See the main crate cu29 for more information.
+It is no-std compatible with some limitations, see below.
+
+Low level CPU counter implementations are provided for:
+
+- x86-64
+- arm64
+- armv7
+- risc-v
+
+We also provide a TOV (Time Of Validity) enum for tagging sensor data.
+
+It can fall back to the posix monotonic clock for other platforms (with std).
+
+It has been created originally for the Copper runtime but can be perfectly used independently.
+See the main crate cu29 for more information about the overall Copper project.

--- a/core/cu29_clock/README.md
+++ b/core/cu29_clock/README.md
@@ -18,3 +18,194 @@ It can fall back to the posix monotonic clock for other platforms (with std).
 
 It has been created originally for the Copper runtime but can be perfectly used independently.
 See the main crate cu29 for more information about the overall Copper project.
+
+## Examples
+
+### Basic Clock Usage
+
+```rust
+use cu29_clock::{RobotClock, CuTime, CuDuration};
+
+// Create a new robot clock
+let clock = RobotClock::new();
+
+// Get the current time (returns CuTime, which is nanoseconds since clock start)
+let now = clock.now();
+println!("Current time: {}", now); // Displays with appropriate units (ns, µs, ms, s, etc.)
+
+// Get a less precise but faster time reading
+let recent = clock.recent();
+
+// Clock is cloneable and all clones share the same time reference
+let clock_clone = clock.clone();
+assert_eq!(clock.now(), clock_clone.now());
+
+// Create a clock with a specific reference time
+let ref_time_ns = 1_000_000_000; // 1 second
+let clock_with_ref = RobotClock::from_ref_time(ref_time_ns);
+```
+
+### Working with Time Durations
+
+```rust
+use cu29_clock::{CuDuration, CuTime};
+use std::time::Duration;
+
+// Create durations
+let duration1 = CuDuration::from(Duration::from_millis(100));
+let duration2 = CuDuration::from(500_000_000u64); // 500ms in nanoseconds
+
+// Arithmetic operations
+let sum = duration1 + duration2;  // 600ms
+let diff = duration2 - duration1; // 400ms
+let scaled = duration1 * 2u32;    // 200ms
+let divided = duration2 / 5u32;   // 100ms
+
+// Display formatting automatically chooses appropriate units
+println!("Duration: {}", sum);        // "600.000 ms"
+println!("Large duration: {}", CuDuration::from(Duration::from_secs(3600))); // "1.000 h"
+
+// Min/max operations
+let min_duration = duration1.min(duration2);
+let max_duration = duration1.max(duration2);
+
+// Convert to standard Duration
+let std_duration: Duration = duration1.into();
+```
+
+### Mock Clock for Testing and Simulation
+
+```rust
+use cu29_clock::{RobotClock, RobotClockMock, CuDuration};
+use std::time::Duration;
+
+// Create a mock clock that you can control
+let (clock, mock_control) = RobotClock::mock();
+
+// The clock starts at 0
+assert_eq!(clock.now(), CuDuration(0));
+
+// Advance the clock by specific amounts
+mock_control.increment(Duration::from_millis(100));
+assert_eq!(clock.now(), CuDuration(100_000_000)); // 100ms in nanoseconds
+
+// Jump to absolute time values
+mock_control.set_value(5_000_000_000); // 5 seconds
+assert_eq!(clock.now(), CuDuration(5_000_000_000));
+
+// You can also decrement (breaks monotonicity, use with caution)
+mock_control.decrement(Duration::from_secs(1));
+assert_eq!(clock.now(), CuDuration(4_000_000_000)); // 4 seconds
+
+// Get current mock time directly from the mock controller
+let current_mock_time = mock_control.now();
+let current_raw_value = mock_control.value();
+
+// All clones of the clock are synchronized with the mock
+let clock_clone = clock.clone();
+assert_eq!(clock.now(), clock_clone.now());
+```
+
+### Time of Validity (Tov)
+
+Tov represents when sensor data was actually valid, which is crucial for robotics applications:
+
+```rust
+use cu29_clock::{RobotClock, Tov, CuTimeRange, CuTime, CuDuration};
+use std::time::Duration;
+
+let clock = RobotClock::new();
+let current_time = clock.now();
+
+// Single timestamp - most common case
+let tov_single = Tov::Time(current_time);
+
+// Time range - for sensors that collect data over time (e.g., lidar scans)
+let tov_range = Tov::Range(CuTimeRange {
+start: current_time,
+end: current_time + CuDuration::from(Duration::from_millis(10)),
+});
+
+// No valid time - for error conditions or initialization
+let tov_none = Tov::None;
+
+// Converting from common types
+let tov_from_option: Tov = Some(current_time).into();
+let tov_from_duration: Tov = current_time.into();
+
+// Pattern matching on Tov in algorithms
+fn process_sensor_data(tov: Tov, last_time: &mut CuTime) -> Result<CuDuration, &'static str> {
+    match tov {
+        Tov::Time(timestamp) => {
+            let dt = timestamp - *last_time;
+            *last_time = timestamp;
+            Ok(dt)
+        }
+        Tov::Range(range) => {
+            // Use start of range for timing calculations
+            let dt = range.start - *last_time;
+            *last_time = range.start;
+            Ok(dt)
+        }
+        Tov::None => Err("No valid timestamp available"),
+    }
+}
+
+// Display Tov values with automatic formatting
+println!("Single time: {}", tov_single);     // "1.500 s"
+println!("Time range: {}", tov_range);       // "[1.500 s – 1.510 s]"
+println!("No time: {}", tov_none);           // "None"
+
+// Create time ranges from collections of timestamps
+let timestamps = [
+CuTime::from(100u64),
+CuTime::from(150u64),
+CuTime::from(120u64)
+];
+let range_from_slice = CuTimeRange::from( & timestamps[..]);
+// range_from_slice.start = 100, range_from_slice.end = 150
+```
+
+### Optional Time Values
+
+```rust
+use cu29_clock::{OptionCuTime, CuTime};
+
+// Efficient optional time representation (avoids 128-bit Option overhead)
+let some_time = OptionCuTime::from(CuTime::from(1000u64));
+let no_time = OptionCuTime::none();
+
+// Check if time is present
+if ! some_time.is_none() {
+let time_value = some_time.unwrap();
+println! ("Time: {}", time_value);
+}
+
+// Convert to/from standard Option
+let std_option: Option<CuTime> = some_time.into();
+let back_to_option_time: OptionCuTime = std_option.into();
+
+// Display formatting
+println!("Some time: {}", some_time);  // "1.000 µs"
+println!("No time: {}", no_time);      // "None"
+```
+
+### Platform-Specific High-Performance Timing
+
+The clock automatically uses the best available timing mechanism for your platform:
+
+- **x86-64**: RDTSC instruction for sub-nanosecond precision
+- **ARM64**: ARM generic timer counters
+- **ARM32**: 64-bit ARM performance counters
+- **RISC-V**: Cycle counter
+- **Other platforms**: Falls back to system monotonic clock (std only)
+
+```rust
+use cu29_clock::{RobotClock, platform};
+
+// The clock automatically calibrates frequency at first use
+let clock = RobotClock::new();
+
+// For no-std environments, frequency calibration is simplified
+// but still provides high precision timing suitable for robotics
+```

--- a/core/cu29_clock/README.md
+++ b/core/cu29_clock/README.md
@@ -38,7 +38,7 @@ let recent = clock.recent();
 
 // Clock is cloneable and all clones share the same time reference
 let clock_clone = clock.clone();
-assert_eq!(clock.now(), clock_clone.now());
+assert_eq!(clock.now(), clock_clone.now()); // more or less :)
 
 // Create a clock with a specific reference time
 let ref_time_ns = 1_000_000_000; // 1 second

--- a/core/cu29_clock/src/lib.rs
+++ b/core/cu29_clock/src/lib.rs
@@ -1,10 +1,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #[cfg(not(feature = "std"))]
 extern crate alloc;
-
 #[cfg(test)]
-#[macro_use]
 extern crate approx;
+
 use bincode::de::BorrowDecoder;
 use bincode::de::Decoder;
 use bincode::enc::Encoder;
@@ -12,14 +11,246 @@ use bincode::error::{DecodeError, EncodeError};
 use bincode::BorrowDecode;
 use bincode::{Decode, Encode};
 use core::ops::{Add, Sub};
-pub use quanta::Instant;
-use quanta::{Clock, Mock};
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "std")]
 use std::convert::Into;
+#[cfg(feature = "std")]
 use std::fmt::{Display, Formatter};
+#[cfg(feature = "std")]
 use std::ops::{AddAssign, Div, Mul, SubAssign};
+#[cfg(feature = "std")]
+use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(feature = "std")]
 use std::sync::Arc;
+#[cfg(feature = "std")]
 use std::time::Duration;
+
+#[cfg(not(feature = "std"))]
+use alloc::format;
+#[cfg(not(feature = "std"))]
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use core::fmt::{Display, Formatter};
+#[cfg(not(feature = "std"))]
+use core::ops::{AddAssign, Div, Mul, SubAssign};
+#[cfg(not(feature = "std"))]
+use core::sync::atomic::{AtomicU64, Ordering};
+
+// Platform-specific high-precision timer implementations
+mod platform {
+    use core::sync::atomic::{AtomicU64, Ordering};
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    pub fn read_raw_counter() -> u64 {
+        unsafe { core::arch::x86_64::_rdtsc() }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub fn read_raw_counter() -> u64 {
+        let mut counter: u64;
+        unsafe {
+            core::arch::asm!("mrs {}, cntvct_el0", out(reg) counter);
+        }
+        counter
+    }
+
+    #[cfg(target_arch = "arm")]
+    pub fn read_raw_counter() -> u64 {
+        let mut counter_lo: u32;
+        let mut counter_hi: u32;
+        unsafe {
+            core::arch::asm!(
+                "mrrc p15, 1, {0}, {1}, c14",
+                out(reg) counter_lo,
+                out(reg) counter_hi,
+            );
+        }
+        ((counter_hi as u64) << 32) | (counter_lo as u64)
+    }
+
+    #[cfg(target_arch = "riscv64")]
+    pub fn read_raw_counter() -> u64 {
+        let counter: u64;
+        unsafe {
+            core::arch::asm!("rdcycle {}", out(reg) counter);
+        }
+        counter
+    }
+
+    #[cfg(not(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "arm",
+        target_arch = "riscv64"
+    )))]
+    pub fn read_raw_counter() -> u64 {
+        // Fallback implementation for unsupported architectures
+        #[cfg(feature = "std")]
+        {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos() as u64
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            // For no-std environments on unsupported platforms, we need a compile-time error
+            compile_error!("Unsupported target architecture for high-precision timing");
+        }
+    }
+
+    // Frequency estimation for converting raw counter values to nanoseconds
+    static FREQUENCY_NS: AtomicU64 = AtomicU64::new(0);
+    static INIT_COUNTER: AtomicU64 = AtomicU64::new(0);
+    static INIT_TIME_NS: AtomicU64 = AtomicU64::new(0);
+
+    pub fn initialize_frequency() {
+        #[cfg(feature = "std")]
+        {
+            let start_counter = read_raw_counter();
+            let start_time = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos() as u64;
+
+            std::thread::sleep(std::time::Duration::from_millis(10));
+
+            let end_counter = read_raw_counter();
+            let end_time = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos() as u64;
+
+            let counter_diff = end_counter.saturating_sub(start_counter);
+            let time_diff_ns = end_time.saturating_sub(start_time);
+
+            if counter_diff > 0 {
+                let freq_ns = (counter_diff * 1_000_000_000) / time_diff_ns;
+                FREQUENCY_NS.store(freq_ns, Ordering::Relaxed);
+                INIT_COUNTER.store(start_counter, Ordering::Relaxed);
+                INIT_TIME_NS.store(start_time, Ordering::Relaxed);
+            }
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            // In no-std environments, we can't do runtime frequency calibration
+            // Use a reasonable default frequency (e.g., 1GHz = 1 tick per nanosecond)
+            // This is a simplification and may not be accurate for all platforms
+            FREQUENCY_NS.store(1_000_000_000, Ordering::Relaxed);
+            INIT_COUNTER.store(0, Ordering::Relaxed);
+            INIT_TIME_NS.store(0, Ordering::Relaxed);
+        }
+    }
+
+    pub fn counter_to_nanos(counter: u64) -> u64 {
+        let freq = FREQUENCY_NS.load(Ordering::Relaxed);
+        if freq == 0 {
+            initialize_frequency();
+            let freq = FREQUENCY_NS.load(Ordering::Relaxed);
+            if freq == 0 {
+                return counter; // Fallback if frequency estimation fails
+            }
+        }
+
+        let init_counter = INIT_COUNTER.load(Ordering::Relaxed);
+        let init_time_ns = INIT_TIME_NS.load(Ordering::Relaxed);
+        let counter_diff = counter.saturating_sub(init_counter);
+
+        init_time_ns + (counter_diff * 1_000_000_000) / freq
+    }
+}
+
+/// High-precision instant in time, represented as nanoseconds since an arbitrary epoch
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Instant(u64);
+
+impl Instant {
+    pub fn now() -> Self {
+        let raw_counter = platform::read_raw_counter();
+        Instant(platform::counter_to_nanos(raw_counter))
+    }
+
+    pub fn as_nanos(&self) -> u64 {
+        self.0
+    }
+}
+
+impl Sub for Instant {
+    type Output = Duration;
+
+    fn sub(self, other: Instant) -> Duration {
+        Duration::from_nanos(self.0.saturating_sub(other.0))
+    }
+}
+
+impl Sub<Duration> for Instant {
+    type Output = Instant;
+
+    fn sub(self, duration: Duration) -> Instant {
+        Instant(self.0.saturating_sub(duration.as_nanos() as u64))
+    }
+}
+
+impl Add<Duration> for Instant {
+    type Output = Instant;
+
+    fn add(self, duration: Duration) -> Instant {
+        Instant(self.0.saturating_add(duration.as_nanos() as u64))
+    }
+}
+
+// Duration type for no-std compatibility
+#[cfg(not(feature = "std"))]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Duration {
+    nanos: u64,
+}
+
+#[cfg(not(feature = "std"))]
+impl Duration {
+    pub const fn from_nanos(nanos: u64) -> Self {
+        Duration { nanos }
+    }
+
+    pub const fn from_millis(millis: u64) -> Self {
+        Duration::from_nanos(millis * 1_000_000)
+    }
+
+    pub const fn from_secs(secs: u64) -> Self {
+        Duration::from_nanos(secs * 1_000_000_000)
+    }
+
+    pub const fn as_nanos(&self) -> u128 {
+        self.nanos as u128
+    }
+
+    pub const fn as_millis(&self) -> u128 {
+        (self.nanos / 1_000_000) as u128
+    }
+
+    pub const fn as_secs(&self) -> u64 {
+        self.nanos / 1_000_000_000
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl Add for Duration {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Duration::from_nanos(self.nanos + rhs.nanos)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl Sub for Duration {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Duration::from_nanos(self.nanos.saturating_sub(rhs.nanos))
+    }
+}
 
 /// For Robot times, the underlying type is a u64 representing nanoseconds.
 /// It is always positive to simplify the reasoning on the user side.
@@ -31,6 +262,7 @@ impl CuDuration {
     pub const MIN: CuDuration = CuDuration(0u64);
     // Highest value a CuDuration can have reserving the max value for None.
     pub const MAX: CuDuration = CuDuration(NONE_VALUE - 1);
+
     pub fn max(self, other: CuDuration) -> CuDuration {
         let Self(lhs) = self;
         let Self(rhs) = other;
@@ -124,7 +356,7 @@ where
         CuDuration(lhs / rhs.into())
     }
 }
-//
+
 // a way to multiply a duration by a scalar.
 // useful to compute offsets for example.
 // CuDuration * scalar
@@ -190,7 +422,7 @@ impl<'de, Context> BorrowDecode<'de, Context> for CuDuration {
 }
 
 impl Display for CuDuration {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         let Self(nanos) = *self;
         if nanos >= 86_400_000_000_000 {
             write!(f, "{:.3} d", nanos as f64 / 86_400_000_000_000.0)
@@ -241,7 +473,7 @@ impl OptionCuTime {
 }
 
 impl Display for OptionCuTime {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         if self.is_none() {
             write!(f, "None")
         } else {
@@ -311,7 +543,7 @@ pub struct PartialCuTimeRange {
 }
 
 impl Display for PartialCuTimeRange {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         let start = if self.start.is_none() {
             "…"
         } else {
@@ -337,7 +569,7 @@ pub enum Tov {
 }
 
 impl Display for Tov {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             Tov::None => write!(f, "None"),
             Tov::Time(t) => write!(f, "{t}"),
@@ -361,62 +593,94 @@ impl From<CuDuration> for Tov {
     }
 }
 
+/// Internal clock implementation that provides high-precision timing
+#[derive(Clone, Debug)]
+struct InternalClock {
+    // For real clocks, this stores the initialization time
+    // For mock clocks, this references the mock state
+    mock_state: Option<Arc<AtomicU64>>,
+}
+
+impl InternalClock {
+    fn new() -> Self {
+        // Initialize the frequency calibration
+        platform::initialize_frequency();
+        InternalClock { mock_state: None }
+    }
+
+    fn mock() -> (Self, Arc<AtomicU64>) {
+        let mock_state = Arc::new(AtomicU64::new(0));
+        let clock = InternalClock {
+            mock_state: Some(Arc::clone(&mock_state)),
+        };
+        (clock, mock_state)
+    }
+
+    fn now(&self) -> Instant {
+        if let Some(ref mock_state) = self.mock_state {
+            Instant(mock_state.load(Ordering::Relaxed))
+        } else {
+            Instant::now()
+        }
+    }
+
+    fn recent(&self) -> Instant {
+        // For simplicity, we use the same implementation as now()
+        // In a more sophisticated implementation, this could use a cached value
+        self.now()
+    }
+}
+
 /// A running Robot clock.
 /// The clock is a monotonic clock that starts at an arbitrary reference time.
 /// It is clone resilient, ie a clone will be the same clock, even when mocked.
 #[derive(Clone, Debug)]
 pub struct RobotClock {
-    inner: Clock,      // This is a wrapper on quanta::Clock today.
-    ref_time: Instant, // The reference instant on which this clock is based.
+    inner: InternalClock,
+    ref_time: Instant,
 }
 
 /// A mock clock that can be controlled by the user.
 #[derive(Debug, Clone)]
-pub struct RobotClockMock(Arc<Mock>); // wraps the Mock from quanta today.
+pub struct RobotClockMock(Arc<AtomicU64>);
 
 impl RobotClockMock {
     pub fn increment(&self, amount: Duration) {
-        let Self(mock) = self;
-        mock.increment(amount);
+        let Self(mock_state) = self;
+        mock_state.fetch_add(amount.as_nanos() as u64, Ordering::Relaxed);
     }
 
     /// Decrements the time by the given amount.
-    /// Be careful this brakes the monotonicity of the clock.
+    /// Be careful this breaks the monotonicity of the clock.
     pub fn decrement(&self, amount: Duration) {
-        let Self(mock) = self;
-        mock.decrement(amount);
+        let Self(mock_state) = self;
+        mock_state.fetch_sub(amount.as_nanos() as u64, Ordering::Relaxed);
     }
 
     /// Gets the current value of time.
     pub fn value(&self) -> u64 {
-        let Self(mock) = self;
-        mock.value()
+        let Self(mock_state) = self;
+        mock_state.load(Ordering::Relaxed)
     }
 
     /// A convenient way to get the current time from the mocking side.
     pub fn now(&self) -> CuTime {
-        let Self(mock) = self;
-        mock.value().into()
+        let Self(mock_state) = self;
+        CuDuration(mock_state.load(Ordering::Relaxed))
     }
 
     /// Sets the absolute value of the time.
     pub fn set_value(&self, value: u64) {
-        let Self(mock) = self;
-        let v = mock.value();
-        // had to work around the quata API here.
-        if v < value {
-            self.increment(Duration::from_nanos(value) - Duration::from_nanos(v));
-        } else {
-            self.decrement(Duration::from_nanos(v) - Duration::from_nanos(value));
-        }
+        let Self(mock_state) = self;
+        mock_state.store(value, Ordering::Relaxed);
     }
 }
 
 impl RobotClock {
     /// Creates a RobotClock using now as its reference time.
-    /// It will start a 0ns incrementing monotonically.
+    /// It will start at 0ns incrementing monotonically.
     pub fn new() -> Self {
-        let clock = Clock::new();
+        let clock = InternalClock::new();
         let ref_time = clock.now();
         RobotClock {
             inner: clock,
@@ -426,10 +690,10 @@ impl RobotClock {
 
     /// Builds a monotonic clock starting at the given reference time.
     pub fn from_ref_time(ref_time_ns: u64) -> Self {
-        let clock = Clock::new();
+        let clock = InternalClock::new();
         let ref_time = clock.now() - Duration::from_nanos(ref_time_ns);
         RobotClock {
-            inner: Clock::new(),
+            inner: clock,
             ref_time,
         }
     }
@@ -437,27 +701,25 @@ impl RobotClock {
     /// Build a fake clock with a reference time of 0.
     /// The RobotMock interface enables you to control all the clones of the clock given.
     pub fn mock() -> (Self, RobotClockMock) {
-        let (clock, mock) = Clock::mock();
+        let (clock, mock_state) = InternalClock::mock();
         let ref_time = clock.now();
         (
             RobotClock {
                 inner: clock,
                 ref_time,
             },
-            RobotClockMock(mock),
+            RobotClockMock(mock_state),
         )
     }
 
-    // Now returns the time that passed since the reference time, usually the start time.
-    // It is a monotonically increasing value.
+    /// Now returns the time that passed since the reference time, usually the start time.
+    /// It is a monotonically increasing value.
     #[inline]
     pub fn now(&self) -> CuTime {
-        // TODO: this could be further optimized to avoid this constant conversion from 2 fields to one under the hood.
-        // Let's say this is the default implementation.
         (self.inner.now() - self.ref_time).into()
     }
 
-    // A less precise but quicker time
+    /// A less precise but quicker time
     #[inline]
     pub fn recent(&self) -> CuTime {
         (self.inner.recent() - self.ref_time).into()
@@ -478,6 +740,7 @@ pub trait ClockProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[test]
     fn test_cuduration_comparison_operators() {
         let a = CuDuration(100);
@@ -501,291 +764,29 @@ mod tests {
     }
 
     #[test]
-    fn test_option_cutime_handling() {
-        let some_time = OptionCuTime::from(Some(CuTime::from(100u64)));
-        let none_time = OptionCuTime::none();
-
-        assert!(!some_time.is_none());
-        assert!(none_time.is_none());
-        assert_eq!(some_time.unwrap(), CuTime::from(100u64));
-        assert_eq!(
-            Option::<CuTime>::from(some_time),
-            Some(CuTime::from(100u64))
-        );
-        assert_eq!(Option::<CuTime>::from(none_time), None);
+    fn test_robot_clock_monotonic() {
+        let clock = RobotClock::new();
+        let t1 = clock.now();
+        let t2 = clock.now();
+        assert!(t2 >= t1);
     }
 
     #[test]
-    fn test_mock() {
+    fn test_robot_clock_mock() {
         let (clock, mock) = RobotClock::mock();
-        assert_eq!(clock.now(), Duration::from_secs(0).into());
-        mock.increment(Duration::from_secs(1));
-        assert_eq!(clock.now(), Duration::from_secs(1).into());
+        let t1 = clock.now();
+        mock.increment(Duration::from_millis(100));
+        let t2 = clock.now();
+        assert!(t2 > t1);
+        assert_eq!(t2 - t1, CuDuration(100_000_000)); // 100ms in nanoseconds
     }
 
     #[test]
-    fn test_mock_clone() {
-        let (clock, mock) = RobotClock::mock();
-        assert_eq!(clock.now(), Duration::from_secs(0).into());
-        let clock_clone = clock.clone();
-        mock.increment(Duration::from_secs(1));
-        assert_eq!(clock_clone.now(), Duration::from_secs(1).into());
-    }
-
-    #[test]
-    fn test_robot_clock_synchronization() {
-        // Test that multiple clocks created from the same mock stay synchronized
+    fn test_robot_clock_clone_consistency() {
         let (clock1, mock) = RobotClock::mock();
         let clock2 = clock1.clone();
 
-        assert_eq!(clock1.now(), CuDuration(0));
-        assert_eq!(clock2.now(), CuDuration(0));
-
-        mock.increment(Duration::from_secs(5));
-
-        assert_eq!(clock1.now(), Duration::from_secs(5).into());
-        assert_eq!(clock2.now(), Duration::from_secs(5).into());
-    }
-
-    #[test]
-    fn test_from_ref_time() {
-        let tolerance_ms = 10;
-        let clock = RobotClock::from_ref_time(1_000_000_000);
-        assert_relative_eq!(
-            <CuDuration as Into<Duration>>::into(clock.now()).as_millis() as f64,
-            Duration::from_secs(1).as_millis() as f64,
-            epsilon = tolerance_ms as f64
-        );
-    }
-
-    #[test]
-    fn longest_duration() {
-        let maxcu = CuDuration(u64::MAX);
-        let maxd: Duration = maxcu.into();
-        assert_eq!(maxd.as_nanos(), u64::MAX as u128);
-        let s = maxd.as_secs();
-        let y = s / 60 / 60 / 24 / 365;
-        assert!(y >= 584); // 584 years of robot uptime, we should be good.
-    }
-
-    #[test]
-    fn test_some_time_arithmetics() {
-        let a: CuDuration = 10.into();
-        let b: CuDuration = 20.into();
-        let c = a + b;
-        assert_eq!(c.0, 30);
-        let d = b - a;
-        assert_eq!(d.0, 10);
-    }
-
-    #[test]
-    fn test_build_range_from_slice() {
-        let range = CuTimeRange::from(&[20.into(), 10.into(), 30.into()][..]);
-        assert_eq!(range.start, 10.into());
-        assert_eq!(range.end, 30.into());
-    }
-
-    #[test]
-    fn test_time_range_operations() {
-        // Test creating a time range and checking its properties
-        let start = CuTime::from(100u64);
-        let end = CuTime::from(200u64);
-        let range = CuTimeRange { start, end };
-
-        assert_eq!(range.start, start);
-        assert_eq!(range.end, end);
-
-        // Test creating from a slice
-        let times = [
-            CuTime::from(150u64),
-            CuTime::from(120u64),
-            CuTime::from(180u64),
-        ];
-        let range_from_slice = CuTimeRange::from(&times[..]);
-
-        // Range should capture min and max values
-        assert_eq!(range_from_slice.start, CuTime::from(120u64));
-        assert_eq!(range_from_slice.end, CuTime::from(180u64));
-    }
-
-    #[test]
-    fn test_partial_time_range() {
-        // Test creating a partial time range with defined start/end
-        let start = CuTime::from(100u64);
-        let end = CuTime::from(200u64);
-
-        let partial_range = PartialCuTimeRange {
-            start: OptionCuTime::from(start),
-            end: OptionCuTime::from(end),
-        };
-
-        // Test converting to Option
-        let opt_start: Option<CuTime> = partial_range.start.into();
-        let opt_end: Option<CuTime> = partial_range.end.into();
-
-        assert_eq!(opt_start, Some(start));
-        assert_eq!(opt_end, Some(end));
-
-        // Test partial range with undefined values
-        let partial_undefined = PartialCuTimeRange::default();
-        assert!(partial_undefined.start.is_none());
-        assert!(partial_undefined.end.is_none());
-    }
-
-    #[test]
-    fn test_tov_conversions() {
-        // Test different Time of Validity (Tov) variants
-        let time = CuTime::from(100u64);
-
-        // Test conversion from CuTime
-        let tov_time: Tov = time.into();
-        assert!(matches!(tov_time, Tov::Time(_)));
-
-        if let Tov::Time(t) = tov_time {
-            assert_eq!(t, time);
-        }
-
-        // Test conversion from Option<CuTime>
-        let some_time = Some(time);
-        let tov_some: Tov = some_time.into();
-        assert!(matches!(tov_some, Tov::Time(_)));
-
-        let none_time: Option<CuDuration> = None;
-        let tov_none: Tov = none_time.into();
-        assert!(matches!(tov_none, Tov::None));
-
-        // Test range
-        let start = CuTime::from(100u64);
-        let end = CuTime::from(200u64);
-        let range = CuTimeRange { start, end };
-        let tov_range = Tov::Range(range);
-
-        assert!(matches!(tov_range, Tov::Range(_)));
-    }
-
-    #[test]
-    fn test_cuduration_display() {
-        // Test the display implementation for different magnitudes
-        let nano = CuDuration(42);
-        assert_eq!(nano.to_string(), "42 ns");
-
-        let micro = CuDuration(42_000);
-        assert_eq!(micro.to_string(), "42.000 µs");
-
-        let milli = CuDuration(42_000_000);
-        assert_eq!(milli.to_string(), "42.000 ms");
-
-        let sec = CuDuration(1_500_000_000);
-        assert_eq!(sec.to_string(), "1.500 s");
-
-        let min = CuDuration(90_000_000_000);
-        assert_eq!(min.to_string(), "1.500 m");
-
-        let hour = CuDuration(3_600_000_000_000);
-        assert_eq!(hour.to_string(), "1.000 h");
-
-        let day = CuDuration(86_400_000_000_000);
-        assert_eq!(day.to_string(), "1.000 d");
-    }
-
-    #[test]
-    fn test_robot_clock_precision() {
-        // Test that RobotClock::now() and RobotClock::recent() return different values
-        // and that recent() is always <= now()
-        let clock = RobotClock::new();
-
-        // We can't guarantee the exact values, but we can check relationships
-        let recent = clock.recent();
-        let now = clock.now();
-
-        // recent() should be less than or equal to now()
-        assert!(recent <= now);
-
-        // Test precision of from_ref_time
-        let ref_time_ns = 1_000_000_000; // 1 second
-        let clock = RobotClock::from_ref_time(ref_time_ns);
-
-        // Clock should start at approximately ref_time_ns
-        let now = clock.now();
-        let now_ns: u64 = now.into();
-
-        // Allow reasonable tolerance for clock initialization time
-        let tolerance_ns = 50_000_000; // 50ms tolerance
-        assert!(now_ns >= ref_time_ns);
-        assert!(now_ns < ref_time_ns + tolerance_ns);
-    }
-
-    #[test]
-    fn test_mock_clock_advanced_operations() {
-        // Test more complex operations with the mock clock
-        let (clock, mock) = RobotClock::mock();
-
-        // Test initial state
-        assert_eq!(clock.now(), CuDuration(0));
-
-        // Test increment
-        mock.increment(Duration::from_secs(10));
-        assert_eq!(clock.now(), Duration::from_secs(10).into());
-
-        // Test decrement (unusual but supported)
-        mock.decrement(Duration::from_secs(5));
-        assert_eq!(clock.now(), Duration::from_secs(5).into());
-
-        // Test setting absolute value
-        mock.set_value(30_000_000_000); // 30 seconds in ns
-        assert_eq!(clock.now(), Duration::from_secs(30).into());
-
-        // Test that getting the time from the mock directly works
-        assert_eq!(mock.now(), Duration::from_secs(30).into());
-        assert_eq!(mock.value(), 30_000_000_000);
-    }
-
-    #[test]
-    fn test_cuduration_min_max() {
-        // Test MIN and MAX constants
-        assert_eq!(CuDuration::MIN, CuDuration(0));
-
-        // Test min/max methods
-        let a = CuDuration(100);
-        let b = CuDuration(200);
-
-        assert_eq!(a.min(b), a);
-        assert_eq!(a.max(b), b);
-        assert_eq!(b.min(a), a);
-        assert_eq!(b.max(a), b);
-
-        // Edge cases
-        assert_eq!(a.min(a), a);
-        assert_eq!(a.max(a), a);
-
-        // Test with MIN/MAX constants
-        assert_eq!(a.min(CuDuration::MIN), CuDuration::MIN);
-        assert_eq!(a.max(CuDuration::MAX), CuDuration::MAX);
-    }
-
-    #[test]
-    fn test_clock_provider_trait() {
-        // Test implementing the ClockProvider trait
-        struct TestClockProvider {
-            clock: RobotClock,
-        }
-
-        impl ClockProvider for TestClockProvider {
-            fn get_clock(&self) -> RobotClock {
-                self.clock.clone()
-            }
-        }
-
-        // Create a provider with a mock clock
-        let (clock, mock) = RobotClock::mock();
-        let provider = TestClockProvider { clock };
-
-        // Test that provider returns a clock synchronized with the original
-        let provider_clock = provider.get_clock();
-        assert_eq!(provider_clock.now(), CuDuration(0));
-
-        // Advance the mock clock and check that provider's clock also advances
-        mock.increment(Duration::from_secs(5));
-        assert_eq!(provider_clock.now(), Duration::from_secs(5).into());
+        mock.set_value(1_000_000_000); // 1 second
+        assert_eq!(clock1.now(), clock2.now());
     }
 }

--- a/core/cu29_log_runtime/Cargo.toml
+++ b/core/cu29_log_runtime/Cargo.toml
@@ -18,7 +18,7 @@ ignored = ["simplelog"]  # Used from conditional compilation
 cu29-log = { workspace = true }
 cu29-traits = { workspace = true }
 cu29-clock = { workspace = true }
-bincode = { workspace = true }
+bincode = { workspace = true, features = ["derive", "std"] }
 smallvec = { workspace = true }
 log = "0.4.27"
 


### PR DESCRIPTION
This included the removal of the quanta dependency that I wanted to do for a long time.

Now all the counters for the supported platforms are direct in assembly. We keep around some wrapped types for backward compatibility.