### PR TITLE
[CHORE] cache GStreamer installation for macOS and consolidate CI actions

### DIFF
--- a/.github/actions/embedded-rust-setup/action.yml
+++ b/.github/actions/embedded-rust-setup/action.yml
@@ -11,7 +11,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
     - name: Configure CARGO_TARGET_DIR
       if: inputs.cargo_target_dir != ''
       shell: bash

--- a/.github/actions/rust-ci-setup/action.yml
+++ b/.github/actions/rust-ci-setup/action.yml
@@ -29,7 +29,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
     - name: Configure CARGO_TARGET_DIR
       if: inputs.cargo_target_dir != ''
       shell: bash

--- a/.github/workflows/reusable-embedded.yml
+++ b/.github/workflows/reusable-embedded.yml
@@ -19,6 +19,7 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/embedded-rust-setup
         with:
           toolchain: ${{ inputs.toolchain }}
@@ -38,6 +39,7 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/embedded-rust-setup
         with:
           toolchain: ${{ inputs.toolchain }}
@@ -55,6 +57,7 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/embedded-rust-setup
         with:
           toolchain: ${{ inputs.toolchain }}

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -44,6 +44,7 @@ jobs:
             mode: cuda-debug
 
     steps:
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/rust-ci-setup
         with:
           toolchain: ${{ inputs.toolchain }}
@@ -134,6 +135,7 @@ jobs:
             mode: cuda-debug
 
     steps:
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/rust-ci-setup
         with:
           toolchain: ${{ inputs.toolchain }}
@@ -206,6 +208,7 @@ jobs:
         mode: [ debug ]
 
     steps:
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/rust-ci-setup
         with:
           toolchain: ${{ inputs.toolchain }}


### PR DESCRIPTION
1. Speed up GStreamer installation for macos from 9 min to 3 min by using the action `gerlero/brew-install`.
2. Consolidated the repeated CI setup blocks into composite actions so the unit/test/templates jobs and the embedded jobs reuse the same setup steps
