### PR TITLE
First pass on refactoring Sections to be baremetal friendly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ cu29-log-runtime = { path = "core/cu29_log_runtime", default-features = false, v
 cu29-runtime = { path = "core/cu29_runtime", default-features = false, version = "0.9.0" }
 cu29-soa-derive = { path = "core/cu29_soa_derive", default-features = false, version = "0.9.0" }
 cu29-traits = { path = "core/cu29_traits", default-features = false, version = "0.9.0" }
-cu29-unifiedlog = { path = "core/cu29_unifiedlog", default-features = false, version = "0.9.0" }
+cu29-unifiedlog = { path = "core/cu29_unifiedlog", default-features = false, features = ["compact"], version = "0.9.0" }
 cu29-value = { path = "core/cu29_value", default-features = false, version = "0.9.0" }
 
 # Payload definitions

--- a/core/cu29_unifiedlog/Cargo.toml
+++ b/core/cu29_unifiedlog/Cargo.toml
@@ -22,5 +22,6 @@ page_size = { version = "0.6.0", optional = true }
 tempfile = { workspace = true }
 
 [features]
-default = ["std"]
+default = ["std", "compact"]
 std = ["dep:memmap2", "dep:page_size", "cu29-traits/std", "bincode/std"]
+compact = [] # favor compactness over pure memory page alignment in the log


### PR DESCRIPTION
It comes from the fact that if the storage is not memory mapped, the minimum size we can write is usually 512 bytes.

This aligns the size of a section header to be 512 bytes minimum. It avoids a scary read, patch, rewrite cycle on bare metal (on an OS the memory mapped file takes care of this).