### PR TITLE
chore: typo in example readme

### DIFF
--- a/examples/cu_rp_balancebot/README.md
+++ b/examples/cu_rp_balancebot/README.md
@@ -22,7 +22,7 @@ See the UI help for the navigation.
 
 ```bash
 $ cd examples/cu_rp_balancebot
-$ cargo run --bin balancebot_resim --release
+$ cargo run --bin balancebot-resim --release
 ```
 
 It will recreate the logs from only the inputs of the previous run in `logs/balancebot_resim*.copper`.


### PR DESCRIPTION
## Summary

I just saw the excellent talk at Fosdem so went to try out your demo.

## Related issues

I noticed a small type in the demo README

## Changes

## Testing

reproduce

```
cd examples/cu_rp_balancebot/
cat README
cargo run --bin balancebot_resim --release
error: no bin target named `balancebot_resim` in default-run packages

help: a target with a similar name exists: `balancebot-resim`
```

```
cargo run --bin balancebot-resim --release
   Compiling zstd-sys v2.0.16+zstd.1.5.7
   Compiling bevy_render v0.18.0
   Compiling bevy_light v0.18.0
```
## Checklist
- [x] I have updated docs or examples where needed
- [x] I have added or updated tests where needed
- [x] I have considered platform impact (Linux/macOS/Windows/embedded)
- [x] I have considered config/logging changes (if applicable)
- [x] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
