### PR TITLE
feat(components): cu-spidriver resource

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
   "components/payloads/cu_spatial_payloads",
   "components/res/cu_micoairh743",
   "components/res/cu_linux_resources",
+  "components/res/cu_spidriver",
   "components/libs/cu_sdlogger",
   "components/bridges/cu_bdshot",
   "components/sinks/cu_rp_gpio",
@@ -171,6 +172,7 @@ cu29-unifiedlog = { path = "core/cu29_unifiedlog", default-features = false, fea
 cu29-units = { path = "core/cu29_units", version = "0.15.0" }
 cu29-value = { path = "core/cu29_value", default-features = false, version = "0.15.0" }
 cu-linux-resources = { path = "components/res/cu_linux_resources", version = "0.15.0" }
+cu-spidriver = { path = "components/res/cu_spidriver", version = "0.15.0" }
 
 # Payload definitions
 cu-sensor-payloads = { path = "components/payloads/cu_sensor_payloads", version = "0.15.0" }

--- a/components/res/cu_spidriver/Cargo.toml
+++ b/components/res/cu_spidriver/Cargo.toml
@@ -23,12 +23,9 @@ embedded-io = { version = "0.7.1", default-features = false, features = [
 serialport = { workspace = true }
 linux-embedded-hal = { workspace = true }
 
-# spidriver = "0.1"
-# spidriver-hal = "0.1"
-spidriver = {version = "0.1", git = "https://github.com/LechevSpace/spidriver", branch = "feat/bump-dependencies" }
-spidriver-hal = {version = "0.1", git = "https://github.com/LechevSpace/spidriver", branch = "feat/bump-dependencies" }
-# spidriver = {version = "0.1", path ="../spidriver/spidriver" }
-# spidriver-hal = {version = "0.1", path ="../spidriver/spidriver-hal" }
+#for embedded-hal 1.0 support:
+spidriver = { version = "0.1", git = "https://github.com/LechevSpace/spidriver", branch = "feat/bump-dependencies" }
+spidriver-hal = { version = "0.1", git = "https://github.com/LechevSpace/spidriver", branch = "feat/bump-dependencies" }
 
 thiserror = "2"
 

--- a/components/res/cu_spidriver/Cargo.toml
+++ b/components/res/cu_spidriver/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "cu-spidriver"
+description = "SPI Driver (a USB to SPI bridge) support."
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+cu29 = { path = "../../../core/cu29", version = "0.15", default-features = false, features = [
+  "std",
+] }
+embedded-hal = { version = "1.0.0", default-features = false }
+embedded-hal-nb = "1.0.0"
+embedded-io = { version = "0.7.1", default-features = false, features = [
+  "std",
+] }
+
+serialport = { workspace = true }
+linux-embedded-hal = { workspace = true }
+
+# spidriver = "0.1"
+# spidriver-hal = "0.1"
+spidriver = {version = "0.1", git = "https://github.com/LechevSpace/spidriver", branch = "feat/bump-dependencies" }
+spidriver-hal = {version = "0.1", git = "https://github.com/LechevSpace/spidriver", branch = "feat/bump-dependencies" }
+# spidriver = {version = "0.1", path ="../spidriver/spidriver" }
+# spidriver-hal = {version = "0.1", path ="../spidriver/spidriver-hal" }
+
+thiserror = "2"
+
+[features]
+default = []
+defmt = ["embedded-io/defmt", "embedded-hal/defmt-03", "cu29/defmt"]
+alloc = ["embedded-io/alloc"]

--- a/components/res/cu_spidriver/README.md
+++ b/components/res/cu_spidriver/README.md
@@ -1,0 +1,30 @@
+# cu-spidriver
+
+SpiDriver (a Usb to SPI device) resource to be used with `embedded_hal@1.0` (`embedded_hal::blocking::spi`).
+
+
+## Provider
+
+Use `cu_linux_resources::SpiDriverResources` in `copperconfig.ron`.
+
+```ron
+resources: [
+  (
+    id: "spidriver0",
+    provider: "cu_spidriver::SpiDriverResources",
+    config: {
+      "dev": "/dev/ttyUSB0",
+    },
+  ),
+],
+```
+
+## Resource
+
+`SpiDriverResources` exposes the following resources:
+- SpiBus: `spi`
+- Chip Select: `chip_select`
+- Pin A: `pin_a`
+- Pin B: `pin_b`
+
+Bind tasks/bridges to these resources via `<bundle>.spi` (for example `spidriver0.spi`).

--- a/components/res/cu_spidriver/build.rs
+++ b/components/res/cu_spidriver/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=LOG_INDEX_DIR={}",
+        std::env::var("OUT_DIR").unwrap()
+    );
+}

--- a/components/res/cu_spidriver/src/lib.rs
+++ b/components/res/cu_spidriver/src/lib.rs
@@ -1,0 +1,365 @@
+use cu29::bundle_resources;
+use cu29::prelude::*;
+use cu29::resource::{ResourceBundle, ResourceManager};
+use embedded_hal::digital;
+use embedded_hal::spi;
+use embedded_io::{ErrorType as EmbeddedErrorType, Read as EmbeddedRead, Write as EmbeddedWrite};
+use std::string::String;
+use std::sync::Arc;
+use std::sync::Mutex;
+use thiserror::Error;
+
+use crate::serial::find_serial_device;
+
+pub mod parts;
+pub mod serial;
+
+pub const SPIDRIVER_VID: u16 = 0x0403;
+pub const SPIDRIVER_PID: u16 = 0x6015;
+
+// FIXME: We should re-use Exclusive from cu_linux_resources!
+
+/// Wrapper for resources that are logically exclusive/owned by a single
+/// component but still need to satisfy `Sync` bounds at registration time.
+///
+/// This keeps synchronization adaptation at the bundle/resource boundary instead
+/// of pushing wrappers into every bridge/task that consumes the resource.
+pub struct Exclusive<T>(T);
+
+impl<T> Exclusive<T> {
+    pub const fn new(inner: T) -> Self {
+        Self(inner)
+    }
+
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+// SAFETY: `Exclusive<T>` is only handed out by value via `take()` for owned
+// resources. The wrapped `T` is not concurrently aliased through this wrapper.
+unsafe impl<T: Send> Sync for Exclusive<T> {}
+
+impl<T: std::io::Read> std::io::Read for Exclusive<T> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl<T: std::io::Write> std::io::Write for Exclusive<T> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.flush()
+    }
+}
+
+impl<T: EmbeddedErrorType> EmbeddedErrorType for Exclusive<T> {
+    type Error = T::Error;
+}
+
+impl<T: EmbeddedRead> EmbeddedRead for Exclusive<T> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.0.read(buf)
+    }
+}
+
+impl<T: EmbeddedWrite> EmbeddedWrite for Exclusive<T> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.0.flush()
+    }
+}
+
+impl<T> embedded_hal::i2c::ErrorType for Exclusive<T>
+where
+    T: embedded_hal::i2c::ErrorType,
+{
+    type Error = T::Error;
+}
+
+impl<T> embedded_hal::i2c::I2c for Exclusive<T>
+where
+    T: embedded_hal::i2c::I2c,
+{
+    fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
+        self.0.read(address, read)
+    }
+
+    fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Self::Error> {
+        self.0.write(address, write)
+    }
+
+    fn write_read(
+        &mut self,
+        address: u8,
+        write: &[u8],
+        read: &mut [u8],
+    ) -> Result<(), Self::Error> {
+        self.0.write_read(address, write, read)
+    }
+
+    fn transaction(
+        &mut self,
+        address: u8,
+        operations: &mut [embedded_hal::i2c::Operation<'_>],
+    ) -> Result<(), Self::Error> {
+        self.0.transaction(address, operations)
+    }
+}
+
+impl<T> embedded_hal::digital::ErrorType for Exclusive<T>
+where
+    T: embedded_hal::digital::ErrorType,
+{
+    type Error = T::Error;
+}
+
+pub type Spi = parts::SPI<SpiDriverShared<crate::serial::Tx, crate::serial::Rx>>;
+pub type PinA = parts::PinA<SpiDriverShared<crate::serial::Tx, crate::serial::Rx>>;
+pub type PinB = parts::PinB<SpiDriverShared<crate::serial::Tx, crate::serial::Rx>>;
+pub type CS = parts::CS<SpiDriverShared<crate::serial::Tx, crate::serial::Rx>>;
+
+pub struct SpiDriverResources;
+
+bundle_resources!(
+    SpiDriverResources:
+    Spi,
+    ChipSelect,
+    PinA,
+    PinB,
+);
+
+impl ResourceBundle for SpiDriverResources {
+    fn build(
+        bundle: cu29::resource::BundleContext<Self>,
+        config: Option<&ComponentConfig>,
+        manager: &mut ResourceManager,
+    ) -> CuResult<()> {
+        let serial_dev = match get_string(config, "dev")? {
+            Some(x) => x,
+            // if no device path is specified, scan by Vendor/Product ID
+            None => match find_serial_device(SPIDRIVER_VID, SPIDRIVER_PID)? {
+                Some(serialport::SerialPortInfo {
+                    port_name,
+                    port_type: serialport::SerialPortType::UsbPort(port_info),
+                }) => {
+                    info!(
+                        "Using serial device: {} ({:x}:{:x}) (serial: {:?})",
+                        &port_name, SPIDRIVER_VID, SPIDRIVER_PID, &port_info.serial_number
+                    );
+                    port_name
+                }
+                _ => {
+                    return Err(CuError::from(format!(
+                        "Could not find USB spidriver device with VID {:x} and PID {:x}",
+                        SPIDRIVER_VID, SPIDRIVER_PID
+                    )));
+                }
+            },
+        };
+
+        let serial_builder = linux_embedded_hal::serialport::new(serial_dev, 460_800)
+            .data_bits(linux_embedded_hal::serialport::DataBits::Eight)
+            .flow_control(linux_embedded_hal::serialport::FlowControl::None)
+            .parity(linux_embedded_hal::serialport::Parity::None)
+            .stop_bits(linux_embedded_hal::serialport::StopBits::One);
+
+        let serial = linux_embedded_hal::Serial::open_from_builder(serial_builder)
+            .map_err(|e| CuError::new_with_cause("Failed to open serial port", e))?;
+        let serial = crate::serial::Serial::new(serial);
+        let (tx, rx) = serial.split();
+
+        let spi_driver = spidriver::SPIDriver::new(tx, rx);
+        // owned SpiDriver device
+        let cu_driver = SpiDriverShared {
+            spi_driver: Arc::new(Mutex::new(spi_driver)),
+        };
+
+        let spi = crate::parts::SPI::new(cu_driver.clone());
+        let cs = crate::parts::CS::new(cu_driver.clone());
+        let pin_a = crate::parts::PinA::new(cu_driver.clone());
+        let pin_b = crate::parts::PinB::new(cu_driver);
+
+        manager.add_shared(
+            bundle.key(SpiDriverResourcesId::Spi),
+            std::sync::Arc::new(spi),
+        )?;
+
+        manager.add_shared(
+            bundle.key(SpiDriverResourcesId::ChipSelect),
+            std::sync::Arc::new(cs),
+        )?;
+
+        manager.add_shared(
+            bundle.key(SpiDriverResourcesId::PinA),
+            std::sync::Arc::new(pin_a),
+        )?;
+
+        manager.add_shared(
+            bundle.key(SpiDriverResourcesId::PinB),
+            std::sync::Arc::new(pin_b),
+        )?;
+
+        Ok(())
+    }
+}
+
+fn get_string(config: Option<&ComponentConfig>, key: &str) -> CuResult<Option<String>> {
+    match config {
+        Some(cfg) => Ok(cfg.get::<String>(key)?.filter(|value| !value.is_empty())),
+        None => Ok(None),
+    }
+}
+
+#[derive(Clone)]
+/// Wrapper around the [`spidriver::SPIDriver`] which allows it to be shared across multiple tasks while still satisfying Sync bounds.
+pub struct SpiDriverShared<TX = crate::serial::Tx, RX = crate::serial::Rx>
+where
+    TX: embedded_io::Write,
+    RX: embedded_io::Read,
+    RX::Error: core::fmt::Debug,
+    TX::Error: core::fmt::Debug,
+{
+    spi_driver: Arc<Mutex<spidriver::SPIDriver<TX, RX>>>,
+}
+
+#[derive(Debug, Error)]
+#[error("SPI driver error: {inner:?}")]
+pub struct Error<TX, RX> {
+    inner: spidriver::Error<TX, RX>,
+}
+
+impl<TX, RX> From<spidriver::Error<TX, RX>> for Error<TX, RX> {
+    fn from(error: spidriver::Error<TX, RX>) -> Self {
+        Self { inner: error }
+    }
+}
+
+impl<TX, RX> digital::ErrorType for Error<TX, RX>
+where
+    TX: core::fmt::Debug,
+    RX: core::fmt::Debug,
+{
+    type Error = Error<TX, RX>;
+}
+
+impl<TX, RX> digital::Error for Error<TX, RX>
+where
+    TX: core::fmt::Debug,
+    RX: core::fmt::Debug,
+{
+    fn kind(&self) -> digital::ErrorKind {
+        digital::ErrorKind::Other
+    }
+}
+
+impl<TX, RX> spi::ErrorType for Error<TX, RX>
+where
+    TX: core::fmt::Debug,
+    RX: core::fmt::Debug,
+{
+    type Error = Error<TX, RX>;
+}
+
+impl<TX, RX> spi::Error for Error<TX, RX>
+where
+    TX: core::fmt::Debug,
+    RX: core::fmt::Debug,
+{
+    fn kind(&self) -> spi::ErrorKind {
+        spi::ErrorKind::Other
+    }
+}
+
+impl<TX, RX> embedded_io::ErrorType for Error<TX, RX>
+where
+    TX: embedded_io::ErrorType + core::fmt::Debug,
+    RX: embedded_io::ErrorType + core::fmt::Debug,
+{
+    type Error = Error<TX, RX>;
+}
+
+impl<TX, RX> embedded_io::Error for Error<TX, RX>
+where
+    TX: embedded_io::ErrorType + core::fmt::Debug,
+    RX: embedded_io::ErrorType + core::fmt::Debug,
+{
+    fn kind(&self) -> embedded_io::ErrorKind {
+        match self.inner {
+            spidriver::Error::Protocol => {
+                // Map the underlying Pin error to an embedded_io::ErrorKind
+                // For simplicity, we treat all Pin errors as Other, but this could be refined
+                embedded_io::ErrorKind::Other
+            }
+            spidriver::Error::Request => embedded_io::ErrorKind::Other,
+            spidriver::Error::Write(ref _tx_err) => embedded_io::ErrorKind::Other,
+            spidriver::Error::Read(ref _rx_err) => embedded_io::ErrorKind::Other,
+        }
+    }
+}
+
+/// Copied from [`spidriver_hal`]
+impl<TX, RX> spidriver_hal::hal::Comms for SpiDriverShared<TX, RX>
+where
+    TX: embedded_io::Write,
+    RX: embedded_io::Read,
+{
+    type Error = Error<TX::Error, RX::Error>;
+
+    fn set_cs(&self, high: bool) -> Result<(), Self::Error> {
+        let mut sd = self.spi_driver.lock().unwrap();
+        // let sd = &mut *sd;
+        if high {
+            Ok(sd.unselect()?) // SPI is active low, so high means unselected
+        } else {
+            Ok(sd.select()?)
+        }
+    }
+
+    fn set_a(&self, high: bool) -> Result<(), Self::Error> {
+        let mut sd = self.spi_driver.lock().unwrap();
+        Ok(sd.set_a(high)?)
+    }
+
+    fn set_b(&self, high: bool) -> Result<(), Self::Error> {
+        let mut sd = self.spi_driver.lock().unwrap();
+        Ok(sd.set_b(high)?)
+    }
+
+    fn write(&self, data: &[u8]) -> Result<(), Self::Error> {
+        let mut sd = self.spi_driver.lock().unwrap();
+
+        let mut remain = data;
+        while !remain.is_empty() {
+            let len: usize = if remain.len() > 64 { 64 } else { remain.len() };
+            let (this, next) = remain.split_at(len);
+            sd.write(this).map_err(|err| Error { inner: err })?;
+            remain = next;
+        }
+        Ok(())
+    }
+
+    fn transfer_in_place<'w>(&self, data: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
+        let mut sd = self.spi_driver.lock().unwrap();
+
+        let mut remain = &mut data[..];
+        while !remain.is_empty() {
+            let len: usize = if remain.len() > 64 { 64 } else { remain.len() };
+            let (this, next) = remain.split_at_mut(len);
+            sd.transfer_in_place(this)
+                .map_err(|err| Error { inner: err })?;
+            remain = next;
+        }
+        Ok(data)
+    }
+}

