### PR TITLE
FC: Move the default sim to a city

### DIFF
--- a/examples/cu_flight_controller/copperconfig.ron
+++ b/examples/cu_flight_controller/copperconfig.ron
@@ -77,7 +77,8 @@
             logging: (enabled: false),
             config: {
                 "angle_limit_deg": 60.0,
-                "acro_rate_dps": 200.0,
+                "rate_limit_dps": 210.0,
+                "acro_rate_dps": 500.0,
                 "acro_expo": 0.4,
                 "kp": 1.0,
                 "ki": 0.0,

--- a/examples/cu_flight_controller/src/sim.rs
+++ b/examples/cu_flight_controller/src/sim.rs
@@ -16,11 +16,11 @@ use bevy::ecs::schedule::IntoScheduleConfigs;
 use bevy::prelude::{
     App, AssetPlugin, AssetServer, ButtonInput, Camera, Camera3d, Color, Commands, Component,
     DefaultPlugins, Dir3, DirectionalLight, EnvironmentMapLight, FixedUpdate, GlobalAmbientLight,
-    GlobalTransform, GltfAssetLabel, IsDefaultUiCamera, KeyCode, MessageReader, MessageWriter,
-    MinimalPlugins, Name, Node, PerspectiveProjection, PluginGroup, PositionType, PostUpdate,
-    Projection, Quat, Query, Res, ResMut, Resource, SceneRoot, Startup, Text, TextColor, TextFont,
-    Time, Transform, UiRect, Update, Val, Vec3, Visibility, Window, WindowPlugin, With, Without,
-    default,
+    GlobalTransform, GltfAssetLabel, Handle, IsDefaultUiCamera, KeyCode, MessageReader,
+    MessageWriter, MinimalPlugins, Name, Node, PerspectiveProjection, PluginGroup, PositionType,
+    PostUpdate, Projection, Quat, Query, Res, ResMut, Resource, Scene, SceneRoot, Startup, Text,
+    TextColor, TextFont, Time, Transform, UiRect, Update, Val, Vec3, Visibility, Window,
+    WindowPlugin, With, Without, default,
 };
 use bevy::window::PrimaryWindow;
 use cached_path::{Cache, Error as CacheError, ProgressBar};
@@ -53,8 +53,8 @@ struct SimVehicleState {
 impl Default for SimVehicleState {
     fn default() -> Self {
         Self {
-            position: Vec3::new(0.0, 1.0, 0.0),
-            rotation: Quat::IDENTITY,
+            position: SIM_SPAWN_POSITION,
+            rotation: spawn_rotation(),
             body_accel_fc: [0.0, 0.0, 9.81],
             body_gyro_fc: [0.0; 3],
         }
@@ -103,6 +103,12 @@ impl Default for SimRcInput {
 #[derive(Resource, Default)]
 struct SimKinematics {
     prev_linear_velocity: Option<Vec3>,
+}
+
+#[derive(Resource)]
+struct PendingQuadcopterSpawn {
+    quadcopter_scene: Handle<Scene>,
+    city_scene: Handle<Scene>,
 }
 
 #[derive(Resource, Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -325,10 +331,40 @@ const BASE_ASSETS_URL: &str = "https://cdn.copper-robotics.com/";
 const SKYBOX: &str = "skybox.ktx2";
 const SPECULAR_MAP: &str = "specular_map.ktx2";
 const QUADCOPTER: &str = "quadcopter.glb";
-const LEVEL: &str = "level.glb";
+const CITY: &str = "city.glb";
+// Measured from `gltf-transform inspect city.glb` in source model units.
+const LOCAL_CITY_BBOX_MIN_UNITS: Vec3 = Vec3::new(-30_614.165, -648.2196, -4_185.883);
+const LOCAL_CITY_BBOX_MAX_UNITS: Vec3 = Vec3::new(18_754.953, 11_102.407, 35_871.875);
+// Source appears to be authored in centimeters; convert units to meters.
+const LOCAL_CITY_SCALE: f32 = 0.01;
+const SIM_SPAWN_POSITION: Vec3 = Vec3::new(-10.0, 1.0, 20.0);
 const ARM_SWITCH_NAMES: &[&str] = &["sf", "se", "arm", "btn1"];
 const KEYBOARD_HOVER_THROTTLE_LOW: f32 = 0.56;
 const KEYBOARD_HOVER_THROTTLE_HIGH: f32 = 0.62;
+
+fn spawn_rotation() -> Quat {
+    Quat::from_rotation_y(core::f32::consts::PI)
+}
+
+fn spawn_pose_components() -> (
+    Transform,
+    Position,
+    Rotation,
+    LinearVelocity,
+    AngularVelocity,
+) {
+    (
+        Transform::from_translation(SIM_SPAWN_POSITION).with_rotation(spawn_rotation()),
+        Position::from_xyz(
+            SIM_SPAWN_POSITION.x,
+            SIM_SPAWN_POSITION.y,
+            SIM_SPAWN_POSITION.z,
+        ),
+        Rotation(spawn_rotation()),
+        LinearVelocity(Vec3::ZERO),
+        AngularVelocity(Vec3::ZERO),
+    )
+}
 
 fn create_symlink(src: &str, dst: &str) -> io::Result<()> {
     let dst_path = Path::new(dst);
@@ -496,12 +532,31 @@ fn setup_world(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     let quadcopter_path = precached_asset_path(&online_cache, &offline_cache, QUADCOPTER)
         .expect("failed to get quadcopter.glb (online or cached)");
-    let level_path = precached_asset_path(&online_cache, &offline_cache, LEVEL)
-        .expect("failed to get level.glb (online or cached)");
     let skybox_path = precached_asset_path(&online_cache, &offline_cache, SKYBOX)
         .expect("failed to get skybox.ktx2 (online or cached)");
     let specular_map_path = precached_asset_path(&online_cache, &offline_cache, SPECULAR_MAP)
         .expect("failed to get specular_map.ktx2 (online or cached)");
+    let city_path = precached_asset_path(&online_cache, &offline_cache, CITY)
+        .expect("failed to get city.glb (online or cached)");
+
+    let city_size_units = LOCAL_CITY_BBOX_MAX_UNITS - LOCAL_CITY_BBOX_MIN_UNITS;
+    let city_size_m = city_size_units * LOCAL_CITY_SCALE;
+    let city_translation = Vec3::ZERO;
+    let city_scale = Vec3::splat(LOCAL_CITY_SCALE);
+    let city_path_str = city_path.to_string_lossy().into_owned();
+    info!(
+        "sim world: loading city {} (bbox {}x{}x{} units, scaled to {}x{}x{} m) with translation ({}, {}, {})",
+        city_path_str,
+        city_size_units.x,
+        city_size_units.y,
+        city_size_units.z,
+        city_size_m.x,
+        city_size_m.y,
+        city_size_m.z,
+        city_translation.x,
+        city_translation.y,
+        city_translation.z
+    );
 
     let skybox_handle = asset_server.load(skybox_path.clone());
     let specular_map_handle = asset_server.load(specular_map_path);
@@ -544,32 +599,66 @@ fn setup_world(mut commands: Commands, asset_server: Res<AssetServer>) {
         Transform::from_translation(Vec3::new(3.0, 10.0, 1.0)).looking_at(Vec3::ZERO, Vec3::Y),
     ));
 
-    commands.spawn((
-        Name::new("quadcopter"),
-        SceneRoot(asset_server.load(
-            GltfAssetLabel::Scene(0).from_asset(format!("{}#scene0", quadcopter_path.display())),
-        )),
-        RigidBody::Dynamic,
-        Transform::from_xyz(0.0, 1.0, 0.0),
-        Collider::cuboid(0.14, 0.05, 0.14),
-        Multicopter::new(quad_x_propellers()),
-        Mass(0.7),
-        AngularInertia::new(Vec3::new(0.012, 0.02, 0.012)),
-        AngularDamping(0.4),
-        LinearDamping(0.2),
-        SweptCcd::NON_LINEAR,
-    ));
+    let quadcopter_scene = asset_server
+        .load(GltfAssetLabel::Scene(0).from_asset(format!("{}#scene0", quadcopter_path.display())));
+    let city_scene = asset_server
+        .load(GltfAssetLabel::Scene(0).from_asset(format!("{}#scene0", city_path.display())));
+    commands.insert_resource(PendingQuadcopterSpawn {
+        quadcopter_scene: quadcopter_scene.clone(),
+        city_scene: city_scene.clone(),
+    });
 
     commands.spawn((
-        Name::new("level"),
-        SceneRoot(
-            asset_server.load(
-                GltfAssetLabel::Scene(0).from_asset(format!("{}#scene0", level_path.display())),
-            ),
-        ),
+        Name::new("city"),
+        SceneRoot(city_scene),
+        Transform {
+            translation: city_translation,
+            scale: city_scale,
+            ..default()
+        },
         ColliderConstructorHierarchy::new(ColliderConstructor::TrimeshFromMesh),
         RigidBody::Static,
     ));
+}
+
+fn spawn_quadcopter_when_world_ready(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    pending_spawn: Option<Res<PendingQuadcopterSpawn>>,
+    colliders: Query<(), (With<Collider>, Without<Multicopter>)>,
+) {
+    let Some(pending_spawn) = pending_spawn else {
+        return;
+    };
+
+    if !asset_server.is_loaded_with_dependencies(pending_spawn.city_scene.id())
+        || !asset_server.is_loaded_with_dependencies(pending_spawn.quadcopter_scene.id())
+        || colliders.is_empty()
+    {
+        return;
+    }
+
+    let (transform, position, rotation, lin_vel, ang_vel) = spawn_pose_components();
+    commands
+        .spawn((
+            Name::new("quadcopter"),
+            SceneRoot(pending_spawn.quadcopter_scene.clone()),
+            RigidBody::Dynamic,
+            transform,
+            position,
+            rotation,
+            lin_vel,
+            ang_vel,
+            Collider::cuboid(0.14, 0.05, 0.14),
+            Multicopter::new(quad_x_propellers()),
+            Mass(0.7),
+            AngularInertia::new(Vec3::new(0.012, 0.02, 0.012)),
+            AngularDamping(0.4),
+            LinearDamping(0.2),
+            SweptCcd::NON_LINEAR,
+        ))
+        .insert(Visibility::Visible);
+    commands.remove_resource::<PendingQuadcopterSpawn>();
 }
 
 fn setup_osd_overlay(mut commands: Commands) {
@@ -804,7 +893,13 @@ fn adjust_keyboard_throttle(
 fn reset_vehicle(
     keyboard: Res<ButtonInput<KeyCode>>,
     mut query: Query<
-        (&mut Transform, &mut LinearVelocity, &mut AngularVelocity),
+        (
+            &mut Transform,
+            &mut Position,
+            &mut Rotation,
+            &mut LinearVelocity,
+            &mut AngularVelocity,
+        ),
         With<Multicopter>,
     >,
     mut motors: ResMut<SimMotorCommands>,
@@ -814,10 +909,16 @@ fn reset_vehicle(
         return;
     }
 
-    if let Ok((mut transform, mut lin_vel, mut ang_vel)) = query.single_mut() {
-        *transform = Transform::from_xyz(0.0, 1.0, 0.0);
-        *lin_vel = LinearVelocity(Vec3::ZERO);
-        *ang_vel = AngularVelocity(Vec3::ZERO);
+    if let Ok((mut transform, mut position, mut rotation, mut lin_vel, mut ang_vel)) =
+        query.single_mut()
+    {
+        let (spawn_tf, spawn_pos, spawn_rot, spawn_lin_vel, spawn_ang_vel) =
+            spawn_pose_components();
+        *transform = spawn_tf;
+        *position = spawn_pos;
+        *rotation = spawn_rot;
+        *lin_vel = spawn_lin_vel;
+        *ang_vel = spawn_ang_vel;
     }
 
     motors.dshot = [0; 4];
@@ -1013,6 +1114,20 @@ fn camera_follow_quadcopter(
     *camera_tf = camera_tf.looking_to(quad_tf.forward(), quad_tf.up());
 }
 
+fn update_quadcopter_visibility(
+    camera_view: Res<CameraView>,
+    mut quad_query: Query<&mut Visibility, With<Multicopter>>,
+) {
+    let Ok(mut visibility) = quad_query.single_mut() else {
+        return;
+    };
+    *visibility = if *camera_view == CameraView::FirstPerson {
+        Visibility::Hidden
+    } else {
+        Visibility::Visible
+    };
+}
+
 fn track_sim_led_state() {
     let _on = sim_support::sim_activity_led_is_on();
 }
@@ -1198,6 +1313,7 @@ pub fn make_world(headless: bool) -> App {
     .add_systems(
         Update,
         (
+            spawn_quadcopter_when_world_ready,
             poll_joystick,
             update_rc_input_keyboard,
             adjust_keyboard_throttle,
@@ -1208,6 +1324,7 @@ pub fn make_world(headless: bool) -> App {
         Update,
         (
             toggle_camera_view,
+            update_quadcopter_visibility,
             camera_follow_quadcopter,
             track_sim_led_state,
             update_help_overlay,

--- a/examples/cu_flight_controller/src/sim/rc_joystick.rs
+++ b/examples/cu_flight_controller/src/sim/rc_joystick.rs
@@ -3,8 +3,6 @@
 use std::collections::HashMap;
 use std::io::{self, Error, ErrorKind};
 use std::path::PathBuf;
-use std::thread;
-use std::time::Duration;
 
 use evdev::{AbsoluteAxisCode, AttributeSetRef, Device, EventSummary, EventType, KeyCode};
 
@@ -22,10 +20,9 @@ pub struct RcFrame {
     pub switches: Vec<SwitchState>,
 }
 
-/// AUX channel with a stable name.
+/// AUX channel value.
 #[derive(Debug, Clone)]
 pub struct AuxChannel {
-    pub name: String,
     pub value: f32,
 }
 
@@ -93,11 +90,8 @@ impl RcJoystick {
             .filter(|a| matches!(a.0, RcAxis::Aux(_)))
             .count();
         let mut aux = Vec::with_capacity(aux_count);
-        for i in 0..aux_count {
-            aux.push(AuxChannel {
-                name: format!("aux{}", i + 1),
-                value: 0.0,
-            });
+        for _ in 0..aux_count {
+            aux.push(AuxChannel { value: 0.0 });
         }
 
         let switches = build_switches(&device);
@@ -200,42 +194,6 @@ impl RcJoystick {
     /// Returns the input device name used for RC mapping.
     pub fn device_name(&self) -> String {
         self.device.name().unwrap_or("unknown").to_string()
-    }
-
-    /// Convenience helper that logs changes to stdout.
-    pub fn print_loop(&mut self) -> io::Result<()> {
-        println!("Waiting for RC joystick events...");
-        loop {
-            match self.next_frame()? {
-                Some(frame) => {
-                    let aux_values = frame
-                        .aux
-                        .iter()
-                        .map(|a| format!("{}:{:+.2}", a.name, a.value))
-                        .collect::<Vec<_>>()
-                        .join(" ");
-                    let switch_values = frame
-                        .switches
-                        .iter()
-                        .map(|s| format!("{}:{}", s.name, if s.on { "on" } else { "off" }))
-                        .collect::<Vec<_>>()
-                        .join(" ");
-                    println!(
-                        "roll {:+.2} pitch {:+.2} yaw {:+.2} throttle {:+.2} sa {:+.2} sb {:+.2} sc {:+.2} | {} | {}",
-                        frame.roll,
-                        frame.pitch,
-                        frame.yaw,
-                        frame.throttle,
-                        frame.knob_sa,
-                        frame.knob_sb,
-                        frame.knob_sc,
-                        aux_values,
-                        switch_values
-                    );
-                }
-                None => thread::sleep(Duration::from_millis(10)),
-            }
-        }
     }
 
     fn update_axis(&mut self, role: RcAxis, value: f32) -> bool {

--- a/examples/cu_flight_controller/src/sim/rc_tester.rs
+++ b/examples/cu_flight_controller/src/sim/rc_tester.rs
@@ -6,6 +6,8 @@ use rc_joystick::RcJoystick;
 use std::env;
 use std::io;
 use std::process;
+use std::thread;
+use std::time::Duration;
 
 fn main() -> io::Result<()> {
     if cfg!(not(feature = "sim")) {
@@ -22,5 +24,60 @@ fn main() -> io::Result<()> {
         e
     })?;
 
-    joystick.print_loop()
+    let bindings = joystick.axis_bindings();
+    println!("Using RC joystick: {}", joystick.device_name());
+    println!(
+        "Axis bindings: roll={:?} pitch={:?} yaw={:?} throttle={:?} sa={:?} sb={:?} sc={:?}",
+        bindings.roll,
+        bindings.pitch,
+        bindings.yaw,
+        bindings.throttle,
+        bindings.knob_sa,
+        bindings.knob_sb,
+        bindings.knob_sc
+    );
+    let frame = joystick.current_frame();
+    println!(
+        "Initial frame: roll {:+.2} pitch {:+.2} yaw {:+.2} throttle {:+.2} sa {:+.2} sb {:+.2} sc {:+.2}",
+        frame.roll,
+        frame.pitch,
+        frame.yaw,
+        frame.throttle,
+        frame.knob_sa,
+        frame.knob_sb,
+        frame.knob_sc
+    );
+    println!("Waiting for RC joystick events...");
+    loop {
+        match joystick.next_frame()? {
+            Some(frame) => {
+                let aux_values = frame
+                    .aux
+                    .iter()
+                    .enumerate()
+                    .map(|(i, a)| format!("aux{}:{:+.2}", i + 1, a.value))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                let switch_values = frame
+                    .switches
+                    .iter()
+                    .map(|s| format!("{}:{}", s.name, if s.on { "on" } else { "off" }))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                println!(
+                    "roll {:+.2} pitch {:+.2} yaw {:+.2} throttle {:+.2} sa {:+.2} sb {:+.2} sc {:+.2} | {} | {}",
+                    frame.roll,
+                    frame.pitch,
+                    frame.yaw,
+                    frame.throttle,
+                    frame.knob_sa,
+                    frame.knob_sb,
+                    frame.knob_sc,
+                    aux_values,
+                    switch_values
+                );
+            }
+            None => thread::sleep(Duration::from_millis(10)),
+        }
+    }
 }


### PR DESCRIPTION
+ relaxed the rate (they were very conservative for the real quad)


https://github.com/user-attachments/assets/fb68cf7b-033d-4655-9f68-73c223d1320a



## Summary

## Related issues
- Closes #

## Changes

## Testing
- [x] `just fmt`
- [x] `just lint`
- [x] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [x] I have updated docs or examples where needed
- [x] I have added or updated tests where needed
- [x] I have considered platform impact (Linux/macOS/Windows/embedded)
- [x] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
