### PR TITLE
chore(cu_ads7883): simplify code

### DIFF
--- a/components/sources/cu_ads7883/src/lib.rs
+++ b/components/sources/cu_ads7883/src/lib.rs
@@ -179,14 +179,12 @@ pub mod test_support {
 
 #[cfg(hardware)]
 fn read_spi_config(config: Option<&ComponentConfig>) -> CuResult<(Option<String>, Option<u32>)> {
-    let config = match config {
-        Some(config) => config,
-        None => return Ok((None, None)),
-    };
-
-    let spi_dev = config.get::<String>("spi_dev")?;
-    let max_speed_hz = config.get::<u32>("max_speed_hz")?;
-    Ok((spi_dev, max_speed_hz))
+    config.map_or(Ok((None, None)), |cfg| {
+        Ok((
+            cfg.get::<String>("spi_dev")?,
+            cfg.get::<u32>("max_speed_hz")?,
+        ))
+    })
 }
 
 fn read_adc_value(spi: &mut Spidev) -> CuResult<u16> {

--- a/components/sources/cu_ads7883/tests/ads7883_tester.rs
+++ b/components/sources/cu_ads7883/tests/ads7883_tester.rs
@@ -6,7 +6,7 @@ use cu29_helpers::basic_copper_setup;
 struct ADS78883Tester {}
 
 #[derive(Reflect)]
-pub struct ADS78883TestSink {}
+pub struct ADS78883TestSink;
 
 impl Freezable for ADS78883TestSink {}
 
@@ -17,7 +17,7 @@ impl CuSinkTask for ADS78883TestSink {
     where
         Self: Sized,
     {
-        Ok(Self {})
+        Ok(Self)
     }
 
     fn process(&mut self, _clock: &RobotClock, new_msg: &Self::Input<'_>) -> CuResult<()> {


### PR DESCRIPTION
## Summary
simplify code for `cu_ads7883` crate.
## Testing
- [x] `just std-ci`
- [x] `just lint`
- [x] `cargo +stable nextest run --workspace --all-targets`
## Checklist
- [x] I have updated docs or examples where needed
- [x] I have added or updated tests where needed
- [x] I have considered platform impact (Linux/macOS/Windows/embedded)
- [x] I have considered config/logging changes (if applicable)
- [x] This change is not a breaking change (or I documented it below)