### PR TITLE
[BREAKING] update config parsing to propagate types errors

### DIFF
--- a/components/bridges/cu_bdshot/src/bridge.rs
+++ b/components/bridges/cu_bdshot/src/bridge.rs
@@ -64,7 +64,7 @@ impl<P: BdshotBoardProvider> CuBridge for CuBdshotBridge<P> {
             active[ch.channel.id.as_index()] = true;
         }
         let send_interval = if let Some(cfg) = config {
-            if let Some(rate_hz) = cfg.get::<f64>("rate_hz") {
+            if let Some(rate_hz) = cfg.get::<f64>("rate_hz")? {
                 if rate_hz <= 0.0 {
                     return Err(CuError::from("BDShot rate_hz must be > 0"));
                 }

--- a/components/bridges/cu_crsf/src/lib.rs
+++ b/components/bridges/cu_crsf/src/lib.rs
@@ -241,14 +241,14 @@ impl ResourceBundle for StdSerialBundle {
                 bundle.bundle_id()
             ))
         })?;
-        let path = cfg.get::<String>(SERIAL_PATH_KEY).ok_or_else(|| {
+        let path = cfg.get::<String>(SERIAL_PATH_KEY)?.ok_or_else(|| {
             CuError::from(format!(
                 "CRSF serial bundle `{}` missing `serial_path` entry",
                 bundle.bundle_id()
             ))
         })?;
-        let baud = cfg.get::<u32>(SERIAL_BAUD_KEY).unwrap_or(420_000);
-        let timeout_ms = cfg.get::<u32>(SERIAL_TIMEOUT_KEY).unwrap_or(100) as u64;
+        let baud = cfg.get::<u32>(SERIAL_BAUD_KEY)?.unwrap_or(420_000);
+        let timeout_ms = cfg.get::<u32>(SERIAL_TIMEOUT_KEY)?.unwrap_or(100) as u64;
 
         let serial = std_serial::open(&path, baud, timeout_ms).map_err(|err| {
             CuError::from(format!(

--- a/components/bridges/cu_msp_bridge/src/lib.rs
+++ b/components/bridges/cu_msp_bridge/src/lib.rs
@@ -407,11 +407,11 @@ impl ResourceBundle for StdSerialBundle {
             ))
         })?;
         let device = cfg
-            .get::<String>(DEVICE_KEY)
+            .get::<String>(DEVICE_KEY)?
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| DEFAULT_DEVICE.to_string());
-        let baudrate = cfg.get::<u32>(BAUD_KEY).unwrap_or(DEFAULT_BAUDRATE);
-        let timeout_ms = cfg.get::<u64>(TIMEOUT_KEY).unwrap_or(DEFAULT_TIMEOUT_MS);
+        let baudrate = cfg.get::<u32>(BAUD_KEY)?.unwrap_or(DEFAULT_BAUDRATE);
+        let timeout_ms = cfg.get::<u64>(TIMEOUT_KEY)?.unwrap_or(DEFAULT_TIMEOUT_MS);
 
         let serial = std_serial::open(&device, baudrate, timeout_ms).map_err(|err| {
             CuError::from(format!(

--- a/components/bridges/cu_zenoh_bridge/src/lib.rs
+++ b/components/bridges/cu_zenoh_bridge/src/lib.rs
@@ -87,12 +87,12 @@ where
 {
     fn parse_session_config(config: Option<&ComponentConfig>) -> CuResult<Config> {
         if let Some(config) = config {
-            if let Some(path) = config.get::<String>("zenoh_config_file") {
+            if let Some(path) = config.get::<String>("zenoh_config_file")? {
                 return Config::from_file(&path).map_err(|e| {
                     CuError::from(format!("ZenohBridge: Failed to read config file: {e}"))
                 });
             }
-            if let Some(json) = config.get::<String>("zenoh_config_json") {
+            if let Some(json) = config.get::<String>("zenoh_config_json")? {
                 return Config::from_json5(&json).map_err(|e| {
                     CuError::from(format!("ZenohBridge: Failed to parse config json: {e}"))
                 });
@@ -103,7 +103,7 @@ where
 
     fn parse_default_wire_format(config: Option<&ComponentConfig>) -> CuResult<WireFormat> {
         if let Some(config) = config
-            && let Some(raw) = config.get::<String>("wire_format")
+            && let Some(raw) = config.get::<String>("wire_format")?
         {
             return WireFormat::parse(&raw).ok_or_else(|| {
                 CuError::from(format!(
@@ -131,7 +131,7 @@ where
         default: WireFormat,
     ) -> CuResult<WireFormat> {
         if let Some(config) = channel.config.as_ref()
-            && let Some(raw) = config.get::<String>("wire_format")
+            && let Some(raw) = config.get::<String>("wire_format")?
         {
             return WireFormat::parse(&raw).ok_or_else(|| {
                 CuError::from(format!(

--- a/components/res/cu_micoairh743/src/lib.rs
+++ b/components/res/cu_micoairh743/src/lib.rs
@@ -338,9 +338,10 @@ impl ResourceBundle for MicoAirH743 {
             overrun_period_cycles,
         );
 
-        let uart2_baud = _config
-            .and_then(|cfg| cfg.get::<u32>("uart2_baud"))
-            .unwrap_or(UART2_BAUD);
+        let uart2_baud = match _config {
+            Some(cfg) => cfg.get::<u32>("uart2_baud")?.unwrap_or(UART2_BAUD),
+            None => UART2_BAUD,
+        };
         let uart2_config = Config::default().baudrate(uart2_baud.bps());
         let uart2 = SerialWrapper::new(
             dp.USART2
@@ -355,9 +356,10 @@ impl ResourceBundle for MicoAirH743 {
             overrun_period_cycles,
         );
 
-        let uart4_baud = _config
-            .and_then(|cfg| cfg.get::<u32>("uart4_baud"))
-            .unwrap_or(UART4_BAUD);
+        let uart4_baud = match _config {
+            Some(cfg) => cfg.get::<u32>("uart4_baud")?.unwrap_or(UART4_BAUD),
+            None => UART4_BAUD,
+        };
         let uart4_config = Config::default().baudrate(uart4_baud.bps());
         let uart4 = SerialWrapper::new(
             dp.UART4

--- a/components/sinks/cu_iceoryx2_sink/src/lib.rs
+++ b/components/sinks/cu_iceoryx2_sink/src/lib.rs
@@ -38,7 +38,7 @@ where
         Self: Sized,
     {
         let config = config.ok_or_else(|| CuError::from("IceoryxSink: Missing configuration."))?;
-        let service_name_str = config.get::<String>("service").ok_or_else(|| {
+        let service_name_str = config.get::<String>("service")?.ok_or_else(|| {
             CuError::from("IceoryxSink: Configuration requires 'service' key (string).")
         })?;
 

--- a/components/sinks/cu_rp_sn754410/src/lib.rs
+++ b/components/sinks/cu_rp_sn754410/src/lib.rs
@@ -138,8 +138,8 @@ impl CuSinkTask for SN754410 {
     {
         let (deadzone, dryrun) = match config {
             Some(config) => (
-                config.get::<f64>("deadzone").unwrap_or(0.0) as f32,
-                config.get::<bool>("dryrun").unwrap_or(false),
+                config.get::<f64>("deadzone")?.unwrap_or(0.0) as f32,
+                config.get::<bool>("dryrun")?.unwrap_or(false),
             ),
             None => (0.0, false),
         };

--- a/components/sinks/cu_zenoh_ros_sink/src/lib.rs
+++ b/components/sinks/cu_zenoh_ros_sink/src/lib.rs
@@ -72,7 +72,7 @@ where
         let config = config.ok_or(CuError::from("ZenohRosSink: Missing configuration"))?;
 
         // Get json zenoh config
-        let session_config = match config.get::<String>("zenoh_config_json") {
+        let session_config = match config.get::<String>("zenoh_config_json")? {
             Some(json) => Config::from_json5(&json)
                 .map_err(cu_error_map("ZenohRosSink: Failed to create zenoh config"))?,
             None => Config::default(),
@@ -82,10 +82,10 @@ where
             _marker: Default::default(),
             config: ZenohRosConfig {
                 session: session_config,
-                domain_id: config.get::<u32>("domain_id").unwrap_or(0),
-                namespace: config.get::<String>("namespace").unwrap_or("node".into()),
-                node: config.get::<String>("node").unwrap_or("node".into()),
-                topic: config.get::<String>("topic").unwrap_or("copper".into()),
+                domain_id: config.get::<u32>("domain_id")?.unwrap_or(0),
+                namespace: config.get::<String>("namespace")?.unwrap_or("node".into()),
+                node: config.get::<String>("node")?.unwrap_or("node".into()),
+                topic: config.get::<String>("topic")?.unwrap_or("copper".into()),
             },
             ctx: None,
         })

--- a/components/sinks/cu_zenoh_sink/src/lib.rs
+++ b/components/sinks/cu_zenoh_sink/src/lib.rs
@@ -53,13 +53,15 @@ where
         let config = config.ok_or(CuError::from("ZenohSink: Missing configuration"))?;
 
         // Get json zenoh config
-        let session_config = match config.get::<String>("zenoh_config_file") {
+        let session_config = match config.get::<String>("zenoh_config_file")? {
             Some(path) => Config::from_file(&path)
                 .map_err(cu_error_map("ZenohSink: Failed to create zenoh config"))?,
             None => Config::default(),
         };
 
-        let topic = config.get::<String>("topic").unwrap_or("copper".to_owned());
+        let topic = config
+            .get::<String>("topic")?
+            .unwrap_or("copper".to_owned());
 
         Ok(Self {
             _marker: Default::default(),

--- a/components/sources/cu_ads7883/src/lib.rs
+++ b/components/sources/cu_ads7883/src/lib.rs
@@ -100,9 +100,9 @@ impl CuSrcTask for ADS7883 {
         match config {
             #[allow(unused_variables)]
             Some(config) => {
-                let maybe_string: Option<String> = config.get::<String>("spi_dev");
+                let maybe_string: Option<String> = config.get::<String>("spi_dev")?;
                 let maybe_spidev: Option<&str> = maybe_string.as_deref();
-                let maybe_max_speed_hz: Option<u32> = config.get("max_speed_hz");
+                let maybe_max_speed_hz: Option<u32> = config.get("max_speed_hz")?;
 
                 #[cfg(hardware)]
                 let spi = open_spi(maybe_spidev, maybe_max_speed_hz).map_err(|e| {

--- a/components/sources/cu_gstreamer/src/cu_gstreamer_impl.rs
+++ b/components/sources/cu_gstreamer/src/cu_gstreamer_impl.rs
@@ -101,7 +101,7 @@ impl<const N: usize> CuSrcTask for CuGStreamer<N> {
 
         let config = config.ok_or_else(|| CuError::from("No config provided."))?;
 
-        let pipeline = if let Some(pipeline_str) = config.get::<String>("pipeline") {
+        let pipeline = if let Some(pipeline_str) = config.get::<String>("pipeline")? {
             debug!("Creating with pipeline: {}", &pipeline_str);
             let pipeline = parse::launch(pipeline_str.as_str())
                 .map_err(|e| CuError::new_with_cause("Failed to parse pipeline.", e))?;
@@ -109,7 +109,7 @@ impl<const N: usize> CuSrcTask for CuGStreamer<N> {
         } else {
             Err(CuError::from("No pipeline provided."))
         }?;
-        let caps_str = if let Some(caps_str) = config.get::<String>("caps") {
+        let caps_str = if let Some(caps_str) = config.get::<String>("caps")? {
             debug!("Creating with caps: {}", &caps_str);
             Ok(caps_str)
         } else {

--- a/components/sources/cu_hesai/src/lib.rs
+++ b/components/sources/cu_hesai/src/lib.rs
@@ -67,7 +67,9 @@ impl CuSrcTask for Xt32 {
         Self: Sized,
     {
         let addr: SocketAddr = if let Some(cfg) = config {
-            let addr_str = cfg.get("socket_addr").unwrap_or(DEFAULT_ADDR.to_string());
+            let addr_str = cfg
+                .get::<String>("socket_addr")?
+                .unwrap_or(DEFAULT_ADDR.to_string());
             addr_str.as_str().parse().unwrap()
         } else {
             DEFAULT_ADDR.parse().unwrap()

--- a/components/sources/cu_iceoryx2_src/src/lib.rs
+++ b/components/sources/cu_iceoryx2_src/src/lib.rs
@@ -45,7 +45,7 @@ where
     {
         let config =
             config.ok_or_else(|| CuError::from("IceoryxSource: Missing configuration."))?;
-        let service_name_str = config.get::<String>("service").ok_or_else(|| {
+        let service_name_str = config.get::<String>("service")?.ok_or_else(|| {
             CuError::from("IceoryxSource: Configuration requires 'service' key (string).")
         })?;
 

--- a/components/sources/cu_livox/src/lib.rs
+++ b/components/sources/cu_livox/src/lib.rs
@@ -36,7 +36,9 @@ impl CuSrcTask for Tele15 {
         Self: Sized,
     {
         let addr: SocketAddr = if let Some(cfg) = config {
-            let addr_str = cfg.get("socket_addr").unwrap_or(DEFAULT_ADDR.to_string());
+            let addr_str = cfg
+                .get::<String>("socket_addr")?
+                .unwrap_or(DEFAULT_ADDR.to_string());
             addr_str.as_str().parse().unwrap()
         } else {
             DEFAULT_ADDR.parse().unwrap()

--- a/components/sources/cu_mpu9250/src/embedded_hal.rs
+++ b/components/sources/cu_mpu9250/src/embedded_hal.rs
@@ -36,18 +36,24 @@ pub struct EmbeddedHalSettings {
 }
 
 impl EmbeddedHalSettings {
-    pub fn from_config(config: Option<&ComponentConfig>) -> Self {
-        let gyro_cal_ms = config
-            .and_then(|cfg| cfg.get("gyro_cal_ms"))
-            .unwrap_or(DEFAULT_GYRO_CAL_MS);
-        let gyro_sample_delay_ms = config
-            .and_then(|cfg| cfg.get("gyro_sample_delay_ms"))
-            .unwrap_or(DEFAULT_GYRO_SAMPLE_DELAY_MS);
+    pub fn from_config(config: Option<&ComponentConfig>) -> CuResult<Self> {
+        let gyro_cal_ms = match config {
+            Some(cfg) => cfg
+                .get::<u32>("gyro_cal_ms")?
+                .unwrap_or(DEFAULT_GYRO_CAL_MS),
+            None => DEFAULT_GYRO_CAL_MS,
+        };
+        let gyro_sample_delay_ms = match config {
+            Some(cfg) => cfg
+                .get::<u32>("gyro_sample_delay_ms")?
+                .unwrap_or(DEFAULT_GYRO_SAMPLE_DELAY_MS),
+            None => DEFAULT_GYRO_SAMPLE_DELAY_MS,
+        };
 
-        Self {
+        Ok(Self {
             gyro_cal_ms,
             gyro_sample_delay_ms,
-        }
+        })
     }
 }
 

--- a/components/sources/cu_mpu9250/src/lib.rs
+++ b/components/sources/cu_mpu9250/src/lib.rs
@@ -122,17 +122,20 @@ where
     type Output<'m> = output_msg!(ImuPayload);
 
     fn new(config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self> {
-        let settings = embedded_hal::EmbeddedHalSettings::from_config(config);
+        let settings = embedded_hal::EmbeddedHalSettings::from_config(config)?;
 
-        let spi_slot = config
-            .and_then(|cfg| cfg.get::<u32>("spi_slot"))
-            .unwrap_or(0) as usize;
-        let cs_slot = config
-            .and_then(|cfg| cfg.get::<u32>("cs_slot"))
-            .unwrap_or(0) as usize;
-        let delay_slot = config
-            .and_then(|cfg| cfg.get::<u32>("delay_slot"))
-            .unwrap_or(0) as usize;
+        let spi_slot = match config {
+            Some(cfg) => cfg.get::<u32>("spi_slot")?.unwrap_or(0) as usize,
+            None => 0,
+        };
+        let cs_slot = match config {
+            Some(cfg) => cfg.get::<u32>("cs_slot")?.unwrap_or(0) as usize,
+            None => 0,
+        };
+        let delay_slot = match config {
+            Some(cfg) => cfg.get::<u32>("delay_slot")?.unwrap_or(0) as usize,
+            None => 0,
+        };
 
         let spi: SPI = reg::take_spi(spi_slot).ok_or_else(|| {
             CuError::from(format!(

--- a/components/sources/cu_rp_encoder/src/lib.rs
+++ b/components/sources/cu_rp_encoder/src/lib.rs
@@ -62,14 +62,13 @@ impl CuSrcTask for Encoder {
     where
         Self: Sized,
     {
-        let ComponentConfig(config) =
-            config.ok_or("Encoder needs a config with clk_pin and dat_pin.")?;
-
-        let clk_pin_nb_value = config.get("clk_pin").ok_or("Encoder needs a clk_pin")?;
-        let clk_pin: u8 = clk_pin_nb_value.clone().into();
-
-        let dat_pin_nb_value = config.get("dat_pin").ok_or("Encoder needs a dat_pin")?;
-        let dat_pin: u8 = dat_pin_nb_value.clone().into();
+        let config = config.ok_or("Encoder needs a config with clk_pin and dat_pin.")?;
+        let clk_pin = config
+            .get::<u8>("clk_pin")?
+            .ok_or("Encoder needs a clk_pin")?;
+        let dat_pin = config
+            .get::<u8>("dat_pin")?
+            .ok_or("Encoder needs a dat_pin")?;
 
         let clk_pin: InputPin = get_pin(clk_pin)?;
         let dat_pin: InputPin = get_pin(dat_pin)?;

--- a/components/sources/cu_v4l/src/lib.rs
+++ b/components/sources/cu_v4l/src/lib.rs
@@ -88,25 +88,25 @@ mod linux_impl {
             let mut req_timeout: Duration = Duration::from_millis(500); // 500ms tolerance to get a frame
 
             if let Some(config) = _config {
-                if let Some(device) = config.get::<u32>("device") {
+                if let Some(device) = config.get::<u32>("device")? {
                     v4l_device = device as usize;
                 }
-                if let Some(width) = config.get::<u32>("width") {
+                if let Some(width) = config.get::<u32>("width")? {
                     req_width = Some(width);
                 }
-                if let Some(height) = config.get::<u32>("height") {
+                if let Some(height) = config.get::<u32>("height")? {
                     req_height = Some(height);
                 }
-                if let Some(fps) = config.get::<u32>("fps") {
+                if let Some(fps) = config.get::<u32>("fps")? {
                     req_fps = Some(fps);
                 }
-                if let Some(fourcc) = config.get::<String>("fourcc") {
+                if let Some(fourcc) = config.get::<String>("fourcc")? {
                     req_fourcc = Some(fourcc);
                 }
-                if let Some(buffers) = config.get::<u32>("buffers") {
+                if let Some(buffers) = config.get::<u32>("buffers")? {
                     req_buffers = buffers;
                 }
-                if let Some(timeout) = config.get::<u32>("timeout_ms") {
+                if let Some(timeout) = config.get::<u32>("timeout_ms")? {
                     req_timeout = Duration::from_millis(timeout as u64);
                 }
             }

--- a/components/sources/cu_vlp16/src/lib.rs
+++ b/components/sources/cu_vlp16/src/lib.rs
@@ -26,12 +26,17 @@ impl CuSrcTask for Vlp16 {
     where
         Self: Sized,
     {
-        let config: &ComponentConfig = config.expect("Vlp16 requires a config");
+        let config: &ComponentConfig =
+            config.ok_or_else(|| CuError::from("Vlp16 requires a config"))?;
         let listen_addr: String = config
-            .get("listen_addr")
+            .get::<String>("listen_addr")?
             .unwrap_or("0.0.0.0:2368".to_string());
-        let return_type: String = config.get("return_type").unwrap_or("last".to_string());
-        let test_mode: String = config.get("test_mode").unwrap_or("false".to_string());
+        let return_type: String = config
+            .get::<String>("return_type")?
+            .unwrap_or("last".to_string());
+        let test_mode: String = config
+            .get::<String>("test_mode")?
+            .unwrap_or("false".to_string());
         let velo_config = match return_type.as_str() {
             "strongest" => Config16::new_vlp_16_strongest(),
             "last" => Config16::new_vlp_16_last(),

--- a/components/tasks/cu_aligner/src/lib.rs
+++ b/components/tasks/cu_aligner/src/lib.rs
@@ -36,11 +36,11 @@ macro_rules! define_task {
             {
                 let config = config.ok_or_else(|| cu29::CuError::from("Config Missing"))?;
                 let target_alignment_window_ms: u64 = config
-                    .get::<u32>("target_alignment_window_ms")
+                    .get::<u32>("target_alignment_window_ms")?
                     .ok_or_else(|| cu29::CuError::from("Missing target_alignment_window"))?
                     .into();
                 let stale_data_horizon_ms: u64 = config
-                    .get::<u32>("stale_data_horizon_ms")
+                    .get::<u32>("stale_data_horizon_ms")?
                     .ok_or_else(|| cu29::CuError::from("Missing stale_data_horizon"))?
                     .into();
 

--- a/components/tasks/cu_apriltag/src/lib.rs
+++ b/components/tasks/cu_apriltag/src/lib.rs
@@ -195,14 +195,16 @@ impl CuTask for AprilTags {
         Self: Sized,
     {
         if let Some(config) = _config {
-            let family_cfg: String = config.get("family").unwrap_or(FAMILY.to_string());
+            let family_cfg = config
+                .get::<String>("family")?
+                .unwrap_or(FAMILY.to_string());
             let family: Family = family_cfg.parse().unwrap();
-            let bits_corrected: u32 = config.get("bits_corrected").unwrap_or(1);
-            let tagsize = config.get("tag_size").unwrap_or(TAG_SIZE);
-            let fx = config.get("fx").unwrap_or(FX);
-            let fy = config.get("fy").unwrap_or(FY);
-            let cx = config.get("cx").unwrap_or(CX);
-            let cy = config.get("cy").unwrap_or(CY);
+            let bits_corrected: u32 = config.get::<u32>("bits_corrected")?.unwrap_or(1);
+            let tagsize = config.get::<f64>("tag_size")?.unwrap_or(TAG_SIZE);
+            let fx = config.get::<f64>("fx")?.unwrap_or(FX);
+            let fy = config.get::<f64>("fy")?.unwrap_or(FY);
+            let cx = config.get::<f64>("cx")?.unwrap_or(CX);
+            let cy = config.get::<f64>("cy")?.unwrap_or(CY);
             let tag_params = TagParams {
                 fx,
                 fy,

--- a/components/tasks/cu_dynthreshold/src/cu_dynthreshold_impl.rs
+++ b/components/tasks/cu_dynthreshold/src/cu_dynthreshold_impl.rs
@@ -121,12 +121,16 @@ impl CuTask for DynThreshold {
     where
         Self: Sized,
     {
-        let config = config.expect("No config provided");
-        let width = config.get::<u32>("width").expect("No width provided");
-        let height = config.get::<u32>("height").expect("No height provided");
+        let config = config.ok_or_else(|| CuError::from("No config provided"))?;
+        let width = config
+            .get::<u32>("width")?
+            .ok_or_else(|| CuError::from("No width provided"))?;
+        let height = config
+            .get::<u32>("height")?
+            .ok_or_else(|| CuError::from("No height provided"))?;
         let block_radius = config
-            .get::<u32>("block_radius")
-            .expect("No block_radius provided");
+            .get::<u32>("block_radius")?
+            .ok_or_else(|| CuError::from("No block_radius provided"))?;
 
         let pool =
             CuHostMemoryPool::new("dynthreshold", 3, || vec![0u8; (width * height) as usize])?;

--- a/components/tasks/cu_ratelimit/src/lib.rs
+++ b/components/tasks/cu_ratelimit/src/lib.rs
@@ -37,9 +37,12 @@ where
     type Output<'m> = output_msg!(T);
 
     fn new(config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self> {
-        let hz = config
-            .and_then(|cfg| cfg.get::<f64>("rate"))
-            .ok_or("Missing required 'rate' config for CuRateLimiter")?;
+        let hz = match config {
+            Some(cfg) => cfg
+                .get::<f64>("rate")?
+                .ok_or("Missing required 'rate' config for CuRateLimiter")?,
+            None => return Err("Missing required 'rate' config for CuRateLimiter".into()),
+        };
         let interval_ns = (1e9 / hz) as u64;
         Ok(Self {
             _marker: PhantomData,

--- a/core/cu29_clock/Cargo.toml
+++ b/core/cu29_clock/Cargo.toml
@@ -19,7 +19,7 @@ portable-atomic = { version = "1.11", default-features = false, features = [
 ] }
 
 [target.'cfg(all(target_arch = "arm", target_os = "none"))'.dependencies]
-cortex-m = { version = "0.7", features = ["critical-section"] }
+cortex-m = { version = "0.7" }
 
 [dev-dependencies]
 approx = "0.5"

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -1550,7 +1550,10 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
         let config_load_stmt = if std {
             quote! {
                 let config = if let Some(overridden_config) = config_override {
-                    debug!("CuConfig: Overridden programmatically: {}", overridden_config.serialize_ron());
+                    let serialized = overridden_config
+                        .serialize_ron()
+                        .unwrap_or_else(|err| format!("<failed to serialize config: {err}>"));
+                    debug!("CuConfig: Overridden programmatically: {}", serialized);
                     overridden_config
                 } else if ::std::path::Path::new(config_filename).exists() {
                     debug!("CuConfig: Reading configuration from file: {}", config_filename);

--- a/core/cu29_runtime/src/cubridge.rs
+++ b/core/cu29_runtime/src/cubridge.rs
@@ -579,7 +579,7 @@ mod tests {
         ) -> CuResult<Self> {
             let mut instance = ExampleBridge::default();
             if let Some(cfg) = config
-                && let Some(port) = cfg.get::<String>("port")
+                && let Some(port) = cfg.get::<String>("port")?
             {
                 instance.port = port;
             }

--- a/core/cu29_runtime/src/resource.rs
+++ b/core/cu29_runtime/src/resource.rs
@@ -410,10 +410,13 @@ impl ResourceBundle for ThreadPoolBundle {
         use rayon::ThreadPoolBuilder;
 
         const DEFAULT_THREADS: usize = 2;
-        let threads: usize = config
-            .and_then(|cfg| cfg.get::<u64>("threads"))
-            .map(|v| v as usize)
-            .unwrap_or(DEFAULT_THREADS);
+        let threads: usize = match config {
+            Some(cfg) => cfg
+                .get::<u64>("threads")?
+                .map(|v| v as usize)
+                .unwrap_or(DEFAULT_THREADS),
+            None => DEFAULT_THREADS,
+        };
 
         let pool = ThreadPoolBuilder::new()
             .num_threads(threads)

--- a/core/cu29_runtime/tests/includes.rs
+++ b/core/cu29_runtime/tests/includes.rs
@@ -110,7 +110,11 @@ mod tests {
         let (_, node) = all_nodes[0];
         assert_eq!(node.get_id(), "task_42");
         assert_eq!(node.get_type(), "tasks::Task42");
-        assert_eq!(node.get_param::<i32>("param_value").unwrap(), 100);
+        assert_eq!(
+            node.get_param::<i32>("param_value")
+                .expect("param_value lookup failed"),
+            Some(100)
+        );
     }
 
     #[test]
@@ -271,7 +275,12 @@ mod tests {
             .1;
 
         assert_eq!(common_task.get_type(), "tasks::MainTask");
-        assert_eq!(common_task.get_param::<i32>("param").unwrap(), 20);
+        assert_eq!(
+            common_task
+                .get_param::<i32>("param")
+                .expect("param lookup failed"),
+            Some(20)
+        );
 
         assert_eq!(
             config.monitor.as_ref().unwrap().get_type(),
@@ -425,7 +434,11 @@ mod tests {
             assert_eq!(camera.get_type(), "cu_camera::Camera");
 
             let expected_port = format!("/dev/video{id}");
-            assert_eq!(camera.get_param::<String>("port").unwrap(), expected_port);
+            let port = camera
+                .get_param::<String>("port")
+                .expect("port lookup failed")
+                .expect("missing port");
+            assert_eq!(port, expected_port);
         }
 
         // Verify detector tasks with correct thresholds
@@ -442,7 +455,10 @@ mod tests {
             let detector = detect_task.unwrap();
             assert_eq!(detector.get_type(), "cu_detector::Detector");
 
-            let threshold = detector.get_param::<f64>("threshold").unwrap();
+            let threshold = detector
+                .get_param::<f64>("threshold")
+                .expect("threshold lookup failed")
+                .expect("missing threshold");
             assert_eq!(threshold, expected_thresholds[id]);
         }
 

--- a/core/cu29_runtime/tests/modular_config.rs
+++ b/core/cu29_runtime/tests/modular_config.rs
@@ -112,11 +112,16 @@ mod tests {
             .1;
 
         assert_eq!(left_motor.get_type(), "tasks::RPGpio");
-        assert_eq!(left_motor.get_param::<i32>("pin").unwrap(), 4);
         assert_eq!(
-            left_motor.get_param::<String>("direction").unwrap(),
-            "forward"
+            left_motor
+                .get_param::<i32>("pin")
+                .expect("pin lookup failed"),
+            Some(4)
         );
+        let left_direction = left_motor
+            .get_param::<String>("direction")
+            .expect("direction lookup failed");
+        assert_eq!(left_direction.as_deref(), Some("forward"));
 
         // Verify parameter substitution for the right motor
         let right_motor = all_nodes
@@ -126,11 +131,16 @@ mod tests {
             .1;
 
         assert_eq!(right_motor.get_type(), "tasks::RPGpio");
-        assert_eq!(right_motor.get_param::<i32>("pin").unwrap(), 5);
         assert_eq!(
-            right_motor.get_param::<String>("direction").unwrap(),
-            "reverse"
+            right_motor
+                .get_param::<i32>("pin")
+                .expect("pin lookup failed"),
+            Some(5)
         );
+        let right_direction = right_motor
+            .get_param::<String>("direction")
+            .expect("direction lookup failed");
+        assert_eq!(right_direction.as_deref(), Some("reverse"));
 
         // Get the graph and verify connections
         let graph = config.graphs.get_graph(None).unwrap();
@@ -294,7 +304,12 @@ mod tests {
             .1;
 
         assert_eq!(front_sensor.get_type(), "tasks::SensorInfrared");
-        assert_eq!(front_sensor.get_param::<i32>("rate").unwrap(), 20);
+        assert_eq!(
+            front_sensor
+                .get_param::<i32>("rate")
+                .expect("rate lookup failed"),
+            Some(20)
+        );
 
         // Verify rear sensor parameters
         let rear_sensor = all_nodes
@@ -304,7 +319,12 @@ mod tests {
             .1;
 
         assert_eq!(rear_sensor.get_type(), "tasks::SensorUltrasonic");
-        assert_eq!(rear_sensor.get_param::<i32>("rate").unwrap(), 10);
+        assert_eq!(
+            rear_sensor
+                .get_param::<i32>("rate")
+                .expect("rate lookup failed"),
+            Some(10)
+        );
 
         // Verify front processor parameters
         let front_processor = all_nodes
@@ -313,7 +333,12 @@ mod tests {
             .unwrap()
             .1;
 
-        assert_eq!(front_processor.get_param::<f64>("threshold").unwrap(), 0.75);
+        assert_eq!(
+            front_processor
+                .get_param::<f64>("threshold")
+                .expect("threshold lookup failed"),
+            Some(0.75)
+        );
 
         // Verify rear processor parameters
         let rear_processor = all_nodes
@@ -322,7 +347,12 @@ mod tests {
             .unwrap()
             .1;
 
-        assert_eq!(rear_processor.get_param::<f64>("threshold").unwrap(), 0.5);
+        assert_eq!(
+            rear_processor
+                .get_param::<f64>("threshold")
+                .expect("threshold lookup failed"),
+            Some(0.5)
+        );
 
         // Get the graph and verify connections
         let graph = config.graphs.get_graph(None).unwrap();
@@ -450,8 +480,16 @@ mod tests {
             .1;
 
         assert_eq!(source.get_type(), "tasks::CustomSource");
-        assert_eq!(source.get_param::<String>("param").unwrap(), "custom");
-        assert!(source.get_param::<bool>("additional").unwrap());
+        let source_param = source
+            .get_param::<String>("param")
+            .expect("param lookup failed");
+        assert_eq!(source_param.as_deref(), Some("custom"));
+        assert_eq!(
+            source
+                .get_param::<bool>("additional")
+                .expect("additional lookup failed"),
+            Some(true)
+        );
 
         // Verify processor remains from base config
         let processor = all_nodes

--- a/examples/cu_background_task/src/main.rs
+++ b/examples/cu_background_task/src/main.rs
@@ -43,7 +43,10 @@ pub mod tasks {
         where
             Self: Sized,
         {
-            let sleep_duration_ms: u64 = config.unwrap().get("sleep_duration_ms").unwrap();
+            let config = config.ok_or_else(|| CuError::from("Missing config"))?;
+            let sleep_duration_ms = config
+                .get::<u64>("sleep_duration_ms")?
+                .ok_or_else(|| CuError::from("Missing sleep_duration_ms"))?;
             Ok(Self { sleep_duration_ms })
         }
 

--- a/examples/cu_config_gen/src/main.rs
+++ b/examples/cu_config_gen/src/main.rs
@@ -18,5 +18,10 @@ fn main() {
 
     graph.connect(n2, n1, "imgmsgpkg::Image").unwrap();
     graph.connect(n1, n3, "imgmsgpkg::Image").unwrap();
-    println!("{}", copperconfig.serialize_ron());
+    println!(
+        "{}",
+        copperconfig
+            .serialize_ron()
+            .expect("Failed to serialize configuration")
+    );
 }

--- a/examples/cu_flight_controller/src/tasks/battery.rs
+++ b/examples/cu_flight_controller/src/tasks/battery.rs
@@ -22,15 +22,15 @@ impl CuSrcTask for BatteryAdcSource {
     where
         Self: Sized,
     {
-        let vref_mv = cfg_u32(config, "vref_mv", BATTERY_VREF_MV_DEFAULT).max(1);
-        let vbat_scale = cfg_u32(config, "vbat_scale", BATTERY_VBAT_SCALE_DEFAULT);
+        let vref_mv = cfg_u32(config, "vref_mv", BATTERY_VREF_MV_DEFAULT)?.max(1);
+        let vbat_scale = cfg_u32(config, "vbat_scale", BATTERY_VBAT_SCALE_DEFAULT)?;
         let vbat_res_div_val =
-            cfg_u32(config, "vbat_res_div_val", BATTERY_VBAT_RES_DIV_VAL_DEFAULT).max(1);
+            cfg_u32(config, "vbat_res_div_val", BATTERY_VBAT_RES_DIV_VAL_DEFAULT)?.max(1);
         let vbat_res_div_mult = cfg_u32(
             config,
             "vbat_res_div_mult",
             BATTERY_VBAT_RES_DIV_MULT_DEFAULT,
-        )
+        )?
         .max(1);
         Ok(Self {
             adc: resources.battery_adc.0,

--- a/examples/cu_flight_controller/src/tasks/vtx.rs
+++ b/examples/cu_flight_controller/src/tasks/vtx.rs
@@ -46,22 +46,22 @@ impl CuTask for VtxOsd {
     where
         Self: Sized,
     {
-        let cols = tasks::cfg_u16(config, "cols", 53)
+        let cols = tasks::cfg_u16(config, "cols", 53)?
             .max(1)
             .min(u8::MAX as u16) as u8;
-        let rows = tasks::cfg_u16(config, "rows", 16)
+        let rows = tasks::cfg_u16(config, "rows", 16)?
             .max(1)
             .min(u8::MAX as u16) as u8;
         let default_center = (cols / 2) as u16;
-        let col_center = tasks::cfg_u16(config, "col_center", default_center)
+        let col_center = tasks::cfg_u16(config, "col_center", default_center)?
             .min(cols.saturating_sub(1) as u16) as u8;
-        let row = tasks::cfg_u16(config, "row", 13).min(u8::MAX as u16) as u8;
+        let row = tasks::cfg_u16(config, "row", 13)?.min(u8::MAX as u16) as u8;
         let watermark_height = VTX_WATERMARK_LINES.len() as u8;
         let default_watermark_row = rows.saturating_sub(watermark_height);
-        let watermark_row = tasks::cfg_u16(config, "watermark_row", default_watermark_row as u16)
+        let watermark_row = tasks::cfg_u16(config, "watermark_row", default_watermark_row as u16)?
             .min(rows.saturating_sub(1) as u16) as u8;
         let watermark_col =
-            tasks::cfg_u16(config, "watermark_col", 0).min(cols.saturating_sub(1) as u16) as u8;
+            tasks::cfg_u16(config, "watermark_col", 0)?.min(cols.saturating_sub(1) as u16) as u8;
         Ok(Self {
             row,
             cols,
@@ -355,39 +355,42 @@ impl CuTask for VtxMspResponder {
     where
         Self: Sized,
     {
-        let vbat_scale = tasks::cfg_u32(config, "vbat_scale", BATTERY_VBAT_SCALE_DEFAULT)
+        let vbat_scale = tasks::cfg_u32(config, "vbat_scale", BATTERY_VBAT_SCALE_DEFAULT)?
             .min(u32::from(u8::MAX)) as u8;
         let vbat_res_div_val =
-            tasks::cfg_u32(config, "vbat_res_div_val", BATTERY_VBAT_RES_DIV_VAL_DEFAULT)
+            tasks::cfg_u32(config, "vbat_res_div_val", BATTERY_VBAT_RES_DIV_VAL_DEFAULT)?
                 .max(1)
                 .min(u32::from(u8::MAX)) as u8;
         let vbat_res_div_mult = tasks::cfg_u32(
             config,
             "vbat_res_div_mult",
             BATTERY_VBAT_RES_DIV_MULT_DEFAULT,
-        )
+        )?
         .max(1)
         .min(u32::from(u8::MAX)) as u8;
-        let battery_capacity = tasks::cfg_u16(config, "battery_capacity_mah", 0);
+        let battery_capacity = tasks::cfg_u16(config, "battery_capacity_mah", 0)?;
         let vbat_min_cell_centivolts = tasks::cfg_u16(
             config,
             "vbat_min_cell_centivolts",
             BATTERY_MIN_CELL_CENTIVOLTS_DEFAULT,
-        );
+        )?;
         let vbat_max_cell_centivolts = tasks::cfg_u16(
             config,
             "vbat_max_cell_centivolts",
             BATTERY_MAX_CELL_CENTIVOLTS_DEFAULT,
-        );
+        )?;
         let vbat_warn_cell_centivolts = tasks::cfg_u16(
             config,
             "vbat_warn_cell_centivolts",
             BATTERY_WARN_CELL_CENTIVOLTS_DEFAULT,
-        );
-        let battery_cells = config
-            .and_then(|cfg| cfg.get::<u32>("battery_cells"))
-            .and_then(|cells| u8::try_from(cells).ok())
-            .filter(|cells| *cells > 0);
+        )?;
+        let battery_cells = match config {
+            Some(cfg) => cfg
+                .get::<u32>("battery_cells")?
+                .and_then(|cells| u8::try_from(cells).ok())
+                .filter(|cells| *cells > 0),
+            None => None,
+        };
         Ok(Self {
             last_voltage_centi: None,
             battery_cells,

--- a/examples/cu_human_pose/src/tasks/gst_to_image.rs
+++ b/examples/cu_human_pose/src/tasks/gst_to_image.rs
@@ -33,14 +33,14 @@ impl CuTask for GstToCuImage {
         let config = config.ok_or_else(|| CuError::from("GstToCuImage requires configuration"))?;
 
         let width = config
-            .get::<u32>("width")
+            .get::<u32>("width")?
             .ok_or_else(|| CuError::from("GstToCuImage requires width"))?;
         let height = config
-            .get::<u32>("height")
+            .get::<u32>("height")?
             .ok_or_else(|| CuError::from("GstToCuImage requires height"))?;
-        let fourcc = if let Some(fourcc) = config.get::<String>("fourcc") {
+        let fourcc = if let Some(fourcc) = config.get::<String>("fourcc")? {
             fourcc
-        } else if let Some(pixel_format) = config.get::<String>("pixel_format") {
+        } else if let Some(pixel_format) = config.get::<String>("pixel_format")? {
             pixel_format
         } else {
             return Err(CuError::from(
@@ -49,14 +49,14 @@ impl CuTask for GstToCuImage {
         };
         let pixel_format = fourcc_to_bytes(&fourcc)?;
         let stride = config
-            .get::<u32>("stride")
+            .get::<u32>("stride")?
             .unwrap_or_else(|| default_stride(width, pixel_format));
 
         // Calculate buffer size based on pixel format
         let buffer_size = compute_buffer_size(height, stride, pixel_format);
-        let pool_size = config.get::<u32>("pool_size").unwrap_or(4) as usize;
+        let pool_size = config.get::<u32>("pool_size")?.unwrap_or(4) as usize;
         let pool_id = config
-            .get::<String>("pool_id")
+            .get::<String>("pool_id")?
             .unwrap_or_else(|| "gst_image_pool".to_string());
 
         let pool = CuHostMemoryPool::new(&pool_id, pool_size, || vec![0u8; buffer_size])?;

--- a/examples/cu_human_pose/src/tasks/yolo_pose.rs
+++ b/examples/cu_human_pose/src/tasks/yolo_pose.rs
@@ -32,11 +32,11 @@ impl CuTask for YoloPose {
         let config = config.ok_or_else(|| CuError::from("YoloPose requires configuration"))?;
 
         let variant = config
-            .get::<String>("variant")
+            .get::<String>("variant")?
             .unwrap_or_else(|| "yolov8n-pose".to_string());
 
-        let conf_threshold = config.get::<f64>("conf_threshold").unwrap_or(0.25) as f32;
-        let iou_threshold = config.get::<f64>("iou_threshold").unwrap_or(0.7) as f32;
+        let conf_threshold = config.get::<f64>("conf_threshold")?.unwrap_or(0.25) as f32;
+        let iou_threshold = config.get::<f64>("iou_threshold")?.unwrap_or(0.7) as f32;
 
         // Determine model size from variant
         let multiples = match variant.as_str() {

--- a/examples/cu_image_aligner/src/tasks.rs
+++ b/examples/cu_image_aligner/src/tasks.rs
@@ -34,18 +34,18 @@ impl CuSrcTask for ImageSrcTask {
     {
         let config = config.ok_or_else(|| CuError::from("Missing config"))?;
         let width = config
-            .get::<u32>("width")
+            .get::<u32>("width")?
             .ok_or_else(|| CuError::from("Missing width"))?;
         let height = config
-            .get::<u32>("height")
+            .get::<u32>("height")?
             .ok_or_else(|| CuError::from("Missing height"))?;
-        let base_value = config.get::<u32>("base_value").unwrap_or(0) as u8;
-        let tov_offset_ms = config.get::<u32>("tov_offset_ms").unwrap_or(0);
+        let base_value = config.get::<u32>("base_value")?.unwrap_or(0) as u8;
+        let tov_offset_ms = config.get::<u32>("tov_offset_ms")?.unwrap_or(0);
         let pool_size = config
-            .get::<u32>("pool_size")
+            .get::<u32>("pool_size")?
             .unwrap_or((BUFFER_CAP + 1) as u32) as usize;
         let pool_id = config
-            .get::<String>("pool_id")
+            .get::<String>("pool_id")?
             .unwrap_or_else(|| "image_src_pool".to_string());
 
         if pool_size <= BUFFER_CAP {

--- a/examples/cu_resources_test/src/resources.rs
+++ b/examples/cu_resources_test/src/resources.rs
@@ -68,10 +68,16 @@ impl ResourceBundle for BoardBundle {
         config: Option<&cu29::config::ComponentConfig>,
         manager: &mut ResourceManager,
     ) -> CuResult<()> {
-        let label: String = config
-            .and_then(|cfg| cfg.get("label"))
-            .unwrap_or_else(|| format!("{}-bus", bundle.bundle_id()));
-        let offset: i64 = config.and_then(|cfg| cfg.get("offset")).unwrap_or(0);
+        let label: String = match config {
+            Some(cfg) => cfg
+                .get::<String>("label")?
+                .unwrap_or_else(|| format!("{}-bus", bundle.bundle_id())),
+            None => format!("{}-bus", bundle.bundle_id()),
+        };
+        let offset: i64 = match config {
+            Some(cfg) => cfg.get::<i64>("offset")?.unwrap_or(0),
+            None => 0,
+        };
 
         let bus_key = bundle.key(BoardBundleId::Bus);
         let counter_key = bundle.key(BoardBundleId::Counter);
@@ -95,9 +101,12 @@ impl ResourceBundle for ExtraBundle {
         config: Option<&cu29::config::ComponentConfig>,
         manager: &mut ResourceManager,
     ) -> CuResult<()> {
-        let note: String = config
-            .and_then(|cfg| cfg.get("note"))
-            .unwrap_or_else(|| format!("{}-note", bundle.bundle_id()));
+        let note: String = match config {
+            Some(cfg) => cfg
+                .get::<String>("note")?
+                .unwrap_or_else(|| format!("{}-note", bundle.bundle_id())),
+            None => format!("{}-note", bundle.bundle_id()),
+        };
         let note_key = bundle.key(ExtraBundleId::Note);
         manager.add_owned(note_key, note)?;
         Ok(())

--- a/examples/cu_zenoh_bridge_demo/src/lib.rs
+++ b/examples/cu_zenoh_bridge_demo/src/lib.rs
@@ -66,9 +66,12 @@ pub mod tasks {
         where
             Self: Sized,
         {
-            let label = config
-                .and_then(|cfg| cfg.get::<String>("label"))
-                .unwrap_or_else(|| "ping".to_string());
+            let label = match config {
+                Some(cfg) => cfg
+                    .get::<String>("label")?
+                    .unwrap_or_else(|| "ping".to_string()),
+                None => "ping".to_string(),
+            };
             Ok(Self { seq: 0, label })
         }
 
@@ -98,9 +101,12 @@ pub mod tasks {
         where
             Self: Sized,
         {
-            let label = config
-                .and_then(|cfg| cfg.get::<String>("label"))
-                .unwrap_or_else(|| "pong".to_string());
+            let label = match config {
+                Some(cfg) => cfg
+                    .get::<String>("label")?
+                    .unwrap_or_else(|| "pong".to_string()),
+                None => "pong".to_string(),
+            };
             Ok(Self { label })
         }
 
@@ -137,9 +143,12 @@ pub mod tasks {
         where
             Self: Sized,
         {
-            let label = config
-                .and_then(|cfg| cfg.get::<String>("label"))
-                .unwrap_or_else(|| "sink".to_string());
+            let label = match config {
+                Some(cfg) => cfg
+                    .get::<String>("label")?
+                    .unwrap_or_else(|| "sink".to_string()),
+                None => "sink".to_string(),
+            };
             Ok(Self { label })
         }
 


### PR DESCRIPTION
## Summary
This PR introduces a breaking change to config parsing throughout the Copper codebase. The core change is modifying ComponentConfig::get<T>() to return Result<Option<T>, ConfigError> instead of Option<T>, enabling type errors to propagate rather than being silently
  ignored.

## Details

- Core Changes (`core/cu29_runtime/src/config.rs`)

  1. New ConfigError type with proper error handling traits
  2. Changed `ComponentConfig::get<T>()` signature from `Option<T>` to `Result<Option<T>, ConfigError>`
  3. Added `TryFrom<&Value>` implementations for `bool`, `integers`, `f64`, and `String` with proper type-mismatch errors
  4. Updated `serialize_ron()` and `deserialize_ron()` to return `CuResult` instead of panicking
  5. Updated `render()` methods to propagate write errors instead of unwrapping

- Additional Improvements

  1. Mutex poisoning recovery in `cu29_log_runtime` and `cu29_unifiedlog`
  2. CUDA error handling improvements in pool.rs
  3. Test updates to use the new error-returning APIs
  4. Removed panic-based tests in favor of proper error assertions
  
## Migration Guide

- ComponentConfig::get<T>() Signature Change
  ```
  // Before:
  pub fn get<T: From<Value>>(&self, key: &str) -> Option<T>

  // After:
  pub fn get<T>(&self, key: &str) -> Result<Option<T>, ConfigError>
  where
      T: for<'a> TryFrom<&'a Value, Error = ConfigError>,
  ```
- Migration Pattern
  ```
  // Before
  let value: u32 = config.get("key").unwrap_or(default);

  // After
  let value: u32 = config.get::<u32>("key")?.unwrap_or(default);

  // Before
  let value = config.and_then(|cfg| cfg.get::<String>("key"));

  // After
  let value = match config {
      Some(cfg) => cfg.get::<String>("key")?,
      None => None,
  };
  ```
 - Related Changes

   1. `Node::get_param<T>()` - same signature change
   2. `CuConfig::serialize_ron()` - now returns `CuResult<String>` instead of String
   3. `CuConfig::deserialize_ron()` - now returns `CuResult<Self> `instead of panicking