### PR TITLE
chore(cu_v4l): replace implicit pointer casts with explicit void pointer helper

### DIFF
--- a/components/sources/cu_v4l/src/v4lstream.rs
+++ b/components/sources/cu_v4l/src/v4lstream.rs
@@ -25,6 +25,7 @@ pub struct CuV4LStream {
 use std::fs;
 use std::os::fd::RawFd;
 use std::path::PathBuf;
+use std::ptr;
 
 fn get_original_dev_path(fd: RawFd) -> Option<PathBuf> {
     let link_path = format!("/proc/self/fd/{fd}");
@@ -35,6 +36,10 @@ fn get_original_dev_path(fd: RawFd) -> Option<PathBuf> {
         return Some(path);
     }
     None
+}
+
+fn as_mut_void_ptr<T>(value: &mut T) -> *mut std::os::raw::c_void {
+    ptr::from_mut(value).cast::<std::os::raw::c_void>()
 }
 
 impl CuV4LStream {
@@ -122,7 +127,7 @@ impl CuV4LStream {
             v4l2::ioctl(
                 self.v4l_handle.fd(),
                 v4l2::vidioc::VIDIOC_G_FMT,
-                &mut v4l2_fmt as *mut _ as *mut std::os::raw::c_void,
+                as_mut_void_ptr(&mut v4l2_fmt),
             )?;
         }
 
@@ -135,7 +140,7 @@ impl CuV4LStream {
             v4l2::ioctl(
                 self.v4l_handle.fd(),
                 v4l2::vidioc::VIDIOC_REQBUFS,
-                &mut v4l2_reqbufs as *mut _ as *mut std::os::raw::c_void,
+                as_mut_void_ptr(&mut v4l2_reqbufs),
             )?;
         }
 
@@ -154,7 +159,7 @@ impl CuV4LStream {
             v4l2::ioctl(
                 self.v4l_handle.fd(),
                 v4l2::vidioc::VIDIOC_REQBUFS,
-                &mut v4l2_reqbufs as *mut _ as *mut std::os::raw::c_void,
+                as_mut_void_ptr(&mut v4l2_reqbufs),
             )
         }
     }
@@ -196,7 +201,7 @@ impl Stream for CuV4LStream {
             v4l2::ioctl(
                 self.v4l_handle.fd(),
                 v4l2::vidioc::VIDIOC_STREAMON,
-                &mut type_ as *mut _ as *mut std::os::raw::c_void,
+                as_mut_void_ptr(&mut type_),
             )?;
         }
         self.active = true;
@@ -210,7 +215,7 @@ impl Stream for CuV4LStream {
             v4l2::ioctl(
                 self.v4l_handle.fd(),
                 v4l2::vidioc::VIDIOC_STREAMOFF,
-                &mut type_ as *mut _ as *mut std::os::raw::c_void,
+                as_mut_void_ptr(&mut type_),
             )?;
         }
 


### PR DESCRIPTION
## Summary
replace repeated implicit pointer casts with a small helper to convert `&mut T` to `*mut c_void` in the V4L `ioctl` calls. No functional change intended.

## Changes
- `components/sources/cu_v4l/src/v4lstream.rs`: added `as_mut_void_ptr` helper to centralize the pointer cast logic.
- replaced five inline casts in `VIDIOC_G_FMT`, `VIDIOC_REQBUFS` (two call sites), `VIDIOC_STREAMON`, and `VIDIOC_STREAMOFF` with `as_mut_void_ptr(&mut ...)`.
- 
## Testing
- [x] `just std-ci`
- [x] `just lint`
- [x] `cargo +stable nextest run --workspace --all-targets`

## Checklist
- [x] I have updated docs or examples where needed
- [x] I have added or updated tests where needed
- [x] I have considered platform impact (Linux/macOS/Windows/embedded)
- [x] I have considered config/logging changes (if applicable)
- [x] This change is not a breaking change (or I documented it below)

## Additional context
Consolidating the cast into a single helper makes the unsafe conversion explicit, consistent, and easier to review, which supports deterministic behavior and reduces review surface area for low-level I/O paths.