### PR TITLE
bug: Jumping on the same spot makes the debugger API step

### DIFF
--- a/core/cu29_runtime/src/debug.rs
+++ b/core/cu29_runtime/src/debug.rs
@@ -445,6 +445,14 @@ where
 
         // Fast path: forward stepping from current state.
         if let Some(current) = self.current_idx {
+            if target_idx == current {
+                return Ok(JumpOutcome {
+                    culistid: target_culistid,
+                    keyframe_culistid: self.last_keyframe,
+                    replayed: 0,
+                });
+            }
+
             if target_idx >= current {
                 replay_start = current + 1;
                 keyframe_used = self.last_keyframe;


### PR DESCRIPTION
## Summary

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just std-ci`
- [ ] `just lint`
- [ ] `cargo +stable nextest run --workspace --all-targets`
- [ ] Other (please specify):

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
