### PR TITLE
chore(caterpillar, config_variation): Caterpillar log helper and config variation cleanup

### DIFF
--- a/examples/cu_caterpillar/src/tasks.rs
+++ b/examples/cu_caterpillar/src/tasks.rs
@@ -42,7 +42,7 @@ impl CuSrcTask for CaterpillarSource {
     }
 }
 
-pub struct CaterpillarTask {}
+pub struct CaterpillarTask;
 
 impl Freezable for CaterpillarTask {}
 
@@ -55,7 +55,7 @@ impl CuTask for CaterpillarTask {
     where
         Self: Sized,
     {
-        Ok(Self {})
+        Ok(Self)
     }
 
     fn process(

--- a/examples/cu_config_variation/Cargo.toml
+++ b/examples/cu_config_variation/Cargo.toml
@@ -16,7 +16,6 @@ cu29 = { workspace = true }
 cu29-helpers = { workspace = true }
 cu-caterpillar = { path = "../cu_caterpillar", version = "0.12.0" }
 cu-rp-gpio = { path = "../../components/sinks/cu_rp_gpio", version = "0.12.0" }
-tempfile = { workspace = true }
 serde = { workspace = true }
 
 [package.metadata.cargo-machete]


### PR DESCRIPTION
## Summary

- Factor log reader setup into a helper for the caterpillar `resim` example.
- Simplify `cu_config_variation` to reuse a run helper, use a stable logs path, and adjust node lookup.
- Remove unused dependency and minor struct simplification.

## Details

- `examples/cu_caterpillar/src/resim.rs`: add `open_log_reader` helper, reuse it for keyframes and copperlists, improve error handling.
- `examples/cu_caterpillar/src/tasks.rs`: make `CaterpillarTask` a unit struct and adjust constructor accordingly.
- `examples/cu_config_variation/src/main.rs`: add `run_once` helper, switch logger path to `logs/cu_config_variation.copper`, ensure log dir exists, and update graph lookup to use `get_node_id_by_name`.
- `examples/cu_config_variation/Cargo.toml`: drop unused `tempfile` dependency