### PR TITLE
Fix: Consistent TUI colors across renderers

### DIFF
--- a/components/libs/cu_tuimon/src/lib.rs
+++ b/components/libs/cu_tuimon/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "log_pane")]
 mod logpane;
 mod model;
+mod palette;
 mod system_info;
 mod tui_nodes;
 mod ui;

--- a/components/libs/cu_tuimon/src/logpane.rs
+++ b/components/libs/cu_tuimon/src/logpane.rs
@@ -1,4 +1,5 @@
 use crate::MonitorModel;
+use crate::palette;
 use ratatui::style::{Color, Style};
 
 #[cfg(debug_assertions)]
@@ -177,13 +178,13 @@ fn styled_line_from_structured(
             message_runs.push(StyledRun {
                 start: cursor,
                 end: start,
-                style: Style::default().fg(Color::Gray),
+                style: Style::default().fg(palette::GRAY),
             });
         }
         message_runs.push(StyledRun {
             start,
             end,
-            style: Style::default().fg(Color::Magenta),
+            style: Style::default().fg(palette::MAGENTA),
         });
         cursor = end;
     }
@@ -192,7 +193,7 @@ fn styled_line_from_structured(
         message_runs.push(StyledRun {
             start: cursor,
             end: message_text.chars().count(),
-            style: Style::default().fg(Color::Gray),
+            style: Style::default().fg(palette::GRAY),
         });
     }
 
