### PR TITLE
Adds a symlink to _0 to simplify logreader / tools

### DIFF
--- a/core/cu29_unifiedlog/src/memmap.rs
+++ b/core/cu29_unifiedlog/src/memmap.rs
@@ -456,7 +456,7 @@ fn create_base_alias_link(base_file_path: &Path) -> io::Result<()> {
                 "First slab file has no name component",
             )
         })?);
-        return symlink(relative_target, base_file_path).map_err(|e| {
+        symlink(relative_target, base_file_path).map_err(|e| {
             io::Error::new(
                 e.kind(),
                 format!(
@@ -465,7 +465,7 @@ fn create_base_alias_link(base_file_path: &Path) -> io::Result<()> {
                     first_slab_path.display()
                 ),
             )
-        });
+        })
     }
 
     #[cfg(windows)]
@@ -488,7 +488,7 @@ fn create_base_alias_link(base_file_path: &Path) -> io::Result<()> {
                 },
             ),
         }?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(any(unix, windows)))]


### PR DESCRIPTION
## Summary

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
