### PR TITLE
chore(cu29_helpers): simplify code

### DIFF
--- a/core/cu29_helpers/tests/end2end.rs
+++ b/core/cu29_helpers/tests/end2end.rs
@@ -14,7 +14,6 @@ use cu29_log_runtime::log;
 #[cfg(debug_assertions)]
 #[allow(unused_imports)]
 use cu29_log_runtime::log_debug_mode;
-
 use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
 
@@ -34,13 +33,11 @@ fn log_derive_end2end() {
         b: i32,
     }
     let mytuple = (1, "toto", 3.34f64, true, 'a');
-    {
-        let _gigantic_vec = vec![0u8; 1_000_000];
-        debug!("Just a string {}", "zarma");
-        debug!("anonymous param constants {} {}", 42u16, 43u8);
-        debug!("named param constants {} {}", a = 3, b = 2);
-        debug!("mixed named param constants, {} {} {}", a = 3, 54, b = 2);
-        debug!("complex tuple", mytuple);
-        debug!("Struct", Test { a: 3, b: 4 });
-    }
+    let _gigantic_vec = vec![0u8; 1_000_000];
+    debug!("Just a string {}", "zarma");
+    debug!("anonymous param constants {} {}", 42u16, 43u8);
+    debug!("named param constants {} {}", a = 3, b = 2);
+    debug!("mixed named param constants, {} {} {}", a = 3, 54, b = 2);
+    debug!("complex tuple", mytuple);
+    debug!("Struct", Test { a: 3, b: 4 });
 }


### PR DESCRIPTION
## Summary
simple linting of `cu29-helpers`

## Testing
- [x] `just std-ci`
- [x] `just lint`
- [x] `cargo +stable nextest run --workspace --all-targets`

## Checklist
- [x] I have updated docs or examples where needed
- [x] I have added or updated tests where needed
- [x] I have considered platform impact (Linux/macOS/Windows/embedded)
- [x] I have considered config/logging changes (if applicable)
- [x] This change is not a breaking change (or I documented it below)
