### PR TITLE
chore: bump uom to 0.38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ quote = "1.0"                                  # proc macros
 syn = { version = "2.0", features = ["full"] } # proc macros
 
 # Unit of measure to be consistent across the project
-uom = { version = "0.37", default-features = false, features = [
+uom = { version = "0.38", default-features = false, features = [
   "autoconvert",
   "f32",
   "f64",


### PR DESCRIPTION
## Summary
bump uom from `0.37` to `0.38`
CHANGELOG: https://github.com/iliekturtles/uom/blob/master/CHANGELOG.md#v0380--2026-02-13

## Testing
- [x] `just fmt`
- [x] `just lint`
- [x] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-top: ` just` with no parameters in the root defaults to `just fmt`, `just lint` and `just test`.

## Checklist
- [x] I have updated docs or examples where needed
- [x] I have added or updated tests where needed
- [x] I have considered platform impact (Linux/macOS/Windows/embedded)
- [x] I have considered config/logging changes (if applicable)
- [x] This change is not a breaking change (or I documented it below)