### PR TITLE
[FIX] (cu_caterpillar) just file mcap profile configuration 

### DIFF
--- a/examples/cu_caterpillar/justfile
+++ b/examples/cu_caterpillar/justfile
@@ -98,4 +98,4 @@ mcap:
 	echo "=========================================="
 
 	# Run mcap-info to show the user what was created
-	cargo run -r --bin cu-caterpillar-logreader --profile screaming -- "${copper_base}" mcap-info "${mcap_file}"
+	cargo run --bin cu-caterpillar-logreader --profile screaming -- "${copper_base}" mcap-info "${mcap_file}"


### PR DESCRIPTION
## Issue
`error: the argument '--release' cannot be used with '--profile <PROFILE-NAME>`
## Solution
remove `-r` from `cargo run`