### PR TITLE
chore: update pyo3 to 0.28

### DIFF
--- a/core/cu29_export/Cargo.toml
+++ b/core/cu29_export/Cargo.toml
@@ -27,7 +27,7 @@ num-format = "0.4"
 indicatif = { version = "0.18", optional = true }
 
 # PyO3 is not supported for macOS at the moment, don't allow people to opt-in since it won't work
-pyo3 = { version = "0.27", optional = true, features = ["extension-module"] }
+pyo3 = { version = "0.28", optional = true, features = ["extension-module"] }
 
 serde_json = "1.0"
 


### PR DESCRIPTION
## Summary
Update pyo3 to 0.28
CHANGELOG: https://github.com/PyO3/pyo3/blob/main/CHANGELOG.md

## Testing
- [x] `just std-ci`
- [x] `just lint`
- [x] `cargo +stable nextest run --workspace --all-targets`

## Checklist
- [x] I have updated docs or examples where needed
- [x] I have added or updated tests where needed
- [x] I have considered platform impact (Linux/macOS/Windows/embedded)
- [x] I have considered config/logging changes (if applicable)
- [x] This change is not a breaking change (or I documented it below)