### PR TITLE
wrap recurring graph pattern as CuGraph helpers

### DIFF
--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -2504,12 +2504,7 @@ fn build_culist_tuple_default(all_msgs_types_in_culist_order: &[Type]) -> ItemIm
 
 fn collect_bridge_channel_usage(graph: &CuGraph) -> HashMap<BridgeChannelKey, String> {
     let mut usage = HashMap::new();
-    for edge_idx in graph.0.edge_indices() {
-        let cnx = graph
-            .0
-            .edge_weight(edge_idx)
-            .expect("Edge should exist while collecting bridge usage")
-            .clone();
+    for cnx in graph.edges() {
         if let Some(channel) = &cnx.src_channel {
             let key = BridgeChannelKey {
                 bridge_id: cnx.src.clone(),
@@ -3082,13 +3077,7 @@ fn build_execution_plan(
         }
     }
 
-    for edge_idx in graph.0.edge_indices() {
-        let cnx = graph
-            .0
-            .edge_weight(edge_idx)
-            .expect("Edge should exist while building plan")
-            .clone();
-
+    for cnx in graph.edges() {
         let src_plan = if let Some(channel) = &cnx.src_channel {
             let key = BridgeChannelKey {
                 bridge_id: cnx.src.clone(),

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -13,9 +13,9 @@ use hashbrown::HashMap;
 pub use petgraph::Direction::Incoming;
 pub use petgraph::Direction::Outgoing;
 use petgraph::stable_graph::{EdgeIndex, NodeIndex, StableDiGraph};
-use petgraph::visit::EdgeRef;
 #[cfg(feature = "std")]
 use petgraph::visit::IntoEdgeReferences;
+use petgraph::visit::{Bfs, EdgeRef};
 use ron::extensions::Extensions;
 use ron::value::Value as RonValue;
 use ron::{Number, Options};
@@ -628,6 +628,43 @@ impl CuGraph {
             .neighbors_directed(node_id.into(), dir.into())
             .map(|petgraph_index| petgraph_index.index() as NodeId)
             .collect()
+    }
+
+    #[allow(dead_code)]
+    pub fn node_ids(&self) -> Vec<NodeId> {
+        self.0
+            .node_indices()
+            .map(|index| index.index() as NodeId)
+            .collect()
+    }
+
+    #[allow(dead_code)]
+    pub fn edge_id_between(&self, source: NodeId, target: NodeId) -> Option<usize> {
+        self.0
+            .find_edge(source.into(), target.into())
+            .map(|edge| edge.index())
+    }
+
+    #[allow(dead_code)]
+    pub fn edge(&self, edge_id: usize) -> Option<&Cnx> {
+        self.0.edge_weight(EdgeIndex::new(edge_id))
+    }
+
+    #[allow(dead_code)]
+    pub fn edges(&self) -> impl Iterator<Item = &Cnx> {
+        self.0
+            .edge_indices()
+            .filter_map(|edge| self.0.edge_weight(edge))
+    }
+
+    #[allow(dead_code)]
+    pub fn bfs_nodes(&self, start: NodeId) -> Vec<NodeId> {
+        let mut visitor = Bfs::new(&self.0, start.into());
+        let mut nodes = Vec::new();
+        while let Some(node) = visitor.next(&self.0) {
+            nodes.push(node.index() as NodeId);
+        }
+        nodes
     }
 
     #[allow(dead_code)]

--- a/core/cu29_runtime/src/monitoring.rs
+++ b/core/cu29_runtime/src/monitoring.rs
@@ -8,7 +8,6 @@ use cu29_clock::{CuDuration, RobotClock};
 #[allow(unused_imports)]
 use cu29_log::CuLogLevel;
 use cu29_traits::{CuError, CuResult};
-use petgraph::visit::IntoEdgeReferences;
 use serde_derive::{Deserialize, Serialize};
 
 #[cfg(not(feature = "std"))]
@@ -112,8 +111,7 @@ pub fn build_monitor_topology(
         bridge_lookup.insert(bridge.id.as_str(), bridge);
     }
 
-    for edge in graph.0.edge_references() {
-        let cnx = edge.weight();
+    for cnx in graph.edges() {
         io_usage.entry(cnx.src.clone()).or_default().has_outgoing = true;
         io_usage.entry(cnx.dst.clone()).or_default().has_incoming = true;
     }
@@ -161,8 +159,7 @@ pub fn build_monitor_topology(
     }
 
     let mut connections = Vec::new();
-    for edge in graph.0.edge_references() {
-        let cnx = edge.weight();
+    for cnx in graph.edges() {
         let src = cnx.src.clone();
         let dst = cnx.dst.clone();
 


### PR DESCRIPTION
## Summary
Identified the recurring patterns (BFS traversal, edge iteration, edge-id lookup) and surfaced them as CuGraph helpers, then refactored runtime/monitoring/derive to consume the new API so petgraph stays internal.

address issue: https://github.com/copper-project/copper-rs/issues/335
## Details
- Added CuGraph traversal/edge helpers (node_ids, edges, edge, edge_id_between, bfs_nodes) in core/cu29_runtime/src/config.rs to cover the patterns without exposing petgraph types.
- Swapped runtime planning over to the new helpers (BFS traversal, edge lookup, neighbor enqueueing) in core/cu29_runtime/src/curuntime.rs.
- Updated monitoring and codegen to iterate connections via graph.edges() instead of petgraph iterators in core/cu29_runtime/src/monitoring.rs and core/cu29_derive/src/lib.rs.
