### PR TITLE
fix(cu_caterpillar): correct justfile commands

### DIFF
--- a/examples/cu_caterpillar/README.md
+++ b/examples/cu_caterpillar/README.md
@@ -7,8 +7,6 @@ See the crate cu29 for more information about the Copper project.
 
 ### Justfile commands
 
-- `just caterpillar-copperlist` — dump the Copper list from a log at `/tmp/caterpillar.copper`.
-- `just caterpillar-rendercfg` — open the rendered `copperconfig.ron` via the built `copper-rendercfg` binary.
-- `just caterpillar-logreader` — extract logs from `logs/caterpillar.copper` into `../../target/debug/copper_log_index`.
-- `just caterpillar-resim` — rerun the logged mission from `logs/caterpillar.copper`.
-- `just caterpillar-cross-armv7` — cross-compile for armv7 and scp the binary to `copper7:copper`.
+- `just cl` — dump the Copper list from a log at `logs/caterpillar.copper`.
+- `just logreader` — extract logs from `logs/caterpillar.copper` into `../../target/debug/cu29_log_index`.
+- `just resim` — rerun the logged mission from `logs/caterpillar.copper`.

--- a/examples/cu_caterpillar/justfile
+++ b/examples/cu_caterpillar/justfile
@@ -3,12 +3,12 @@ import "../../justfile"
 cl:
 	#!/usr/bin/env bash
 	set -euo pipefail
-	RUST_BACKTRACE=1 cargo run --bin logreader /tmp/caterpillar.copper extract-copperlist
+	RUST_BACKTRACE=1 cargo run --bin cu-caterpillar-logreader logs/caterpillar.copper extract-copperlists
 
 logreader:
 	#!/usr/bin/env bash
 	set -euo pipefail
-	RUST_BACKTRACE=1 cargo run --bin cu-caterpillar-logreader logs/caterpillar.copper extract-log ../../target/debug/copper_log_index
+	RUST_BACKTRACE=1 cargo run --bin cu-caterpillar-logreader logs/caterpillar.copper extract-text-log ../../target/debug/cu29_log_index
 
 resim:
 	#!/usr/bin/env bash


### PR DESCRIPTION
Fixes incorrect params in `cu_caterpillar` justfile commands.
Related PR: #542 introduces justfile for this example to replace old bash script (not working anymore at that stage)