### PR TITLE
[CHORE] linting and use rg to replace find

### DIFF
--- a/components/testing/cu_udp_inject/src/lib.rs
+++ b/components/testing/cu_udp_inject/src/lib.rs
@@ -32,9 +32,8 @@ impl PcapStreamer {
     /// Returns false if the end of the pcap file is reached
     pub fn send_next<const PS: usize>(&mut self) -> CuResult<bool> {
         // Get the next packet and check for end of stream
-        let packet = match self.capture.next_packet() {
-            Ok(packet) => packet,
-            Err(_) => return Ok(false), // End of the stream
+        let Ok(packet) = self.capture.next_packet() else {
+            return Ok(false); // End of the stream
         };
 
         // Assume 42-byte header (Ethernet + IP + UDP) and an optional 4-byte FCS

--- a/core/cu29_unifiedlog/src/lib.rs
+++ b/core/cu29_unifiedlog/src/lib.rs
@@ -332,9 +332,8 @@ impl<S: SectionStorage, L: UnifiedLogWrite<S>> Drop for LogStream<S, L> {
         let mut logger_guard = self.parent_logger.lock();
 
         #[cfg(feature = "std")]
-        let mut logger_guard = match logger_guard {
-            Ok(g) => g,
-            Err(_) => return,
+        let Ok(mut logger_guard) = logger_guard else {
+            return;
         };
         logger_guard.flush_section(&mut self.current_section);
         #[cfg(feature = "std")]

--- a/examples/cu_human_pose/src/main.rs
+++ b/examples/cu_human_pose/src/main.rs
@@ -71,12 +71,9 @@ fn main() {
 
     // Run the main loop
     loop {
-        match application.run_one_iteration() {
-            Ok(_) => {}
-            Err(e) => {
-                eprintln!("Error during iteration: {:?}", e);
-                break;
-            }
+        if let Err(e) = application.run_one_iteration() {
+            eprintln!("Error during iteration: {:?}", e);
+            break;
         }
     }
 }

--- a/examples/cu_human_pose/src/yolo/postprocess.rs
+++ b/examples/cu_human_pose/src/yolo/postprocess.rs
@@ -28,15 +28,13 @@ pub fn process_predictions(
     let mut poses = CuPoses::new();
 
     // Move to CPU for processing
-    let predictions = match predictions.to_device(&Device::Cpu) {
-        Ok(p) => p,
-        Err(_) => return poses,
+    let Ok(predictions) = predictions.to_device(&Device::Cpu) else {
+        return poses;
     };
 
     // Expected shape: (56, num_preds) where 56 = 4 (bbox) + 1 (conf) + 51 (17*3 keypoints)
-    let (pred_size, num_preds) = match predictions.dims2() {
-        Ok(dims) => dims,
-        Err(_) => return poses,
+    let Ok((pred_size, num_preds)) = predictions.dims2() else {
+        return poses;
     };
 
     // Validate prediction size: 4 + 1 + 17*3 = 56
@@ -51,14 +49,12 @@ pub fn process_predictions(
     let mut candidates: Vec<PoseCandidate> = Vec::new();
 
     for idx in 0..num_preds {
-        let pred = match predictions.i((.., idx)) {
-            Ok(p) => p,
-            Err(_) => continue,
+        let Ok(pred) = predictions.i((.., idx)) else {
+            continue;
         };
 
-        let pred_vec: Vec<f32> = match pred.to_vec1() {
-            Ok(v) => v,
-            Err(_) => continue,
+        let Ok(pred_vec) = pred.to_vec1() else {
+            continue;
         };
 
         let confidence = pred_vec[4];

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ fmt-check: check-format-tools
 	cargo +stable fmt --all -- --check
 	git ls-files -z '*.toml' | xargs -0 taplo format --check
 	git ls-files -z '*.ron' ':!examples/modular_config_example/motors.ron' | xargs -0 -n 1 ronfmt
-	find . -name '*.ron.bak' -type f -delete
+	rg --files -g '*.ron.bak' | xargs rm -f
 	git diff --exit-code -- '*.ron'
 
 # Apply formatting to Rust, TOML, and RON files
@@ -26,7 +26,7 @@ fmt: check-format-tools
 	cargo +stable fmt --all
 	git ls-files -z '*.toml' | xargs -0 taplo format
 	git ls-files -z '*.ron' ':!examples/modular_config_example/motors.ron' | xargs -0 -n 1 ronfmt
-	find . -name '*.ron.bak' -type f -delete
+	rg --files -g '*.ron.bak' | xargs rm -f
 
 check-format-tools:
 	#!/usr/bin/env bash
@@ -38,10 +38,13 @@ check-format-tools:
 		missing=1
 	fi
 	if ! command -v ronfmt >/dev/null 2>&1; then
-		echo "Missing ronfmt. Install with: cargo install ronfmt"
+		echo "Missing ronfmt. Install with: cargo install --locked ronfmt"
 		missing=1
 	fi
-
+	if ! command -v rg > /dev/null 2>&1; then
+		echo "Missing rg. Install with: cargo install --locked rg"
+		missing=1
+	fi
 	if [[ "$missing" -ne 0 ]]; then
 		exit 1
 	fi


### PR DESCRIPTION
## Summary
1. reduce match nesting into early-return/let-else flows and tightening small `Result/Option` parsing
2. use `rg` to replace `find`, speed-up `just lint`