### PR TITLE
[CHORE] add missing just recipe comments

### DIFF
--- a/components/libs/cu_msp_lib/justfile
+++ b/components/libs/cu_msp_lib/justfile
@@ -1,4 +1,5 @@
 import "../../../justfile"
 
+# Run the MSP dump example against a serial device.
 msp-dump:
 	cargo run --example msp_dump -- /dev/ttyACM0 115200

--- a/components/payloads/cu_ros_payloads/justfile
+++ b/components/payloads/cu_ros_payloads/justfile
@@ -1,5 +1,6 @@
 import "../../../justfile"
 
+# Emit a markdown table of RIHS01 type hashes from installed ROS messages.
 ros-rihs01-hashes:
 	#!/usr/bin/env bash
 	set -euo pipefail

--- a/components/sinks/cu_rp_sn754410/justfile
+++ b/components/sinks/cu_rp_sn754410/justfile
@@ -1,5 +1,6 @@
 import "../../../justfile"
 
+# Build and deploy the SN754410 tests to the copper7 target.
 deploy-cu-sn754410-tests:
 	#!/usr/bin/env bash
 	set -euo pipefail

--- a/components/sources/cu_ads7883/justfile
+++ b/components/sources/cu_ads7883/justfile
@@ -1,5 +1,6 @@
 import "../../../justfile"
 
+# Build and deploy the ADS7883 tests to the copper7 target.
 deploy-cu-ads7883-tests:
 	#!/usr/bin/env bash
 	set -euo pipefail

--- a/examples/cu_elrs_bdshot_demo/justfile
+++ b/examples/cu_elrs_bdshot_demo/justfile
@@ -1,5 +1,6 @@
 import "../../justfile"
 
+# Attach to the ELRS BDShot demo target with probe-rs.
 elrs-bdshot-attach:
 	#!/usr/bin/env bash
 	set -euo pipefail

--- a/examples/cu_flight_controller/justfile
+++ b/examples/cu_flight_controller/justfile
@@ -5,6 +5,7 @@ rc:
   #!/usr/bin/env bash
   cargo run -p cu-flight-controller --no-default-features --features sim --bin rc-tester
 
+# Extract CopperLists from a log file (JSON export).
 logreader log="logs/embedded.copper":
   #!/usr/bin/env bash
   set -euo pipefail
@@ -15,6 +16,7 @@ logreader log="logs/embedded.copper":
   fi
   RUST_BACKTRACE=1 cargo run -p cu-flight-controller --no-default-features --features logreader --bin quad-logreader -- "$log" extract-copperlists --export-format json
 
+# Run log reader fsck against a log file.
 fsck log="logs/embedded.copper":
   #!/usr/bin/env bash
   set -euo pipefail
@@ -25,6 +27,7 @@ fsck log="logs/embedded.copper":
   fi
   RUST_BACKTRACE=1 cargo run -p cu-flight-controller --no-default-features --features logreader --bin quad-logreader -- "$log" fsck
 
+# Extract text logs with a specified log index directory.
 textlogs log="logs/embedded.copper" index="../../target/debug/cu29_log_index":
   #!/usr/bin/env bash
   set -euo pipefail
@@ -40,6 +43,7 @@ textlogs log="logs/embedded.copper" index="../../target/debug/cu29_log_index":
   [[ -e "$index" ]] || { echo "log index not found: $index" >&2; exit 1; }
   RUST_BACKTRACE=1 cargo run -p cu-flight-controller --no-default-features --features logreader --bin quad-logreader -- "$log" extract-text-log "$index"
 
+# Build and run firmware with textlogs enabled (release profile).
 fw:
   #!/usr/bin/env bash
   set -euo pipefail

--- a/examples/cu_standalone_structlog/justfile
+++ b/examples/cu_standalone_structlog/justfile
@@ -1,10 +1,12 @@
 import "../../justfile"
 
+# Generate a flamegraph for the standardlog benchmark binary.
 profile-standardlog:
 	#!/usr/bin/env bash
 	set -euo pipefail
 	CARGO_PROFILE_RELEASE_DEBUG=true cargo flamegraph --bin standardlog_perf
 
+# Generate a flamegraph for the structlog benchmark binary.
 profile-structlog:
 	#!/usr/bin/env bash
 	set -euo pipefail

--- a/examples/ros_caterpillar/justfile
+++ b/examples/ros_caterpillar/justfile
@@ -1,5 +1,6 @@
 import "../../justfile"
 
+# Build and launch the ROS caterpillar nodes locally.
 ros-caterpillar-run:
 	#!/usr/bin/env bash
 	set -euo pipefail

--- a/examples/ros_zenoh_caterpillar/justfile
+++ b/examples/ros_zenoh_caterpillar/justfile
@@ -1,5 +1,6 @@
 import "../../justfile"
 
+# Build and launch the ROS Zenoh caterpillar nodes locally.
 ros-zenoh-caterpillar-run:
 	#!/usr/bin/env bash
 	set -euo pipefail

