### PR TITLE
remove limited space for weekly CI by disabling CARGO_INCREMENTAL

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -8,6 +8,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_TARGET_DIR: ${{ github.workspace }}/target
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
+  CARGO_PROFILE_RELEASE_DEBUG: "0"
 
 jobs:
   audit:


### PR DESCRIPTION
## Issue
weekly CI triggered "No space left on device" during the phase "Build generated project"
## Solution
Set CARGO_INCREMENTAL and debug flags to '0'