### PR TITLE
fix nostdci justfile in none-x86_64 platform for target configuration

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,7 +25,7 @@ ci:
   act -W .github/workflows/general.yml -j Unit-Tests --matrix os:ubuntu-latest --matrix mode:debug -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest
 
 # Host target detection for cross-platform logreader builds
-host_target := `rustc -vV | sed -n 's/host: //p'`
+host_target := `rustc +stable -vV | sed -n 's/host: //p'`
 
 nostd-ci: lint
 	cargo +stable build --no-default-features


### PR DESCRIPTION
## Summary
fix nostdci justfile in none-x86_64 platform for target configuration. The previous version cause compilation issue since `examples/cu_rp2350_skeleton/.cargo/config.toml` hardcoded x86_64 platform as the target for logreader. The `.cargo/config.toml` cannot dynamically configure platform target. Therefore we fix the justfile in the root to support `just nostd-ci` alias for none-x86_64 platform