--- a/justfile
+++ b/justfile
@@ -4,6 +4,7 @@ WINDOWS_BASE_FEATURES := "mock,image,kornia,python,gst,faer,nalgebra,glam,debug_
 export ROOT := `git rev-parse --show-toplevel`
 EMBEDDED_EXCLUDES := shell('python3 $1/support/ci/embedded_crates.py excludes', ROOT)
 
+# Default to the CI-aligned std workflow.
 default:
 	just std-ci
 
@@ -28,6 +29,7 @@ fmt: check-format-tools
 	git ls-files -z '*.ron' ':!examples/modular_config_example/motors.ron' | xargs -0 -n 1 ronfmt
 	find . -name '*.ron.bak' -type f -delete
 
+# Ensure the formatters needed by fmt/fmt-check are installed.
 check-format-tools:
 	#!/usr/bin/env bash
 	set -euo pipefail
@@ -50,12 +52,14 @@ check-format-tools:
 typos:
 	typos -c .config/_typos.toml
 
+# Run the Unit-Tests job locally via act (debug/ubuntu matrix).
 ci:
   act -W .github/workflows/general.yml -j Unit-Tests --matrix os:ubuntu-latest --matrix mode:debug -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest
 
 # Host target detection for cross-platform logreader builds
 host_target := `rustc +stable -vV | sed -n 's/host: //p'`
 
+# Run the no_std/embedded CI flow locally.
 nostd-ci: lint
 	cargo +stable build --no-default-features
 	cargo +stable nextest run --no-default-features

--- a/support/docker/justfile
+++ b/support/docker/justfile
@@ -1,20 +1,24 @@
 import "../../justfile"
 
+# Build the base Ubuntu devcontainer image.
 docker-build-env:
 	#!/usr/bin/env bash
 	set -euo pipefail
 	docker build -f Dockerfile.ubuntu -t copper-rs-env .
 
+# Build the CUDA-enabled Ubuntu devcontainer image.
 docker-build-cuda-env:
 	#!/usr/bin/env bash
 	set -euo pipefail
 	docker build -f Dockerfile.ubuntu-cuda -t copper-rs-cuda-env .
 
+# Run the base devcontainer image with the repo mounted.
 docker-run-env:
 	#!/usr/bin/env bash
 	set -euo pipefail
 	docker run -it -entrypoint="" --mount type=bind,source="$(pwd)"/../..,target=/home/copper-rs copper-rs-env
 
+# Run the CUDA devcontainer image with the repo mounted.
 docker-run-cuda-env:
 	#!/usr/bin/env bash
 	set -euo pipefail

--- a/support/justfile
+++ b/support/justfile
@@ -1,5 +1,6 @@
 import "../justfile"
 
+# Cross-compile armv7 binaries and deploy them to copper7.
 cross-armv7-deploy:
 	#!/usr/bin/env bash
 	set -euo pipefail
@@ -8,6 +9,7 @@ cross-armv7-deploy:
 	find target/armv7-unknown-linux-gnueabihf/release -maxdepth 1 -type f -executable -exec scp -r {} gbin@copper7:copper/ \;
 	scp copper_derive_test/copperconfig.ron gbin@copper7:copper
 
+# Cross-compile riscv64 binaries and deploy them to copperv.
 cross-riscv64-deploy:
 	#!/usr/bin/env bash
 	set -euo pipefail

--- a/templates/justfile
+++ b/templates/justfile
@@ -1,20 +1,24 @@
 # Template generation helpers for local testing.
 
+# Generate the single-project template into templates/test_project.
 gen-project:
   #!/usr/bin/env bash
   set -euo pipefail
   rm -rf test_project
   cargo +stable generate -p cu_project --name test_project --destination . -d copper_source=local -d copper_root_path=../..
 
+# Generate the workspace template into templates/test_workspace.
 gen-workspace:
   #!/usr/bin/env bash
   set -euo pipefail
   rm -rf test_workspace
   cargo +stable generate -p cu_full --name test_workspace --destination . -d copper_source=local -d copper_root_path=../..
 
+# Generate both template variants.
 gen-all:
   just gen-project
   just gen-workspace
 
+# Remove generated template outputs.
 clean-generated:
   rm -rf test_project test_workspace


### PR DESCRIPTION
## Summary
Added missing recipe comments across the `justfile` so every command has a short description
## Details
- Root CI helpers annotated in `justfile`
- Template generation comments added in `templates/justfile`
- Component helper recipes documented in c`omponents/sources/cu_ads7883/justfile`, `components/sinks/cu_rp_sn754410/justfile`, `components/payloads/cu_ros_payloads/justfile`, `components/libs/cu_msp_lib/justfile`
- Example workflows documented in `examples/cu_standalone_structlog/justfile`, `examples/cu_flight_controller/justfile`, `examples/cu_elrs_bdshot_demo/justfile`, `examples/ros_caterpillar/justfile`, `examples/ros_zenoh_caterpillar/justfile`
- Support tooling recipes documented in `support/justfile`, `support/docker/justfile`