### PR TITLE
[FIX] finalize the copper list before propagating monitor error

### DIFF
--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -1903,13 +1903,14 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                     #(#runtime_plan_code)*
                 } // drop(msgs);
                 let (raw_payload_bytes, handle_bytes) = #mission_mod::compute_payload_bytes(&culist);
-                monitor.process_copperlist(&#mission_mod::collect_metadata(&culist))?;
+                let monitor_result = monitor.process_copperlist(&#mission_mod::collect_metadata(&culist));
 
                 // here drop the payloads if we don't want them to be logged.
                 #(#preprocess_logging_calls)*
 
                 cl_manager.end_of_processing(clid)?;
                 kf_manager.end_of_processing(clid)?;
+                monitor_result?;
                 let stats = cu29::monitoring::CopperListIoStats {
                     raw_culist_bytes: core::mem::size_of::<CuList>() as u64 + raw_payload_bytes,
                     handle_bytes,
@@ -3682,8 +3683,9 @@ fn generate_task_execution_tokens(
                     Decision::Abort => {
                         debug!("Process: ABORT decision from monitoring. Task '{}' errored out \
                                 during process. Skipping the processing of CL {}.", #mission_mod::TASKS_IDS[#tid], clid);
-                        monitor.process_copperlist(&#mission_mod::collect_metadata(&culist))?;
+                        let monitor_result = monitor.process_copperlist(&#mission_mod::collect_metadata(&culist));
                         cl_manager.end_of_processing(clid)?;
+                        monitor_result?;
                         return Ok(());
                     }
                     Decision::Ignore => {
@@ -3789,8 +3791,9 @@ fn generate_task_execution_tokens(
                     Decision::Abort => {
                         debug!("Process: ABORT decision from monitoring. Task '{}' errored out \
                                 during process. Skipping the processing of CL {}.", #mission_mod::TASKS_IDS[#tid], clid);
-                        monitor.process_copperlist(&#mission_mod::collect_metadata(&culist))?;
+                        let monitor_result = monitor.process_copperlist(&#mission_mod::collect_metadata(&culist));
                         cl_manager.end_of_processing(clid)?;
+                        monitor_result?;
                         return Ok(());
                     }
                     Decision::Ignore => {
@@ -3889,8 +3892,9 @@ fn generate_task_execution_tokens(
                     Decision::Abort => {
                         debug!("Process: ABORT decision from monitoring. Task '{}' errored out \
                                 during process. Skipping the processing of CL {}.", #mission_mod::TASKS_IDS[#tid], clid);
-                        monitor.process_copperlist(&#mission_mod::collect_metadata(&culist))?;
+                        let monitor_result = monitor.process_copperlist(&#mission_mod::collect_metadata(&culist));
                         cl_manager.end_of_processing(clid)?;
+                        monitor_result?;
                         return Ok(());
                     }
                     Decision::Ignore => {
@@ -4022,8 +4026,10 @@ fn generate_bridge_rx_execution_tokens(
                     match decision {
                         Decision::Abort => {
                             debug!("Process: ABORT decision from monitoring. Task '{}' errored out during process. Skipping the processing of CL {}.", #mission_mod::TASKS_IDS[#monitor_index], clid);
-                            monitor.process_copperlist(&#mission_mod::collect_metadata(&culist))?;
+                            let monitor_result =
+                                monitor.process_copperlist(&#mission_mod::collect_metadata(&culist));
                             cl_manager.end_of_processing(clid)?;
+                            monitor_result?;
                             return Ok(());
                         }
                         Decision::Ignore => {
@@ -4066,8 +4072,10 @@ fn generate_bridge_rx_execution_tokens(
                         match decision {
                             Decision::Abort => {
                                 debug!("Process: ABORT decision from monitoring. Task '{}' errored out during process. Skipping the processing of CL {}.", #mission_mod::TASKS_IDS[#monitor_index], clid);
-                                monitor.process_copperlist(&#mission_mod::collect_metadata(&culist))?;
+                                let monitor_result = monitor
+                                    .process_copperlist(&#mission_mod::collect_metadata(&culist));
                                 cl_manager.end_of_processing(clid)?;
+                                monitor_result?;
                                 return Ok(());
                             }
                             Decision::Ignore => {
@@ -4144,8 +4152,10 @@ fn generate_bridge_tx_execution_tokens(
                     match decision {
                         Decision::Abort => {
                             debug!("Process: ABORT decision from monitoring. Task '{}' errored out during process. Skipping the processing of CL {}.", #mission_mod::TASKS_IDS[#monitor_index], clid);
-                            monitor.process_copperlist(&#mission_mod::collect_metadata(&culist))?;
+                            let monitor_result =
+                                monitor.process_copperlist(&#mission_mod::collect_metadata(&culist));
                             cl_manager.end_of_processing(clid)?;
+                            monitor_result?;
                             return Ok(());
                         }
                         Decision::Ignore => {
@@ -4187,8 +4197,10 @@ fn generate_bridge_tx_execution_tokens(
                         match decision {
                             Decision::Abort => {
                                 debug!("Process: ABORT decision from monitoring. Task '{}' errored out during process. Skipping the processing of CL {}.", #mission_mod::TASKS_IDS[#monitor_index], clid);
-                                monitor.process_copperlist(&#mission_mod::collect_metadata(&culist))?;
+                                let monitor_result = monitor
+                                    .process_copperlist(&#mission_mod::collect_metadata(&culist));
                                 cl_manager.end_of_processing(clid)?;
+                                monitor_result?;
                                 return Ok(());
                             }
                             Decision::Ignore => {


### PR DESCRIPTION
## Summary

- This PR Ensures `copperlist` finalization (end_of_processing) happens before propagating monitor errors by deferring `monitor.process_copperlist` error handling.

## Issue
- when you quit an example app (`cu-rp-balancebot`) with `cu-consolemon`, it will crash with a backtrace of log as below.
- The panic is caused by the monitor returning `Err("Exiting...")` on q, which short‑circuits `run_one_iteration` before the copper list is finalized. That leaks the list, and after a few frames you hit `Ran out of space for copper lists.`

## Details

- `core/cu29_derive/src/lib.rs`: store the result of `monitor.process_copperlist(...)` in monitor_result, finalize processing (`cl_manager.end_of_processing`, `kf_manager.end_of_processing` where applicable), then return `monitor_result?` across the main runtime path and all abort branches in task/bridge execution.

## Backtrace log
- reproduce: `cargo run -p cu-rp-balancebot` on commit [`c0a3859`](https://github.com/copper-project/copper-rs/commit/c0a3859831f6deb41949be5bba8a7f2544463399), then hit 'q' to exit the app.

```
  Simulation stopped: Exiting...
     context:None
  Simulation stopped: Exiting...
     context:None
  CuConsoleMon panic: panicked at examples/cu_rp_balancebot/src/sim.rs:23:1:
  Ran out of space for copper lists
  Backtrace:
     0: std::backtrace_rs::backtrace::libunwind::trace
               at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/std/src/../../backtrace/src/backtrace/libunwind.rs:117:9
     1: std::backtrace_rs::backtrace::trace_unsynchronized
               at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/std/src/../../backtrace/src/backtrace/mod.rs:66:14
     2: std::backtrace::Backtrace::create
               at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/std/src/backtrace.rs:331:13
     3: cu_consolemon::init_error_hooks::{{closure}}
               at ./components/monitors/cu_consolemon/src/lib.rs:2148:18
     4: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
               at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/alloc/src/boxed.rs:2220:9
     5: std::panicking::panic_with_hook
               at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/std/src/panicking.rs:833:13
     6: std::panicking::panic_handler::{{closure}}
               at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/std/src/panicking.rs:698:13
     7: std::sys::backtrace::__rust_end_short_backtrace
               at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/std/src/sys/backtrace.rs:176:18
     8: __rustc::rust_begin_unwind
               at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/std/src/panicking.rs:689:5
     9: core::panicking::panic_fmt
               at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/core/src/panicking.rs:80:14
    10: core::panicking::panic_display
               at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/core/src/panicking.rs:259:5
    11: core::option::expect_failed
               at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/core/src/option.rs:2184:5
    12: core::option::Option<T>::expect
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/option.rs:971:21
    13: <balancebot_sim::default::BalanceBotSim as cu29_runtime::app::CuSimApplication<S,L>>::run_one_iteration
               at ./examples/cu_rp_balancebot/src/sim.rs:23:1
    14: balancebot_sim::default::BalanceBotSim::run_one_iteration
               at ./examples/cu_rp_balancebot/src/sim.rs:23:1
    15: balancebot_sim::run_copper_callback
               at ./examples/cu_rp_balancebot/src/sim.rs:202:45
    16: core::ops::function::FnMut::call_mut
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/
  function.rs:166:5
    17: core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/
  function.rs:298:21
    18: <Func as bevy_ecs::system::function_system::SystemParamFunction<fn(F0,F1,F2,F3,F4,F5) .> Out>>::run::call_inner
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.18.0/src/system/
  function_system.rs:903:21
    19: <Func as bevy_ecs::system::function_system::SystemParamFunction<fn(F0,F1,F2,F3,F4,F5) .> Out>>::run
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.18.0/src/system/
  function_system.rs:906:17
    20: <bevy_ecs::system::function_system::FunctionSystem<Marker,In,Out,F> as bevy_ecs::system::system::System>::run_unsafe
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.18.0/src/system/
  function_system.rs:681:29
    21: bevy_ecs::schedule::executor::__rust_begin_short_backtrace::run_unsafe
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.18.0/src/schedule/executor/
  mod.rs:264:38
    22: bevy_ecs::schedule::executor::multi_threaded::ExecutorState::spawn_system_task::{{closure}}::{{closure}}
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.18.0/src/schedule/executor/
  multi_threaded.rs:688:25
    23: core::ops::function::FnOnce::call_once
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/
  function.rs:250:5
    24: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/panic/
  unwind_safe.rs:274:9
    25: std::panicking::catch_unwind::do_call
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/
  panicking.rs:581:40
    26: ___rust_try
    27: std::panicking::catch_unwind
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/
  panicking.rs:544:19
    28: std::panic::catch_unwind
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
    29: bevy_ecs::schedule::executor::multi_threaded::ExecutorState::spawn_system_task::{{closure}}
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.18.0/src/schedule/executor/
  multi_threaded.rs:681:23
    30: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::future::future::Future>::poll
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/panic/
  unwind_safe.rs:299:9
    31: <futures_lite::future::CatchUnwind<F> as core::future::future::Future>::poll::{{closure}}
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-lite-2.6.1/src/future.rs:653:53
    32: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/panic/
  unwind_safe.rs:274:9
    33: std::panicking::catch_unwind::do_call
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/
  panicking.rs:581:40
    34: ___rust_try
    35: std::panicking::catch_unwind
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/
  panicking.rs:544:19
    36: std::panic::catch_unwind
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
    37: <futures_lite::future::CatchUnwind<F> as core::future::future::Future>::poll
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-lite-2.6.1/src/future.rs:653:9
    38: <async_executor::AsyncCallOnDrop<Fut,Cleanup> as core::future::future::Future>::poll
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-executor-1.13.3/src/lib.rs:1197:31
    39: async_task::raw::RawTask<F,T,S,M>::run::{{closure}}
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-task-4.7.1/src/raw.rs:550:21
    40: core::ops::function::FnOnce::call_once
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/
  function.rs:250:5
    41: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/panic/
  unwind_safe.rs:274:9
    42: std::panicking::catch_unwind::do_call
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/
  panicking.rs:581:40
    43: ___rust_try
    44: std::panicking::catch_unwind
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/
  panicking.rs:544:19
    45: std::panic::catch_unwind
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
    46: async_task::raw::RawTask<F,T,S,M>::run
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-task-4.7.1/src/raw.rs:549:23
    47: async_task::runnable::Runnable<M>::run
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-task-4.7.1/src/runnable.rs:781:18
    48: async_executor::State::run::{{closure}}::{{closure}}
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-executor-1.13.3/src/lib.rs:751:30
    49: <futures_lite::future::Or<F1,F2> as core::future::future::Future>::poll
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-lite-2.6.1/src/future.rs:454:46
    50: async_executor::State::run::{{closure}}
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-executor-1.13.3/src/lib.rs:758:32
    51: async_executor::Executor::run::{{closure}}
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-executor-1.13.3/src/lib.rs:344:34
    52: futures_lite::future::block_on::{{closure}}
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-lite-2.6.1/src/future.rs:96:35
    53: std::thread::local::LocalKey<T>::try_with
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/
  local.rs:513:12
    54: std::thread::local::LocalKey<T>::with
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/
  local.rs:477:20
    55: futures_lite::future::block_on
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-lite-2.6.1/src/future.rs:75:11
    56: bevy_tasks::task_pool::TaskPool::new_internal::{{closure}}::{{closure}}::{{closure}}::{{closure}}
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_tasks-0.18.0/src/task_pool.rs:203:37
    57: std::panicking::catch_unwind::do_call
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/
  panicking.rs:581:40
    58: ___rust_try
    59: std::panicking::catch_unwind
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/
  panicking.rs:544:19
    60: std::panic::catch_unwind
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
    61: bevy_tasks::task_pool::TaskPool::new_internal::{{closure}}::{{closure}}::{{closure}}
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_tasks-0.18.0/src/task_pool.rs:197:43
    62: std::thread::local::LocalKey<T>::try_with
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/
  local.rs:513:12
    63: std::thread::local::LocalKey<T>::with
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/
  local.rs:477:20
    64: bevy_tasks::task_pool::TaskPool::new_internal::{{closure}}::{{closure}}
               at /Users/yang/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_tasks-0.18.0/src/task_pool.rs:190:50
    65: std::sys::backtrace::__rust_begin_short_backtrace
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys/
  backtrace.rs:160:18
    66: std::thread::lifecycle::spawn_unchecked::{{closure}}::{{closure}}
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/
  lifecycle.rs:92:13
    67: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/panic/
  unwind_safe.rs:274:9
    68: std::panicking::catch_unwind::do_call
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/
  panicking.rs:581:40
    69: ___rust_try
    70: std::panicking::catch_unwind
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/
  panicking.rs:544:19
    71: std::panic::catch_unwind
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
    72: std::thread::lifecycle::spawn_unchecked::{{closure}}
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/
  lifecycle.rs:90:26
    73: core::ops::function::FnOnce::call_once{{vtable.shim}}
               at /Users/yang/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/
  function.rs:250:5
    74: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
               at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/alloc/src/boxed.rs:2206:9
    75: std::sys::thread::unix::Thread::new::thread_start
               at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/std/src/sys/thread/unix.rs:118:17
    76: __pthread_cond_wait
```