### PR TITLE
feat: add logreader to workspace template example app

### DIFF
--- a/templates/cu_full/README.md
+++ b/templates/cu_full/README.md
@@ -9,7 +9,7 @@ This template bootstraps a Copper workspace with an app crate and a shared-compo
 - `components/bridges/cu_example_shared_bridge/`: shared bridge example crate.
 - `components/`: shared components by category (placeholders to extend).
 - `doc/`: design notes and project docs.
-- `justfile`: automation helpers like `just rcfg`.
+- `justfile`: automation helpers like `just rcfg`, `just log`, and `just cl`.
 
 ## Quick start
 
@@ -18,3 +18,10 @@ cargo run -p cu_example_app
 ```
 
 The runtime config lives in `apps/cu_example_app/copperconfig.ron`.
+
+To decode structured logs, use the logreader helpers:
+
+```bash
+just log
+just cl
+```

--- a/templates/cu_full/apps/README.md
+++ b/templates/cu_full/apps/README.md
@@ -1,1 +1,1 @@
-Application crates live here. `cu_example_app` is the starter app and owns its runtime config and logs.
+Application crates live here. Each app owns its runtime config, logs, and logreader binary.

--- a/templates/cu_full/apps/cu_example_app/Cargo.toml.template
+++ b/templates/cu_full/apps/cu_example_app/Cargo.toml.template
@@ -9,8 +9,18 @@ default-run = "cu_example_app"
 name = "cu_example_app"
 path = "src/main.rs"
 
+[[bin]]
+name = "cu_example_app-logreader"
+path = "src/logreader.rs"
+required-features = ["logreader"]
+
+[features]
+default = []
+logreader = ["dep:cu29-export"]
+
 [dependencies]
 cu29 = { workspace = true }
 cu29-helpers = { workspace = true }
+cu29-export = { workspace = true, optional = true }
 bincode = { workspace = true }
 serde = { workspace = true }

--- a/templates/cu_full/apps/cu_example_app/src/logreader.rs
+++ b/templates/cu_full/apps/cu_example_app/src/logreader.rs
@@ -1,0 +1,12 @@
+mod messages;
+mod tasks;
+
+use cu29::prelude::*;
+use cu29_export::run_cli;
+
+gen_cumsgs!("copperconfig.ron");
+
+#[cfg(feature = "logreader")]
+fn main() {
+    run_cli::<CuStampedDataSet>().expect("Failed to run the export CLI");
+}

--- a/templates/cu_full/justfile
+++ b/templates/cu_full/justfile
@@ -6,3 +6,21 @@ rcfg:
   set -euo pipefail
   APP_DIR="${APP_DIR:-cu_example_app}"
   {{copper_root_path}}/target/debug/cu29-rendercfg apps/"${APP_DIR}"/copperconfig.ron --open
+
+# Extract the structured log via the log reader.
+log:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  APP_DIR="${APP_DIR:-cu_example_app}"
+  APP_NAME="${APP_NAME:-${APP_DIR}}"
+  RUST_BACKTRACE=1 cargo run -p "${APP_NAME}" --features=logreader --bin "${APP_NAME}-logreader" \
+    apps/"${APP_DIR}"/logs/"${APP_NAME}".copper extract-text-log target/debug/cu29_log_index
+
+# Extract CopperLists from the log output.
+cl:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  APP_DIR="${APP_DIR:-cu_example_app}"
+  APP_NAME="${APP_NAME:-${APP_DIR}}"
+  RUST_BACKTRACE=1 cargo run -p "${APP_NAME}" --features=logreader --bin "${APP_NAME}-logreader" \
+    apps/"${APP_DIR}"/logs/"${APP_NAME}".copper extract-copperlists


### PR DESCRIPTION
## Summary

- Adds a logreader binary + feature to the template app and wires in the optional export dependency (`cu29-export`).
- Introduces a logreader entrypoint and justfile helpers for extracting logs (`just log` / `just cl`).
- Updates template docs to describe logreader usage per app.

## Changes

- `templates/cu_full/apps/cu_example_app/Cargo.toml.template`: adds bin `cu_example_app-logreader`, feature `logreader`, and optional dep `cu29-export`.
- `templates/cu_full/apps/cu_example_app/src/logreader.rs`: new logreader main using `run_cli::<CuStampedDataSet>()`.
- `templates/cu_full/justfile`: adds `log` and `cl` recipes for log extraction.
- `templates/cu_full/README.md`: mentions `just log` / `just cl`.
- `templates/cu_full/apps/README.md`: clarifies each app owns its `logreader` binary.

## Testing
- [x] `just std-ci`
- [x] `just lint` 
- [x] `cd templates; cargo +stable generate -p cu_full --name test_workspace --destination . -d copper_source=local -d copper_root_path=../.. --silent`
  - `cargo run`
  - `just log`
  - `just cl`
  - `just rcfg`

## Checklist
- [x] I have updated docs or examples where needed
- [x] I have added or updated tests where needed
- [x] I have considered platform impact (Linux/macOS/Windows/embedded)
- [x] I have considered config/logging changes (if applicable)
- [x] This change is not a breaking change (or I documented it below)
