### PR TITLE
Fix: avoid u128 as debug doesn't support it

### DIFF
--- a/examples/cu_background_task/src/main.rs
+++ b/examples/cu_background_task/src/main.rs
@@ -31,7 +31,6 @@ pub mod tasks {
 
     #[derive(Reflect)]
     pub struct ExampleTask {
-        sleep_duration_ms: u64,
         sleep_duration: std::time::Duration,
     }
 
@@ -51,10 +50,7 @@ pub mod tasks {
                 .get::<u64>("sleep_duration_ms")?
                 .ok_or_else(|| CuError::from("Missing sleep_duration_ms"))?;
             let sleep_duration = std::time::Duration::from_millis(sleep_duration_ms);
-            Ok(Self {
-                sleep_duration_ms,
-                sleep_duration,
-            })
+            Ok(Self { sleep_duration })
         }
 
         fn process(
@@ -66,13 +62,15 @@ pub mod tasks {
             let Some(payload) = input.payload() else {
                 return Ok(());
             };
+            let sleep_duration_ms = u64::try_from(self.sleep_duration.as_millis())
+                .expect("sleep_duration comes from u64 milliseconds");
             // Emulate a long-running task
             debug!(
                 "Task is tasking a {}ms time to process input: {}",
-                self.sleep_duration_ms, &payload
+                sleep_duration_ms, &payload
             );
             sleep(self.sleep_duration);
-            debug!("Task ({}ms) done.", self.sleep_duration_ms);
+            debug!("Task ({}ms) done.", sleep_duration_ms);
             output.set_payload(payload + 1);
             Ok(())
         }


### PR DESCRIPTION
## Summary

Just a quick fix for the example, as_millis went to u128 in Rust but we don't support it in cu29_value. 

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