--- a/components/res/cu_spidriver/src/parts.rs
+++ b/components/res/cu_spidriver/src/parts.rs
@@ -1,0 +1,261 @@
+use embedded_hal::{
+    digital,
+    spi::{self, Operation},
+};
+use spidriver_hal::hal::Comms;
+
+/// `SPI` implements some of the SPI-related traits from `embedded-hal` in terms
+/// of an SPIDriver device.
+pub struct SPI<SD>(SD);
+
+impl<SD> Clone for SPI<SD>
+where
+    SD: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<SD> SPI<SD>
+where
+    SD: Comms,
+{
+    pub(crate) fn new(sd: SD) -> Self {
+        Self(sd)
+    }
+}
+
+impl<SD, E> spi::ErrorType for SPI<SD>
+where
+    SD: Comms<Error = E>,
+    E: spi::Error,
+{
+    type Error = E;
+}
+
+impl<SD, E> spi::SpiDevice for SPI<SD>
+where
+    SD: Comms<Error = E>,
+    E: spi::Error,
+{
+    /// Implements blocking SPI `Transfer` by passing the given data to the
+    /// `SPIDriver` in chunks of up to 64 bytes each.
+    ///
+    /// Because of the chunking behaviour, larger messages may have inconsistent
+    /// timing at the chunk boundaries, which may affect devices with particularly
+    /// sensitive clock timing constraints.
+    fn transaction(
+        &mut self,
+        operations: &mut [spi::Operation<'_, u8>],
+    ) -> Result<(), Self::Error> {
+        for op in operations {
+            match op {
+                Operation::TransferInPlace(words) => self.0.transfer_in_place(words).map(drop)?,
+                _ => {
+                    // do nothing for now
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<SD, E> spi::SpiBus for SPI<SD>
+where
+    SD: Comms<Error = E>,
+    E: spi::Error,
+{
+    fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+        // Send dummy bytes while reading
+        words.fill(0);
+        self.0.transfer_in_place(words).map(|_| ())
+    }
+
+    fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+        self.0.write(words)
+    }
+
+    fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
+        // SPI requires equal-length buffers
+        let len = read.len().min(write.len());
+
+        // Copy write data into read buffer so we can perform in-place transfer
+        read[..len].copy_from_slice(&write[..len]);
+
+        self.0.transfer_in_place(&mut read[..len]).map(|_| ())
+    }
+
+    fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+        self.0.transfer_in_place(words).map(|_| ())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        // Backend appears synchronous, so nothing to flush
+        Ok(())
+    }
+}
+/// `CS` implements some of the digital IO traits from `embedded-hal` in
+/// terms of an SPIDriver device's Chip Select pin.
+pub struct CS<SD: Comms>(SD);
+
+impl<SD> Clone for CS<SD>
+where
+    SD: Comms + Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<SD> CS<SD>
+where
+    SD: Comms,
+{
+    pub(crate) fn new(sd: SD) -> Self {
+        Self(sd)
+    }
+}
+
+impl<SD, E> digital::ErrorType for CS<SD>
+where
+    SD: Comms<Error = E>,
+    E: digital::Error,
+{
+    type Error = E;
+}
+
+impl<SD, E> digital::OutputPin for CS<SD>
+where
+    SD: Comms<Error = E>,
+    E: digital::Error,
+{
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.0.set_cs(false)
+    }
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.0.set_cs(true)
+    }
+}
+
+/// `PinA` implements some of the digital IO traits from `embedded-hal` in
+/// terms of an `SPIDriver` device's auxiliary output pin A.
+pub struct PinA<SD: Comms>(SD);
+
+impl<SD> Clone for PinA<SD>
+where
+    SD: Comms + Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<SD> PinA<SD>
+where
+    SD: Comms,
+{
+    pub(crate) fn new(sd: SD) -> Self {
+        Self(sd)
+    }
+}
+
+impl<SD, E> digital::ErrorType for PinA<SD>
+where
+    SD: Comms<Error = E>,
+    E: digital::Error,
+{
+    type Error = E;
+}
+
+impl<SD, E> digital::OutputPin for PinA<SD>
+where
+    SD: Comms<Error = E>,
+    E: digital::Error,
+{
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.0.set_a(false)
+    }
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.0.set_a(true)
+    }
+}
+
+/// `PinB` implements some of the digital IO traits from `embedded-hal` in
+/// terms of an `SPIDriver` device's auxiliary output pin B.
+pub struct PinB<SD: Comms>(SD);
+
+impl<SD> Clone for PinB<SD>
+where
+    SD: Comms + Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<SD> PinB<SD>
+where
+    SD: Comms,
+{
+    pub(crate) fn new(sd: SD) -> Self {
+        Self(sd)
+    }
+}
+
+impl<SD, E> digital::ErrorType for PinB<SD>
+where
+    SD: Comms<Error = E>,
+    E: digital::Error,
+{
+    type Error = E;
+}
+
+impl<SD, E> digital::OutputPin for PinB<SD>
+where
+    SD: Comms<Error = E>,
+    E: digital::Error,
+{
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.0.set_b(false)
+    }
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.0.set_b(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use embedded_hal::{digital, spi};
+
+    use crate::SpiDriverShared;
+
+    use super::*;
+
+    fn assert_digital_error_type<P: digital::ErrorType>() {}
+    fn assert_is_output_pin<P: digital::OutputPin>() {}
+
+    fn assert_spi_error_type<P: spi::ErrorType>() {}
+    fn assert_is_spi<P: spi::SpiBus>() {}
+
+    #[test]
+    fn test_is_type_digital_pin() {
+        assert_digital_error_type::<CS<SpiDriverShared>>();
+        assert_is_output_pin::<CS<SpiDriverShared>>();
+
+        assert_digital_error_type::<PinA<SpiDriverShared>>();
+        assert_is_output_pin::<PinA<SpiDriverShared>>();
+
+        assert_digital_error_type::<PinB<SpiDriverShared>>();
+        assert_is_output_pin::<PinB<SpiDriverShared>>();
+    }
+
+    #[test]
+    fn test_is_type_spi() {
+        assert_spi_error_type::<SPI<SpiDriverShared>>();
+        assert_is_spi::<SPI<SpiDriverShared>>();
+    }
+}

