### PR TITLE
Make cu29_log_derive no-std friendly error handling

### DIFF
--- a/core/cu29_log_derive/src/lib.rs
+++ b/core/cu29_log_derive/src/lib.rs
@@ -159,17 +159,11 @@ fn create_log_entry(input: TokenStream, level: CuLogLevel) -> TokenStream {
         }
     };
 
-    let error_handling: Option<TokenStream2> = if STD {
-        Some(quote! {
-            if let Err(e) = r {
-                eprintln!("Warning: Failed to log: {}", e);
-                let backtrace = std::backtrace::Backtrace::capture();
-                eprintln!("{:?}", backtrace);
-            }
-        })
-    } else {
-        None
-    };
+    let error_handling: Option<TokenStream2> = Some(quote! {
+        if let Err(_e) = r {
+            let _ = &_e;
+        }
+    });
 
     #[cfg(debug_assertions)]
     let defmt_macro: TokenStream2 = match level {


### PR DESCRIPTION
The code was assuming eprintln was there and it was causing issues through chained dependencies. Let's revisit it properly at some point