### PR TITLE
fix: clippy of cu_linux_resources on non-linux platform

### DIFF
--- a/components/res/cu_linux_resources/src/lib.rs
+++ b/components/res/cu_linux_resources/src/lib.rs
@@ -396,12 +396,14 @@ const SERIAL_SLOTS: &[SerialSlot] = &[
     },
 ];
 
+#[cfg(target_os = "linux")]
 struct I2cSlot {
     id: LinuxResourcesId,
     dev_key: &'static str,
     default_dev: &'static str,
 }
 
+#[cfg(target_os = "linux")]
 const I2C_SLOTS: &[I2cSlot] = &[
     I2cSlot {
         id: LinuxResourcesId::I2c0,


### PR DESCRIPTION
## Summary
introduced new port should only run on linux platform

## Testing
- [x] `just std-ci`
- [x] `just lint`
- [x] `cargo +stable nextest run --workspace --all-targets`

## Checklist
- [x] I have updated docs or examples where needed
- [x] I have added or updated tests where needed
- [x] I have considered platform impact (Linux/macOS/Windows/embedded)
- [x] I have considered config/logging changes (if applicable)
- [x] This change is not a breaking change (or I documented it below)