--- a/components/res/cu_spidriver/src/serial.rs
+++ b/components/res/cu_spidriver/src/serial.rs
@@ -1,0 +1,107 @@
+use std::sync::{Arc, Mutex};
+
+use cu29::{CuError, CuResult};
+
+use embedded_hal_nb::{
+    nb::block,
+    serial::{Read as _, Write as _},
+};
+use linux_embedded_hal::SerialError;
+use serialport::{SerialPortInfo, SerialPortType};
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("IO error")]
+    Io(#[from] std::io::Error),
+    #[error("Serial error")]
+    Linux(#[from] SerialError),
+}
+
+impl embedded_io::Error for Error {
+    fn kind(&self) -> embedded_io::ErrorKind {
+        embedded_io::ErrorKind::Other
+    }
+}
+
+#[derive(Clone)]
+pub struct Tx(Arc<Mutex<linux_embedded_hal::Serial>>);
+
+#[derive(Clone)]
+pub struct Rx(Arc<Mutex<linux_embedded_hal::Serial>>);
+
+pub struct Serial(Arc<Mutex<linux_embedded_hal::Serial>>);
+
+impl Serial {
+    pub fn new(port: linux_embedded_hal::Serial) -> Self {
+        Serial(Arc::new(Mutex::new(port)))
+    }
+
+    pub fn split(self) -> (Tx, Rx) {
+        (Tx(Arc::clone(&self.0)), Rx(Arc::clone(&self.0)))
+    }
+}
+
+impl embedded_io::ErrorType for Rx {
+    type Error = Error;
+}
+impl embedded_io::Read for Rx {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        // we should return 0 on buf.len() = 0
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        let mut written = 0_usize;
+        for byte in buf.iter_mut() {
+            match block!((*self.0).lock().unwrap().read()) {
+                Ok(read_byte) => {
+                    *byte = read_byte;
+                    written = written.wrapping_add(1);
+                }
+                Err(e) => return Err(Error::Linux(e)),
+            }
+        }
+        Ok(written)
+    }
+}
+
+impl embedded_io::ErrorType for Tx {
+    type Error = Error;
+}
+impl embedded_io::Write for Tx {
+    fn write(&mut self, bytes: &[u8]) -> Result<usize, Self::Error> {
+        let mut written = 0_usize;
+        for byte in bytes {
+            match block!((*self.0).lock().unwrap().write(*byte)) {
+                Ok(_) => {
+                    written = written.wrapping_add(1);
+                }
+                // todo: bad write
+                Err(e) => return Err(Error::Linux(e)),
+            }
+        }
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        match block!((*self.0).lock().unwrap().flush()) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(Error::Linux(e)),
+        }
+    }
+}
+
+/// Finds the first serial port matching the given VID and PID.
+pub fn find_serial_device(vid: u16, pid: u16) -> CuResult<Option<SerialPortInfo>> {
+    let available_ports = serialport::available_ports().map_err(|cause| {
+        CuError::new_with_cause("Failed to enumerate available serial ports", cause)
+    })?;
+
+    let device_port_info = available_ports
+        .into_iter()
+        .find(|port| matches!(&port.port_type, SerialPortType::UsbPort(usb_port) if usb_port.pid == pid && usb_port.vid == vid));
+
+    Ok(device_port_info)
+}


### PR DESCRIPTION
## Summary

Adds support for the SpiDriver (https://spidriver.com/) device by Excamera Labs.

<img width="1200" height="676" alt="image" src="https://github.com/user-attachments/assets/ba808b0e-91d6-44e4-8532-92b058411a65" />

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
