### PR TITLE
logmon: top4 instead of just top1 for latency

### DIFF
--- a/components/monitors/cu_logmon/src/lib.rs
+++ b/components/monitors/cu_logmon/src/lib.rs
@@ -195,7 +195,10 @@ fn end_to_end_latency(msgs: &[&CuMsgMetadata]) -> Option<CuDuration> {
     }
 }
 
-fn find_top_tasks_by_max(per_task: &[CuDurationStatistics], limit: usize) -> Vec<(usize, CuDuration)> {
+fn find_top_tasks_by_max(
+    per_task: &[CuDurationStatistics],
+    limit: usize,
+) -> Vec<(usize, CuDuration)> {
     let mut ranked: Vec<(usize, CuDuration)> = per_task
         .iter()
         .enumerate()


### PR DESCRIPTION
This is kind of annoying when you don't see at least of couple top tasks

## Summary

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
