### PR TITLE
Flight Sim: UI box + realistic battery

### DIFF
--- a/examples/cu_flight_controller/README.md
+++ b/examples/cu_flight_controller/README.md
@@ -92,6 +92,42 @@ just textlogs log=logs/embedded.copper
 just rc
 ```
 
+### Simulator (Bevy + Copper)
+
+```bash
+# Run the flight simulator
+just sim
+```
+
+### RC Input In Simulation
+
+The simulator reads RC input from a host joystick device (`evdev`). By default it only auto-connects to
+radio-style joystick profiles, to avoid false positives from keyboards/mice/gamepads that also expose joystick interfaces.
+
+Environment variables:
+
+```bash
+# Prefer a specific device name substring (case-insensitive)
+CU_SIM_JOYSTICK="radiomaster" just sim
+
+# Allow generic/non-radio joystick devices as RC input
+CU_SIM_ALLOW_GENERIC_JOYSTICK=1 just sim
+```
+
+Notes:
+- If no compatible RC joystick is found, the sim falls back to keyboard controls.
+- When connected, the bottom-right help panel shows the selected device name and technical axis bindings (`ABS_X`, `ABS_RY`, etc.).
+- USB and Bluetooth radios both work if they appear as a joystick device on the host.
+
+### Compatible TX/RX Notes
+
+- **Simulation path**: no receiver is used directly; input is read from the host joystick interface.
+- **Auto-detected TX joystick profiles**:
+  - ExpressLRS-style USB joystick names (`expresslrs`, `radiomaster`)
+  - OpenTX / EdgeTX USB joystick names (`opentx`, `edgetx`)
+- **Firmware path (real hardware)**: RC input is CRSF on UART, so use a CRSF-compatible RX link
+  (for example ExpressLRS/Crossfire-class receivers and compatible transmitters).
+
 ## Configuration
 
 The task graph is defined in `copperconfig.ron`. Key configurable parameters:

--- a/examples/cu_flight_controller/copperconfig.ron
+++ b/examples/cu_flight_controller/copperconfig.ron
@@ -65,7 +65,7 @@
             id: "imu_cal",
             type: "tasks::ImuCalibrator",
             logging: (enabled: false),
-            config: {"cal_ms": 3000},
+            config: {"cal_ms": 500},
         ),
         (
             id: "ahrs",
@@ -106,7 +106,7 @@
             config: {
                 "motor_index": 0,
                 "props_out": true,
-                "airmode_idle_percent": 20.0,
+                "airmode_idle_percent": 10.0,
             },
         ),
         (
@@ -116,7 +116,7 @@
             config: {
                 "motor_index": 1,
                 "props_out": true,
-                "airmode_idle_percent": 20.0,
+                "airmode_idle_percent": 10.0,
             },
         ),
         (
@@ -126,7 +126,7 @@
             config: {
                 "motor_index": 2,
                 "props_out": true,
-                "airmode_idle_percent": 20.0,
+                "airmode_idle_percent": 10.0,
             },
         ),
         (
@@ -136,7 +136,7 @@
             config: {
                 "motor_index": 3,
                 "props_out": true,
-                "airmode_idle_percent": 20.0,
+                "airmode_idle_percent": 10.0,
             },
         ),
         (
@@ -316,6 +316,11 @@
             src: "mapper",
             dst: "vtx_osd",
             msg: "crate::messages::ControlInputs",
+        ),
+        (
+            src: "imu_cal",
+            dst: "vtx_osd",
+            msg: "cu_sensor_payloads::ImuPayload",
         ),
         (
             src: "rate",

--- a/examples/cu_flight_controller/src/sim.rs
+++ b/examples/cu_flight_controller/src/sim.rs
@@ -19,7 +19,8 @@ use bevy::prelude::{
     GlobalTransform, GltfAssetLabel, IsDefaultUiCamera, KeyCode, MessageReader, MessageWriter,
     MinimalPlugins, Name, Node, PerspectiveProjection, PluginGroup, PositionType, PostUpdate,
     Projection, Quat, Query, Res, ResMut, Resource, SceneRoot, Startup, Text, TextColor, TextFont,
-    Time, Transform, Update, Val, Vec3, Visibility, Window, WindowPlugin, With, Without, default,
+    Time, Transform, UiRect, Update, Val, Vec3, Visibility, Window, WindowPlugin, With, Without,
+    default,
 };
 use bevy::window::PrimaryWindow;
 use cached_path::{Cache, Error as CacheError, ProgressBar};
@@ -32,7 +33,7 @@ use cu_msp_lib::structs::{
     MSP_DP_CLEAR_SCREEN, MSP_DP_DRAW_SCREEN, MSP_DP_WRITE_STRING, MspDisplayPort, MspRequest,
 };
 use cu_sensor_payloads::{BarometerPayload, ImuPayload, MagnetometerPayload};
-use rc_joystick::{RcFrame, RcJoystick};
+use rc_joystick::{RcAxisBindings, RcFrame, RcJoystick};
 
 use std::fs;
 use std::io;
@@ -243,6 +244,9 @@ fn sanitize_osd_char(byte: u8) -> char {
 #[derive(Component)]
 struct OsdOverlayText;
 
+#[derive(Component)]
+struct SimHelpValuesText;
+
 #[derive(Debug)]
 struct QuadcopterForceTorque {
     force: Vec3,
@@ -322,6 +326,9 @@ const SKYBOX: &str = "skybox.ktx2";
 const SPECULAR_MAP: &str = "specular_map.ktx2";
 const QUADCOPTER: &str = "quadcopter.glb";
 const LEVEL: &str = "level.glb";
+const ARM_SWITCH_NAMES: &[&str] = &["sf", "se", "arm", "btn1"];
+const KEYBOARD_HOVER_THROTTLE_LOW: f32 = 0.56;
+const KEYBOARD_HOVER_THROTTLE_HIGH: f32 = 0.62;
 
 fn create_symlink(src: &str, dst: &str) -> io::Result<()> {
     let dst_path = Path::new(dst);
@@ -585,6 +592,47 @@ fn setup_osd_overlay(mut commands: Commands) {
     ));
 }
 
+fn setup_help_overlay(mut commands: Commands) {
+    commands
+        .spawn((
+            Name::new("sim-help"),
+            Node {
+                position_type: PositionType::Absolute,
+                bottom: Val::Px(5.0),
+                right: Val::Px(5.0),
+                padding: UiRect::new(Val::Px(15.0), Val::Px(15.0), Val::Px(10.0), Val::Px(10.0)),
+                column_gap: Val::Px(10.0),
+                flex_direction: bevy::ui::FlexDirection::Row,
+                justify_content: bevy::ui::JustifyContent::SpaceBetween,
+                border: UiRect::all(Val::Px(2.0)),
+                border_radius: bevy::ui::BorderRadius::all(Val::Px(10.0)),
+                ..default()
+            },
+            bevy::ui::BackgroundColor(Color::srgba(0.25, 0.41, 0.88, 0.7)),
+            bevy::ui::BorderColor::all(Color::srgba(0.8, 0.8, 0.8, 0.7)),
+        ))
+        .with_children(|parent| {
+            parent.spawn((
+                Text::new("View\nRC Link\nArm\nMode\nThrottle\nRoll/Pitch\nYaw\nReset"),
+                TextFont {
+                    font_size: 12.0,
+                    ..default()
+                },
+                TextColor(Color::srgba(0.25, 0.25, 0.75, 1.0)),
+            ));
+
+            parent.spawn((
+                SimHelpValuesText,
+                Text::new("FPV (V)\nChecking RC link..."),
+                TextFont {
+                    font_size: 12.0,
+                    ..default()
+                },
+                TextColor(Color::WHITE),
+            ));
+        });
+}
+
 fn setup_joystick(
     mut rc_input: ResMut<SimRcInput>,
     mut rc_source: ResMut<RcInputSource>,
@@ -595,13 +643,19 @@ fn setup_joystick(
         Ok(joystick) => {
             apply_joystick_frame(&joystick.current_frame(), &mut rc_input);
             *rc_source = RcInputSource::Joystick;
-            info!("sim rc: joystick source active (set CU_SIM_JOYSTICK=<name> to target a device)");
+            info!(
+                "sim rc: joystick source active: {} (set CU_SIM_JOYSTICK=<name> to target a device)",
+                joystick.device_name()
+            );
             joystick_state.reader = Some(joystick);
         }
         Err(err) => {
             *rc_source = RcInputSource::Keyboard;
+            rc_input.mode = messages::FlightMode::Angle;
+            rc_input.armed = true;
+            rc_input.throttle = KEYBOARD_HOVER_THROTTLE_LOW;
             info!(
-                "sim rc: joystick unavailable ({}), using keyboard controls",
+                "sim rc: joystick unavailable ({}), using keyboard controls (auto-armed, hover throttle) (set CU_SIM_ALLOW_GENERIC_JOYSTICK=1 to allow non-radio joysticks)",
                 err.to_string()
             );
             joystick_state.reader = None;
@@ -636,6 +690,9 @@ fn poll_joystick(
             );
             joystick.reader = None;
             *rc_source = RcInputSource::Keyboard;
+            rc_input.mode = messages::FlightMode::Angle;
+            rc_input.armed = true;
+            rc_input.throttle = KEYBOARD_HOVER_THROTTLE_LOW;
         }
     }
 }
@@ -650,20 +707,22 @@ fn mode_from_three_pos(value: f32) -> messages::FlightMode {
     }
 }
 
-fn arm_from_switches(frame: &RcFrame) -> Option<bool> {
-    const ARM_SWITCH_NAMES: &[&str] = &["sf", "se", "arm", "btn1"];
-
+fn find_arm_switch(frame: &RcFrame) -> Option<&rc_joystick::SwitchState> {
     for name in ARM_SWITCH_NAMES {
         if let Some(sw) = frame
             .switches
             .iter()
             .find(|s| s.name.eq_ignore_ascii_case(name))
         {
-            return Some(sw.on);
+            return Some(sw);
         }
     }
 
-    frame.switches.first().map(|s| s.on)
+    frame.switches.first()
+}
+
+fn arm_from_switches(frame: &RcFrame) -> Option<bool> {
+    find_arm_switch(frame).map(|s| s.on)
 }
 
 fn apply_joystick_frame(frame: &RcFrame, rc_input: &mut SimRcInput) {
@@ -695,7 +754,7 @@ fn update_rc_input_keyboard(
     }
 
     let roll =
-        (keyboard.pressed(KeyCode::KeyA) as i8 - keyboard.pressed(KeyCode::KeyD) as i8) as f32;
+        (keyboard.pressed(KeyCode::KeyD) as i8 - keyboard.pressed(KeyCode::KeyA) as i8) as f32;
     let pitch =
         (keyboard.pressed(KeyCode::KeyS) as i8 - keyboard.pressed(KeyCode::KeyW) as i8) as f32;
     let yaw =
@@ -717,6 +776,10 @@ fn update_rc_input_keyboard(
 
     if keyboard.just_pressed(KeyCode::KeyT) {
         rc_input.armed = !rc_input.armed;
+        if rc_input.armed {
+            // Keyboard arming should start in a safe stabilized mode.
+            rc_input.mode = messages::FlightMode::Angle;
+        }
         info!("sim rc: armed={} mode={:?}", rc_input.armed, rc_input.mode);
     }
 }
@@ -724,24 +787,18 @@ fn update_rc_input_keyboard(
 fn adjust_keyboard_throttle(
     mut rc_input: ResMut<SimRcInput>,
     keyboard: Res<ButtonInput<KeyCode>>,
-    time: Res<Time>,
     rc_source: Res<RcInputSource>,
 ) {
     if *rc_source == RcInputSource::Joystick {
         return;
     }
 
-    let dt = time.delta_secs();
-    let mut throttle = rc_input.throttle;
-
-    if keyboard.pressed(KeyCode::Space) {
-        throttle += dt * 0.5;
-    }
-    if keyboard.pressed(KeyCode::ControlLeft) {
-        throttle -= dt * 0.5;
-    }
-
-    rc_input.throttle = throttle.clamp(0.0, 1.0);
+    // Keyboard mode is a simple "descend a bit / climb a bit" control around hover.
+    rc_input.throttle = if keyboard.pressed(KeyCode::Space) {
+        KEYBOARD_HOVER_THROTTLE_HIGH
+    } else {
+        KEYBOARD_HOVER_THROTTLE_LOW
+    };
 }
 
 fn reset_vehicle(
@@ -811,6 +868,8 @@ fn run_copper(
 ) {
     let vehicle = sim_state.vehicle.clone();
     let rc = rc_input.clone();
+    sim_support::sim_battery_set_armed(rc.armed);
+    sim_support::sim_battery_set_throttle(rc.throttle);
     let clock = copper._ctx.clock.clone();
     let dshot = &mut motor_commands.dshot;
 
@@ -958,6 +1017,75 @@ fn track_sim_led_state() {
     let _on = sim_support::sim_activity_led_is_on();
 }
 
+fn axis_or_unmapped(axis: Option<&String>) -> &str {
+    axis.map_or("unmapped", String::as_str)
+}
+
+fn connected_help_values(view_label: &str, joystick: &RcJoystick) -> String {
+    let axes: RcAxisBindings = joystick.axis_bindings();
+    let frame = joystick.current_frame();
+    let arm_switch = find_arm_switch(&frame);
+    let device_name = joystick.device_name();
+
+    let arm_line = if let Some(sw) = arm_switch {
+        format!("switch {}", sw.name)
+    } else {
+        format!("knob_sa {} > 0.5", axis_or_unmapped(axes.knob_sa.as_ref()))
+    };
+
+    let mode_line = if arm_switch.is_some() {
+        format!(
+            "knob_sa {} (3-pos)",
+            axis_or_unmapped(axes.knob_sa.as_ref())
+        )
+    } else {
+        format!(
+            "knob_sb {} (3-pos)",
+            axis_or_unmapped(axes.knob_sb.as_ref())
+        )
+    };
+
+    format!(
+        "{view_label}\nConnected ({device_name})\n{arm_line}\n{mode_line}\n{}\n{} / {}\n{}\nR",
+        axis_or_unmapped(axes.throttle.as_ref()),
+        axis_or_unmapped(axes.roll.as_ref()),
+        axis_or_unmapped(axes.pitch.as_ref()),
+        axis_or_unmapped(axes.yaw.as_ref()),
+    )
+}
+
+fn update_help_overlay(
+    camera_view: Res<CameraView>,
+    rc_source: Res<RcInputSource>,
+    joystick_state: Res<SimJoystickState>,
+    mut help_text_query: Query<&mut Text, With<SimHelpValuesText>>,
+) {
+    let Ok(mut text) = help_text_query.single_mut() else {
+        return;
+    };
+
+    let view_label = match *camera_view {
+        CameraView::FirstPerson => "FPV (V -> 3RD)",
+        CameraView::ThirdPerson => "3RD (V -> FPV)",
+    };
+
+    let values = match *rc_source {
+        RcInputSource::Keyboard => format!(
+            "{view_label}\nNot connected (plug RC via USB/BT)\nT\n1=Acro 2=Angle 3=PosHold\nSpace (boost)\nWASD\nQ / E\nR"
+        ),
+        RcInputSource::Joystick => joystick_state.reader.as_ref().map_or_else(
+            || {
+                format!(
+                    "{view_label}\nConnected (USB/BT)\nRC source initializing...\n-\n-\n-\n-\nR"
+                )
+            },
+            |joy| connected_help_values(view_label, joy),
+        ),
+    };
+
+    *text = Text::new(values);
+}
+
 fn update_osd_overlay(
     camera_view: Res<CameraView>,
     osd_overlay: Res<SimOsdOverlay>,
@@ -1059,7 +1187,13 @@ pub fn make_world(headless: bool) -> App {
     .insert_resource(Time::<Physics>::default())
     .add_systems(
         Startup,
-        (setup_world, setup_osd_overlay, setup_copper, setup_joystick),
+        (
+            setup_world,
+            setup_osd_overlay,
+            setup_help_overlay,
+            setup_copper,
+            setup_joystick,
+        ),
     )
     .add_systems(
         Update,
@@ -1076,6 +1210,7 @@ pub fn make_world(headless: bool) -> App {
             toggle_camera_view,
             camera_follow_quadcopter,
             track_sim_led_state,
+            update_help_overlay,
             update_osd_overlay,
         )
             .chain(),

--- a/examples/cu_flight_controller/src/sim/rc_joystick.rs
+++ b/examples/cu_flight_controller/src/sim/rc_joystick.rs
@@ -36,6 +36,17 @@ pub struct SwitchState {
     pub on: bool,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct RcAxisBindings {
+    pub roll: Option<String>,
+    pub pitch: Option<String>,
+    pub yaw: Option<String>,
+    pub throttle: Option<String>,
+    pub knob_sa: Option<String>,
+    pub knob_sb: Option<String>,
+    pub knob_sc: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum RcAxis {
     Roll,
@@ -66,7 +77,8 @@ impl RcJoystick {
     /// Create a joystick reader. When `preferred_name` is provided it will match the
     /// device name (case insensitive). Otherwise the best joystick-like device is picked.
     pub fn open(preferred_name: Option<&str>) -> io::Result<Self> {
-        let (_path, device) = discover_device(preferred_name)?;
+        let allow_generic = env_flag_true("CU_SIM_ALLOW_GENERIC_JOYSTICK");
+        let (_path, device) = discover_device(preferred_name, allow_generic)?;
 
         let axis_map = build_axis_map(&device);
         if axis_map.is_empty() {
@@ -164,6 +176,30 @@ impl RcJoystick {
     /// Returns the latest known joystick state snapshot.
     pub fn current_frame(&self) -> RcFrame {
         self.state.clone()
+    }
+
+    /// Returns technical axis names currently bound to each RC role.
+    pub fn axis_bindings(&self) -> RcAxisBindings {
+        let mut bindings = RcAxisBindings::default();
+        for (code, (role, _scale)) in &self.axis_map {
+            let label = axis_code_label(*code);
+            match role {
+                RcAxis::Roll => bindings.roll = Some(label),
+                RcAxis::Pitch => bindings.pitch = Some(label),
+                RcAxis::Yaw => bindings.yaw = Some(label),
+                RcAxis::Throttle => bindings.throttle = Some(label),
+                RcAxis::KnobSa => bindings.knob_sa = Some(label),
+                RcAxis::KnobSb => bindings.knob_sb = Some(label),
+                RcAxis::KnobSc => bindings.knob_sc = Some(label),
+                RcAxis::Aux(_) => {}
+            }
+        }
+        bindings
+    }
+
+    /// Returns the input device name used for RC mapping.
+    pub fn device_name(&self) -> String {
+        self.device.name().unwrap_or("unknown").to_string()
     }
 
     /// Convenience helper that logs changes to stdout.
@@ -364,10 +400,13 @@ fn build_switch_map(device: &Device, switches: &[SwitchState]) -> HashMap<u16, u
     map
 }
 
-fn discover_device(preferred_name: Option<&str>) -> io::Result<(PathBuf, Device)> {
+fn discover_device(
+    preferred_name: Option<&str>,
+    allow_generic: bool,
+) -> io::Result<(PathBuf, Device)> {
     let mut best: Option<(i32, PathBuf, Device)> = None;
     for (path, device) in evdev::enumerate() {
-        let score = score_device(&device, preferred_name);
+        let score = score_device(&device, preferred_name, allow_generic);
         if score <= 0 {
             continue;
         }
@@ -381,7 +420,7 @@ fn discover_device(preferred_name: Option<&str>) -> io::Result<(PathBuf, Device)
         .ok_or_else(|| Error::new(ErrorKind::NotFound, "no RC joystick device found"))
 }
 
-fn score_device(device: &Device, preferred_name: Option<&str>) -> i32 {
+fn score_device(device: &Device, preferred_name: Option<&str>, allow_generic: bool) -> i32 {
     let mut score = 0;
     if device.supported_events().contains(EventType::ABSOLUTE) {
         score += 10;
@@ -399,22 +438,24 @@ fn score_device(device: &Device, preferred_name: Option<&str>) -> i32 {
         score += 5;
     }
 
-    if let Some(name) = device.name() {
-        let lower = name.to_lowercase();
-        if lower.contains("radio") || lower.contains("rc") || lower.contains("tx") {
-            score += 20;
-        }
-        if lower.contains("opentx") || lower.contains("edgetx") {
-            score += 20;
-        }
-        if lower.contains("joystick") {
-            score += 5;
-        }
-        if let Some(pref) = preferred_name
-            && lower.contains(&pref.to_lowercase())
-        {
-            score += 100;
-        }
+    let lower = joystick_device_name(device);
+    if let Some(pref) = preferred_name
+        && lower.contains(&pref.to_lowercase())
+    {
+        return score + 1000;
+    }
+
+    let is_radio = is_radio_profile_name(&lower);
+    if is_radio {
+        score += 40;
+    } else if !allow_generic {
+        return 0;
+    } else if lower.contains("joystick") {
+        score += 5;
+    }
+
+    if lower.contains("radio") || lower.contains("rc") || lower.contains("tx") {
+        score += 20;
     }
 
     score
@@ -643,4 +684,29 @@ fn normalize_axis(device: &Device, axis_code: u16, raw: i32) -> f32 {
 
     let raw = raw as f32;
     (raw / 32767.0).clamp(-1.0, 1.0)
+}
+
+fn axis_code_label(code: u16) -> String {
+    match code {
+        x if x == AbsoluteAxisCode::ABS_X.0 => "ABS_X".to_string(),
+        x if x == AbsoluteAxisCode::ABS_Y.0 => "ABS_Y".to_string(),
+        x if x == AbsoluteAxisCode::ABS_Z.0 => "ABS_Z".to_string(),
+        x if x == AbsoluteAxisCode::ABS_RX.0 => "ABS_RX".to_string(),
+        x if x == AbsoluteAxisCode::ABS_RY.0 => "ABS_RY".to_string(),
+        x if x == AbsoluteAxisCode::ABS_RZ.0 => "ABS_RZ".to_string(),
+        x if x == AbsoluteAxisCode::ABS_THROTTLE.0 => "ABS_THROTTLE".to_string(),
+        x if x == AbsoluteAxisCode::ABS_RUDDER.0 => "ABS_RUDDER".to_string(),
+        x if x == AbsoluteAxisCode::ABS_WHEEL.0 => "ABS_WHEEL".to_string(),
+        _ => format!("ABS_0x{code:02X}"),
+    }
+}
+
+fn env_flag_true(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|v| {
+        let v = v.trim();
+        v == "1"
+            || v.eq_ignore_ascii_case("true")
+            || v.eq_ignore_ascii_case("yes")
+            || v.eq_ignore_ascii_case("on")
+    })
 }

--- a/examples/cu_flight_controller/src/sim_support.rs
+++ b/examples/cu_flight_controller/src/sim_support.rs
@@ -2,13 +2,27 @@
 
 use cu_sensor_payloads::{BarometerPayload, ImuPayload, MagnetometerPayload};
 use cu29::prelude::*;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, OnceLock};
 
 static SIM_ACTIVITY_LED_STATE: OnceLock<Arc<AtomicBool>> = OnceLock::new();
+static SIM_BATTERY_THROTTLE_BITS: OnceLock<Arc<AtomicU32>> = OnceLock::new();
+static SIM_BATTERY_ARMED_STATE: OnceLock<Arc<AtomicBool>> = OnceLock::new();
 
 fn sim_activity_led_state() -> Arc<AtomicBool> {
     SIM_ACTIVITY_LED_STATE
+        .get_or_init(|| Arc::new(AtomicBool::new(false)))
+        .clone()
+}
+
+fn sim_battery_throttle_state() -> Arc<AtomicU32> {
+    SIM_BATTERY_THROTTLE_BITS
+        .get_or_init(|| Arc::new(AtomicU32::new(0.0_f32.to_bits())))
+        .clone()
+}
+
+fn sim_battery_armed_state() -> Arc<AtomicBool> {
+    SIM_BATTERY_ARMED_STATE
         .get_or_init(|| Arc::new(AtomicBool::new(false)))
         .clone()
 }
@@ -34,10 +48,29 @@ pub fn sim_activity_led_is_on() -> bool {
     sim_activity_led_state().load(Ordering::Relaxed)
 }
 
+pub fn sim_battery_set_throttle(throttle: f32) {
+    let clamped = throttle.clamp(0.0, 1.0);
+    sim_battery_throttle_state().store(clamped.to_bits(), Ordering::Relaxed);
+}
+
+pub fn sim_battery_set_armed(armed: bool) {
+    sim_battery_armed_state().store(armed, Ordering::Relaxed);
+}
+
+fn sim_battery_throttle() -> f32 {
+    let bits = sim_battery_throttle_state().load(Ordering::Relaxed);
+    f32::from_bits(bits).clamp(0.0, 1.0)
+}
+
+fn sim_battery_is_armed() -> bool {
+    sim_battery_armed_state().load(Ordering::Relaxed)
+}
+
 #[derive(Clone, Reflect)]
 pub struct SimBatteryAdc {
     base_voltage: f32,
     phase: f32,
+    sag_max_ratio: f32,
 }
 
 impl Default for SimBatteryAdc {
@@ -45,23 +78,31 @@ impl Default for SimBatteryAdc {
         Self {
             base_voltage: 16.0,
             phase: 0.0,
+            sag_max_ratio: 0.08,
         }
     }
 }
 
 impl SimBatteryAdc {
     pub fn read_voltage_v(&mut self) -> f32 {
+        if !sim_battery_is_armed() {
+            self.phase = 0.0;
+            return self.base_voltage.max(0.0);
+        }
         // Keep a small deterministic ripple so downstream battery logic sees live updates.
         self.phase += 0.05;
         let ripple = self.phase.sin() * 0.2;
-        (self.base_voltage + ripple).max(0.0)
+        let sag_ratio = (self.sag_max_ratio * sim_battery_throttle()).clamp(0.0, 0.5);
+        let sagged = self.base_voltage * (1.0 - sag_ratio);
+        (sagged + ripple).max(0.0)
     }
 }
 
-pub fn sim_battery_adc(base_voltage: f32) -> SimBatteryAdc {
+pub fn sim_battery_adc(base_voltage: f32, sag_max_ratio: f32) -> SimBatteryAdc {
     SimBatteryAdc {
         base_voltage,
         phase: 0.0,
+        sag_max_ratio: sag_max_ratio.clamp(0.0, 0.5),
     }
 }
 

--- a/examples/cu_flight_controller/src/tasks/battery.rs
+++ b/examples/cu_flight_controller/src/tasks/battery.rs
@@ -19,6 +19,11 @@ type BatteryAdcBackendImpl = cu_micoairh743::BatteryAdc;
 #[cfg(all(feature = "sim", not(feature = "firmware")))]
 type BatteryAdcBackendImpl = crate::sim_support::SimBatteryAdc;
 
+#[cfg(all(feature = "sim", not(feature = "firmware")))]
+const SIM_BATTERY_BASE_VOLTAGE_V: f32 = 16.0;
+#[cfg(all(feature = "sim", not(feature = "firmware")))]
+const SIM_BATTERY_SAG_MAX_RATIO: f32 = 0.08;
+
 #[cfg(feature = "firmware")]
 impl BatteryAdcBackend for BatteryAdcBackendImpl {
     fn read_centivolts(&mut self, calib: &BatteryAdcCalibration) -> u16 {
@@ -94,7 +99,10 @@ impl CuSrcTask for BatteryAdcSource {
         #[cfg(feature = "firmware")]
         let adc = _resources.battery_adc.0;
         #[cfg(all(feature = "sim", not(feature = "firmware")))]
-        let adc = crate::sim_support::sim_battery_adc(cfg_f32(config, "sim_voltage_v", 16.0)?);
+        let adc = crate::sim_support::sim_battery_adc(
+            SIM_BATTERY_BASE_VOLTAGE_V,
+            SIM_BATTERY_SAG_MAX_RATIO,
+        );
 
         Ok(Self { adc, calib })
     }

--- a/examples/cu_flight_controller/src/tasks/mod.rs
+++ b/examples/cu_flight_controller/src/tasks/mod.rs
@@ -113,6 +113,7 @@ static LOG_MOTORS: spin::Mutex<LogRateLimiter> =
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect)]
 enum StatusLabel {
     Disarmed,
+    Calibrating,
     Angle,
     Air,
     Position,
@@ -122,6 +123,7 @@ impl StatusLabel {
     const fn as_str(self) -> &'static str {
         match self {
             StatusLabel::Disarmed => " XXX ",
+            StatusLabel::Calibrating => " CAL ",
             StatusLabel::Angle => "ANGLE",
             StatusLabel::Air => " AIR ",
             StatusLabel::Position => " POS ",

--- a/examples/cu_flight_controller/src/tasks/vtx.rs
+++ b/examples/cu_flight_controller/src/tasks/vtx.rs
@@ -17,6 +17,7 @@ use cu_msp_lib::structs::{
     MspFlightControllerVersion, MspRequest, MspStatus, MspStatusSensors, MspVoltageMeter,
     MspVoltageMeterConfig,
 };
+use cu_sensor_payloads::ImuPayload;
 use cu29::prelude::*;
 use cu29::units::si::electric_potential::volt;
 
@@ -52,13 +53,14 @@ pub struct VtxOsd {
     last_heartbeat: Option<CuTime>,
     last_draw: Option<CuTime>,
     last_armed: bool,
+    last_mode: FlightMode,
     last_voltage_centi: Option<u16>,
 }
 
 impl Freezable for VtxOsd {}
 
 impl CuTask for VtxOsd {
-    type Input<'m> = input_msg!('m, ControlInputs, BatteryVoltage, MspRequestBatch);
+    type Input<'m> = input_msg!('m, ControlInputs, ImuPayload, BatteryVoltage, MspRequestBatch);
     type Output<'m> = CuMsg<MspRequestBatch>;
     type Resources<'r> = ();
 
@@ -93,6 +95,7 @@ impl CuTask for VtxOsd {
             last_heartbeat: None,
             last_draw: None,
             last_armed: false,
+            last_mode: FlightMode::Angle,
             last_voltage_centi: None,
         })
     }
@@ -103,7 +106,7 @@ impl CuTask for VtxOsd {
         input: &Self::Input<'i>,
         output: &mut Self::Output<'o>,
     ) -> CuResult<()> {
-        let (ctrl_msg, batt_msg, incoming_msg) = *input;
+        let (ctrl_msg, imu_msg, batt_msg, incoming_msg) = *input;
         let tov_time = tasks::expect_tov_time(ctrl_msg.tov)?;
         output.tov = Tov::Time(tov_time);
         let now = tov_time;
@@ -121,6 +124,7 @@ impl CuTask for VtxOsd {
 
         if let Some(ctrl) = ctrl {
             self.last_armed = ctrl.armed;
+            self.last_mode = ctrl.mode;
         }
 
         let heartbeat_due = self
@@ -133,19 +137,11 @@ impl CuTask for VtxOsd {
             self.last_heartbeat = Some(now);
         }
 
-        let Some(ctrl) = ctrl else {
-            if batch.0.is_empty() {
-                status_if_not_firmware!(output.metadata, "osd wait");
-                output.clear_payload();
-            } else {
-                status_if_not_firmware!(output.metadata, format!("osd wait q{}", batch.0.len()));
-                output.set_payload(batch);
-            }
-            return Ok(());
-        };
-
-        let label = if ctrl.armed {
-            match ctrl.mode {
+        let calibrating = self.last_armed && imu_msg.payload().is_none();
+        let label = if calibrating {
+            StatusLabel::Calibrating
+        } else if self.last_armed {
+            match self.last_mode {
                 FlightMode::Acro => StatusLabel::Air,
                 FlightMode::Angle => StatusLabel::Angle,
                 FlightMode::PositionHold => StatusLabel::Position,


### PR DESCRIPTION

<img width="1048" height="652" alt="image" src="https://github.com/user-attachments/assets/9750ede5-16fd-481a-b029-141fabe579b5" />

## Summary

1. explicitely tells if this is keyboard or RC
2. shows the RC bindings
3. better fake battery simulation: ripple only with armed, sag on throttle
4. foolproof mode for keyboard mode: automatically arm in angle mode

## Related issues
- Closes #

## Changes

## Testing
- [x] `just fmt`
- [x] `just lint`
- [x] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [x] I have updated docs or examples where needed
- [x] I have added or updated tests where needed
- [x] I have considered platform impact (Linux/macOS/Windows/embedded)
- [x] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
