### PR TITLE
fix: ROS2 zenoh attachement format

### DIFF
--- a/components/bridges/cu_ros2_bridge/src/attachment.rs
+++ b/components/bridges/cu_ros2_bridge/src/attachment.rs
@@ -4,11 +4,8 @@ use zenoh_ext::ZSerializer;
 
 pub fn encode_attachment(sequence_number: u64, clock: &RobotClock, zid: &ZenohId) -> ZBytes {
     let mut serializer = ZSerializer::new();
-    serializer.serialize("sequence_number".to_string());
     serializer.serialize(sequence_number);
-    serializer.serialize("source_timestamp".to_string());
     serializer.serialize(clock.now().as_nanos());
-    serializer.serialize("source_gid");
     serializer.serialize(zid.to_le_bytes());
     serializer.finish()
 }


### PR DESCRIPTION
## Summary

Serialization format has changed.
https://github.com/ros2/rmw_zenoh/pull/601

## Related issues
- Closes #

## Changes

## Testing
- [x] `just fmt`
- [x] `just lint`
- [ ] `just test` (got some issues)
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