@@ -202,7 +203,7 @@ fn styled_line_from_structured(
         StyledRun {
             start: 0,
             end: timestamp.chars().count(),
-            style: Style::default().fg(Color::Blue),
+            style: Style::default().fg(palette::BLUE),
         },
         StyledRun {
             start: timestamp.chars().count() + 1,
@@ -232,7 +233,7 @@ pub fn styled_line_from_stderr(text: &str) -> StyledLine {
         runs: vec![StyledRun {
             start: 0,
             end: text.chars().count(),
-            style: Style::default().fg(Color::Red),
+            style: Style::default().fg(palette::RED),
         }],
     }
 }
@@ -240,10 +241,10 @@ pub fn styled_line_from_stderr(text: &str) -> StyledLine {
 #[cfg(debug_assertions)]
 fn color_for_level(level: CuLogLevel) -> Color {
     match level {
-        CuLogLevel::Debug => Color::Green,
-        CuLogLevel::Info => Color::Gray,
-        CuLogLevel::Warning => Color::Yellow,
-        CuLogLevel::Error | CuLogLevel::Critical => Color::Red,
+        CuLogLevel::Debug => palette::GREEN,
+        CuLogLevel::Info => palette::GRAY,
+        CuLogLevel::Warning => palette::YELLOW,
+        CuLogLevel::Error | CuLogLevel::Critical => palette::RED,
     }
 }
 

--- a/components/libs/cu_tuimon/src/palette.rs
+++ b/components/libs/cu_tuimon/src/palette.rs
@@ -1,0 +1,107 @@
+use ratatui::{style::Color, text::Text};
+
+pub(crate) const BACKGROUND: Color = Color::Rgb(0, 0, 0);
+pub(crate) const BLACK: Color = Color::Rgb(0, 0, 0);
+pub(crate) const RED: Color = Color::Rgb(204, 4, 3);
+pub(crate) const GREEN: Color = Color::Rgb(25, 203, 0);
+pub(crate) const YELLOW: Color = Color::Rgb(206, 203, 0);
+pub(crate) const BLUE: Color = Color::Rgb(13, 115, 204);
+pub(crate) const MAGENTA: Color = Color::Rgb(203, 30, 209);
+pub(crate) const CYAN: Color = Color::Rgb(13, 205, 205);
+pub(crate) const GRAY: Color = Color::Rgb(221, 221, 221);
+pub(crate) const DARK_GRAY: Color = Color::Rgb(118, 118, 118);
+pub(crate) const LIGHT_RED: Color = Color::Rgb(242, 32, 31);
+pub(crate) const LIGHT_GREEN: Color = Color::Rgb(35, 253, 0);
+pub(crate) const LIGHT_YELLOW: Color = Color::Rgb(255, 253, 0);
+pub(crate) const LIGHT_BLUE: Color = Color::Rgb(26, 143, 255);
+pub(crate) const LIGHT_MAGENTA: Color = Color::Rgb(253, 40, 255);
+pub(crate) const LIGHT_CYAN: Color = Color::Rgb(20, 255, 255);
+pub(crate) const WHITE: Color = Color::Rgb(255, 255, 255);
+pub(crate) const FOREGROUND: Color = GRAY;
+
+pub(crate) fn normalize_text_colors(text: &mut Text<'_>, fallback_fg: Color, fallback_bg: Color) {
+    for line in &mut text.lines {
+        for span in &mut line.spans {
+            if let Some(fg) = span.style.fg {
+                span.style.fg = Some(resolve_color(fg, fallback_fg, fallback_bg, true));
+            }
+            if let Some(bg) = span.style.bg {
+                span.style.bg = Some(resolve_color(bg, fallback_fg, fallback_bg, false));
+            }
+        }
+    }
+}
+
+pub(crate) fn indexed_color(index: u8) -> Color {
+    match index {
+        0 => BLACK,
+        1 => RED,
+        2 => GREEN,
+        3 => YELLOW,
+        4 => BLUE,
+        5 => MAGENTA,
+        6 => CYAN,
+        7 => GRAY,
+        8 => DARK_GRAY,
+        9 => LIGHT_RED,
+        10 => LIGHT_GREEN,
+        11 => LIGHT_YELLOW,
+        12 => LIGHT_BLUE,
+        13 => LIGHT_MAGENTA,
+        14 => LIGHT_CYAN,
+        15 => WHITE,
+        16..=231 => {
+            let idx = index - 16;
+            let r = idx / 36;
+            let g = (idx % 36) / 6;
+            let b = idx % 6;
+            Color::Rgb(cube_level(r), cube_level(g), cube_level(b))
+        }
+        232..=255 => {
+            let level = 8 + (index - 232) * 10;
+            Color::Rgb(level, level, level)
+        }
+    }
+}
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub(crate) fn explicit_fg(color: Color) -> Color {
+    resolve_color(color, FOREGROUND, BACKGROUND, true)
+}
+
+fn resolve_color(color: Color, fallback_fg: Color, fallback_bg: Color, is_fg: bool) -> Color {
+    match color {
+        Color::Reset => {
+            if is_fg {
+                fallback_fg
+            } else {
+                fallback_bg
+            }
+        }
+        Color::Black => BLACK,
+        Color::Red => RED,
+        Color::Green => GREEN,
+        Color::Yellow => YELLOW,
+        Color::Blue => BLUE,
+        Color::Magenta => MAGENTA,
+        Color::Cyan => CYAN,
+        Color::Gray => GRAY,
+        Color::DarkGray => DARK_GRAY,
+        Color::LightRed => LIGHT_RED,
+        Color::LightGreen => LIGHT_GREEN,
+        Color::LightYellow => LIGHT_YELLOW,
+        Color::LightBlue => LIGHT_BLUE,
+        Color::LightMagenta => LIGHT_MAGENTA,
+        Color::LightCyan => LIGHT_CYAN,
+        Color::White => WHITE,
+        Color::Indexed(index) => indexed_color(index),
+        Color::Rgb(r, g, b) => Color::Rgb(r, g, b),
+    }
+}
+
+fn cube_level(component: u8) -> u8 {
+    match component {
+        0 => 0,
+        _ => 55 + component * 40,
+    }
+}

--- a/components/libs/cu_tuimon/src/system_info.rs
+++ b/components/libs/cu_tuimon/src/system_info.rs
@@ -227,6 +227,7 @@ mod native {
 
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 mod browser {
+    use crate::palette;
     use crate::system_info::SystemInfo;
     use js_sys::{Array, Intl, Reflect};
     use ratatui::{
@@ -654,7 +655,7 @@ mod browser {
     }
 
     fn colored_logo_line(color: Color, text: &'static str) -> Line<'static> {
-        let style = Style::default().fg(color);
+        let style = Style::default().fg(palette::explicit_fg(color));
         let mut spans = Vec::new();
         let mut buf = String::new();
         let mut buf_is_space: Option<bool> = None;
@@ -699,12 +700,12 @@ mod browser {
 
     fn label_style() -> Style {
         Style::default()
-            .fg(Color::Blue)
+            .fg(palette::BLUE)
             .add_modifier(Modifier::BOLD)
     }
 
     fn value_style() -> Style {
-        Style::default().fg(Color::White)
+        Style::default().fg(palette::WHITE)
     }
 }
 

--- a/components/libs/cu_tuimon/src/tui_nodes/graph.rs
+++ b/components/libs/cu_tuimon/src/tui_nodes/graph.rs
@@ -1,3 +1,4 @@
+use crate::palette;
 use ratatui::layout::{Position, Size};
 
 use super::*;
@@ -370,7 +371,9 @@ impl<'a> NodeGraph<'a> {
                                 .unwrap()
                                 .set_symbol(alias_char)
                                 .set_style(
-                                    Style::default().add_modifier(Modifier::BOLD).bg(Color::Red),
+                                    Style::default()
+                                        .add_modifier(Modifier::BOLD)
+                                        .bg(palette::RED),
                                 );
                         }
                     }
@@ -400,7 +403,11 @@ impl<'a> NodeGraph<'a> {
                         ))
                         .unwrap()
                         .set_symbol(alias_char)
-                        .set_style(Style::default().add_modifier(Modifier::BOLD).bg(Color::Red));
+                        .set_style(
+                            Style::default()
+                                .add_modifier(Modifier::BOLD)
+                                .bg(palette::RED),
+                        );
                     }
 
                     // draw port

--- a/components/libs/cu_tuimon/src/tui_nodes/mod.rs
+++ b/components/libs/cu_tuimon/src/tui_nodes/mod.rs
@@ -1,7 +1,7 @@
 // Vendored from tui-nodes v0.9.0 (MIT) to avoid depending on an unpublished fork.
 
 use ratatui::layout::Margin;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::{buffer::Buffer, layout::Rect, widgets::Widget};
 use std::collections::{BTreeSet as Set, HashMap as Map};
 

--- a/components/libs/cu_tuimon/src/ui.rs
+++ b/components/libs/cu_tuimon/src/ui.rs
@@ -2,6 +2,7 @@ use crate::MonitorModel;
 #[cfg(feature = "log_pane")]
 use crate::logpane::StyledLine;
 use crate::model::ComponentStatus;
+use crate::palette;
 use crate::system_info::{SystemInfo, default_system_info};
 use crate::tui_nodes::{Connection, NodeGraph, NodeLayout};
 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
@@ -407,7 +408,7 @@ impl MonitorUi {
     pub fn draw_content(&mut self, f: &mut Frame, area: Rect) {
         // Avoid backend-specific "reset" colors bleeding through the scrollable canvases.
         f.render_widget(
-            Block::default().style(Style::default().bg(Color::Black)),
+            Block::default().style(Style::default().bg(palette::BACKGROUND)),
             area,
         );
 
@@ -458,7 +459,7 @@ impl MonitorUi {
             #[cfg(all(target_family = "wasm", target_os = "unknown"))]
             SystemInfo::Rich(text) => text.clone(),
         };
-        normalize_reset_colors(&mut body, Color::White, Color::Black);
+        palette::normalize_text_colors(&mut body, palette::FOREGROUND, palette::BACKGROUND);
         lines.append(&mut body.lines);
         lines.push(Line::raw(" "));
         let text = Text::from(lines);
@@ -492,13 +493,13 @@ impl MonitorUi {
             };
             Cell::from(Line::from(*header).alignment(align)).style(
                 Style::default()
-                    .fg(Color::Yellow)
+                    .fg(palette::YELLOW)
                     .add_modifier(Modifier::BOLD),
             )
         });
 
         let header = Row::new(header_cells)
-            .style(Style::default().fg(Color::Yellow))
+            .style(Style::default().fg(palette::YELLOW))
             .bottom_margin(1)
             .top_margin(1);
 
@@ -612,7 +613,7 @@ impl MonitorUi {
         self.clamp_latency_scroll_offset(area, content_size);
         let mut scroll_view = ScrollView::new(content_size);
         scroll_view.render_widget(
-            Block::default().style(Style::default().bg(Color::Black)),
+            Block::default().style(Style::default().bg(palette::BACKGROUND)),
             Rect::new(0, 0, content_size.width, content_size.height),
         );
         scroll_view.render_widget(
@@ -642,13 +643,13 @@ impl MonitorUi {
         .map(|header| {
             Cell::from(Line::from(*header).alignment(Alignment::Right)).style(
                 Style::default()
-                    .fg(Color::Yellow)
+                    .fg(palette::YELLOW)
                     .add_modifier(Modifier::BOLD),
             )
         });
 
         let header = Row::new(header_cells)
-            .style(Style::default().fg(Color::Yellow))
+            .style(Style::default().fg(palette::YELLOW))
             .bottom_margin(1);
 
         let pool_stats = self.model.inner.pool_stats.lock().unwrap();
@@ -741,7 +742,7 @@ impl MonitorUi {
         let header_cells = ["Metric", "Value"].iter().map(|header| {
             Cell::from(Line::from(*header)).style(
                 Style::default()
-                    .fg(Color::Yellow)
+                    .fg(palette::YELLOW)
                     .add_modifier(Modifier::BOLD),
             )
         });
@@ -755,7 +756,7 @@ impl MonitorUi {
         };
         let spacer = row(" ", " ".to_string());
 
-        let rate_style = Style::default().fg(Color::Cyan);
+        let rate_style = Style::default().fg(palette::CYAN);
         let mem_rows = vec![
             row("Observed rate", rate_display).style(rate_style),
             spacer.clone(),
@@ -908,7 +909,7 @@ impl MonitorUi {
             .log_selection
             .range()
             .filter(|(start, end)| start != end);
-        let selection_style = Style::default().bg(Color::Blue).fg(Color::Black);
+        let selection_style = Style::default().bg(palette::BLUE).fg(palette::BACKGROUND);
         let visible_lines = self
             .log_lines
             .iter()
@@ -1117,7 +1118,7 @@ impl MonitorUi {
                     Span::styled(
                         clid_inner,
                         Style::default()
-                            .fg(Color::Black)
+                            .fg(palette::BACKGROUND)
                             .bg(badge_bg)
                             .add_modifier(Modifier::BOLD),
                     ),
@@ -1129,35 +1130,22 @@ impl MonitorUi {
     }
 }
 
-fn normalize_reset_colors(text: &mut Text<'_>, fallback_fg: Color, fallback_bg: Color) {
-    for line in &mut text.lines {
-        for span in &mut line.spans {
-            if span.style.fg == Some(Color::Reset) {
-                span.style.fg = Some(fallback_fg);
-            }
-            if span.style.bg == Some(Color::Reset) {
-                span.style.bg = Some(fallback_bg);
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn normalize_reset_colors_replaces_reset_fg_and_bg() {
+    fn normalize_text_colors_replaces_reset_fg_and_bg() {
         let mut text = Text::from(Line::from(vec![Span::styled(
             "pfetch",
             Style::default().fg(Color::Reset).bg(Color::Reset),
         )]));
 
-        normalize_reset_colors(&mut text, Color::White, Color::Black);
+        palette::normalize_text_colors(&mut text, palette::FOREGROUND, palette::BACKGROUND);
 
         let span = &text.lines[0].spans[0];
-        assert_eq!(span.style.fg, Some(Color::White));
-        assert_eq!(span.style.bg, Some(Color::Black));
+        assert_eq!(span.style.fg, Some(palette::FOREGROUND));
+        assert_eq!(span.style.bg, Some(palette::BACKGROUND));
     }
 }
 
@@ -1366,10 +1354,10 @@ impl std::fmt::Display for NodeType {
 impl NodeType {
     fn color(self) -> Color {
         match self {
-            Self::Unknown => Color::Gray,
+            Self::Unknown => palette::GRAY,
             Self::Source => Color::Rgb(255, 191, 0),
             Self::Sink => Color::Rgb(255, 102, 204),
-            Self::Task => Color::White,
+            Self::Task => palette::WHITE,
             Self::Bridge => Color::Rgb(204, 153, 255),
         }
     }
@@ -1596,7 +1584,10 @@ impl NodesScrollableWidgetState {
                         format!(" {}", node.node_type),
                         Style::default().fg(node.node_type.color()),
                     ),
-                    Span::styled(format!(" {} ", node.id), Style::default().fg(Color::White)),
+                    Span::styled(
+                        format!(" {} ", node.id),
+                        Style::default().fg(palette::WHITE),
+                    ),
                 ]);
                 NodeLayout::new((NODE_WIDTH, height)).with_title_line(title_line)
             })
@@ -1652,7 +1643,7 @@ impl StatefulWidget for NodesScrollableWidget<'_> {
         let content_size = state.ensure_graph_cache(area);
         let mut scroll_view = ScrollView::new(content_size);
         scroll_view.render_widget(
-            Block::default().style(Style::default().bg(Color::Black)),
+            Block::default().style(Style::default().bg(palette::BACKGROUND)),
             Rect::new(0, 0, content_size.width, content_size.height),
         );
 
@@ -1684,9 +1675,9 @@ impl StatefulWidget for NodesScrollableWidget<'_> {
                 let type_label = clip_tail(&node.type_label, label_width);
                 let status_text = clip_tail(&status_line, label_width);
                 let base_style = if status.is_error {
-                    Style::default().fg(Color::Red)
+                    Style::default().fg(palette::RED)
                 } else {
-                    Style::default().fg(Color::Green)
+                    Style::default().fg(palette::GREEN)
                 };
                 let mut lines = vec![
                     Line::styled(format!(" {}", type_label), base_style),
@@ -1697,9 +1688,9 @@ impl StatefulWidget for NodesScrollableWidget<'_> {
                 if max_ports > 0 {
                     let left_width = (NODE_WIDTH_CONTENT as usize - 2) / 2;
                     let right_width = NODE_WIDTH_CONTENT as usize - 2 - left_width;
-                    let input_style = Style::default().fg(Color::Yellow);
-                    let output_style = Style::default().fg(Color::Cyan);
-                    let dotted_style = Style::default().fg(Color::DarkGray);
+                    let input_style = Style::default().fg(palette::YELLOW);
+                    let output_style = Style::default().fg(palette::CYAN);
+                    let dotted_style = Style::default().fg(palette::DARK_GRAY);
                     for port_idx in 0..max_ports {
                         let input = node
                             .inputs


### PR DESCRIPTION
## Summary

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
