### PR TITLE
chore: replace cargo-machete with cargo-shear

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,7 @@ cargo nextest run --workspace --all-targets --features mock,image,kornia,python,
     ```bash
     git checkout -b user/feat/description
     ```
+
 4. **Make Changes**: Implement your feature or fix the bug. Write clear and concise code.
 
 5. **Run Checks**: Before committing, ensure your code adheres to the project's standards. The easiest way is to run `just std-ci` which executes all CI checks. Alternatively, run individual checks:
@@ -160,24 +161,24 @@ cargo nextest run --workspace --all-targets --features mock,image,kornia,python,
 
 We keep our dependencies minimal and up-to-date.
 
-We use ```cargo-machete``` to identify and remove unused dependencies. Before submitting a PR, please run:
+We use ```cargo-shear``` to identify and remove unused dependencies. Before submitting a PR, please run:
 
-1. Install ```cargo-machete```
+1. Install ```cargo-shear```
 ```bash
-cargo install cargo-machete
+cargo install cargo-shear
 ```
 
-2. Run ```cargo-machete``` to find unused dependencies:
+2. Run ```cargo-shear``` to find unused dependencies:
 ```bash
-cargo machete --with-metadata
+cargo shear
 ```
 
 3. Handling False Positives
 
-```cargo-machete``` is not perfect. If it incorrectly flags a necessary dependency (e.g., required by a feature flag or build script), add it to the ignored list in the relevant Cargo.toml file:
+```cargo-shear``` is not perfect. If it incorrectly flags a necessary dependency (e.g., required by a feature flag or build script), add it to the ignored list in the relevant Cargo.toml file:
 
 ```toml
-[package.metadata.cargo-machete]
+[package.metadata.cargo-shear]
 # Explain *why* the dependency is needed despite not being directly used in code.
 # e.g. "Required for X feature" or "Used in build.rs"
 ignored = ["some-crate", "another-crate"]

--- a/components/sinks/cu_rp_gpio/Cargo.toml
+++ b/components/sinks/cu_rp_gpio/Cargo.toml
@@ -10,9 +10,6 @@ categories.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
-[package.metadata.cargo-machete]
-ignored = ["cu29-log", "cu29-log-runtime"] # proc macro
-
 [dependencies]
 cu29 = { workspace = true }
 bincode = { workspace = true }

--- a/components/sources/cu_rp_encoder/Cargo.toml
+++ b/components/sources/cu_rp_encoder/Cargo.toml
@@ -10,9 +10,6 @@ categories.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
-[package.metadata.cargo-machete]
-ignored = ["cu29-log", "cu29-log-runtime"]
-
 [dependencies]
 cu29 = { workspace = true }
 cu29-traits = { workspace = true }

--- a/components/sources/cu_vlp16/Cargo.toml
+++ b/components/sources/cu_vlp16/Cargo.toml
@@ -10,9 +10,6 @@ categories.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
-[package.metadata.cargo-machete]
-ignored = ["cu29-log", "cu29-log-runtime", "cu29-soa-derive"] # proc macro
-
 [dependencies]
 cu29 = { workspace = true }
 cu-sensor-payloads = { workspace = true }

--- a/components/sources/cu_wt901/Cargo.toml
+++ b/components/sources/cu_wt901/Cargo.toml
@@ -11,9 +11,6 @@ categories.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
-[package.metadata.cargo-machete]
-ignored = ["cu29-log", "cu29-log-runtime"] # proc macro
-
 [dependencies]
 cu29 = { workspace = true }
 cu29-log-derive = { workspace = true }

--- a/core/cu29_log_runtime/Cargo.toml
+++ b/core/cu29_log_runtime/Cargo.toml
@@ -11,9 +11,6 @@ categories.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
-[package.metadata.cargo-machete]
-ignored = ["simplelog"] # Used from conditional compilation
-
 [dependencies]
 cu29-log = { workspace = true }
 cu29-traits = { workspace = true }

--- a/examples/cu_caterpillar/Cargo.toml
+++ b/examples/cu_caterpillar/Cargo.toml
@@ -13,15 +13,6 @@ homepage.workspace = true
 repository.workspace = true
 
 publish = false
-[package.metadata.cargo-machete]
-ignored = [
-  "cu29-log",
-  "cu29-log-runtime",
-  "cu29-unifiedlog",
-  "cu-consolemon",
-  "copper-traits",
-] # proc macro and console
-
 [[bin]]
 name = "cu-caterpillar"
 path = "src/main.rs"

--- a/examples/cu_config_variation/Cargo.toml
+++ b/examples/cu_config_variation/Cargo.toml
@@ -18,11 +18,5 @@ cu-caterpillar = { path = "../cu_caterpillar", version = "0.12.0" }
 cu-rp-gpio = { path = "../../components/sinks/cu_rp_gpio", version = "0.12.0" }
 serde = { workspace = true }
 
-[package.metadata.cargo-machete]
-ignored = [
-  "cu-caterpillar",
-  "cu-rp-gpio",
-] # copperconfig.ron use caterpillar and rp-gpio as an example
-
 [package.metadata.cargo-shear]
 ignored = ["cu-caterpillar", "cu-rp-gpio", "serde"]

--- a/examples/cu_dorabench/Cargo.toml
+++ b/examples/cu_dorabench/Cargo.toml
@@ -13,15 +13,6 @@ homepage.workspace = true
 repository.workspace = true
 
 publish = false
-[package.metadata.cargo-machete]
-ignored = [
-  "cu29-log",
-  "cu29-log-runtime",
-  "cu29-unifiedlog",
-  "cu-consolemon",
-  "copper-traits",
-] # proc macro and console
-
 [[bin]]
 name = "cu-dorabench"
 path = "src/main.rs"

--- a/examples/cu_rp_balancebot/Cargo.toml
+++ b/examples/cu_rp_balancebot/Cargo.toml
@@ -16,15 +16,6 @@ publish = false
 [package.metadata.cargo-shear]
 ignored = ["serde"]
 
-[package.metadata.cargo-machete]
-ignored = [
-  "cu-consolemon",
-  "cu29-log",
-  "cu29-log-runtime",
-  "cu29-unifiedlog",
-  "copper-traits",
-] # proc macro and console
-
 [dependencies]
 # Core dependencies
 cu29 = { workspace = true }

--- a/examples/cu_zenoh/Cargo.toml
+++ b/examples/cu_zenoh/Cargo.toml
@@ -11,9 +11,6 @@ repository.workspace = true
 description = "Copper example to use zenoh as a middleware."
 
 publish = false
-[package.metadata.cargo-machete]
-ignored = ["bincode", "cu-caterpillar", "cu-consolemon"]
-
 [dependencies]
 cu29 = { workspace = true }
 cu29-helpers = { workspace = true }


### PR DESCRIPTION
## Summary
replace `cargo-machete` with `cargo-shear`

## Changes
1. `CONTRIBUTING.md` - Updated documentation to reference `cargo-shear` instead of `cargo-machete`
2. `Cargo.toml` files with `cargo-machete` metadata removed:
- `core/cu29_log_runtime/Cargo.toml`
- `components/sources/cu_wt901/Cargo.toml`
- `components/sources/cu_rp_encoder/Cargo.toml`
- `components/sources/cu_vlp16/Cargo.toml`
- `components/sinks/cu_rp_gpio/Cargo.toml`
- `examples/cu_zenoh/Cargo.toml` (kept existing cargo-shear section)
- `examples/cu_caterpillar/Cargo.toml` (kept existing cargo-shear section)
- `examples/cu_dorabench/Cargo.toml`
- `examples/cu_config_variation/Cargo.toml` (kept existing cargo-shear section)
- `examples/cu_rp_balancebot/Cargo.toml` (kept existing cargo-shear section)

## Checklist
- [x] I have updated docs or examples where needed
- [x] I have added or updated tests where needed
- [x] I have considered platform impact (Linux/macOS/Windows/embedded)
- [x] I have considered config/logging changes (if applicable)
- [x] This change is not a breaking change (or I documented it below)