### PR TITLE
Add liveliness token for subscriber in cu_ros2_bridge

### DIFF
--- a/components/bridges/cu_ros2_bridge/src/lib.rs
+++ b/components/bridges/cu_ros2_bridge/src/lib.rs
@@ -10,7 +10,7 @@ use cdr::{CdrBe, Infinite};
 use cu_ros2_payloads::RosBridgeAdapter;
 use cu29::cubridge::{BridgeChannel, BridgeChannelConfig, BridgeChannelSet, CuBridge};
 use cu29::prelude::*;
-use liveliness::{node_liveliness, publisher_liveliness};
+use liveliness::{node_liveliness, publisher_liveliness, subscriber_liveliness};
 use node::Node;
 use topic::Topic;
 use zenoh::bytes::Encoding;
@@ -155,7 +155,9 @@ struct Ros2TxChannel<Id: Copy> {
 struct Ros2RxChannel<Id: Copy> {
     id: Id,
     route: String,
+    entity_id: u32,
     subscriber: Option<Ros2Subscriber>,
+    subscriber_token: Option<zenoh::liveliness::LivelinessToken>,
 }
 
 struct Ros2Context<TxId: Copy, RxId: Copy> {
@@ -389,13 +391,24 @@ where
         }
 
         let route = ctx.rx_channels[rx_idx].route.clone();
+        let entity_id = ctx.rx_channels[rx_idx].entity_id;
         let topic = Self::topic_for_codec(route.as_str(), codec);
         let node = Self::make_node(domain_id, namespace, node_name, &ctx.session);
+
+        let subscriber_token = zenoh::Wait::wait(
+            ctx.session
+                .liveliness()
+                .declare_token(subscriber_liveliness(&node, &topic, entity_id)?),
+        )
+        .map_err(cu_error_map(
+            "Ros2Bridge: Failed to declare subscriber liveliness token",
+        ))?;
 
         let keyexpr = topic.pubsub_keyexpr(&node)?;
         let subscriber = zenoh::Wait::wait(ctx.session.declare_subscriber(keyexpr))
             .map_err(cu_error_map("Ros2Bridge: Failed to declare subscriber"))?;
 
+        ctx.rx_channels[rx_idx].subscriber_token = Some(subscriber_token);
         ctx.rx_channels[rx_idx].subscriber = Some(subscriber);
         Ok(())
     }
@@ -492,10 +505,13 @@ where
         let rx_channels = self
             .rx_channels
             .iter()
-            .map(|channel| Ros2RxChannel {
+            .enumerate()
+            .map(|(index, channel)| Ros2RxChannel {
                 id: channel.id,
                 route: channel.route.clone(),
+                entity_id: (index + 1) as u32,
                 subscriber: None,
+                subscriber_token: None,
             })
             .collect();
 

--- a/components/bridges/cu_ros2_bridge/src/liveliness.rs
+++ b/components/bridges/cu_ros2_bridge/src/liveliness.rs
@@ -10,6 +10,7 @@ const ADMIN_SPACE: &str = "@ros2_lv";
 enum Entity {
     Node,
     Publisher,
+    Subscriber,
 }
 
 impl fmt::Display for Entity {
@@ -17,12 +18,25 @@ impl fmt::Display for Entity {
         match self {
             Entity::Node => write!(f, "NN"),
             Entity::Publisher => write!(f, "MP"),
+            Entity::Subscriber => write!(f, "MS"),
         }
     }
 }
 
 pub fn node_liveliness(node: &Node) -> CuResult<KeyExpr<'static>> {
     liveliness_base_keyexpr(node, Entity::Node, node.id)
+}
+
+pub fn subscriber_liveliness(
+    node: &Node,
+    topic: &Topic,
+    instance_id: u32,
+) -> CuResult<KeyExpr<'static>> {
+    let base_keyexpr = liveliness_base_keyexpr(node, Entity::Subscriber, instance_id)?;
+    let topic_keyexpr =
+        format_liveliness_keyexpr!(topic.name(), topic.type_name(), topic.hash(), topic.qos())?;
+
+    Ok(base_keyexpr / topic_keyexpr.as_ref())
 }
 
 pub fn publisher_liveliness(


### PR DESCRIPTION
## Summary
Mimic what's being done for Publisher and add a liveliness token for Subscriber in cu_ros2_bridge.
Fixes issues where Isaac Sim could receive from Copper but could not send to it through the bridges

## Related issues
- Closes #

## Changes

## Testing
- [X] `just fmt`
- [X] `just lint`
- [X] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [X] I have updated docs or examples where needed
- [X] I have added or updated tests where needed
- [X] I have considered platform impact (Linux/macOS/Windows/embedded)
- [X] I have considered config/logging changes (if applicable)
- [X] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
