### PR TITLE
chore(cu_bdshot): guard telemetry run-length shifts and period division

### DIFF
--- a/components/bridges/cu_bdshot/src/board/stm32.rs
+++ b/components/bridges/cu_bdshot/src/board/stm32.rs
@@ -307,6 +307,9 @@ fn decode_telemetry(
             run_len += 1;
         } else {
             let len_bits = core::cmp::max(1, ((run_len + 1) / TELE_OVERSAMPLE) as i32);
+            if len_bits > 31 {
+                return None;
+            }
             let len_bits_u = len_bits as u32;
             bits += len_bits;
             value <<= len_bits_u;

--- a/components/bridges/cu_bdshot/src/decode.rs
+++ b/components/bridges/cu_bdshot/src/decode.rs
@@ -103,6 +103,10 @@ pub fn decode_telemetry_packet(payload: u16) -> DShotTelemetry {
                 return DShotTelemetry::EncodingError;
             }
             let period_us = base << exp;
+            let Some(period_us) = core::num::NonZeroU32::new(period_us) else {
+                return DShotTelemetry::EncodingError;
+            };
+            let period_us = period_us.get();
             let erpm = (60_000_000u32 + (period_us >> 1)) / period_us;
             DShotTelemetry::Erpm(erpm.min(u32::from(u16::MAX)) as u16)
         }


### PR DESCRIPTION
## Summary
- Adds defensive guards in `cu_bdshot` telemetry decoding to prevent oversized bit-shifts and zero-period divisions.
- Ensures malformed or extreme telemetry inputs return EncodingError/None instead of risking undefined behavior.
## Changes
- `components/bridges/cu_bdshot/src/board/stm32.rs`: caps `len_bits` for telemetry run-length decoding; if it exceeds `31`, decoding exits early with None to avoid invalid shifts.
- `components/bridges/cu_bdshot/src/decode.rs`: wraps period_us in `NonZeroU32` before division; if zero, returns `DShotTelemetry::EncodingError` to avoid divide-by-zero.
## Testing
- [x] `just std-ci`
- [x] `just lint`
- [x] `cargo +stable nextest run --workspace --all-targets`
- [x] `just nostd-ci`

## Checklist
- [x] I have updated docs or examples where needed
- [x] I have added or updated tests where needed
- [x] I have considered platform impact (Linux/macOS/Windows/embedded)
- [x] I have considered config/logging changes (if applicable)
- [x] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
For safety‑critical systems, telemetry decoding must be robust against malformed or noisy inputs. These guards prevent undefined behavior (oversized shifts and divide‑by‑zero), which could otherwise propagate into control loops or monitoring logic. Failing fast with explicit error states improves determinism and fault containment.