### PR TITLE
5 limit to 12 inputs per task

### DIFF
--- a/core/cu29_runtime/src/cutask.rs
+++ b/core/cu29_runtime/src/cutask.rs
@@ -44,16 +44,25 @@ macro_rules! impl_cu_msg_pack {
     };
 }
 
+macro_rules! impl_cu_msg_pack_up_to {
+    ($first:ident, $second:ident $(, $rest:ident)* $(,)?) => {
+        impl_cu_msg_pack!($first, $second);
+        impl_cu_msg_pack_up_to!(@accumulate ($first, $second); $($rest),*);
+    };
+    (@accumulate ($($acc:ident),+);) => {};
+    (@accumulate ($($acc:ident),+); $next:ident $(, $rest:ident)*) => {
+        impl_cu_msg_pack!($($acc),+, $next);
+        impl_cu_msg_pack_up_to!(@accumulate ($($acc),+, $next); $($rest),*);
+    };
+}
+
 impl<T: CuMsgPayload> CuMsgPack for CuMsg<T> {}
 impl<T: CuMsgPayload> CuMsgPack for &CuMsg<T> {}
 impl<T: CuMsgPayload> CuMsgPack for (&CuMsg<T>,) {}
 impl CuMsgPack for () {}
 
-// Apply the macro to generate implementations for tuple sizes up to 5
-impl_cu_msg_pack!(T1, T2);
-impl_cu_msg_pack!(T1, T2, T3);
-impl_cu_msg_pack!(T1, T2, T3, T4);
-impl_cu_msg_pack!(T1, T2, T3, T4, T5);
+// Apply the macro to generate implementations for tuple sizes up to 12.
+impl_cu_msg_pack_up_to!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
 
 // A convenience macro to get from a payload or a list of payloads to a proper CuMsg or CuMsgPack
 // declaration for your tasks used for input messages.

--- a/core/cu29_runtime/src/simulation.rs
+++ b/core/cu29_runtime/src/simulation.rs
@@ -265,11 +265,19 @@ macro_rules! impl_sim_sink_input_tuple {
     };
 }
 
-impl_sim_sink_input_tuple!(T1);
-impl_sim_sink_input_tuple!(T1, T2);
-impl_sim_sink_input_tuple!(T1, T2, T3);
-impl_sim_sink_input_tuple!(T1, T2, T3, T4);
-impl_sim_sink_input_tuple!(T1, T2, T3, T4, T5);
+macro_rules! impl_sim_sink_input_up_to {
+    ($first:ident $(, $rest:ident)* $(,)?) => {
+        impl_sim_sink_input_tuple!($first);
+        impl_sim_sink_input_up_to!(@accumulate ($first); $($rest),*);
+    };
+    (@accumulate ($($acc:ident),+);) => {};
+    (@accumulate ($($acc:ident),+); $next:ident $(, $rest:ident)*) => {
+        impl_sim_sink_input_tuple!($($acc),+, $next);
+        impl_sim_sink_input_up_to!(@accumulate ($($acc),+, $next); $($rest),*);
+    };
+}
+
+impl_sim_sink_input_up_to!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
 
 /// This is a placeholder task for a sink task for the simulations.
 /// It basically does nothing in place of a real driver so it won't try to initialize any hardware.


### PR DESCRIPTION
## Summary

We hit the limit with the VTX on the flight controller because we display more than 5 things.

Pushed it up to 12, macro base, no runtime cost.

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
