### PR TITLE
fix: prevent erroneous early returns in sim mode 

### DIFF
--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -1495,25 +1495,26 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 quote! {
                     {
                         #call_sim
-                        if !doit { return Ok(()); }
-                        let bridge = &mut __cu_bridges.#bridge_index;
-                        let maybe_error = {
-                            #rt_guard
-                            bridge.preprocess(clock)
-                        };
-                        if let Err(error) = maybe_error {
-                            let decision = monitor.process_error(#monitor_index, CuTaskState::Preprocess, &error);
-                            match decision {
-                                Decision::Abort => {
-                                    debug!("Preprocess: ABORT decision from monitoring. Task '{}' errored out during preprocess. Aborting all the other starts.", #mission_mod::TASKS_IDS[#monitor_index]);
-                                    return Ok(());
-                                }
-                                Decision::Ignore => {
-                                    debug!("Preprocess: IGNORE decision from monitoring. Task '{}' errored out during preprocess. The runtime will continue.", #mission_mod::TASKS_IDS[#monitor_index]);
-                                }
-                                Decision::Shutdown => {
-                                    debug!("Preprocess: SHUTDOWN decision from monitoring. Task '{}' errored out during preprocess. The runtime cannot continue.", #mission_mod::TASKS_IDS[#monitor_index]);
-                                    return Err(CuError::new_with_cause("Task errored out during preprocess.", error));
+                        if doit {
+                            let bridge = &mut __cu_bridges.#bridge_index;
+                            let maybe_error = {
+                                #rt_guard
+                                bridge.preprocess(clock)
+                            };
+                            if let Err(error) = maybe_error {
+                                let decision = monitor.process_error(#monitor_index, CuTaskState::Preprocess, &error);
+                                match decision {
+                                    Decision::Abort => {
+                                        debug!("Preprocess: ABORT decision from monitoring. Task '{}' errored out during preprocess. Aborting all the other starts.", #mission_mod::TASKS_IDS[#monitor_index]);
+                                        return Ok(());
+                                    }
+                                    Decision::Ignore => {
+                                        debug!("Preprocess: IGNORE decision from monitoring. Task '{}' errored out during preprocess. The runtime will continue.", #mission_mod::TASKS_IDS[#monitor_index]);
+                                    }
+                                    Decision::Shutdown => {
+                                        debug!("Preprocess: SHUTDOWN decision from monitoring. Task '{}' errored out during preprocess. The runtime cannot continue.", #mission_mod::TASKS_IDS[#monitor_index]);
+                                        return Err(CuError::new_with_cause("Task errored out during preprocess.", error));
+                                    }
                                 }
                             }
                         }
@@ -1558,26 +1559,27 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 quote! {
                     {
                         #call_sim
-                        if !doit { return Ok(()); }
-                        let bridge = &mut __cu_bridges.#bridge_index;
-                        kf_manager.freeze_any(clid, bridge)?;
-                        let maybe_error = {
-                            #rt_guard
-                            bridge.postprocess(clock)
-                        };
-                        if let Err(error) = maybe_error {
-                            let decision = monitor.process_error(#monitor_index, CuTaskState::Postprocess, &error);
-                            match decision {
-                                Decision::Abort => {
-                                    debug!("Postprocess: ABORT decision from monitoring. Task '{}' errored out during postprocess. Aborting all the other starts.", #mission_mod::TASKS_IDS[#monitor_index]);
-                                    return Ok(());
-                                }
-                                Decision::Ignore => {
-                                    debug!("Postprocess: IGNORE decision from monitoring. Task '{}' errored out during postprocess. The runtime will continue.", #mission_mod::TASKS_IDS[#monitor_index]);
-                                }
-                                Decision::Shutdown => {
-                                    debug!("Postprocess: SHUTDOWN decision from monitoring. Task '{}' errored out during postprocess. The runtime cannot continue.", #mission_mod::TASKS_IDS[#monitor_index]);
-                                    return Err(CuError::new_with_cause("Task errored out during postprocess.", error));
+                        if doit {
+                            let bridge = &mut __cu_bridges.#bridge_index;
+                            kf_manager.freeze_any(clid, bridge)?;
+                            let maybe_error = {
+                                #rt_guard
+                                bridge.postprocess(clock)
+                            };
+                            if let Err(error) = maybe_error {
+                                let decision = monitor.process_error(#monitor_index, CuTaskState::Postprocess, &error);
+                                match decision {
+                                    Decision::Abort => {
+                                        debug!("Postprocess: ABORT decision from monitoring. Task '{}' errored out during postprocess. Aborting all the other starts.", #mission_mod::TASKS_IDS[#monitor_index]);
+                                        return Ok(());
+                                    }
+                                    Decision::Ignore => {
+                                        debug!("Postprocess: IGNORE decision from monitoring. Task '{}' errored out during postprocess. The runtime will continue.", #mission_mod::TASKS_IDS[#monitor_index]);
+                                    }
+                                    Decision::Shutdown => {
+                                        debug!("Postprocess: SHUTDOWN decision from monitoring. Task '{}' errored out during postprocess. The runtime cannot continue.", #mission_mod::TASKS_IDS[#monitor_index]);
+                                        return Err(CuError::new_with_cause("Task errored out during postprocess.", error));
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
I noticed that the process() functions for my tasks that were supposed to be executed by runtime were not being called, and I discovered an early return in the preprocess and post process sim logic that was exiting too early.

(I may add a test for this if you think its a good idea)

## Changes
Simple replacement of an early return with an if statement wrapping around the logic.

## Testing
- [x] `just std-ci`
- [x] `just lint`
- [x] `cargo +stable nextest run --workspace --all-targets`
- [x] Tested it out on my own project, made sure that tasks that were executed in sim and executed by runtime behaved as expected.

## Checklist
- [x] I have updated docs or examples where needed
- [x] I have added or updated tests where needed
- [x] I have considered platform impact (Linux/macOS/Windows/embedded)
- [x] I have considered config/logging changes (if applicable)
- [x] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)
N/A
## Additional context
