### PR TITLE
Added From<Value> for f32 and TryFrom<Value> for f32 implementations

### DIFF
--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -404,6 +404,45 @@ impl From<Value> for f64 {
     }
 }
 
+//Basically just a copy of the From<Value> for f64.
+impl TryFrom<&Value> for f32 {
+    type Error = ConfigError;
+
+    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+        if let Value(RonValue::Number(num)) = value {
+            let number = match num {
+                Number::I8(n) => *n as f32,
+                Number::I16(n) => *n as f32,
+                Number::I32(n) => *n as f32,
+                Number::I64(n) => *n as f32,
+                Number::U8(n) => *n as f32,
+                Number::U16(n) => *n as f32,
+                Number::U32(n) => *n as f32,
+                Number::U64(n) => *n as f32,
+                Number::F32(n) => n.0,
+                Number::F64(n) => n.0 as f32,
+                _ => {
+                    return Err(ConfigError::type_mismatch("number", value));
+                }
+            };
+            Ok(number)
+        } else {
+            Err(ConfigError::type_mismatch("number", value))
+        }
+    }
+}
+
+impl From<Value> for f32 {
+    fn from(value: Value) -> Self {
+        if let Value(RonValue::Number(num)) = value {
+            num.into_f64() as f32
+        } else {
+            panic!("Expected a Number variant but got {value:?}")
+        }
+    }
+}
+
+
 impl From<String> for Value {
     fn from(value: String) -> Self {
         Value(RonValue::String(value))

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -442,7 +442,6 @@ impl From<Value> for f32 {
     }
 }
 
-
 impl From<String> for Value {
     fn from(value: String) -> Self {
         Value(RonValue::String(value))


### PR DESCRIPTION
## Summary
Copied the implementations of From<Value> and TryFrom<Value> for f64 and repurposed them to work with f32.

## Related issues
- Closes #

## Changes
Added implementations for From<cu29_runtime::config::Value> for f32 and TryFrom<cu29_runtime::config::Value> for f32

## Testing
- [x] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [x] Other (please specify):
Built with cargo build and tested if the implementation compiled correctly on a local repo.

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [x] I have updated docs or examples where needed
- [x] I have added or updated tests where needed
- [x] I have considered platform impact (Linux/macOS/Windows/embedded)
- [x] I have considered config/logging changes (if applicable)
- [x] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
The just commands don't play super well with my system at the moment which is why they were not run in the Testing section. 