### PR TITLE
chore(ci): Reduce sccache Artifacts with Restore-Only PR Caching

### DIFF
--- a/.github/actions/embedded-rust-setup/action.yml
+++ b/.github/actions/embedded-rust-setup/action.yml
@@ -12,6 +12,24 @@ inputs:
     description: Whether to install nextest.
     required: false
     default: "false"
+  sccache_restore:
+    description: Whether to restore sccache.
+    required: false
+    default: "true"
+  sccache_key_suffix:
+    description: Suffix used to separate sccache writers per job/task.
+    required: true
+  sccache_dir:
+    description: Optional SCCACHE_DIR override.
+    required: false
+    default: ""
+outputs:
+  sccache_cache_hit:
+    description: Whether sccache restore matched the primary key.
+    value: ${{ steps.restore_sccache.outputs.cache-hit }}
+  sccache_cache_primary_key:
+    description: Primary sccache key for this job.
+    value: ${{ steps.restore_sccache.outputs.cache-primary-key }}
 runs:
   using: composite
   steps:
@@ -24,13 +42,29 @@ runs:
         toolchain: ${{ inputs.toolchain }}
         targets: aarch64-unknown-none,thumbv7em-none-eabihf,thumbv8m.main-none-eabihf,riscv32imac-unknown-none-elf
         components: rustc,cargo,rust-std,rustfmt,clippy
-    - name: Enable sccache
-      shell: bash
-      run: |
-        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-        echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
+    - name: Configure sccache
+      shell: bash
+      run: |
+        SCCACHE_DIR="${{ inputs.sccache_dir }}"
+        if [[ -z "$SCCACHE_DIR" ]]; then
+          SCCACHE_DIR="$PWD/.sccache"
+        fi
+        mkdir -p "$SCCACHE_DIR"
+        echo "SCCACHE_DIR=$SCCACHE_DIR" >> "$GITHUB_ENV"
+        echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+    - name: Restore sccache
+      if: inputs.sccache_restore == 'true'
+      id: restore_sccache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-${{ runner.os }}-${{ inputs.toolchain }}-embedded-${{ inputs.sccache_key_suffix }}-${{ github.sha }}
+        restore-keys: |
+          sccache-${{ runner.os }}-${{ inputs.toolchain }}-embedded-${{ inputs.sccache_key_suffix }}-
+          sccache-${{ runner.os }}-${{ inputs.toolchain }}-embedded-
+          sccache-${{ runner.os }}-${{ inputs.toolchain }}-
     - name: Install latest nextest
       if: inputs.install_nextest == 'true'
       uses: taiki-e/install-action@nextest

--- a/.github/actions/rust-ci-setup/action.yml
+++ b/.github/actions/rust-ci-setup/action.yml
@@ -26,6 +26,24 @@ inputs:
     description: Whether to set WORKSPACE_FLAG from WORKSPACE_SCOPE.
     required: false
     default: "true"
+  sccache_restore:
+    description: Whether to restore sccache.
+    required: false
+    default: "true"
+  sccache_key_suffix:
+    description: Suffix used to separate sccache writers per job/task.
+    required: true
+  sccache_dir:
+    description: Optional SCCACHE_DIR override.
+    required: false
+    default: ""
+outputs:
+  sccache_cache_hit:
+    description: Whether sccache restore matched the primary key.
+    value: ${{ steps.restore_sccache.outputs.cache-hit }}
+  sccache_cache_primary_key:
+    description: Primary sccache key for this job.
+    value: ${{ steps.restore_sccache.outputs.cache-primary-key }}
 runs:
   using: composite
   steps:
@@ -39,6 +57,27 @@ runs:
         components: rustc,cargo,rust-std,rustfmt,clippy
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
+    - name: Configure sccache
+      shell: bash
+      run: |
+        SCCACHE_DIR="${{ inputs.sccache_dir }}"
+        if [[ -z "$SCCACHE_DIR" ]]; then
+          SCCACHE_DIR="$PWD/.sccache"
+        fi
+        mkdir -p "$SCCACHE_DIR"
+        echo "SCCACHE_DIR=$SCCACHE_DIR" >> "$GITHUB_ENV"
+        echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+    - name: Restore sccache
+      if: inputs.sccache_restore == 'true'
+      id: restore_sccache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-${{ runner.os }}-${{ inputs.toolchain }}-${{ inputs.cache_prefix }}-${{ inputs.sccache_key_suffix }}-${{ github.sha }}
+        restore-keys: |
+          sccache-${{ runner.os }}-${{ inputs.toolchain }}-${{ inputs.cache_prefix }}-${{ inputs.sccache_key_suffix }}-
+          sccache-${{ runner.os }}-${{ inputs.toolchain }}-${{ inputs.cache_prefix }}-
+          sccache-${{ runner.os }}-${{ inputs.toolchain }}-
     - name: Install latest nextest
       if: inputs.install_nextest == 'true'
       uses: taiki-e/install-action@nextest

