### PR TITLE
fix(audit): update deny list

### DIFF
--- a/.config/deny.toml
+++ b/.config/deny.toml
@@ -4,4 +4,7 @@ ignore = [
   "RUSTSEC-2024-0436", # paste is no longer maintaind. https://rustsec.org/advisories/RUSTSEC-2024-0436.html
   "RUSTSEC-2025-0141", # bincode is no longer maintained. https://rustsec.org/advisories/RUSTSEC-2025-0141
   "RUSTSEC-2021-0140", # rusttype is deprecated. https://rustsec.org/advisories/RUSTSEC-2021-0140
+  "RUSTSEC-2024-0384", # instant is unmaintained. https://rustsec.org/advisories/RUSTSEC-2024-0384
+  "RUSTSEC-2026-0041", # lz4_flex security vulnerability detected. https://rustsec.org/advisories/RUSTSEC-2026-0041
+  "RUSTSEC-2025-0134", # rustls-pemfile is unmaintained. https://rustsec.org/advisories/RUSTSEC-2025-0134
 ]


### PR DESCRIPTION
## Summary
update audit deny list
## Changes
"RUSTSEC-2024-0384", # instant is unmaintained. https://rustsec.org/advisories/RUSTSEC-2024-0384
"RUSTSEC-2026-0041", # lz4_flex security vulnerability detected. https://rustsec.org/advisories/RUSTSEC-2026-0041
"RUSTSEC-2025-0134", # rustls-pemfile is unmaintained. https://rustsec.org/advisories/RUSTSEC-2025-0134

