### PR TITLE
Web: Cache invalidation buster with hash in files.

### DIFF
--- a/examples/cu_flight_controller/README.md
+++ b/examples/cu_flight_controller/README.md
@@ -123,7 +123,7 @@ just bevy
 # Run the split BevyMon simulator in the browser
 just web
 
-# Build a deployable browser bundle into dist/
+# Build a deployable browser bundle into dist/flight-controller with hashed asset filenames
 just web-dist
 ```
 

--- a/examples/cu_flight_controller/justfile
+++ b/examples/cu_flight_controller/justfile
@@ -59,7 +59,7 @@ web:
   just prepare-assets
   trunk serve --open
 
-# Build a static browser bundle into dist/ with stable filenames.
+# Build a static browser bundle into dist/flight-controller with hashed asset filenames.
 web-dist:
   #!/usr/bin/env bash
   set -euo pipefail
@@ -69,12 +69,9 @@ web-dist:
   fi
   cd "{{invocation_directory()}}"
   just prepare-assets
-  rm -rf dist
-  trunk build --release --public-url ./ --filehash false --dist dist
-  # Trunk 0.17 emits /./asset paths here; normalize them so the dist tree is
-  # relocatable and can be served from any subdirectory.
-  sed -i 's#/\./#./#g' dist/index.html
-  echo "Static web bundle written to ${PWD}/dist"
+  rm -rf dist/flight-controller
+  trunk build --release --public-url ./ --dist dist/flight-controller
+  echo "Static web bundle written to ${PWD}/dist/flight-controller"
 
 # Extract CopperLists from a log file (JSON export).
 logreader log="logs/flight_controller_sim.copper":

--- a/examples/cu_rp_balancebot/README.md
+++ b/examples/cu_rp_balancebot/README.md
@@ -42,7 +42,7 @@ $ cd examples/cu_rp_balancebot
 $ just web-dist
 ```
 
-This writes a relocatable static Trunk bundle into `dist/` with stable filenames.
+This writes a relocatable static Trunk bundle into `dist/balancebot/` with hashed asset filenames.
 
 ## To run the resimulation
 
@@ -86,7 +86,7 @@ $ cargo run --bin balancebot-logreader --release
 
 - `just bevy` — run the split-view Bevy sim with `cu_bevymon`.
 - `just web` — serve the split-view wasm demo with Trunk.
-- `just web-dist` — build a deployable static wasm bundle into `dist/`.
+- `just web-dist` — build a deployable static wasm bundle into `dist/balancebot/`.
 - `just balancebot-dump-text-logs` — extract human-readable logs from `logs/balance.copper` into `../../target/debug/cu29_log_index/strings.bin`.
 - `just balancebot-fsck` — integrity check of `logs/balance.copper`.
 - `just balancebot-set-pwm-permissions` — fix PWM sysfs permissions on the target (requires appropriate privileges).

--- a/examples/cu_rp_balancebot/justfile
+++ b/examples/cu_rp_balancebot/justfile
@@ -48,7 +48,7 @@ web:
 	just prepare-assets
 	trunk serve --open
 
-# Build a static browser bundle into dist/ with stable filenames.
+# Build a static browser bundle into dist/balancebot with hashed asset filenames.
 web-dist:
 	#!/usr/bin/env bash
 	set -euo pipefail
@@ -58,12 +58,9 @@ web-dist:
 	fi
 	cd "{{invocation_directory()}}"
 	just prepare-assets
-	rm -rf dist
-	trunk build --release --public-url ./ --filehash false --dist dist
-	# Trunk 0.17 emits /./asset paths here; normalize them so the dist tree is
-	# relocatable and can be served from any subdirectory.
-	sed -i 's#/\./#./#g' dist/index.html
-	echo "Static web bundle written to ${PWD}/dist"
+	rm -rf dist/balancebot
+	trunk build --release --public-url ./ --dist dist/balancebot
+	echo "Static web bundle written to ${PWD}/dist/balancebot"
 
 # Extract a text log using the balancebot logreader.
 text-logs:


### PR DESCRIPTION
## Summary

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
