### PR TITLE
Fix README links to point to GitHub wiki pages instead of doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ fn main() {
 
 ```
 
-But this is a very minimal example for a task; please see [lifecycle](doc/lifecycle.md) for a more complete explanation
+But this is a very minimal example for a task; please see [lifecycle](https://github.com/copper-project/copper-rs/wiki/Task-Lifecycle) for a more complete explanation
 of a task lifecycle.
 
 ### Modular Configuration
@@ -290,11 +290,11 @@ You can parameterize your included configurations using template variables:
 )
 ```
 
-For more details on modular configuration, see the [Modular Configuration documentation](doc/modular_config.md).
+For more details on modular configuration, see the [Modular Configuration documentation](https://github.com/copper-project/copper-rs/wiki/Modular-Configuration).
 
 ### Deployment of the application
 
-Check out the [deployment](doc/deploy.md) page for more information.
+Check out the [deployment](https://github.com/copper-project/copper-rs/wiki/Build-and-Deploy-a-Copper-Application) page for more information.
 
 ## FAQ
 


### PR DESCRIPTION
Links pointing to doc/*.md are broken, replaced with equivalent pages under https://github.com/copper-project/copper-rs/wiki/