### PR TITLE
Adds a horus deterministic benchmark

### DIFF
--- a/examples/horus_caterpillar/Cargo.toml
+++ b/examples/horus_caterpillar/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "horus-caterpillar"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+resolver = "2"
+
+[dependencies]
+horus = { git = "https://github.com/softmata/horus", tag = "v0.1.6" }
+serde = { version = "1", features = ["derive"] }

--- a/examples/horus_caterpillar/README.md
+++ b/examples/horus_caterpillar/README.md
@@ -1,0 +1,19 @@
+## Horus caterpillar example
+
+This is a Horus version of the caterpillar chain used for Copper vs ROS comparisons.
+It matches the Copper constraints: 17 tasks (1 source + 8 propagate + 8 GPIO sinks) and
+16 connections (8 chain + 8 GPIO). Per-message logging is disabled to keep the console
+quiet; instead, the app records every message and prints a summary table once per second.
+
+### Run
+
+```
+cd examples/horus_caterpillar
+cargo run --release
+```
+
+### Notes
+
+- Deterministic execution is enabled via `Scheduler::enable_determinism()`.
+- End-to-end latency uses `Instant` (monotonic); it reports src → gpio-7 in the `End2End` row.
+- Per-task rows show node tick duration (recv + publish work) for each task.

--- a/examples/horus_caterpillar/src/main.rs
+++ b/examples/horus_caterpillar/src/main.rs
@@ -1,0 +1,469 @@
+use horus::prelude::*;
+use horus::TopicMetadata;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::any::type_name;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+const CHAIN_LEN: usize = 8;
+const CHAIN_TOPICS: [&str; CHAIN_LEN] = [
+    "ct-0", "ct-1", "ct-2", "ct-3", "ct-4", "ct-5", "ct-6", "ct-7",
+];
+const GPIO_TOPICS: [&str; CHAIN_LEN] = [
+    "gpio-0", "gpio-1", "gpio-2", "gpio-3", "gpio-4", "gpio-5", "gpio-6", "gpio-7",
+];
+const TASK_COUNT: usize = 1 + CHAIN_LEN + CHAIN_LEN;
+const CONNECTION_COUNT: usize = CHAIN_LEN + CHAIN_LEN;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct CaterpillarMsg {
+    seq: u64,
+    state: bool,
+    origin_ns: u64,
+}
+
+impl LogSummary for CaterpillarMsg {
+    fn log_summary(&self) -> String {
+        format!(
+            "seq={} state={} origin_ns={}",
+            self.seq, self.state, self.origin_ns
+        )
+    }
+}
+
+static START: OnceLock<Instant> = OnceLock::new();
+
+fn now_ns() -> u64 {
+    let start = START.get_or_init(Instant::now);
+    start.elapsed().as_nanos() as u64
+}
+
+struct CaterpillarSource {
+    output: Hub<CaterpillarMsg>,
+    output_topic: &'static str,
+    state: bool,
+    seq: u64,
+    stats: Arc<Mutex<StatsStore>>,
+}
+
+impl CaterpillarSource {
+    fn new(output_topic: &'static str, stats: Arc<Mutex<StatsStore>>) -> Result<Self> {
+        Ok(Self {
+            output: Hub::new(output_topic)?,
+            output_topic,
+            state: false,
+            seq: 0,
+            stats,
+        })
+    }
+}
+
+impl Node for CaterpillarSource {
+    fn name(&self) -> &'static str {
+        "src"
+    }
+
+    fn get_publishers(&self) -> Vec<TopicMetadata> {
+        vec![TopicMetadata {
+            topic_name: self.output_topic.to_string(),
+            type_name: type_name::<CaterpillarMsg>().to_string(),
+        }]
+    }
+
+    fn tick(&mut self, mut ctx: Option<&mut NodeInfo>) {
+        let tick_start = Instant::now();
+        self.state = !self.state;
+        self.seq += 1;
+        let msg = CaterpillarMsg {
+            seq: self.seq,
+            state: self.state,
+            origin_ns: now_ns(),
+        };
+        let _ = self.output.send(msg, &mut ctx);
+        let tick_ns = tick_start.elapsed().as_nanos() as u64;
+        self.stats.lock().unwrap().record("src", tick_ns);
+    }
+}
+
+struct CaterpillarTask {
+    name: &'static str,
+    input: Hub<CaterpillarMsg>,
+    output: Option<Hub<CaterpillarMsg>>,
+    gpio: Hub<CaterpillarMsg>,
+    input_topic: &'static str,
+    output_topic: Option<&'static str>,
+    gpio_topic: &'static str,
+    stats: Arc<Mutex<StatsStore>>,
+}
+
+impl CaterpillarTask {
+    fn new(
+        name: &'static str,
+        input_topic: &'static str,
+        output_topic: Option<&'static str>,
+        gpio_topic: &'static str,
+        stats: Arc<Mutex<StatsStore>>,
+    ) -> Result<Self> {
+        Ok(Self {
+            name,
+            input: Hub::new(input_topic)?,
+            output: match output_topic {
+                Some(topic) => Some(Hub::new(topic)?),
+                None => None,
+            },
+            gpio: Hub::new(gpio_topic)?,
+            input_topic,
+            output_topic,
+            gpio_topic,
+            stats,
+        })
+    }
+}
+
+impl Node for CaterpillarTask {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn get_publishers(&self) -> Vec<TopicMetadata> {
+        let mut pubs = Vec::new();
+        if let Some(topic) = self.output_topic {
+            pubs.push(TopicMetadata {
+                topic_name: topic.to_string(),
+                type_name: type_name::<CaterpillarMsg>().to_string(),
+            });
+        }
+        pubs.push(TopicMetadata {
+            topic_name: self.gpio_topic.to_string(),
+            type_name: type_name::<CaterpillarMsg>().to_string(),
+        });
+        pubs
+    }
+
+    fn get_subscribers(&self) -> Vec<TopicMetadata> {
+        vec![TopicMetadata {
+            topic_name: self.input_topic.to_string(),
+            type_name: type_name::<CaterpillarMsg>().to_string(),
+        }]
+    }
+
+    fn tick(&mut self, mut ctx: Option<&mut NodeInfo>) {
+        let tick_start = Instant::now();
+        if let Some(msg) = self.input.recv(&mut ctx) {
+            if let Some(ref output) = self.output {
+                let _ = output.send(msg.clone(), &mut ctx);
+            }
+            let _ = self.gpio.send(msg, &mut ctx);
+            let tick_ns = tick_start.elapsed().as_nanos() as u64;
+            self.stats.lock().unwrap().record(self.name, tick_ns);
+        }
+    }
+}
+
+struct GpioSink {
+    name: &'static str,
+    input: Hub<CaterpillarMsg>,
+    input_topic: &'static str,
+    record_end_to_end: bool,
+    stats: Arc<Mutex<StatsStore>>,
+}
+
+impl GpioSink {
+    fn new(
+        name: &'static str,
+        input_topic: &'static str,
+        record_end_to_end: bool,
+        stats: Arc<Mutex<StatsStore>>,
+    ) -> Result<Self> {
+        Ok(Self {
+            name,
+            input: Hub::new(input_topic)?,
+            input_topic,
+            record_end_to_end,
+            stats,
+        })
+    }
+}
+
+impl Node for GpioSink {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn get_subscribers(&self) -> Vec<TopicMetadata> {
+        vec![TopicMetadata {
+            topic_name: self.input_topic.to_string(),
+            type_name: type_name::<CaterpillarMsg>().to_string(),
+        }]
+    }
+
+    fn tick(&mut self, mut ctx: Option<&mut NodeInfo>) {
+        let tick_start = Instant::now();
+        if let Some(msg) = self.input.recv(&mut ctx) {
+            let tick_ns = tick_start.elapsed().as_nanos() as u64;
+            let mut stats = self.stats.lock().unwrap();
+            stats.record(self.name, tick_ns);
+
+            if self.record_end_to_end {
+                let end_to_end_ns = now_ns().saturating_sub(msg.origin_ns);
+                stats.record("End2End", end_to_end_ns);
+            }
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let _ = START.set(Instant::now());
+    let stats = Arc::new(Mutex::new(StatsStore::new(Duration::from_secs(1))));
+
+    println!(
+        "horus caterpillar: tasks={} connections={} (chain={}, gpio={})",
+        TASK_COUNT, CONNECTION_COUNT, CHAIN_LEN, CHAIN_LEN
+    );
+
+    let mut scheduler = Scheduler::new()
+        .enable_determinism()
+        .with_capacity(TASK_COUNT);
+
+    scheduler.add(
+        Box::new(CaterpillarSource::new(
+            CHAIN_TOPICS[0],
+            stats.clone(),
+        )?),
+        0,
+        Some(false),
+    );
+
+    for i in 0..CHAIN_LEN {
+        let output_topic = if i + 1 < CHAIN_LEN {
+            Some(CHAIN_TOPICS[i + 1])
+        } else {
+            None
+        };
+        let task = CaterpillarTask::new(
+            CHAIN_TOPICS[i],
+            CHAIN_TOPICS[i],
+            output_topic,
+            GPIO_TOPICS[i],
+            stats.clone(),
+        )?;
+        scheduler.add(Box::new(task), (1 + i) as u32, Some(false));
+    }
+
+    for i in 0..CHAIN_LEN {
+        let gpio = GpioSink::new(
+            GPIO_TOPICS[i],
+            GPIO_TOPICS[i],
+            i + 1 == CHAIN_LEN,
+            stats.clone(),
+        )?;
+        scheduler.add(
+            Box::new(gpio),
+            (1 + CHAIN_LEN + i) as u32,
+            Some(false),
+        );
+    }
+
+    scheduler.run()?;
+    Ok(())
+}
+
+struct StatsStore {
+    stats: BTreeMap<&'static str, Stat>,
+    last_report: Instant,
+    report_interval: Duration,
+}
+
+impl StatsStore {
+    fn new(report_interval: Duration) -> Self {
+        Self {
+            stats: BTreeMap::new(),
+            last_report: Instant::now(),
+            report_interval,
+        }
+    }
+
+    fn record(&mut self, name: &'static str, sample_ns: u64) {
+        self.stats
+            .entry(name)
+            .or_insert_with(Stat::default)
+            .record(sample_ns);
+
+        if self.last_report.elapsed() >= self.report_interval {
+            self.last_report = Instant::now();
+            println!("\n{}", self.format_table());
+        }
+    }
+
+    fn format_table(&self) -> String {
+        let mut rows: Vec<[String; 7]> = Vec::new();
+        rows.push([
+            "Task".to_string(),
+            "Min".to_string(),
+            "Max".to_string(),
+            "Mean".to_string(),
+            "Stddev".to_string(),
+            "Jitter".to_string(),
+            "Max Jitter".to_string(),
+        ]);
+
+        for name in TASK_ORDER {
+            if let Some(stat) = self.stats.get(name) {
+                if stat.count > 0 {
+                    let mean = stat.mean();
+                    let stddev = stat.stddev();
+                    let jitter_avg = stat.jitter_avg();
+                    rows.push([
+                        name.to_string(),
+                        format_ns(stat.min_ns),
+                        format_ns(stat.max_ns),
+                        format_ns(mean),
+                        format_ns(stddev),
+                        format_ns(jitter_avg),
+                        format_ns(stat.jitter_max),
+                    ]);
+                    continue;
+                }
+            }
+
+            rows.push([
+                name.to_string(),
+                "-".to_string(),
+                "-".to_string(),
+                "-".to_string(),
+                "-".to_string(),
+                "-".to_string(),
+                "-".to_string(),
+            ]);
+        }
+
+        let mut widths = [0usize; 7];
+        for row in &rows {
+            for (idx, cell) in row.iter().enumerate() {
+                widths[idx] = widths[idx].max(cell.len());
+            }
+        }
+
+        let mut out = String::new();
+        for (row_idx, row) in rows.iter().enumerate() {
+            let line = format!(
+                "{:<w0$}  {:>w1$}  {:>w2$}  {:>w3$}  {:>w4$}  {:>w5$}  {:>w6$}",
+                row[0],
+                row[1],
+                row[2],
+                row[3],
+                row[4],
+                row[5],
+                row[6],
+                w0 = widths[0],
+                w1 = widths[1],
+                w2 = widths[2],
+                w3 = widths[3],
+                w4 = widths[4],
+                w5 = widths[5],
+                w6 = widths[6],
+            );
+            out.push_str(&line);
+            if row_idx + 1 < rows.len() {
+                out.push('\n');
+            }
+        }
+        out
+    }
+}
+
+#[derive(Default)]
+struct Stat {
+    count: u64,
+    min_ns: u64,
+    max_ns: u64,
+    mean_ns: f64,
+    m2: f64,
+    last_ns: Option<u64>,
+    jitter_sum: u128,
+    jitter_max: u64,
+    jitter_count: u64,
+}
+
+impl Stat {
+    fn record(&mut self, sample_ns: u64) {
+        self.count += 1;
+        if self.count == 1 {
+            self.min_ns = sample_ns;
+            self.max_ns = sample_ns;
+            self.mean_ns = sample_ns as f64;
+            self.m2 = 0.0;
+        } else {
+            self.min_ns = self.min_ns.min(sample_ns);
+            self.max_ns = self.max_ns.max(sample_ns);
+            let delta = sample_ns as f64 - self.mean_ns;
+            self.mean_ns += delta / self.count as f64;
+            let delta2 = sample_ns as f64 - self.mean_ns;
+            self.m2 += delta * delta2;
+        }
+
+        if let Some(prev) = self.last_ns {
+            let jitter = sample_ns.abs_diff(prev);
+            self.jitter_sum += jitter as u128;
+            self.jitter_max = self.jitter_max.max(jitter);
+            self.jitter_count += 1;
+        }
+        self.last_ns = Some(sample_ns);
+    }
+
+    fn mean(&self) -> u64 {
+        if self.count == 0 {
+            0
+        } else {
+            self.mean_ns.round() as u64
+        }
+    }
+
+    fn stddev(&self) -> u64 {
+        if self.count == 0 {
+            0
+        } else {
+            (self.m2 / self.count as f64).sqrt().round() as u64
+        }
+    }
+
+    fn jitter_avg(&self) -> u64 {
+        if self.jitter_count == 0 {
+            0
+        } else {
+            (self.jitter_sum / self.jitter_count as u128) as u64
+        }
+    }
+}
+
+fn format_ns(ns: u64) -> String {
+    if ns >= 1_000_000 {
+        format!("{:.3} ms", ns as f64 / 1_000_000.0)
+    } else if ns >= 1_000 {
+        format!("{:.3} us", ns as f64 / 1_000.0)
+    } else {
+        format!("{} ns", ns)
+    }
+}
+
+const TASK_ORDER: [&str; TASK_COUNT + 1] = [
+    "src",
+    "ct-0",
+    "gpio-0",
+    "ct-1",
+    "gpio-1",
+    "ct-2",
+    "gpio-2",
+    "ct-3",
+    "gpio-3",
+    "ct-4",
+    "gpio-4",
+    "ct-5",
+    "gpio-5",
+    "ct-6",
+    "gpio-6",
+    "ct-7",
+    "gpio-7",
+    "End2End",
+];


### PR DESCRIPTION

Horus Caterpillar (cargo run -r):
```
Task            Min         Max        Mean     Stddev     Jitter  Max Jitter
src        4.110 us   70.151 us   36.467 us  15.213 us   9.616 us   48.771 us
ct-0       2.160 us   15.030 us    6.103 us   1.648 us   1.262 us   10.690 us
gpio-0       690 ns    8.330 us    1.717 us     654 ns     439 ns    7.290 us
ct-1       1.820 us    5.470 us    3.907 us     893 ns     777 ns    2.490 us
gpio-1       650 ns   13.011 us    1.515 us   1.014 us     506 ns   12.071 us
ct-2       2.240 us   29.201 us   12.765 us   3.607 us   2.143 us   14.941 us
gpio-2       670 ns    2.450 us    1.324 us     314 ns     285 ns    1.230 us
ct-3       1.730 us   11.970 us    3.703 us   1.193 us     876 ns    9.360 us
gpio-3       760 ns   21.980 us    8.476 us   2.863 us   1.783 us   12.760 us
ct-4       1.730 us   16.931 us    3.718 us   1.371 us     870 ns   14.581 us
gpio-4       650 ns   14.131 us    1.650 us   1.098 us     547 ns   13.091 us
ct-5       1.690 us    5.260 us    3.163 us     598 ns     530 ns    2.680 us
gpio-5       831 ns   20.720 us    8.472 us   2.759 us   1.464 us   11.700 us
ct-6       1.790 us   31.681 us    3.584 us   2.280 us     929 ns   28.401 us
gpio-6       640 ns    4.360 us    1.342 us     388 ns     303 ns    2.920 us
ct-7       1.210 us   12.200 us    2.543 us     964 ns     625 ns    9.560 us
gpio-7       660 ns   27.001 us    1.405 us   2.001 us     575 ns   25.881 us
End2End  170.973 us  422.748 us  306.218 us  52.525 us  42.404 us  166.743 us
```

Copper Caterpillar (cargo run -r):
<img width="1240" height="707" alt="image" src="https://github.com/user-attachments/assets/812735cf-5a91-49a5-a05a-cbaa767a5cea" />