--- a/.github/workflows/reusable-embedded.yml
+++ b/.github/workflows/reusable-embedded.yml
@@ -20,15 +20,23 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/embedded-rust-setup
+      - id: embedded_setup
+        uses: ./.github/actions/embedded-rust-setup
         with:
           toolchain: ${{ inputs.toolchain }}
           cargo_target_dir: ${{ inputs.cargo_target_dir }}
           install_nextest: "true"
+          sccache_key_suffix: nostd
       - name: Check compilation of core with no-std
         run: cargo +${{ inputs.toolchain }} build --no-default-features
       - name: Unit tests of core with no-std
         run: cargo +${{ inputs.toolchain }} nextest run --no-default-features
+      - name: Save sccache
+        if: github.ref == 'refs/heads/master' && steps.embedded_setup.outputs.sccache_cache_primary_key != '' && steps.embedded_setup.outputs.sccache_cache_hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ steps.embedded_setup.outputs.sccache_cache_primary_key }}
 
   embedded-crates:
     name: Embedded crates
@@ -38,15 +46,23 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/embedded-rust-setup
+      - id: embedded_setup
+        uses: ./.github/actions/embedded-rust-setup
         with:
           toolchain: ${{ inputs.toolchain }}
           cargo_target_dir: ${{ inputs.cargo_target_dir }}
+          sccache_key_suffix: embedded-crates
 
       - name: Clippy embedded-only crates
         run: python3 support/ci/embedded_crates.py run --action clippy --toolchain ${{ inputs.toolchain }}
       - name: Build embedded-only crates
         run: python3 support/ci/embedded_crates.py run --action build --toolchain ${{ inputs.toolchain }}
+      - name: Save sccache
+        if: github.ref == 'refs/heads/master' && steps.embedded_setup.outputs.sccache_cache_primary_key != '' && steps.embedded_setup.outputs.sccache_cache_hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ steps.embedded_setup.outputs.sccache_cache_primary_key }}
 
   rp2350:
     name: RP2350 skeleton
@@ -56,10 +72,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/embedded-rust-setup
+      - id: embedded_setup
+        uses: ./.github/actions/embedded-rust-setup
         with:
           toolchain: ${{ inputs.toolchain }}
           cargo_target_dir: ${{ inputs.cargo_target_dir }}
+          sccache_key_suffix: rp2350
 
       - name: Detect host target
         run: |
@@ -77,3 +95,9 @@ jobs:
       - name: Build logreader (RP2350 host)
         working-directory: examples/cu_rp2350_skeleton
         run: cargo +${{ inputs.toolchain }} build --no-default-features --features host --bin blinky-logreader --target ${HOST_TARGET}
+      - name: Save sccache
+        if: github.ref == 'refs/heads/master' && steps.embedded_setup.outputs.sccache_cache_primary_key != '' && steps.embedded_setup.outputs.sccache_cache_hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ steps.embedded_setup.outputs.sccache_cache_primary_key }}

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -26,8 +26,6 @@ jobs:
 
     env:
       CARGO_TERM_COLOR: always
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
       BASE_FEATURES: mock,image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
       WORKSPACE_SCOPE: ${{ matrix.os == 'windows-latest' && 'core' || 'workspace' }}
 
@@ -49,7 +47,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/rust-ci-setup
+      - id: rust_ci_setup
+        uses: ./.github/actions/rust-ci-setup
         with:
           toolchain: ${{ inputs.toolchain }}
           cargo_target_dir: ${{ inputs.cargo_target_dir }}
@@ -57,6 +56,7 @@ jobs:
           cache_prefix: ${{ matrix.mode }}
           cache_shared_key: rust-${{ matrix.os }}
           install_nextest: ${{ matrix.task == 'test' }}
+          sccache_key_suffix: unit-${{ matrix.task }}
 
       - name: Install CUDA
         uses: Jimver/cuda-toolkit@v0.2.30
@@ -135,6 +135,13 @@ jobs:
           cargo +${{ inputs.toolchain }} test -p cu-caterpillar --features determinism_ci
           -- determinism_record_and_resim --test-threads=1
 
+      - name: Save sccache
+        if: github.ref == 'refs/heads/master' && steps.rust_ci_setup.outputs.sccache_cache_primary_key != '' && steps.rust_ci_setup.outputs.sccache_cache_hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ steps.rust_ci_setup.outputs.sccache_cache_primary_key }}
+
   tests-features:
     name: Unit Tests (all features)
     runs-on: ${{ matrix.os }}
