### PR TITLE
also add web-dist to regen the balancebot demo

### DIFF
--- a/examples/cu_rp_balancebot/README.md
+++ b/examples/cu_rp_balancebot/README.md
@@ -35,6 +35,15 @@ $ just web
 This serves the Bevy sim and the live Copper monitor through Trunk. The first run downloads the scene assets into `assets/` so the browser can load them from the same origin.
 The browser path now uses the same asset filenames as the native sim: `balancebot.glb`, `skybox.ktx2`, and `diffuse_map.ktx2`.
 
+## To build a static browser bundle
+
+```bash
+$ cd examples/cu_rp_balancebot
+$ just web-dist
+```
+
+This writes a relocatable static Trunk bundle into `dist/` with stable filenames.
+
 ## To run the resimulation
 
 (you need at least a log in `logs` for example from a simulation run).
@@ -77,6 +86,7 @@ $ cargo run --bin balancebot-logreader --release
 
 - `just bevy` — run the split-view Bevy sim with `cu_bevymon`.
 - `just web` — serve the split-view wasm demo with Trunk.
+- `just web-dist` — build a deployable static wasm bundle into `dist/`.
 - `just balancebot-dump-text-logs` — extract human-readable logs from `logs/balance.copper` into `../../target/debug/cu29_log_index/strings.bin`.
 - `just balancebot-fsck` — integrity check of `logs/balance.copper`.
 - `just balancebot-set-pwm-permissions` — fix PWM sysfs permissions on the target (requires appropriate privileges).

--- a/examples/cu_rp_balancebot/justfile
+++ b/examples/cu_rp_balancebot/justfile
@@ -48,6 +48,23 @@ web:
 	just prepare-assets
 	trunk serve --open
 
+# Build a static browser bundle into dist/ with stable filenames.
+web-dist:
+	#!/usr/bin/env bash
+	set -euo pipefail
+	if ! command -v trunk >/dev/null 2>&1; then
+		echo "Missing trunk. Install with: cargo install --locked trunk" >&2
+		exit 1
+	fi
+	cd "{{invocation_directory()}}"
+	just prepare-assets
+	rm -rf dist
+	trunk build --release --public-url ./ --filehash false --dist dist
+	# Trunk 0.17 emits /./asset paths here; normalize them so the dist tree is
+	# relocatable and can be served from any subdirectory.
+	sed -i 's#/\./#./#g' dist/index.html
+	echo "Static web bundle written to ${PWD}/dist"
+
 # Extract a text log using the balancebot logreader.
 text-logs:
 	#!/usr/bin/env bash


### PR DESCRIPTION
## Summary

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
