### PR TITLE
BUG: This fixes the unstable timings in sim on web/macos

### DIFF
--- a/examples/cu_flight_controller/src/sim.rs
+++ b/examples/cu_flight_controller/src/sim.rs
@@ -92,6 +92,7 @@ impl Default for SimVehicleState {
 struct CopperState<T: Send + Sync + 'static> {
     _runtime_state: T,
     clock: RobotClock,
+    clock_mock: RobotClockMock,
     app: gnss::FlightControllerSim,
 }
 
@@ -600,9 +601,14 @@ fn setup_copper(mut commands: Commands) {
         fs::create_dir_all(parent).expect("failed to create logs directory");
     }
 
-    let ctx = basic_copper_setup(&PathBuf::from(logger_path), LOG_SLAB_SIZE, true, None)
-        .expect("failed to setup logger");
-    let clock = ctx.clock.clone();
+    let (clock, clock_mock) = RobotClock::mock();
+    let ctx = basic_copper_setup(
+        &PathBuf::from(logger_path),
+        LOG_SLAB_SIZE,
+        true,
+        Some(clock.clone()),
+    )
+    .expect("failed to setup logger");
 
     let mut app = gnss::FlightControllerSimBuilder::new()
         .with_context(&ctx)
@@ -616,6 +622,7 @@ fn setup_copper(mut commands: Commands) {
     commands.insert_resource(CopperState {
         _runtime_state: ctx,
         clock,
+        clock_mock,
         app,
     });
 }
@@ -626,7 +633,7 @@ fn build_bevymon_copper() -> (MonitorModel, CopperState<LoggerRuntime>) {
     const LOG_SLAB_SIZE: Option<usize> = Some(128 * 1024 * 1024);
     const STRUCTURED_LOG_SECTION_SIZE: usize = 4096 * 10;
 
-    let clock = RobotClock::default();
+    let (clock, clock_mock) = RobotClock::mock();
     let unified_logger = build_unified_logger(LOG_SLAB_SIZE).expect("failed to create logger");
     let logger_runtime =
         init_logger_runtime(&clock, unified_logger.clone(), STRUCTURED_LOG_SECTION_SIZE)
@@ -648,6 +655,7 @@ fn build_bevymon_copper() -> (MonitorModel, CopperState<LoggerRuntime>) {
         CopperState {
             _runtime_state: logger_runtime,
             clock,
+            clock_mock,
             app,
         },
     )
@@ -1434,12 +1442,16 @@ fn sync_vehicle_state(
 
 fn run_copper<T: Send + Sync + 'static>(
     mut copper: ResMut<CopperState<T>>,
+    physics_time: Res<Time<Physics>>,
     sim_state: Res<SimState>,
     rc_input: Res<SimRcInput>,
     mut motor_commands: ResMut<SimMotorCommands>,
     mut osd_overlay: ResMut<SimOsdOverlay>,
     mut exit_writer: MessageWriter<AppExit>,
 ) {
+    copper
+        .clock_mock
+        .set_value(physics_time.elapsed().as_nanos() as u64);
     let vehicle = sim_state.vehicle.clone();
     let rc = rc_input.clone();
     sim_support::sim_battery_set_armed(rc.armed);

--- a/examples/cu_rp_balancebot/src/sim_driver.rs
+++ b/examples/cu_rp_balancebot/src/sim_driver.rs
@@ -25,6 +25,7 @@ use std::sync::{Arc, Mutex};
 pub struct CopperSim<T: Send + Sync + 'static> {
     _runtime_state: T,
     clock: RobotClock,
+    clock_mock: RobotClockMock,
     copper_app: crate::BalanceBotSim,
 }
 
@@ -66,10 +67,7 @@ pub fn setup_native_copper(mut commands: Commands) {
         fs::create_dir_all(parent).expect("Failed to create logs directory");
     }
 
-    eprintln!(
-        "[WARNING] BalanceBot sim using real RobotClock; revert when sim clock driving is fixed."
-    );
-    let robot_clock = RobotClock::new();
+    let (robot_clock, robot_clock_mock) = RobotClock::mock();
     let copper_ctx = basic_copper_setup(
         &PathBuf::from(logger_path),
         LOG_SLAB_SIZE,
@@ -95,6 +93,7 @@ pub fn setup_native_copper(mut commands: Commands) {
     commands.insert_resource(CopperSim {
         _runtime_state: copper_ctx,
         clock: robot_clock,
+        clock_mock: robot_clock_mock,
         copper_app,
     });
     commands.insert_resource(LastCopperTick::default());
@@ -106,12 +105,7 @@ pub fn build_bevymon_copper() -> (MonitorModel, CopperSim<LoggerRuntime>) {
     const LOG_SLAB_SIZE: Option<usize> = Some(1 * 1024 * 1024 * 1024);
     const STRUCTURED_LOG_SECTION_SIZE: usize = 4096 * 10;
 
-    #[cfg(not(target_arch = "wasm32"))]
-    eprintln!(
-        "[WARNING] BalanceBot sim using real RobotClock; revert when sim clock driving is fixed."
-    );
-
-    let clock = RobotClock::new();
+    let (clock, clock_mock) = RobotClock::mock();
     let unified_logger = build_unified_logger(LOG_SLAB_SIZE).expect("Failed to create logger.");
     let logger_runtime =
         init_logger_runtime(&clock, unified_logger.clone(), STRUCTURED_LOG_SECTION_SIZE)
@@ -134,6 +128,7 @@ pub fn build_bevymon_copper() -> (MonitorModel, CopperSim<LoggerRuntime>) {
         CopperSim {
             _runtime_state: logger_runtime,
             clock,
+            clock_mock,
             copper_app,
         },
     )
@@ -216,6 +211,7 @@ pub fn run_copper_callback<T: Send + Sync + 'static>(
         return;
     }
     last_tick.0 = Some(current_time);
+    copper_ctx.clock_mock.set_value(current_time);
 
     let clock = copper_ctx.clock.clone();
     let mut sim_callback = move |step: crate::default::SimStep| -> SimOverride {


### PR DESCRIPTION
## Summary

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