@@ -145,8 +152,6 @@ jobs:
 
     env:
       CARGO_TERM_COLOR: always
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
       BASE_FEATURES: mock,image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
       WORKSPACE_SCOPE: ${{ matrix.os == 'windows-latest' && 'core' || 'workspace' }}
 
@@ -163,7 +168,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/rust-ci-setup
+      - id: rust_ci_setup
+        uses: ./.github/actions/rust-ci-setup
         with:
           toolchain: ${{ inputs.toolchain }}
           cargo_target_dir: ${{ inputs.cargo_target_dir }}
@@ -171,6 +177,7 @@ jobs:
           cache_prefix: ${{ matrix.mode }}
           cache_shared_key: rust-${{ matrix.os }}
           install_nextest: "true"
+          sccache_key_suffix: tests-features
 
       - name: Install CUDA
         uses: Jimver/cuda-toolkit@v0.2.30
@@ -235,6 +242,13 @@ jobs:
           fi
           cargo +${{ inputs.toolchain }} nextest run $RELEASE_FLAG --all-targets $WORKSPACE_FLAG $FEATURES_FLAG $EMBEDDED_EXCLUDES
 
+      - name: Save sccache
+        if: github.ref == 'refs/heads/master' && steps.rust_ci_setup.outputs.sccache_cache_primary_key != '' && steps.rust_ci_setup.outputs.sccache_cache_hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ steps.rust_ci_setup.outputs.sccache_cache_primary_key }}
+
   templates:
     name: Templates (debug)
     runs-on: ${{ matrix.os }}
@@ -245,8 +259,6 @@ jobs:
 
     env:
       CARGO_TERM_COLOR: always
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
       BASE_FEATURES: mock,image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
       WORKSPACE_SCOPE: workspace
 
@@ -258,7 +270,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/rust-ci-setup
+      - id: rust_ci_setup
+        uses: ./.github/actions/rust-ci-setup
         with:
           toolchain: ${{ inputs.toolchain }}
           cargo_target_dir: ${{ inputs.cargo_target_dir }}
@@ -266,6 +279,7 @@ jobs:
           cache_prefix: ${{ matrix.mode }}
           cache_shared_key: rust-${{ matrix.os }}
           install_nextest: "false"
+          sccache_key_suffix: templates
 
       - name: Install cargo-generate on (${{ matrix.os }} | debug)
         uses: taiki-e/install-action@v2
@@ -284,3 +298,10 @@ jobs:
           cargo +${{ inputs.toolchain }} build
           cd ../test_workspace
           cargo +${{ inputs.toolchain }} build
+
+      - name: Save sccache
+        if: github.ref == 'refs/heads/master' && steps.rust_ci_setup.outputs.sccache_cache_primary_key != '' && steps.rust_ci_setup.outputs.sccache_cache_hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ steps.rust_ci_setup.outputs.sccache_cache_primary_key }}


### PR DESCRIPTION
## Summary
Changes CI caching so PR jobs restore sccache but do not save new sccache artifacts. Cache writes now happen only on master, while still allowing all Rust jobs on master to refresh cache entries with collision-safe keys.

## Changes
  - Updated .github/actions/rust-ci-setup/action.yml:
      - Added sccache_restore, sccache_key_suffix, sccache_dir inputs.
      - Configured local SCCACHE_DIR + RUSTC_WRAPPER=sccache.
      - Added explicit actions/cache/restore@v4 for sccache.
      - Added outputs for cache hit and primary key.
  - Updated .github/actions/embedded-rust-setup/action.yml similarly:
      - Removed SCCACHE_GHA_ENABLED usage.
      - Added local sccache setup + explicit restore + outputs.
  - Updated .github/workflows/reusable-unit-tests.yml:
      - Removed workflow env-level SCCACHE_GHA_ENABLED/RUSTC_WRAPPER.
      - Passed unique sccache_key_suffix per job/task.
      - Added actions/cache/save@v4 steps gated to refs/heads/master, with cache-hit and non-empty-key guards.
  - Updated .github/workflows/reusable-embedded.yml:
      - Passed unique sccache_key_suffix per embedded job.
      - Added actions/cache/save@v4 with the same master/cache-hit/key guards.
  - Net effect:
      - PR CI reuses master caches without creating new sccache artifacts.
      - master CI continues to refresh cache from all Rust jobs.
## Checklist
- [x] I have updated docs or examples where needed
- [x] I have added or updated tests where needed
- [x] I have considered platform impact (Linux/macOS/Windows/embedded)
- [x] I have considered config/logging changes (if applicable)
- [x] This change is not a breaking change (or I documented it below)
