### PR TITLE
fix: restore a local dag for fc

### DIFF
--- a/examples/cu_flight_controller/justfile
+++ b/examples/cu_flight_controller/justfile
@@ -3,6 +3,26 @@ ROOT := `git rev-parse --show-toplevel`
 # Run the Bevy + Copper simulation loop.
 default: sim
 
+# Render copperconfig.ron from the current working directory.
+dag mission="":
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  invocation_dir="{{invocation_directory()}}"
+  cfg_path="${invocation_dir}/copperconfig.ron"
+  if [[ ! -f "$cfg_path" ]]; then
+    echo "No copperconfig.ron found in ${invocation_dir}" >&2
+    exit 1
+  fi
+
+  cd "{{ROOT}}"
+  mission_value="{{mission}}"
+  if [[ -n "$mission_value" ]]; then
+    cargo run -p cu29-runtime --bin cu29-rendercfg -- --mission "$mission_value" --open "$cfg_path"
+  else
+    cargo run -p cu29-runtime --bin cu29-rendercfg -- --open "$cfg_path"
+  fi
+
 # A quick test to see if the sim can pick up your RC.
 rc:
   #!/usr/bin/env bash


### PR DESCRIPTION
I got bounced when we added the default

## Summary

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
