### PR TITLE
replace serde_cbor with minicbor_serde for cu_zenoh_bridge for audit

### DIFF
--- a/components/bridges/cu_zenoh_bridge/Cargo.toml
+++ b/components/bridges/cu_zenoh_bridge/Cargo.toml
@@ -15,5 +15,5 @@ zenoh = { version = "1.4.0" }
 cu29 = { workspace = true }
 serde = { workspace = true }
 serde_json = "1.0"
-serde_cbor = "0.11"
+minicbor-serde = { version = "0.6.2", features = ["alloc"] }
 bincode = { workspace = true }

--- a/components/bridges/cu_zenoh_bridge/src/lib.rs
+++ b/components/bridges/cu_zenoh_bridge/src/lib.rs
@@ -151,7 +151,7 @@ where
                 .map_err(|e| CuError::new_with_cause("ZenohBridge: bincode encode failed", e)),
             WireFormat::Json => serde_json::to_vec(msg)
                 .map_err(|e| CuError::new_with_cause("ZenohBridge: json encode failed", e)),
-            WireFormat::Cbor => serde_cbor::to_vec(msg)
+            WireFormat::Cbor => minicbor_serde::to_vec(msg)
                 .map_err(|e| CuError::new_with_cause("ZenohBridge: cbor encode failed", e)),
         }
     }
@@ -170,7 +170,7 @@ where
             }
             WireFormat::Json => serde_json::from_slice(bytes)
                 .map_err(|e| CuError::new_with_cause("ZenohBridge: json decode failed", e)),
-            WireFormat::Cbor => serde_cbor::from_slice(bytes)
+            WireFormat::Cbor => minicbor_serde::from_slice(bytes)
                 .map_err(|e| CuError::new_with_cause("ZenohBridge: cbor decode failed", e)),
         }
     }


### PR DESCRIPTION
## Summary
`serde_cbor is unmaintained for `cu-zenoh-bridge` crate, replace it with `minicbor_serde`
## Details
```
error[unmaintained]: serde_cbor is unmaintained
     ┌─ /home/runner/work/copper-rs/copper-rs/Cargo.lock:1070:1
     │
1070 │ serde_cbor 0.11.2 registry+https://github.com/rust-lang/crates.io-index
     │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
     │
     ├ ID: RUSTSEC-2021-0127
     ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2021-0127
     ├ The `serde_cbor` crate is unmaintained. The author has archived the github repository.
       
       Alternatives proposed by the author:
       
        * [`ciborium`](https://crates.io/crates/ciborium)
        * [`minicbor`](https://crates.io/crates/minicbor)
     ├ Announcement: https://github.com/pyfisch/cbor
     ├ Solution: No safe upgrade is available!
     ├ serde_cbor v0.11.2
       └── cu-zenoh-bridge v0.12.0
           └── cu-zenoh-bridge-demo v0.12.0
```