### PR TITLE
chore(cu29_helpers): simplify basic_copper_setup

### DIFF
--- a/core/cu29_helpers/src/lib.rs
+++ b/core/cu29_helpers/src/lib.rs
@@ -54,10 +54,6 @@ pub fn basic_copper_setup(
         4096 * 10,
     )?;
 
-    #[cfg(debug_assertions)]
-    let extra: Option<TermLogger> = None;
-
-    #[cfg(not(debug_assertions))]
     let extra: Option<TermLogger> = None;
 
     let clock = clock.unwrap_or_default();


### PR DESCRIPTION
remove redundant `let extra: Option<TermLogger> = None;`