### PR TITLE
By default, double buffer Copperlists.

### DIFF
--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -28,8 +28,7 @@ mod format;
 mod resources;
 mod utils;
 
-// TODO: this needs to be determined when the runtime is sizing itself.
-const DEFAULT_CLNB: usize = 10;
+const DEFAULT_CLNB: usize = 2; // We can double buffer for now until we add the parallel copperlist execution support.
 
 #[inline]
 fn int2sliceindex(i: u32) -> syn::Index {


### PR DESCRIPTION
Until we implement the parallel copperlists supports we don't need many preallocated copperlists.

This help for embedded targets where the fast stack sram is limited.