### PR TITLE
FC: Mass of the quad was wrong in sim

### DIFF
--- a/examples/cu_flight_controller/src/sim.rs
+++ b/examples/cu_flight_controller/src/sim.rs
@@ -629,7 +629,7 @@ fn spawn_quadcopter_when_world_ready(
             ang_vel,
             Collider::cuboid(0.14, 0.05, 0.14),
             Multicopter::new(quad_x_propellers()),
-            Mass(0.7),
+            Mass(0.44),
             AngularInertia::new(Vec3::new(0.012, 0.02, 0.012)),
             AngularDamping(0.4),
             LinearDamping(0.2),


### PR DESCRIPTION
## Summary
Felt the quad sluggish in sim, it was almost weight x2

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
