### PR TITLE
fix: ROS2 humble does not support type hash

### DIFF
--- a/components/bridges/cu_ros2_bridge/Cargo.toml
+++ b/components/bridges/cu_ros2_bridge/Cargo.toml
@@ -22,3 +22,6 @@ zenoh = { version = "1.7.0", default-features = false, features = [
 ] }
 zenoh-ext = { version = "1.7.0", default-features = false }
 cdr = { version = "0.2.4" }
+
+[features]
+humble = ["cu-ros2-payloads/humble"]

--- a/components/payloads/cu_ros2_payloads/src/lib.rs
+++ b/components/payloads/cu_ros2_payloads/src/lib.rs
@@ -33,22 +33,6 @@ pub trait RosMsgAdapter<'a>: Sized {
     /// For example Int8 is "RIHS01_26525065a403d972cb672f0777e333f0c799ad444ae5fcd79e43d1e73bd0f440"
     /// This will only be used in ROS 2 Iron and later versions.
     fn type_hash() -> &'static str;
-
-    /// Converts the current Copper type into the corresponding ROS message type.
-    ///
-    /// # Returns
-    /// A tuple containing:
-    /// - The converted ROS message type (`Self::Output`).
-    /// - The type hash as a string, which is used to identify the message type in ROS.
-    #[cfg(not(feature = "humble"))]
-    fn convert(&self) -> (Self::Output, &'static str) {
-        (self.into(), Self::type_hash())
-    }
-
-    #[cfg(feature = "humble")]
-    fn convert(&self) -> (Self::Output, &str) {
-        (self.into(), "TypeHashNotSupported")
-    }
 }
 
 /// Bidirectional ROS adaptation trait used by transport bridges.
@@ -87,8 +71,14 @@ where
         <T as RosMsgAdapter<'static>>::type_name()
     }
 
+    #[cfg(not(feature = "humble"))]
     fn type_hash() -> &'static str {
         <T as RosMsgAdapter<'static>>::type_hash()
+    }
+
+    #[cfg(feature = "humble")]
+    fn type_hash() -> &'static str {
+        "TypeHashNotSupported"
     }
 
     fn to_ros_message(&self) -> Self::RosMessage {

--- a/examples/cu_ros2_bridge_demo/Cargo.toml
+++ b/examples/cu_ros2_bridge_demo/Cargo.toml
@@ -19,5 +19,9 @@ cu-ros2-bridge = { path = "../../components/bridges/cu_ros2_bridge", version = "
 tempfile = { workspace = true }
 serde = { workspace = true }
 
+[features]
+humble = ["cu-ros2-bridge/humble"]
+
+
 [package.metadata.cargo-shear]
 ignored = ["serde"]


### PR DESCRIPTION
## Summary

Restore specific  type hash for ROS2 Humble.

## Related issues

## Changes

## Testing
- [x] `just fmt`
- [x] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
