### PR TITLE
chore: bump rerun to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ tempfile = "3.23"
 spin = { version = "0.10" } # should be removed when std is on, but cargo is bad at negative features
 
 # rerun
-rerun = { version = "0.28", default-features = false, features = [
+rerun = { version = "0.29", default-features = false, features = [
   "sdk",
   "server",
   "log",


### PR DESCRIPTION
## Summary
bump rerun dependency to 0.29
Changelog of rerun: https://github.com/rerun-io/rerun/releases/tag/0.29.0
Migration guide: https://rerun.io/docs/reference/migration/migration-0-29


## Testing
- [x] `just std-ci`
- [x] `just lint`
- [x] `cargo +stable nextest run --workspace --all-targets`

## Checklist
- [x] I have updated docs or examples where needed
- [x] I have added or updated tests where needed
- [x] I have considered platform impact (Linux/macOS/Windows/embedded)
- [x] I have considered config/logging changes (if applicable)
- [x] This change is not a breaking change (or I documented it below)
