### PR TITLE
General Panic Handling cleanup.

### DIFF
--- a/components/monitors/cu_consolemon/src/lib.rs
+++ b/components/monitors/cu_consolemon/src/lib.rs
@@ -10,7 +10,7 @@ pub use cu_tuimon::{
 use cu29::context::CuContext;
 use cu29::monitoring::{
     ComponentId, CopperListIoStats, CopperListView, CuComponentState, CuMonitor,
-    CuMonitoringMetadata, CuMonitoringRuntime, Decision,
+    CuMonitoringMetadata, CuMonitoringRuntime, Decision, PanicHookRegistration,
 };
 use cu29::{CuError, CuResult};
 use ratatui::backend::CrosstermBackend;
@@ -23,9 +23,7 @@ use ratatui::crossterm::terminal::{
 use ratatui::crossterm::tty::IsTty;
 use ratatui::crossterm::{event, execute};
 use ratatui::{Terminal, TerminalOptions, Viewport};
-use std::backtrace::Backtrace;
-use std::io::{Write, stdin, stdout};
-use std::process;
+use std::io::{stdin, stdout};
 #[cfg(feature = "debug_pane")]
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -39,6 +37,8 @@ pub struct CuConsoleMon {
     model: MonitorModel,
     ui_handle: Option<JoinHandle<()>>,
     quitting: Arc<AtomicBool>,
+    monitor_runtime: CuMonitoringRuntime,
+    panic_cleanup: Option<PanicHookRegistration>,
     #[cfg(feature = "debug_pane")]
     log_capture: Option<Mutex<MonitorLogCapture>>,
 }
@@ -52,6 +52,7 @@ impl CuConsoleMon {
 impl Drop for CuConsoleMon {
     fn drop(&mut self) {
         self.quitting.store(true, Ordering::SeqCst);
+        self.panic_cleanup = None;
         let _ = restore_terminal();
         if let Some(handle) = self.ui_handle.take() {
             let _ = handle.join();
@@ -221,11 +222,13 @@ impl UI {
 }
 
 impl CuMonitor for CuConsoleMon {
-    fn new(metadata: CuMonitoringMetadata, _runtime: CuMonitoringRuntime) -> CuResult<Self> {
+    fn new(metadata: CuMonitoringMetadata, runtime: CuMonitoringRuntime) -> CuResult<Self> {
         Ok(Self {
             model: MonitorModel::from_metadata(&metadata),
             ui_handle: None,
             quitting: Arc::new(AtomicBool::new(false)),
+            monitor_runtime: runtime,
+            panic_cleanup: None,
             #[cfg(feature = "debug_pane")]
             log_capture: None,
         })
@@ -248,6 +251,10 @@ impl CuMonitor for CuConsoleMon {
         if !should_start_ui() {
             return Ok(());
         }
+
+        self.panic_cleanup = Some(self.monitor_runtime.register_panic_cleanup(|_| {
+            let _ = restore_terminal();
+        }));
 
         let model = self.model.clone();
         let quitting = self.quitting.clone();
@@ -321,6 +328,7 @@ impl CuMonitor for CuConsoleMon {
 
     fn stop(&mut self, _ctx: &CuContext) -> CuResult<()> {
         self.quitting.store(true, Ordering::SeqCst);
+        self.panic_cleanup = None;
         let _ = restore_terminal();
 
         if let Some(handle) = self.ui_handle.take() {
@@ -351,22 +359,13 @@ fn init_error_hooks() {
         return;
     }
 
-    let (_panic_hook, error) = HookBuilder::default().into_hooks();
+    let (_unused_panic_hook, error) = HookBuilder::default().into_hooks();
     let error = error.into_eyre_hook();
     color_eyre::eyre::set_hook(Box::new(move |err| {
         let _ = restore_terminal();
         error(err)
     }))
     .unwrap();
-
-    std::panic::set_hook(Box::new(move |info| {
-        let _ = restore_terminal();
-        let backtrace = Backtrace::force_capture();
-        println!("CuConsoleMon panic: {info}");
-        println!("Backtrace:\n{backtrace}");
-        let _ = stdout().flush();
-        process::exit(1);
-    }));
 
     let _ = ONCE.set(());
 }

--- a/components/monitors/cu_safetymon/src/lib.rs
+++ b/components/monitors/cu_safetymon/src/lib.rs
@@ -9,7 +9,7 @@
 //!   is observed within `copperlist_deadline_ms`.
 //! - Consumes the runtime execution probe to report the last known
 //!   `(component_id, step, culistid)` when a lock is detected.
-//! - Installs a panic hook and turns panics into explicit process exit codes.
+//! - Registers with Copper's shared panic hook and turns panics into explicit process exit codes.
 //! - Latches runtime errors (`process_error`) as shutdown faults with their own exit code.
 //!   The `process_error` index is a monitored component index into
 //!   `CuMonitoringMetadata::components()`.

--- a/components/monitors/cu_safetymon/src/std_impl.rs
+++ b/components/monitors/cu_safetymon/src/std_impl.rs
@@ -2,12 +2,9 @@ use alloc::format;
 use alloc::string::String;
 use core::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use cu29::prelude::*;
-use std::panic::PanicHookInfo;
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
-
-type PanicHook = Box<dyn Fn(&PanicHookInfo<'_>) + Send + Sync + 'static>;
 
 #[derive(Clone, Debug)]
 struct LastProgress {
@@ -103,7 +100,8 @@ pub struct CuSafetyMon {
     shared: Arc<SharedState>,
     cfg: SafetyCfg,
     watchdog: Option<JoinHandle<()>>,
-    previous_panic_hook: Option<PanicHook>,
+    monitor_runtime: CuMonitoringRuntime,
+    panic_action: Option<PanicHookRegistration>,
     execution_probe: MonitorExecutionProbe,
 }
 
@@ -178,27 +176,19 @@ impl CuSafetyMon {
         }));
     }
 
-    fn install_panic_hook(&mut self) {
+    fn panic_detail_from_report(report: &PanicReport) -> String {
+        match report.location() {
+            Some(location) => format!("panic at {}: {}", location, report.message()),
+            None => format!("panic: {}", report.message()),
+        }
+    }
+
+    fn install_panic_action(&mut self) {
+        let components = self.components;
         let shared = Arc::clone(&self.shared);
         let panic_code = self.cfg.exit_code_panic;
         let probe = self.execution_probe.clone();
-        let previous = std::panic::take_hook();
-        self.previous_panic_hook = Some(previous);
-
-        std::panic::set_hook(Box::new(move |info| {
-            let panic_message = if let Some(s) = info.payload().downcast_ref::<&str>() {
-                (*s).to_string()
-            } else if let Some(s) = info.payload().downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "panic with non-string payload".to_string()
-            };
-
-            let location = info
-                .location()
-                .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
-                .unwrap_or_else(|| "<unknown>".to_string());
-
+        self.panic_action = Some(self.monitor_runtime.register_panic_action(move |report| {
             let marker = probe.marker();
             let last_culistid = {
                 let guard = shared
@@ -209,24 +199,34 @@ impl CuSafetyMon {
             };
 
             let detail = if let Some(marker) = marker {
-                format!(
-                    "panic at {}: {}; last marker component={} step={:?}; last_culist={}",
-                    location,
-                    panic_message,
-                    marker.component_id.index(),
-                    marker.step,
-                    last_culistid
-                )
+                let component = components.get(marker.component_id.index()).map(|c| c.id());
+                match component {
+                    Some(component) => format!(
+                        "{}; last marker component='{}' step={:?}; last_culist={}",
+                        Self::panic_detail_from_report(report),
+                        component,
+                        marker.step,
+                        last_culistid
+                    ),
+                    None => format!(
+                        "{}; last marker component={} step={:?}; last_culist={}",
+                        Self::panic_detail_from_report(report),
+                        marker.component_id.index(),
+                        marker.step,
+                        last_culistid
+                    ),
+                }
             } else {
                 format!(
-                    "panic at {}: {}; last_culist={}",
-                    location, panic_message, last_culistid
+                    "{}; last_culist={}",
+                    Self::panic_detail_from_report(report),
+                    last_culistid
                 )
             };
 
             shared.request_exit(panic_code, detail.clone());
             Self::emit_fault("cu_safetymon panic fault:", &detail);
-            std::process::exit(panic_code);
+            Some(panic_code)
         }));
     }
 
@@ -250,19 +250,21 @@ impl CuSafetyMon {
 impl CuMonitor for CuSafetyMon {
     fn new(metadata: CuMonitoringMetadata, runtime: CuMonitoringRuntime) -> CuResult<Self> {
         let cfg = SafetyCfg::from_monitor_config(metadata.monitor_config())?;
+        let execution_probe = runtime.execution_probe().clone();
         Ok(Self {
             components: metadata.components(),
             shared: Arc::new(SharedState::new()),
             cfg,
             watchdog: None,
-            previous_panic_hook: None,
-            execution_probe: runtime.execution_probe().clone(),
+            monitor_runtime: runtime,
+            panic_action: None,
+            execution_probe,
         })
     }
 
     fn start(&mut self, _ctx: &CuContext) -> CuResult<()> {
         self.shared.touch(0);
-        self.install_panic_hook();
+        self.install_panic_action();
         self.spawn_watchdog();
         info!(
             "cu_safetymon started: deadline={:?} period={:?} codes(shutdown={}, lock={}, panic={})",
@@ -305,14 +307,11 @@ impl CuMonitor for CuSafetyMon {
 
     fn stop(&mut self, _ctx: &CuContext) -> CuResult<()> {
         self.shared.stopping.store(true, Ordering::SeqCst);
+        self.panic_action = None;
 
         if let Some(handle) = self.watchdog.take() {
             handle.thread().unpark();
             let _ = handle.join();
-        }
-
-        if let Some(previous_hook) = self.previous_panic_hook.take() {
-            std::panic::set_hook(previous_hook);
         }
 
         self.maybe_exit_with_latched_code();

--- a/components/monitors/cu_safetymon/src/std_impl.rs
+++ b/components/monitors/cu_safetymon/src/std_impl.rs
@@ -126,12 +126,12 @@ impl CuSafetyMon {
 
         self.watchdog = Some(thread::spawn(move || {
             loop {
-                if shared.stopping.load(Ordering::SeqCst) {
+                if shared.stopping.load(Ordering::SeqCst) || runtime_panic_hook_active() {
                     break;
                 }
                 thread::park_timeout(period);
 
-                if shared.stopping.load(Ordering::SeqCst) {
+                if shared.stopping.load(Ordering::SeqCst) || runtime_panic_hook_active() {
                     break;
                 }
 
@@ -144,6 +144,10 @@ impl CuSafetyMon {
                 };
 
                 if elapsed > deadline {
+                    if shared.stopping.load(Ordering::SeqCst) || runtime_panic_hook_active() {
+                        break;
+                    }
+
                     let marker = probe.marker();
                     let culist_info = format!("last_culist={last_culistid}");
                     let detail = if let Some(marker) = marker {
@@ -167,6 +171,10 @@ impl CuSafetyMon {
                             elapsed, culist_info
                         )
                     };
+
+                    if shared.stopping.load(Ordering::SeqCst) || runtime_panic_hook_active() {
+                        break;
+                    }
 
                     shared.request_exit(exit_code, detail.clone());
                     Self::emit_fault("cu_safetymon lock fault:", &detail);

--- a/components/monitors/cu_safetymon/tests/safety_monitoring.rs
+++ b/components/monitors/cu_safetymon/tests/safety_monitoring.rs
@@ -1,6 +1,8 @@
 use cu_logmon::CuLogMon;
 use cu_safetymon::CuSafetyMon;
 use cu29::prelude::*;
+use std::fs;
+use std::path::PathBuf;
 use std::process::{Command, Output};
 use std::sync::Arc;
 use std::thread;
@@ -80,16 +82,25 @@ fn safetymon_test_config(exit_lock: i32, exit_panic: i32) -> CuConfig {
     safetymon_test_config_with_timing(40, 10, exit_lock, exit_panic)
 }
 
-fn spawn_current_test(test_name: &str, mode: &str) -> Output {
+fn spawn_current_test(test_name: &str, mode: &str) -> (Output, PathBuf) {
     let exe = std::env::current_exe().expect("unable to locate current test executable");
-    Command::new(exe)
+    let child_dir = std::env::temp_dir().join(format!(
+        "cu-safetymon-test-{}-{}-{}",
+        test_name,
+        mode,
+        std::process::id()
+    ));
+    fs::create_dir_all(&child_dir).expect("failed to create child test directory");
+    let output = Command::new(exe)
         .arg("--exact")
         .arg(test_name)
         .arg("--nocapture")
         .arg("--test-threads=1")
         .env(CHILD_MODE_ENV, mode)
+        .current_dir(&child_dir)
         .output()
-        .expect("failed to spawn child test process")
+        .expect("failed to spawn child test process");
+    (output, child_dir)
 }
 
 #[test]
@@ -169,7 +180,7 @@ fn panic_fault_exits_with_configured_code_and_marker_context() {
         panic!("panic path test");
     }
 
-    let output = spawn_current_test(
+    let (output, child_dir) = spawn_current_test(
         "panic_fault_exits_with_configured_code_and_marker_context",
         "panic",
     );
@@ -181,8 +192,24 @@ fn panic_fault_exits_with_configured_code_and_marker_context() {
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("cu_safetymon panic fault:"));
-    assert!(stderr.contains("component=1"));
+    assert!(stderr.contains("component='driver'"));
     assert!(stderr.contains("last_culist=33"));
+    let crash_reports: Vec<_> = fs::read_dir(&child_dir)
+        .expect("failed to read child test directory")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("copper-crash-") && name.ends_with(".txt"))
+        })
+        .collect();
+    assert_eq!(
+        crash_reports.len(),
+        1,
+        "expected one crash report in {child_dir:?}"
+    );
+    let _ = fs::remove_dir_all(&child_dir);
 }
 
 #[test]
@@ -211,7 +238,7 @@ fn lock_fault_exits_with_configured_code_and_last_marker() {
         std::process::exit(254);
     }
 
-    let output = spawn_current_test(
+    let (output, child_dir) = spawn_current_test(
         "lock_fault_exits_with_configured_code_and_last_marker",
         "lock",
     );
@@ -225,6 +252,7 @@ fn lock_fault_exits_with_configured_code_and_last_marker() {
     assert!(stderr.contains("cu_safetymon lock fault:"));
     assert!(stderr.contains("component='driver'"));
     assert!(stderr.contains("last_culist=9"));
+    let _ = fs::remove_dir_all(&child_dir);
 }
 
 #[test]
@@ -246,7 +274,7 @@ fn stop_does_not_trigger_lock_fault_after_shutdown_requested() {
     }
 
     let started = Instant::now();
-    let output = spawn_current_test(
+    let (output, child_dir) = spawn_current_test(
         "stop_does_not_trigger_lock_fault_after_shutdown_requested",
         "stop-race",
     );
@@ -258,6 +286,7 @@ fn stop_does_not_trigger_lock_fault_after_shutdown_requested() {
         output.status,
         String::from_utf8_lossy(&output.stderr)
     );
+    let _ = fs::remove_dir_all(&child_dir);
     assert!(
         elapsed < Duration::from_millis(STOP_RACE_MAX_CHILD_RUNTIME_MS),
         "stop-race child took {:?}; expected stop to wake a parked watchdog well before {}ms",

--- a/core/cu29_runtime/src/monitoring.rs
+++ b/core/cu29_runtime/src/monitoring.rs
@@ -891,6 +891,8 @@ static PANIC_HOOK_REGISTRY: OnceLock<PanicHookRegistry> = OnceLock::new();
 static PANIC_HOOK_INSTALL_ONCE: OnceLock<()> = OnceLock::new();
 #[cfg(feature = "std")]
 static PANIC_HOOK_REGISTRATION_ID: AtomicUsize = AtomicUsize::new(1);
+#[cfg(feature = "std")]
+static PANIC_HOOK_ACTIVE_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 #[cfg(feature = "std")]
 fn panic_hook_registry() -> &'static PanicHookRegistry {
@@ -901,6 +903,7 @@ fn panic_hook_registry() -> &'static PanicHookRegistry {
 fn ensure_runtime_panic_hook_installed() {
     let _ = PANIC_HOOK_INSTALL_ONCE.get_or_init(|| {
         std::panic::set_hook(Box::new(move |info| {
+            let _guard = PanicHookActiveGuard::new();
             let mut report = PanicReport::capture(info);
             run_panic_cleanup_callbacks(&report);
             report.crash_report_path = write_panic_report_to_file(&report);
@@ -911,6 +914,34 @@ fn ensure_runtime_panic_hook_installed() {
             }
         }));
     });
+}
+
+#[cfg(feature = "std")]
+struct PanicHookActiveGuard;
+
+#[cfg(feature = "std")]
+impl PanicHookActiveGuard {
+    fn new() -> Self {
+        PANIC_HOOK_ACTIVE_COUNT.fetch_add(1, Ordering::SeqCst);
+        Self
+    }
+}
+
+#[cfg(feature = "std")]
+impl Drop for PanicHookActiveGuard {
+    fn drop(&mut self) {
+        PANIC_HOOK_ACTIVE_COUNT.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+#[cfg(feature = "std")]
+pub fn runtime_panic_hook_active() -> bool {
+    PANIC_HOOK_ACTIVE_COUNT.load(Ordering::SeqCst) > 0
+}
+
+#[cfg(not(feature = "std"))]
+pub const fn runtime_panic_hook_active() -> bool {
+    false
 }
 
 #[cfg(feature = "std")]

--- a/core/cu29_runtime/src/monitoring.rs
+++ b/core/cu29_runtime/src/monitoring.rs
@@ -34,9 +34,19 @@ extern crate alloc;
 #[cfg(feature = "std")]
 use core::cell::Cell;
 #[cfg(feature = "std")]
-use std::sync::Arc;
+use std::backtrace::Backtrace;
+#[cfg(feature = "std")]
+use std::fs::File;
+#[cfg(feature = "std")]
+use std::io::Write;
+#[cfg(feature = "std")]
+use std::panic::PanicHookInfo;
+#[cfg(feature = "std")]
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 #[cfg(feature = "std")]
 use std::thread_local;
+#[cfg(feature = "std")]
+use std::time::{SystemTime, UNIX_EPOCH};
 #[cfg(feature = "std")]
 use std::{collections::HashMap as Map, string::String, string::ToString, vec::Vec};
 
@@ -719,10 +729,23 @@ pub struct CuMonitoringRuntime {
 }
 
 impl CuMonitoringRuntime {
+    #[cfg(feature = "std")]
+    pub fn new(execution_probe: MonitorExecutionProbe) -> Self {
+        ensure_runtime_panic_hook_installed();
+        Self { execution_probe }
+    }
+
+    #[cfg(not(feature = "std"))]
     pub const fn new(execution_probe: MonitorExecutionProbe) -> Self {
         Self { execution_probe }
     }
 
+    #[cfg(feature = "std")]
+    pub fn unavailable() -> Self {
+        Self::new(MonitorExecutionProbe::unavailable())
+    }
+
+    #[cfg(not(feature = "std"))]
     pub const fn unavailable() -> Self {
         Self::new(MonitorExecutionProbe::unavailable())
     }
@@ -730,6 +753,311 @@ impl CuMonitoringRuntime {
     pub fn execution_probe(&self) -> &MonitorExecutionProbe {
         &self.execution_probe
     }
+
+    #[cfg(feature = "std")]
+    pub fn register_panic_cleanup<F>(&self, callback: F) -> PanicHookRegistration
+    where
+        F: Fn(&PanicReport) + Send + Sync + 'static,
+    {
+        ensure_runtime_panic_hook_installed();
+        register_panic_cleanup(callback)
+    }
+
+    #[cfg(feature = "std")]
+    pub fn register_panic_action<F>(&self, callback: F) -> PanicHookRegistration
+    where
+        F: Fn(&PanicReport) -> Option<i32> + Send + Sync + 'static,
+    {
+        ensure_runtime_panic_hook_installed();
+        register_panic_action(callback)
+    }
+}
+
+#[cfg(feature = "std")]
+type PanicCleanupCallback = Arc<dyn Fn(&PanicReport) + Send + Sync + 'static>;
+#[cfg(feature = "std")]
+type PanicActionCallback = Arc<dyn Fn(&PanicReport) -> Option<i32> + Send + Sync + 'static>;
+
+#[cfg(feature = "std")]
+#[derive(Debug, Clone)]
+pub struct PanicReport {
+    message: String,
+    location: Option<String>,
+    thread_name: Option<String>,
+    backtrace: String,
+    timestamp_unix_ms: u128,
+    crash_report_path: Option<String>,
+}
+
+#[cfg(feature = "std")]
+impl PanicReport {
+    fn capture(info: &PanicHookInfo<'_>) -> Self {
+        let location = info
+            .location()
+            .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()));
+        let thread_name = std::thread::current().name().map(|name| name.to_string());
+        let timestamp_unix_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|dur| dur.as_millis())
+            .unwrap_or(0);
+
+        Self {
+            message: panic_hook_payload_to_string(info),
+            location,
+            thread_name,
+            backtrace: Backtrace::force_capture().to_string(),
+            timestamp_unix_ms,
+            crash_report_path: None,
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn location(&self) -> Option<&str> {
+        self.location.as_deref()
+    }
+
+    pub fn thread_name(&self) -> Option<&str> {
+        self.thread_name.as_deref()
+    }
+
+    pub fn backtrace(&self) -> &str {
+        &self.backtrace
+    }
+
+    pub fn timestamp_unix_ms(&self) -> u128 {
+        self.timestamp_unix_ms
+    }
+
+    pub fn crash_report_path(&self) -> Option<&str> {
+        self.crash_report_path.as_deref()
+    }
+
+    pub fn summary(&self) -> String {
+        match self.location() {
+            Some(location) => format!("panic at {location}: {}", self.message()),
+            None => format!("panic: {}", self.message()),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PanicHookRegistrationKind {
+    Cleanup,
+    Action,
+}
+
+#[cfg(feature = "std")]
+#[derive(Clone)]
+struct RegisteredPanicCleanup {
+    id: usize,
+    callback: PanicCleanupCallback,
+}
+
+#[cfg(feature = "std")]
+#[derive(Clone)]
+struct RegisteredPanicAction {
+    id: usize,
+    callback: PanicActionCallback,
+}
+
+#[cfg(feature = "std")]
+#[derive(Default)]
+struct PanicHookRegistry {
+    cleanup_callbacks: StdMutex<Vec<RegisteredPanicCleanup>>,
+    action_callbacks: StdMutex<Vec<RegisteredPanicAction>>,
+}
+
+#[cfg(feature = "std")]
+#[derive(Debug)]
+pub struct PanicHookRegistration {
+    id: usize,
+    kind: PanicHookRegistrationKind,
+}
+
+#[cfg(feature = "std")]
+impl Drop for PanicHookRegistration {
+    fn drop(&mut self) {
+        unregister_panic_hook(self.kind, self.id);
+    }
+}
+
+#[cfg(feature = "std")]
+static PANIC_HOOK_REGISTRY: OnceLock<PanicHookRegistry> = OnceLock::new();
+#[cfg(feature = "std")]
+static PANIC_HOOK_INSTALL_ONCE: OnceLock<()> = OnceLock::new();
+#[cfg(feature = "std")]
+static PANIC_HOOK_REGISTRATION_ID: AtomicUsize = AtomicUsize::new(1);
+
+#[cfg(feature = "std")]
+fn panic_hook_registry() -> &'static PanicHookRegistry {
+    PANIC_HOOK_REGISTRY.get_or_init(PanicHookRegistry::default)
+}
+
+#[cfg(feature = "std")]
+fn ensure_runtime_panic_hook_installed() {
+    let _ = PANIC_HOOK_INSTALL_ONCE.get_or_init(|| {
+        std::panic::set_hook(Box::new(move |info| {
+            let mut report = PanicReport::capture(info);
+            run_panic_cleanup_callbacks(&report);
+            report.crash_report_path = write_panic_report_to_file(&report);
+            emit_panic_report(&report);
+
+            if let Some(exit_code) = run_panic_action_callbacks(&report) {
+                std::process::exit(exit_code);
+            }
+        }));
+    });
+}
+
+#[cfg(feature = "std")]
+fn register_panic_cleanup<F>(callback: F) -> PanicHookRegistration
+where
+    F: Fn(&PanicReport) + Send + Sync + 'static,
+{
+    let id = PANIC_HOOK_REGISTRATION_ID.fetch_add(1, Ordering::Relaxed);
+    let callback = Arc::new(callback) as PanicCleanupCallback;
+    let mut callbacks = panic_hook_registry()
+        .cleanup_callbacks
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    callbacks.push(RegisteredPanicCleanup { id, callback });
+    PanicHookRegistration {
+        id,
+        kind: PanicHookRegistrationKind::Cleanup,
+    }
+}
+
+#[cfg(feature = "std")]
+fn register_panic_action<F>(callback: F) -> PanicHookRegistration
+where
+    F: Fn(&PanicReport) -> Option<i32> + Send + Sync + 'static,
+{
+    let id = PANIC_HOOK_REGISTRATION_ID.fetch_add(1, Ordering::Relaxed);
+    let callback = Arc::new(callback) as PanicActionCallback;
+    let mut callbacks = panic_hook_registry()
+        .action_callbacks
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    callbacks.push(RegisteredPanicAction { id, callback });
+    PanicHookRegistration {
+        id,
+        kind: PanicHookRegistrationKind::Action,
+    }
+}
+
+#[cfg(feature = "std")]
+fn unregister_panic_hook(kind: PanicHookRegistrationKind, id: usize) {
+    let registry = panic_hook_registry();
+    match kind {
+        PanicHookRegistrationKind::Cleanup => {
+            let mut callbacks = registry
+                .cleanup_callbacks
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            callbacks.retain(|entry| entry.id != id);
+        }
+        PanicHookRegistrationKind::Action => {
+            let mut callbacks = registry
+                .action_callbacks
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            callbacks.retain(|entry| entry.id != id);
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+fn run_panic_cleanup_callbacks(report: &PanicReport) {
+    let callbacks = panic_hook_registry()
+        .cleanup_callbacks
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .clone();
+    for entry in callbacks {
+        (entry.callback)(report);
+    }
+}
+
+#[cfg(feature = "std")]
+fn run_panic_action_callbacks(report: &PanicReport) -> Option<i32> {
+    let callbacks = panic_hook_registry()
+        .action_callbacks
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .clone();
+    let mut exit_code = None;
+    for entry in callbacks {
+        if exit_code.is_none() {
+            exit_code = (entry.callback)(report);
+        } else {
+            let _ = (entry.callback)(report);
+        }
+    }
+    exit_code
+}
+
+#[cfg(feature = "std")]
+fn panic_hook_payload_to_string(info: &PanicHookInfo<'_>) -> String {
+    if let Some(msg) = info.payload().downcast_ref::<&str>() {
+        (*msg).to_string()
+    } else if let Some(msg) = info.payload().downcast_ref::<String>() {
+        msg.clone()
+    } else {
+        "panic with non-string payload".to_string()
+    }
+}
+
+#[cfg(feature = "std")]
+fn render_panic_report(report: &PanicReport) -> String {
+    let mut rendered = String::from("Copper panic\n");
+    rendered.push_str(&format!("time_unix_ms: {}\n", report.timestamp_unix_ms()));
+    rendered.push_str(&format!(
+        "thread: {}\n",
+        report.thread_name().unwrap_or("<unnamed>")
+    ));
+    if let Some(location) = report.location() {
+        rendered.push_str(&format!("location: {location}\n"));
+    }
+    rendered.push_str(&format!("message: {}\n", report.message()));
+    if let Some(path) = report.crash_report_path() {
+        rendered.push_str(&format!("crash_report: {path}\n"));
+    }
+    rendered.push_str("\nBacktrace:\n");
+    rendered.push_str(report.backtrace());
+    if !report.backtrace().ends_with('\n') {
+        rendered.push('\n');
+    }
+    rendered
+}
+
+#[cfg(feature = "std")]
+fn emit_panic_report(report: &PanicReport) {
+    let mut stderr = std::io::stderr().lock();
+    let _ = stderr.write_all(render_panic_report(report).as_bytes());
+    let _ = stderr.flush();
+}
+
+#[cfg(feature = "std")]
+fn write_panic_report_to_file(report: &PanicReport) -> Option<String> {
+    let cwd = std::env::current_dir().ok()?;
+    let file_name = format!(
+        "copper-crash-{}-{}.txt",
+        report.timestamp_unix_ms(),
+        std::process::id()
+    );
+    let path = cwd.join(file_name);
+    let path_string = path.to_string_lossy().to_string();
+    let mut file = File::create(&path).ok()?;
+    let mut report_with_path = report.clone();
+    report_with_path.crash_report_path = Some(path_string.clone());
+    file.write_all(render_panic_report(&report_with_path).as_bytes())
+        .ok()?;
+    file.flush().ok()?;
+    Some(path_string)
 }
 
 /// Monitor decision to be taken when a component step errored out.


### PR DESCRIPTION
## Summary

It was messy with the runtime competing with the monitors to capture and
display the panics.

## Related issues
- Closes #1027 

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
