### PR TITLE
chore: update convert_case to 0.11

### DIFF
--- a/core/cu29_derive/Cargo.toml
+++ b/core/cu29_derive/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 [dependencies]
 cu29-runtime = { workspace = true, features = ["std"] }
 cu29-traits = { workspace = true }
-convert_case = "0.10"
+convert_case = "0.11"
 itertools = "0.14"
 quote = { workspace = true }
 proc-macro2 = { workspace = true }


### PR DESCRIPTION
## Summary
bump `convert_case` dependency to `0.11`
CHANGELOG: https://github.com/rutrum/convert-case
## Changes
- `core/cu29_derive_Cargo.toml`: update dependency `convert_case` from `0.10` to `0.11`
## Testing
- [x] `just std-ci`
- [x] `just lint`
- [x] `cargo +stable nextest run --workspace --all-targets`

## Checklist
- [x] I have updated docs or examples where needed
- [x] I have added or updated tests where needed
- [x] I have considered platform impact (Linux/macOS/Windows/embedded)
- [x] I have considered config/logging changes (if applicable)
- [x] This change is not a breaking change (or I documented it below)
