### PR TITLE
fix: too small chrs in the bevy rendering path

### DIFF
--- a/components/monitors/cu_bevymon/README.md
+++ b/components/monitors/cu_bevymon/README.md
@@ -100,7 +100,7 @@ Input model:
 Font behavior:
 
 - the default bundled font set is JetBrains Mono Nerd Font Mono Light / SemiBold / LightItalic
-- the default bundled font size is 16 px
+- the default bundled font size is 24 px
 - panel resize changes how many rows and columns fit; it does not change the glyph size
 - use `CuBevyMonPlugin::with_font_size(...)` or `CuBevyMonPlugin::with_font_options(...)` to tune the Bevy-side font size
 - use `CuBevyMonPlugin::with_font_options(...)` for full control

--- a/components/monitors/cu_bevymon/src/terminal.rs
+++ b/components/monitors/cu_bevymon/src/terminal.rs
@@ -8,7 +8,7 @@ use soft_ratatui::{EmbeddedTTF, SoftBackend};
 
 const DEFAULT_TERMINAL_COLS: u16 = 100;
 const DEFAULT_TERMINAL_ROWS: u16 = 50;
-const DEFAULT_FONT_SIZE_PX: u32 = 16;
+const DEFAULT_FONT_SIZE_PX: u32 = 24;
 
 const FONT_REGULAR: &[u8] = include_bytes!("../assets/fonts/CopperMono-Light.ttf");
 const FONT_BOLD: &[u8] = include_bytes!("../assets/fonts/CopperMono-SemiBold.ttf");


### PR DESCRIPTION
## Summary

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
