### PR TITLE
chore(CI): Replace ronfmt with fmtron in tooling/docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ just extract-log /dev/sdX1 logs/embedded_0.copper
 - **cargo-nextest**: Fast test runner (install: `cargo install cargo-nextest`)
 - **typos-cli**: Spell checker (install: `cargo install typos-cli`)
 - **taplo-cli**: TOML formatter (install: `cargo install --locked taplo-cli`)
-- **ronfmt**: RON formatter (install: `cargo install ronfmt`)
+- **fmtron**: RON formatter (install: `cargo install fmtron`)
 - **cargo-generate**: Project template tool (install: `cargo install cargo-generate`)
 - **cargo-machete**: Unused dependency detection (install: `cargo install cargo-machete`)
 
@@ -306,7 +306,7 @@ Expand macro output for debugging: `cargo expand -p your-package`
 - **Task order matters**: Tasks execute in dependency order. Check the generated execution plan if tasks aren't running as expected.
 - **Resource lifetimes**: Resources must outlive task execution. Use `'r` lifetime parameters correctly.
 - **Feature conflicts**: Only one of `restore-state-*` features can be enabled at a time.
-- **RON syntax**: RON is similar to Rust but not identical. Use `ronfmt` to validate.
+- **RON syntax**: RON is similar to Rust but not identical. Use `fmtron` to validate.
 - **Frozen state**: Implement `Freezable` properly or replay will fail.
 
 ## Debugging Tips

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ lint:
 fmt-check: check-format-tools
 	cargo +stable fmt --all -- --check
 	git ls-files -z '*.toml' | xargs -0 taplo format --check
-	git ls-files -z '*.ron' ':!examples/modular_config_example/motors.ron' | xargs -0 -n 1 ronfmt
+	git ls-files -z '*.ron' ':!examples/modular_config_example/motors.ron' | xargs -0 -n 1 fmtron --input
 	rg --files -g '*.ron.bak' | xargs rm -f
 	git diff --exit-code -- '*.ron'
 
@@ -26,7 +26,7 @@ fmt-check: check-format-tools
 fmt: check-format-tools
 	cargo +stable fmt --all
 	git ls-files -z '*.toml' | xargs -0 taplo format
-	git ls-files -z '*.ron' ':!examples/modular_config_example/motors.ron' | xargs -0 -n 1 ronfmt
+	git ls-files -z '*.ron' ':!examples/modular_config_example/motors.ron' | xargs -0 -n 1 fmtron --input
 	rg --files -g '*.ron.bak' | xargs rm -f
 
 # Ensure the formatters needed by fmt/fmt-check are installed.
@@ -39,8 +39,8 @@ check-format-tools:
 		echo "Missing taplo (taplo-cli). Install with: cargo install --locked taplo-cli"
 		missing=1
 	fi
-	if ! command -v ronfmt >/dev/null 2>&1; then
-		echo "Missing ronfmt. Install with: cargo install --locked ronfmt"
+	if ! command -v fmtron >/dev/null 2>&1; then
+		echo "Missing fmtron. Install with: cargo install --locked fmtron"
 		missing=1
 	fi
 	if ! command -v rg > /dev/null 2>&1; then

--- a/support/docker/Dockerfile.ubuntu
+++ b/support/docker/Dockerfile.ubuntu
@@ -59,7 +59,7 @@ RUN curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/
 # Install additional tools needed for the CI
 RUN cargo install cargo-generate \
     && cargo install --locked taplo-cli \
-    && cargo install ronfmt \
+    && cargo install fmtron \
     && cargo install cargo-deny \
     && cargo install typos-cli \
     && cargo install sccache

--- a/support/docker/Dockerfile.ubuntu-cuda
+++ b/support/docker/Dockerfile.ubuntu-cuda
@@ -59,7 +59,7 @@ RUN curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/
 # Install additional tools needed for the CI
 RUN cargo install cargo-generate \
     && cargo install --locked taplo-cli \
-    && cargo install ronfmt \
+    && cargo install fmtron \
     && cargo install cargo-deny \
     && cargo install typos-cli \
     && cargo install sccache


### PR DESCRIPTION
## Background
`ronfmt` is not maintained anymore, `fmtron` is a community contribution for replacement
https://github.com/barafael/fmtron

Related Issue: #745 

## Summary

Updates documentation, formatting commands, and CI Docker images to use `fmtron` instead of the unmaintained `ronfmt` for RON formatting.

## Details

- `justfile`: `fmt` and `fmt-check` now run `fmtron --input` over `.Ron` files; tool check now validates `fmtron` instead of `ronfmt`.
- `CLAUDE.md`: installation and guidance references updated to fmtron.
- `support/docker/Dockerfile.ubuntu` and `support/docker/Dockerfile.ubuntu-cuda`: CI images now install `fmtron` in place of `ronfmt`.