### PR TITLE
fix(time): use CuTime for absolute timestamps

### DIFF
--- a/components/libs/cu_transform/README.md
+++ b/components/libs/cu_transform/README.md
@@ -21,23 +21,26 @@ The transform tree maintains a hierarchical relationship between coordinate fram
 
 ```rust
 use cu_transform::{StampedTransform, TransformTree, Transform3D};
-use cu29::clock::CuDuration;
+use cu29::clock::{CuTime, RobotClock};
 
 fn tree_lookup() {
     // Create a transform tree
     let mut tree = TransformTree::<f32>::new();
+    let clock = RobotClock::default();
 
     // Add a transform from "world" to "robot"
     let world_to_robot = StampedTransform {
         transform: Transform3D::default(), // Identity transform
-        stamp: CuDuration(1000),
+        stamp: CuTime::from_nanos(1000),
         parent_frame: "world".try_into().expect("invalid name"),
         child_frame: "robot".try_into().expect("invalid name"),
     };
     tree.add_transform(world_to_robot).unwrap();
 
     // Look up transform
-    let transform = tree.lookup_transform("world", "robot", CuDuration(1000)).unwrap();
+    let transform = tree
+        .lookup_transform("world", "robot", CuTime::from_nanos(1000), &clock)
+        .unwrap();
 }
 ```
 
@@ -47,16 +50,19 @@ The cu_transform library also supports calculating and transforming velocities:
 
 ```rust
 use cu_transform::{VelocityTransform, TransformTree};
-use cu29::clock::CuDuration;
+use cu29::clock::{CuTime, RobotClock};
 
 
 fn velocity_lookup() {
     // Create and set up a transform tree with moving frames
     // ...
+    let clock = RobotClock::default();
 
     // Look up velocity between frames at a specific time
     // This uses caching to speed up repeated lookups
-    let velocity = tree.lookup_velocity("world", "robot", CuDuration(1500)).unwrap();
+    let velocity = tree
+        .lookup_velocity("world", "robot", CuTime::from_nanos(1500), &clock)
+        .unwrap();
 
     // Access linear and angular components
     let linear_x = velocity.linear[0]; // Linear velocity in x direction (m/s)
@@ -140,9 +146,10 @@ fn caching_tree() {
         200,                   // Cache size (max number of entries)
         Duration::from_secs(5) // Cache entry lifetime
     );
+    let clock = RobotClock::default();
 
     // Lookup operations use the cache automatically
-    let velocity = tree.lookup_velocity("world", "robot", time);
+    let velocity = tree.lookup_velocity("world", "robot", time, &clock);
 
     // Cache is automatically invalidated when:
     // - New transforms are added to the tree

--- a/components/libs/cu_transform/examples/basic_usage.rs
+++ b/components/libs/cu_transform/examples/basic_usage.rs
@@ -4,7 +4,7 @@ use cu_transform::{
     ConstTransformBuffer, FrameIdString, FrameTransform, RobotFrame, StampedTransform,
     TransformTree, TypedTransform, TypedTransformBuffer, WorldFrame,
 };
-use cu29::clock::{CuDuration, Tov};
+use cu29::clock::{CuTime, Tov};
 
 fn main() {
     // Example using the typed transform approach
@@ -23,7 +23,7 @@ fn main() {
         [0.0, 0.0, 0.0, 1.0],
     ]);
 
-    let world_to_robot_msg = TypedTransform::new(transform, CuDuration(1000));
+    let world_to_robot_msg = TypedTransform::new(transform, CuTime::from_nanos(1000));
 
     println!(
         "Created transform from {} to {}",
@@ -49,7 +49,7 @@ fn main() {
         [0.0, 0.0, 0.0, 1.0],
     ]);
 
-    let world_to_robot_msg2 = TypedTransform::new(transform2, CuDuration(2000));
+    let world_to_robot_msg2 = TypedTransform::new(transform2, CuTime::from_nanos(2000));
     world_to_robot_buffer.add_transform(world_to_robot_msg2);
 
     // Query the buffer
@@ -68,7 +68,7 @@ fn main() {
     }
 
     // Query closest to a specific time
-    if let Some(closest) = world_to_robot_buffer.get_closest_transform(CuDuration(1500)) {
+    if let Some(closest) = world_to_robot_buffer.get_closest_transform(CuTime::from_nanos(1500)) {
         println!("\nClosest transform to time 1500:");
         println!("  Actual time: {}", closest.timestamp().unwrap().as_nanos());
         if let Some(t) = closest.transform() {
@@ -91,7 +91,7 @@ fn main() {
 
     // Demonstrate velocity computation
     if let Some(latest) = world_to_robot_buffer.get_latest_transform()
-        && let Some(closest) = world_to_robot_buffer.get_closest_transform(CuDuration(1000))
+        && let Some(closest) = world_to_robot_buffer.get_closest_transform(CuTime::from_nanos(1000))
         && let Some(velocity) = latest.compute_velocity(closest)
     {
         println!("\nVelocity computation:");
@@ -110,7 +110,7 @@ fn main() {
     // Add some stamped transforms
     let stamped_transform = StampedTransform {
         transform,
-        stamp: CuDuration(1000),
+        stamp: CuTime::from_nanos(1000),
         parent_frame: "world".try_into().unwrap(),
         child_frame: "robot".try_into().unwrap(),
     };
@@ -147,7 +147,7 @@ fn main() {
     );
 
     let mut sft = StampedFrameTransform::new(Some(frame_transform));
-    sft.tov = Tov::Time(CuDuration(1_000_000_000)); // 1 second
+    sft.tov = Tov::Time(CuTime::from_nanos(1_000_000_000)); // 1 second
 
     // Add using the new API
     tree.add_transform(&sft).expect("Failed to add transform");
@@ -155,7 +155,12 @@ fn main() {
 
     // Query the transform
     let robot_clock = cu29::clock::RobotClock::default();
-    let result = tree.lookup_transform("world", "robot", CuDuration(1_000_000_000), &robot_clock);
+    let result = tree.lookup_transform(
+        "world",
+        "robot",
+        CuTime::from_nanos(1_000_000_000),
+        &robot_clock,
+    );
 
     match result {
         Ok(transform) => {

--- a/components/libs/cu_transform/examples/payload_usage.rs
+++ b/components/libs/cu_transform/examples/payload_usage.rs
@@ -1,7 +1,7 @@
 use cu_spatial_payloads::Transform3D;
 use cu_transform::transform_payload::StampedFrameTransform;
 use cu_transform::{FrameIdString, FrameTransform, TransformTree};
-use cu29::clock::{CuDuration, RobotClock, Tov};
+use cu29::clock::{CuTime, RobotClock, Tov};
 
 fn main() {
     println!("Cu Transform - CuMsg Pattern Demo");
@@ -29,7 +29,7 @@ fn main() {
         FrameIdString::from("base").expect("Frame name too long"),
     );
     let mut sft = StampedFrameTransform::new(Some(frame_transform));
-    sft.tov = Tov::Time(CuDuration(1_000_000_000)); // 1 second
+    sft.tov = Tov::Time(CuTime::from_nanos(1_000_000_000)); // 1 second
 
     // Add to tree using the new API
     tree.add_transform(&sft).expect("Failed to add transform");
@@ -49,7 +49,7 @@ fn main() {
         FrameIdString::from("arm").expect("Frame name too long"),
     );
     let mut sft = StampedFrameTransform::new(Some(msg2));
-    sft.tov = Tov::Time(CuDuration(1_000_000_000)); // 1 second
+    sft.tov = Tov::Time(CuTime::from_nanos(1_000_000_000)); // 1 second
 
     tree.add_transform(&sft).expect("Failed to add transform");
     println!("  Added base->arm transform at t=1s");
@@ -59,9 +59,9 @@ fn main() {
 
     // Create multiple transforms at different times
     let times = [
-        CuDuration(2_000_000_000), // 2 seconds
-        CuDuration(2_100_000_000), // 2.1 seconds
-        CuDuration(2_200_000_000),
+        CuTime::from_nanos(2_000_000_000), // 2 seconds
+        CuTime::from_nanos(2_100_000_000), // 2.1 seconds
+        CuTime::from_nanos(2_200_000_000),
     ];
 
     for (i, &time) in times.iter().enumerate() {
@@ -98,7 +98,7 @@ fn main() {
     // Query the tree
     println!("\nQuerying transforms...");
 
-    let result = tree.lookup_transform("world", "arm", CuDuration(1_000_000_000), &clock);
+    let result = tree.lookup_transform("world", "arm", CuTime::from_nanos(1_000_000_000), &clock);
     match result {
         Ok(transform) => {
             let mat = transform.to_matrix();
@@ -111,7 +111,7 @@ fn main() {
     }
 
     // Query velocity (requires transforms at multiple times)
-    let velocity = tree.lookup_velocity("world", "base", CuDuration(2_100_000_000), &clock);
+    let velocity = tree.lookup_velocity("world", "base", CuTime::from_nanos(2_100_000_000), &clock);
     match velocity {
         Ok(vel) => {
             println!(

--- a/components/libs/cu_transform/src/bin/benchmark.rs
+++ b/components/libs/cu_transform/src/bin/benchmark.rs
@@ -1,7 +1,7 @@
 use cu_spatial_payloads::Transform3D;
 use cu_transform::transform_payload::StampedFrameTransform;
 use cu_transform::{FrameTransform, TransformTree};
-use cu29::clock::{CuDuration, Tov};
+use cu29::clock::{CuTime, Tov};
 use cu29::prelude::RobotClock;
 use std::time::Instant;
 
@@ -38,7 +38,7 @@ fn main() {
 
         let ft = FrameTransform::new(transform, &parent_str, &child_str);
         let mut sft = StampedFrameTransform::new(Some(ft));
-        sft.tov = Tov::Time(CuDuration(1000));
+        sft.tov = Tov::Time(CuTime::from_nanos(1000));
 
         tree.add_transform(&sft).unwrap();
     }
@@ -53,7 +53,7 @@ fn main() {
             .lookup_transform(
                 "base",
                 &format!("frame{num_frames}"),
-                CuDuration(1000),
+                CuTime::from_nanos(1000),
                 &clock,
             )
             .unwrap();
@@ -67,7 +67,7 @@ fn main() {
             .lookup_transform(
                 "base",
                 &format!("frame{num_frames}"),
-                CuDuration(1000),
+                CuTime::from_nanos(1000),
                 &clock,
             )
             .unwrap();
@@ -103,7 +103,7 @@ fn main() {
                     .lookup_transform(
                         "base",
                         &format!("frame{frame_num}"),
-                        CuDuration(1000),
+                        CuTime::from_nanos(1000),
                         &clock_clone,
                     )
                     .unwrap();

--- a/components/libs/cu_transform/src/interpolation.rs
+++ b/components/libs/cu_transform/src/interpolation.rs
@@ -148,7 +148,7 @@ mod tests {
             "expected {expected}, got {actual}, difference {diff} exceeds epsilon {epsilon}",
         );
     }
-    use cu29::clock::CuDuration;
+    use cu29::clock::CuTime;
 
     #[test]
     fn test_interpolate_transforms_f32() {
@@ -159,7 +159,7 @@ mod tests {
                 [0.0, 0.0, 1.0, 0.0],
                 [0.0, 0.0, 0.0, 1.0], // Translation: x=0
             ]),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: frame_id!("world"),
             child_frame: frame_id!("robot"),
         };
@@ -171,24 +171,24 @@ mod tests {
                 [0.0, 0.0, 1.0, 0.0],
                 [10.0, 0.0, 0.0, 1.0], // Translation: x=10
             ]),
-            stamp: CuDuration(3000),
+            stamp: CuTime::from_nanos(3000),
             parent_frame: frame_id!("world"),
             child_frame: frame_id!("robot"),
         };
 
-        let result = interpolate_transforms(&before, &after, CuDuration(2000));
+        let result = interpolate_transforms(&before, &after, CuTime::from_nanos(2000));
         assert!(result.is_ok());
 
         let transform = result.unwrap();
         assert_approx_eq(transform.to_matrix()[3][0], 5.0, 1e-5);
 
-        let result = interpolate_transforms(&before, &after, CuDuration(1500));
+        let result = interpolate_transforms(&before, &after, CuTime::from_nanos(1500));
         assert!(result.is_ok());
 
         let transform = result.unwrap();
         assert_approx_eq(transform.to_matrix()[3][0], 2.5, 1e-5);
 
-        let result = interpolate_transforms(&before, &after, CuDuration(2500));
+        let result = interpolate_transforms(&before, &after, CuTime::from_nanos(2500));
         assert!(result.is_ok());
 
         let transform = result.unwrap();
@@ -204,7 +204,7 @@ mod tests {
                 [0.0, 0.0, 1.0, 0.0],
                 [0.0, 0.0, 0.0, 1.0], // Translation: x=0
             ]),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: frame_id!("world"),
             child_frame: frame_id!("robot"),
         };
@@ -216,13 +216,13 @@ mod tests {
                 [0.0, 0.0, 1.0, 0.0],
                 [10.0, 0.0, 0.0, 1.0],
             ]),
-            stamp: CuDuration(3000),
+            stamp: CuTime::from_nanos(3000),
             parent_frame: frame_id!("world"),
             child_frame: frame_id!("robot"),
         };
 
         // Test at midpoint
-        let result = interpolate_transforms(&before, &after, CuDuration(2000));
+        let result = interpolate_transforms(&before, &after, CuTime::from_nanos(2000));
         assert!(result.is_ok());
         let transform = result.unwrap();
         assert_approx_eq(transform.to_matrix()[3][0], 5.0, 1e-5);
@@ -235,14 +235,14 @@ mod tests {
         // Test with i32
         let mut before: StampedTransform<i32> = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: frame_id!("world"),
             child_frame: frame_id!("robot"),
         };
 
         let mut after: StampedTransform<i32> = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(3000),
+            stamp: CuTime::from_nanos(3000),
             parent_frame: frame_id!("world"),
             child_frame: frame_id!("robot"),
         };
@@ -256,13 +256,13 @@ mod tests {
         after.transform = Transform3D::from_matrix(after_mat);
 
         // Test at midpoint
-        let result = interpolate_transforms(&before, &after, CuDuration(2000));
+        let result = interpolate_transforms(&before, &after, CuTime::from_nanos(2000));
         assert!(result.is_ok());
         let transform = result.unwrap();
         assert_eq!(transform.to_matrix()[0][3], 5);
 
         // Test with non-integer result (should round)
-        let result = interpolate_transforms(&before, &after, CuDuration(1500));
+        let result = interpolate_transforms(&before, &after, CuTime::from_nanos(1500));
         assert!(result.is_ok());
         let transform = result.unwrap();
         assert_eq!(transform.to_matrix()[0][3], 3); // 2.5 rounds to 3
@@ -275,14 +275,14 @@ mod tests {
         // Test with u64
         let mut before: StampedTransform<u64> = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: frame_id!("world"),
             child_frame: frame_id!("robot"),
         };
 
         let mut after: StampedTransform<u64> = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(3000),
+            stamp: CuTime::from_nanos(3000),
             parent_frame: frame_id!("world"),
             child_frame: frame_id!("robot"),
         };
@@ -297,7 +297,7 @@ mod tests {
         after.transform = Transform3D::from_matrix(after_mat);
 
         // Test at 75% point
-        let result = interpolate_transforms(&before, &after, CuDuration(2500));
+        let result = interpolate_transforms(&before, &after, CuTime::from_nanos(2500));
         assert!(result.is_ok());
         let transform = result.unwrap();
         assert_eq!(transform.to_matrix()[0][3], 1_750_000_000);
@@ -307,42 +307,42 @@ mod tests {
     fn test_interpolate_transforms_errors() {
         let before: StampedTransform<f32> = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: frame_id!("world"),
             child_frame: frame_id!("robot"),
         };
 
         let after: StampedTransform<f32> = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(3000),
+            stamp: CuTime::from_nanos(3000),
             parent_frame: frame_id!("different"),
             child_frame: frame_id!("robot"),
         };
 
-        let result = interpolate_transforms(&before, &after, CuDuration(2000));
+        let result = interpolate_transforms(&before, &after, CuTime::from_nanos(2000));
         assert!(result.is_err());
 
         let after: StampedTransform<f32> = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(3000),
+            stamp: CuTime::from_nanos(3000),
             parent_frame: frame_id!("world"),
             child_frame: frame_id!("different"),
         };
 
-        let result = interpolate_transforms(&before, &after, CuDuration(2000));
+        let result = interpolate_transforms(&before, &after, CuTime::from_nanos(2000));
         assert!(result.is_err());
 
         let after: StampedTransform<f32> = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(3000),
+            stamp: CuTime::from_nanos(3000),
             parent_frame: frame_id!("world"),
             child_frame: frame_id!("robot"),
         };
 
-        let result = interpolate_transforms(&before, &after, CuDuration(500));
+        let result = interpolate_transforms(&before, &after, CuTime::from_nanos(500));
         assert!(result.is_err());
 
-        let result = interpolate_transforms(&before, &after, CuDuration(3500));
+        let result = interpolate_transforms(&before, &after, CuTime::from_nanos(3500));
         assert!(result.is_err());
     }
 }

--- a/components/libs/cu_transform/src/transform.rs
+++ b/components/libs/cu_transform/src/transform.rs
@@ -752,7 +752,7 @@ mod tests {
             "expected {expected}, got {actual}, difference {diff} exceeds epsilon {epsilon}",
         );
     }
-    use cu29::clock::CuDuration;
+    use cu29::clock::CuTime;
 
     #[test]
     fn test_add_transform() {
@@ -760,7 +760,7 @@ mod tests {
 
         let transform = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -777,21 +777,21 @@ mod tests {
 
         let transform1 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(2000),
+            stamp: CuTime::from_nanos(2000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
 
         let transform2 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
 
         let transform3 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(3000),
+            stamp: CuTime::from_nanos(3000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -804,7 +804,8 @@ mod tests {
         assert_eq!(range.start.as_nanos(), 1000);
         assert_eq!(range.end.as_nanos(), 3000);
 
-        let transforms = buffer.get_transforms_in_range(CuDuration(1500), CuDuration(2500));
+        let transforms =
+            buffer.get_transforms_in_range(CuTime::from_nanos(1500), CuTime::from_nanos(2500));
         assert_eq!(transforms.len(), 1);
         assert_eq!(transforms[0].stamp.as_nanos(), 2000);
     }
@@ -815,21 +816,21 @@ mod tests {
 
         let transform1 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
 
         let transform2 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(2000),
+            stamp: CuTime::from_nanos(2000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
 
         let transform3 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(3000),
+            stamp: CuTime::from_nanos(3000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -849,14 +850,14 @@ mod tests {
 
         let transform1 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
 
         let transform2 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(3000),
+            stamp: CuTime::from_nanos(3000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -864,23 +865,23 @@ mod tests {
         buffer.add_transform(transform1);
         buffer.add_transform(transform2);
 
-        let closest = buffer.get_closest_transform(CuDuration(1000));
+        let closest = buffer.get_closest_transform(CuTime::from_nanos(1000));
         assert!(closest.is_some());
         assert_eq!(closest.unwrap().stamp.as_nanos(), 1000);
 
-        let closest = buffer.get_closest_transform(CuDuration(500));
+        let closest = buffer.get_closest_transform(CuTime::from_nanos(500));
         assert!(closest.is_some());
         assert_eq!(closest.unwrap().stamp.as_nanos(), 1000);
 
-        let closest = buffer.get_closest_transform(CuDuration(4000));
+        let closest = buffer.get_closest_transform(CuTime::from_nanos(4000));
         assert!(closest.is_some());
         assert_eq!(closest.unwrap().stamp.as_nanos(), 3000);
 
-        let closest = buffer.get_closest_transform(CuDuration(1600));
+        let closest = buffer.get_closest_transform(CuTime::from_nanos(1600));
         assert!(closest.is_some());
         assert_eq!(closest.unwrap().stamp.as_nanos(), 1000);
 
-        let closest = buffer.get_closest_transform(CuDuration(2600));
+        let closest = buffer.get_closest_transform(CuTime::from_nanos(2600));
         assert!(closest.is_some());
         assert_eq!(closest.unwrap().stamp.as_nanos(), 3000);
     }
@@ -891,7 +892,7 @@ mod tests {
 
         let transform = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -899,7 +900,7 @@ mod tests {
         store.add_transform(transform.clone());
 
         let buffer = store.get_buffer("world", "robot").unwrap();
-        let closest = buffer.get_closest_transform(CuDuration(1000));
+        let closest = buffer.get_closest_transform(CuTime::from_nanos(1000));
         assert!(closest.is_some());
 
         // Non-existent buffer
@@ -916,14 +917,14 @@ mod tests {
         // Create two transforms with a small time difference and known position difference
         let mut transform1 = StampedTransform {
             transform: Transform3D::<f32>::default(),
-            stamp: CuDuration(1_000_000_000), // 1 second in nanoseconds
+            stamp: CuTime::from_nanos(1_000_000_000), // 1 second in nanoseconds
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
 
         let mut transform2 = StampedTransform {
             transform: Transform3D::<f32>::default(),
-            stamp: CuDuration(2_000_000_000), // 2 seconds in nanoseconds
+            stamp: CuTime::from_nanos(2_000_000_000), // 2 seconds in nanoseconds
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -968,14 +969,14 @@ mod tests {
         // Test with different frames - should return None
         let transform1 = StampedTransform {
             transform: Transform3D::<f32>::default(),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
 
         let transform2 = StampedTransform {
             transform: Transform3D::<f32>::default(),
-            stamp: CuDuration(2000),
+            stamp: CuTime::from_nanos(2000),
             parent_frame: FrameIdString::from("different").unwrap(), // Different parent frame
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -986,14 +987,14 @@ mod tests {
         // Test with wrong time order - should return None
         let transform1 = StampedTransform {
             transform: Transform3D::<f32>::default(),
-            stamp: CuDuration(2000), // Later time
+            stamp: CuTime::from_nanos(2000), // Later time
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
 
         let transform2 = StampedTransform {
             transform: Transform3D::<f32>::default(),
-            stamp: CuDuration(1000), // Earlier time
+            stamp: CuTime::from_nanos(1000), // Earlier time
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -1009,21 +1010,21 @@ mod tests {
         // Add several transforms
         let transform1 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
 
         let transform2 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(2000),
+            stamp: CuTime::from_nanos(2000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
 
         let transform3 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(3000),
+            stamp: CuTime::from_nanos(3000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -1033,21 +1034,21 @@ mod tests {
         buffer.add_transform(transform3);
 
         // Test getting transforms around a time in the middle
-        let transforms = buffer.get_transforms_around(CuDuration(2500));
+        let transforms = buffer.get_transforms_around(CuTime::from_nanos(2500));
         assert!(transforms.is_some());
         let (t1, t2) = transforms.unwrap();
         assert_eq!(t1.stamp.as_nanos(), 2000); // Should be transform2
         assert_eq!(t2.stamp.as_nanos(), 3000); // Should be transform3
 
         // Test getting transforms around a time before first transform
-        let transforms = buffer.get_transforms_around(CuDuration(500));
+        let transforms = buffer.get_transforms_around(CuTime::from_nanos(500));
         assert!(transforms.is_some());
         let (t1, t2) = transforms.unwrap();
         assert_eq!(t1.stamp.as_nanos(), 1000); // Should be transform1
         assert_eq!(t2.stamp.as_nanos(), 2000); // Should be transform2
 
         // Test getting transforms around a time after last transform
-        let transforms = buffer.get_transforms_around(CuDuration(4000));
+        let transforms = buffer.get_transforms_around(CuTime::from_nanos(4000));
         assert!(transforms.is_some());
         let (t1, t2) = transforms.unwrap();
         assert_eq!(t1.stamp.as_nanos(), 2000); // Should be transform2
@@ -1061,14 +1062,14 @@ mod tests {
         // Add transforms with known positions to compute velocity
         let mut transform1 = StampedTransform {
             transform: Transform3D::<f32>::default(),
-            stamp: CuDuration(1_000_000_000), // 1 second in nanoseconds
+            stamp: CuTime::from_nanos(1_000_000_000), // 1 second in nanoseconds
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
 
         let mut transform2 = StampedTransform {
             transform: Transform3D::<f32>::default(),
-            stamp: CuDuration(2_000_000_000), // 2 seconds in nanoseconds
+            stamp: CuTime::from_nanos(2_000_000_000), // 2 seconds in nanoseconds
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -1093,7 +1094,7 @@ mod tests {
         buffer.add_transform(transform2);
 
         // Compute velocity at time between transforms
-        let velocity = buffer.compute_velocity_at_time(CuDuration(1_500_000_000)); // 1.5 seconds in nanoseconds
+        let velocity = buffer.compute_velocity_at_time(CuTime::from_nanos(1_500_000_000)); // 1.5 seconds in nanoseconds
         assert!(velocity.is_some());
 
         let vel = velocity.unwrap();
@@ -1110,7 +1111,7 @@ mod tests {
         // Create two transforms with a rotation around Z axis
         let mut transform1 = StampedTransform {
             transform: Transform3D::<f32>::default(),
-            stamp: CuDuration(1_000_000_000), // 1 second in nanoseconds
+            stamp: CuTime::from_nanos(1_000_000_000), // 1 second in nanoseconds
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -1125,7 +1126,7 @@ mod tests {
 
         let mut transform2 = StampedTransform {
             transform: Transform3D::<f32>::default(),
-            stamp: CuDuration(2_000_000_000), // 2 seconds in nanoseconds
+            stamp: CuTime::from_nanos(2_000_000_000), // 2 seconds in nanoseconds
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -1144,7 +1145,7 @@ mod tests {
         buffer.add_transform(transform2);
 
         // Compute velocity
-        let velocity = buffer.compute_velocity_at_time(CuDuration(1_500_000_000)); // 1.5 seconds in nanoseconds
+        let velocity = buffer.compute_velocity_at_time(CuTime::from_nanos(1_500_000_000)); // 1.5 seconds in nanoseconds
         assert!(velocity.is_some());
 
         let vel = velocity.unwrap();
@@ -1162,7 +1163,7 @@ mod tests {
 
         let transform = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -1180,21 +1181,21 @@ mod tests {
 
         let transform1 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(2000),
+            stamp: CuTime::from_nanos(2000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
 
         let transform2 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
 
         let transform3 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(3000),
+            stamp: CuTime::from_nanos(3000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -1207,7 +1208,8 @@ mod tests {
         assert_eq!(range.start.as_nanos(), 1000);
         assert_eq!(range.end.as_nanos(), 3000);
 
-        let transforms = buffer.get_transforms_in_range(CuDuration(1500), CuDuration(2500));
+        let transforms =
+            buffer.get_transforms_in_range(CuTime::from_nanos(1500), CuTime::from_nanos(2500));
         assert_eq!(transforms.len(), 1);
         assert_eq!(transforms[0].stamp.as_nanos(), 2000);
     }
@@ -1218,21 +1220,21 @@ mod tests {
 
         let transform1 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
 
         let transform2 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(2000),
+            stamp: CuTime::from_nanos(2000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
 
         let transform3 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(3000),
+            stamp: CuTime::from_nanos(3000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -1246,7 +1248,7 @@ mod tests {
         assert!(latest.is_some());
 
         // Should be able to find closest transforms
-        let closest = buffer.get_closest_transform(CuDuration(2500));
+        let closest = buffer.get_closest_transform(CuTime::from_nanos(2500));
         assert!(closest.is_some());
     }
 
@@ -1256,14 +1258,14 @@ mod tests {
 
         let transform1 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
 
         let transform2 = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(3000),
+            stamp: CuTime::from_nanos(3000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -1271,23 +1273,23 @@ mod tests {
         buffer.add_transform(transform1);
         buffer.add_transform(transform2);
 
-        let closest = buffer.get_closest_transform(CuDuration(1000));
+        let closest = buffer.get_closest_transform(CuTime::from_nanos(1000));
         assert!(closest.is_some());
         assert_eq!(closest.unwrap().stamp.as_nanos(), 1000);
 
-        let closest = buffer.get_closest_transform(CuDuration(500));
+        let closest = buffer.get_closest_transform(CuTime::from_nanos(500));
         assert!(closest.is_some());
         assert_eq!(closest.unwrap().stamp.as_nanos(), 1000);
 
-        let closest = buffer.get_closest_transform(CuDuration(4000));
+        let closest = buffer.get_closest_transform(CuTime::from_nanos(4000));
         assert!(closest.is_some());
         assert_eq!(closest.unwrap().stamp.as_nanos(), 3000);
 
-        let closest = buffer.get_closest_transform(CuDuration(1900));
+        let closest = buffer.get_closest_transform(CuTime::from_nanos(1900));
         assert!(closest.is_some());
         assert_eq!(closest.unwrap().stamp.as_nanos(), 1000); // Closer to 1000 than 3000
 
-        let closest = buffer.get_closest_transform(CuDuration(2100));
+        let closest = buffer.get_closest_transform(CuTime::from_nanos(2100));
         assert!(closest.is_some());
         assert_eq!(closest.unwrap().stamp.as_nanos(), 3000); // Closer to 3000 than 1000
     }
@@ -1298,7 +1300,7 @@ mod tests {
 
         let transform = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -1317,14 +1319,14 @@ mod tests {
         // Add transforms with known positions to compute velocity
         let mut transform1 = StampedTransform {
             transform: Transform3D::<f32>::default(),
-            stamp: CuDuration(1_000_000_000), // 1 second in nanoseconds
+            stamp: CuTime::from_nanos(1_000_000_000), // 1 second in nanoseconds
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
 
         let mut transform2 = StampedTransform {
             transform: Transform3D::<f32>::default(),
-            stamp: CuDuration(2_000_000_000), // 2 seconds in nanoseconds
+            stamp: CuTime::from_nanos(2_000_000_000), // 2 seconds in nanoseconds
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -1349,7 +1351,7 @@ mod tests {
         buffer.add_transform(transform2);
 
         // Compute velocity at time between transforms
-        let velocity = buffer.compute_velocity_at_time(CuDuration(1_500_000_000)); // 1.5 seconds in nanoseconds
+        let velocity = buffer.compute_velocity_at_time(CuTime::from_nanos(1_500_000_000)); // 1.5 seconds in nanoseconds
         assert!(velocity.is_some());
 
         let vel = velocity.unwrap();
@@ -1365,7 +1367,7 @@ mod tests {
 
         let transform = StampedTransform {
             transform: Transform3D::default(),
-            stamp: CuDuration(1000),
+            stamp: CuTime::from_nanos(1000),
             parent_frame: FrameIdString::from("world").unwrap(),
             child_frame: FrameIdString::from("robot").unwrap(),
         };
@@ -1373,7 +1375,7 @@ mod tests {
         store.add_transform(transform.clone());
 
         let buffer = store.get_buffer("world", "robot").unwrap();
-        let closest = buffer.get_closest_transform(CuDuration(1000));
+        let closest = buffer.get_closest_transform(CuTime::from_nanos(1000));
         assert!(closest.is_some());
 
         // Non-existent buffer

--- a/components/libs/cu_transform/src/transform_payload.rs
+++ b/components/libs/cu_transform/src/transform_payload.rs
@@ -26,7 +26,7 @@ pub type StampedFrameTransform<T> = CuStampedData<FrameTransform<T>, ()>;
 /// ```
 /// use cu_transform::{FrameTransform, Transform3D};
 /// use cu29::prelude::*;
-/// use cu29::clock::{CuDuration, Tov};
+/// use cu29::clock::{CuTime, Tov};
 /// use cu_transform::transform_payload::StampedFrameTransform;
 ///
 /// // Create a transform message
@@ -431,7 +431,7 @@ mod tests {
             "expected {expected}, got {actual}, difference {diff} exceeds epsilon {epsilon}",
         );
     }
-    use cu29::clock::CuDuration;
+    use cu29::clock::CuTime;
 
     type WorldToRobotFrameTransform = TypedTransform<f32, WorldFrame, RobotFrame>;
     type WorldToRobotBuffer = TypedTransformBuffer<f32, WorldFrame, RobotFrame, 10>;
@@ -439,7 +439,7 @@ mod tests {
     #[test]
     fn test_typed_transform_msg_creation() {
         let transform = Transform3D::<f32>::default();
-        let time = CuDuration(1000);
+        let time = CuTime::from_nanos(1000);
 
         let msg = WorldToRobotFrameTransform::new(transform, time);
 
@@ -455,10 +455,10 @@ mod tests {
         let mut buffer = WorldToRobotBuffer::new();
 
         let transform1 = Transform3D::<f32>::default();
-        let msg1 = WorldToRobotFrameTransform::new(transform1, CuDuration(1000));
+        let msg1 = WorldToRobotFrameTransform::new(transform1, CuTime::from_nanos(1000));
 
         let transform2 = Transform3D::<f32>::default();
-        let msg2 = WorldToRobotFrameTransform::new(transform2, CuDuration(2000));
+        let msg2 = WorldToRobotFrameTransform::new(transform2, CuTime::from_nanos(2000));
 
         buffer.add_transform(msg1);
         buffer.add_transform(msg2);
@@ -476,18 +476,18 @@ mod tests {
         let mut buffer = WorldToRobotBuffer::new();
 
         let transform1 = Transform3D::<f32>::default();
-        let msg1 = WorldToRobotFrameTransform::new(transform1, CuDuration(1000));
+        let msg1 = WorldToRobotFrameTransform::new(transform1, CuTime::from_nanos(1000));
 
         let transform2 = Transform3D::<f32>::default();
-        let msg2 = WorldToRobotFrameTransform::new(transform2, CuDuration(3000));
+        let msg2 = WorldToRobotFrameTransform::new(transform2, CuTime::from_nanos(3000));
 
         buffer.add_transform(msg1);
         buffer.add_transform(msg2);
 
-        let closest = buffer.get_closest_transform(CuDuration(1500));
+        let closest = buffer.get_closest_transform(CuTime::from_nanos(1500));
         assert_eq!(closest.unwrap().timestamp().unwrap().as_nanos(), 1000);
 
-        let closest = buffer.get_closest_transform(CuDuration(2500));
+        let closest = buffer.get_closest_transform(CuTime::from_nanos(2500));
         assert_eq!(closest.unwrap().timestamp().unwrap().as_nanos(), 3000);
     }
 
@@ -498,8 +498,8 @@ mod tests {
         let transform1 = translation_transform(0.0f32, 0.0, 0.0);
         let transform2 = translation_transform(1.0f32, 2.0, 0.0);
 
-        let msg1 = WorldToRobotFrameTransform::new(transform1, CuDuration(1_000_000_000)); // 1 second
-        let msg2 = WorldToRobotFrameTransform::new(transform2, CuDuration(2_000_000_000)); // 2 seconds
+        let msg1 = WorldToRobotFrameTransform::new(transform1, CuTime::from_nanos(1_000_000_000)); // 1 second
+        let msg2 = WorldToRobotFrameTransform::new(transform2, CuTime::from_nanos(2_000_000_000)); // 2 seconds
 
         let velocity = msg2.compute_velocity(&msg1).unwrap();
 

--- a/components/libs/cu_transform/src/tree.rs
+++ b/components/libs/cu_transform/src/tree.rs
@@ -706,7 +706,7 @@ mod tests {
     use super::*;
     use crate::test_utils::get_translation;
     use crate::{FrameTransform, frame_id};
-    use cu29::clock::{CuDuration, RobotClock};
+    use cu29::clock::{CuTime, RobotClock};
 
     // Helper function to replace assert_relative_eq
     fn assert_approx_eq(actual: f32, expected: f32, epsilon: f32, message: &str) {
@@ -720,7 +720,7 @@ mod tests {
     fn make_stamped(
         parent: &str,
         child: &str,
-        ts: CuDuration,
+        ts: CuTime,
         tf: Transform3D<f32>,
     ) -> StampedFrameTransform<f32> {
         let inner = FrameTransform {
@@ -745,7 +745,7 @@ mod tests {
             child_frame: frame_id!("robot"),
         };
         let mut stf = StampedFrameTransform::new(Some(inner));
-        stf.tov = CuDuration(1000).into();
+        stf.tov = CuTime::from_nanos(1000).into();
 
         assert!(tree.add_transform(&stf).is_ok());
     }
@@ -802,7 +802,7 @@ mod tests {
         let tf = make_stamped(
             "world",
             "robot",
-            CuDuration(1000),
+            CuTime::from_nanos(1000),
             Transform3D::from_matrix(matrix),
         );
 
@@ -811,14 +811,14 @@ mod tests {
         let clock = RobotClock::default();
 
         let forward = tree
-            .lookup_transform("world", "robot", CuDuration(1000), &clock)
+            .lookup_transform("world", "robot", CuTime::from_nanos(1000), &clock)
             .unwrap();
         assert_eq!(get_translation(&forward).0, 2.0);
         assert_eq!(get_translation(&forward).1, 3.0);
         assert_eq!(get_translation(&forward).2, 4.0);
 
         let inverse = tree
-            .lookup_transform("robot", "world", CuDuration(1000), &clock)
+            .lookup_transform("robot", "world", CuTime::from_nanos(1000), &clock)
             .unwrap();
         assert_eq!(get_translation(&inverse).0, -2.0);
         assert_eq!(get_translation(&inverse).1, -3.0);
@@ -828,7 +828,7 @@ mod tests {
     #[test]
     fn test_multi_step_transform_composition() {
         let mut tree = TransformTree::<f32>::new();
-        let ts = CuDuration(1000);
+        let ts = CuTime::from_nanos(1000);
 
         let world_to_base = make_stamped(
             "world",
@@ -926,7 +926,7 @@ mod tests {
     #[test]
     fn test_cache_invalidation() {
         let mut tree = TransformTree::<f32>::with_cache_settings(5, Duration::from_millis(50));
-        let ts = CuDuration(1000);
+        let ts = CuTime::from_nanos(1000);
 
         let tf = make_stamped(
             "a",
@@ -963,7 +963,7 @@ mod tests {
     #[test]
     fn test_multi_step_transform_with_inverse() {
         let mut tree = TransformTree::<f32>::new();
-        let ts = CuDuration(1000);
+        let ts = CuTime::from_nanos(1000);
 
         let world_to_robot = make_stamped(
             "world",
@@ -1033,7 +1033,7 @@ mod tests {
         let w2b_1 = make_stamped(
             "world",
             "base",
-            CuDuration(1_000_000_000),
+            CuTime::from_nanos(1_000_000_000),
             Transform3D::from_matrix([
                 [1.0, 0.0, 0.0, 0.0],
                 [0.0, 1.0, 0.0, 0.0],
@@ -1045,7 +1045,7 @@ mod tests {
         let w2b_2 = make_stamped(
             "world",
             "base",
-            CuDuration(2_000_000_000),
+            CuTime::from_nanos(2_000_000_000),
             Transform3D::from_matrix([
                 [1.0, 0.0, 0.0, 0.0],
                 [0.0, 1.0, 0.0, 0.0],
@@ -1057,7 +1057,7 @@ mod tests {
         let b2s_1 = make_stamped(
             "base",
             "sensor",
-            CuDuration(1_000_000_000),
+            CuTime::from_nanos(1_000_000_000),
             Transform3D::from_matrix([
                 [1.0, 0.0, 0.0, 0.0],
                 [0.0, 1.0, 0.0, 0.0],
@@ -1069,7 +1069,7 @@ mod tests {
         let b2s_2 = make_stamped(
             "base",
             "sensor",
-            CuDuration(2_000_000_000),
+            CuTime::from_nanos(2_000_000_000),
             Transform3D::from_matrix([
                 [1.0, 0.0, 0.0, 0.0],
                 [0.0, 1.0, 0.0, 0.0],
@@ -1084,7 +1084,8 @@ mod tests {
         tree.add_transform(&b2s_2).unwrap();
 
         let clock = RobotClock::default();
-        let velocity = tree.lookup_velocity("world", "sensor", CuDuration(1_500_000_000), &clock);
+        let velocity =
+            tree.lookup_velocity("world", "sensor", CuTime::from_nanos(1_500_000_000), &clock);
         assert!(velocity.is_ok());
 
         let vel = velocity.unwrap();
@@ -1098,8 +1099,8 @@ mod tests {
     fn test_velocity_with_rotation() {
         let mut tree = TransformTree::<f32>::new();
 
-        let ts1 = CuDuration(1_000_000_000);
-        let ts2 = CuDuration(2_000_000_000);
+        let ts1 = CuTime::from_nanos(1_000_000_000);
+        let ts2 = CuTime::from_nanos(2_000_000_000);
 
         let w2b_1 = make_stamped(
             "world",
@@ -1155,7 +1156,7 @@ mod tests {
         tree.add_transform(&b2s_2).unwrap();
 
         let clock = RobotClock::default();
-        let mid_ts = CuDuration(1_500_000_000);
+        let mid_ts = CuTime::from_nanos(1_500_000_000);
 
         let velocity = tree.lookup_velocity("world", "sensor", mid_ts, &clock);
         assert!(velocity.is_ok());
@@ -1176,8 +1177,8 @@ mod tests {
     #[test]
     fn test_velocity_with_angular_motion() {
         let mut tree = TransformTree::<f32>::new();
-        let ts1 = CuDuration(1_000_000_000);
-        let ts2 = CuDuration(2_000_000_000);
+        let ts1 = CuTime::from_nanos(1_000_000_000);
+        let ts2 = CuTime::from_nanos(2_000_000_000);
 
         let w2b_1 = make_stamped(
             "world",
@@ -1234,7 +1235,7 @@ mod tests {
 
         let clock = RobotClock::default();
         let vel = tree
-            .lookup_velocity("world", "sensor", CuDuration(1_500_000_000), &clock)
+            .lookup_velocity("world", "sensor", CuTime::from_nanos(1_500_000_000), &clock)
             .unwrap();
 
         let epsilon = 0.1;
@@ -1254,8 +1255,8 @@ mod tests {
     #[test]
     fn test_velocity_cache() {
         let mut tree = TransformTree::<f32>::new();
-        let ts1 = CuDuration(1_000_000_000);
-        let ts2 = CuDuration(2_000_000_000);
+        let ts1 = CuTime::from_nanos(1_000_000_000);
+        let ts2 = CuTime::from_nanos(2_000_000_000);
 
         let tf1 = make_stamped(
             "world",
@@ -1287,7 +1288,8 @@ mod tests {
         let clock = RobotClock::default();
 
         let start_time = std::time::Instant::now();
-        let velocity1 = tree.lookup_velocity("world", "robot", CuDuration(1_500_000_000), &clock);
+        let velocity1 =
+            tree.lookup_velocity("world", "robot", CuTime::from_nanos(1_500_000_000), &clock);
         let first_lookup_time = start_time.elapsed();
 
         assert!(velocity1.is_ok());
@@ -1295,7 +1297,8 @@ mod tests {
         assert_approx_eq(vel1.linear[0], 2.0, 0.01, "linear_velocity_0");
 
         let start_time = std::time::Instant::now();
-        let velocity2 = tree.lookup_velocity("world", "robot", CuDuration(1_500_000_000), &clock);
+        let velocity2 =
+            tree.lookup_velocity("world", "robot", CuTime::from_nanos(1_500_000_000), &clock);
         let second_lookup_time = start_time.elapsed();
 
         assert!(velocity2.is_ok());
@@ -1305,7 +1308,8 @@ mod tests {
         tree.clear_cache();
 
         let start_time = std::time::Instant::now();
-        let velocity3 = tree.lookup_velocity("world", "robot", CuDuration(1_500_000_000), &clock);
+        let velocity3 =
+            tree.lookup_velocity("world", "robot", CuTime::from_nanos(1_500_000_000), &clock);
         let third_lookup_time = start_time.elapsed();
 
         assert!(velocity3.is_ok());
@@ -1318,9 +1322,9 @@ mod tests {
     #[test]
     fn test_velocity_cache_invalidation() {
         let mut tree = TransformTree::<f32>::new();
-        let ts1 = CuDuration(1_000_000_000);
-        let ts2 = CuDuration(2_000_000_000);
-        let ts3 = CuDuration(3_000_000_000);
+        let ts1 = CuTime::from_nanos(1_000_000_000);
+        let ts2 = CuTime::from_nanos(2_000_000_000);
+        let ts3 = CuTime::from_nanos(3_000_000_000);
 
         let tf1 = make_stamped(
             "world",
@@ -1363,19 +1367,19 @@ mod tests {
 
         let clock = RobotClock::default();
         let velocity1 = tree
-            .lookup_velocity("world", "robot", CuDuration(1_500_000_000), &clock)
+            .lookup_velocity("world", "robot", CuTime::from_nanos(1_500_000_000), &clock)
             .unwrap();
         assert_approx_eq(velocity1.linear[0], 1.0, 0.01, "linear_velocity_0");
 
         tree.add_transform(&tf3).unwrap();
 
         let velocity2 = tree
-            .lookup_velocity("world", "robot", CuDuration(1_500_000_000), &clock)
+            .lookup_velocity("world", "robot", CuTime::from_nanos(1_500_000_000), &clock)
             .unwrap();
         assert_approx_eq(velocity2.linear[0], 1.0, 0.01, "linear_velocity_0");
 
         let velocity3 = tree
-            .lookup_velocity("world", "robot", CuDuration(2_500_000_000), &clock)
+            .lookup_velocity("world", "robot", CuTime::from_nanos(2_500_000_000), &clock)
             .unwrap();
         assert_approx_eq(velocity3.linear[0], 2.0, 0.01, "linear_velocity_0");
     }

--- a/components/payloads/cu_sensor_payloads/src/pointcloud.rs
+++ b/components/payloads/cu_sensor_payloads/src/pointcloud.rs
@@ -141,11 +141,11 @@ impl<const N: usize> CuHandlePayloadInit for PointCloudSoa<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cu29_clock::CuDuration;
+    use cu29_clock::CuTime;
 
     #[test]
     fn test_point_payload() {
-        let payload = PointCloud::new(CuDuration(1), 1.0, 2.0, 3.0, 0.0, None);
+        let payload = PointCloud::new(CuTime::from_nanos(1), 1.0, 2.0, 3.0, 0.0, None);
         assert_eq!(payload.x.value, 1.0);
         assert_eq!(payload.y.value, 2.0);
         assert_eq!(payload.z.value, 3.0);

--- a/components/sources/cu_hesai/src/lib.rs
+++ b/components/sources/cu_hesai/src/lib.rs
@@ -96,9 +96,9 @@ impl Decode<()> for LidarCuMsgPayload {
 // t6 + 1512ns * (i-1) + 280ns
 fn channel_time(t6: CuTime, i: u64) -> CuTime {
     if i == 0 {
-        CuDuration(t6.0 - 1512 + 280) // this is an underflow, so we just subtract the value
+        t6 - CuDuration(1512) + CuDuration(280)
     } else {
-        CuDuration(t6.0 + 1512 * (i - 1) + 280)
+        t6 + CuDuration(1512 * (i - 1) + 280)
     }
 }
 

--- a/components/sources/cu_livox/src/parser.rs
+++ b/components/sources/cu_livox/src/parser.rs
@@ -1,6 +1,6 @@
 use bytemuck::{Pod, Zeroable};
 use chrono::{DateTime, Utc};
-use cu29::prelude::{CuDuration, CuTime};
+use cu29::prelude::CuTime;
 use cu29::units::si::f32::{Length, Ratio};
 use cu29::units::si::length::millimeter;
 use cu29::units::si::ratio::ratio;
@@ -168,8 +168,8 @@ impl Debug for crate::parser::LidarHeader {
 }
 
 impl LidarHeader {
-    pub fn timestamp(&self) -> CuDuration {
-        CuDuration(u64_endianness(self.timestamp))
+    pub fn timestamp(&self) -> CuTime {
+        CuTime::from_nanos(u64_endianness(self.timestamp))
     }
 }
 

--- a/components/sources/cu_zed/src/lib.rs
+++ b/components/sources/cu_zed/src/lib.rs
@@ -1208,7 +1208,7 @@ mod tests {
             },
             CuHandle::new_detached(values),
         )));
-        msg.tov = Tov::Time(CuDuration(42));
+        msg.tov = Tov::from(CuDuration(42));
         msg
     }
 

--- a/components/tasks/cu_aligner/src/buffers.rs
+++ b/components/tasks/cu_aligner/src/buffers.rs
@@ -117,8 +117,7 @@ macro_rules! alignment_buffers {
             /// Call this to be sure we discard the old/ non relevant data
             #[allow(dead_code)]
             pub fn purge(&mut self, now: cu29::clock::CuTime) {
-                use cu29::prelude::SaturatingSub;
-                let horizon_time = now.saturating_sub(self.stale_data_horizon);
+                let horizon_time = now - self.stale_data_horizon;
                 // purge all the stale data from the TimeboundCircularBuffers first
                 $(self.$name.purge(horizon_time);)*
             }
@@ -128,7 +127,6 @@ macro_rules! alignment_buffers {
             pub fn get_latest_aligned_data(
                 &mut self,
             ) -> Option<($(impl Iterator<Item = &cu29::cutask::CuStampedData<$payload, CuMsgMetadata>>),*)> {
-                use cu29::prelude::SaturatingSub;
                 // Now find the min of the max of the last time for all buffers
                 // meaning the most recent time at which all buffers have data
                 let most_recent_time = [
@@ -138,8 +136,7 @@ macro_rules! alignment_buffers {
                 .flatten()
                 .min()?;
 
-                let time_to_get_complete_window =
-                    most_recent_time.saturating_sub(self.target_alignment_window);
+                let time_to_get_complete_window = most_recent_time - self.target_alignment_window;
                 Some(($(self.$name.iter_window(time_to_get_complete_window, most_recent_time)),*))
             }
         }

--- a/components/tasks/cu_aligner/src/lib.rs
+++ b/components/tasks/cu_aligner/src/lib.rs
@@ -131,7 +131,7 @@ mod tests {
 
             let mut left = CuStampedData::<String, CuMsgMetadata>::new(Some("left".to_string()));
             let mut right = CuStampedData::<String, CuMsgMetadata>::new(Some("right".to_string()));
-            let tov_time = CuDuration::from_millis(100);
+            let tov_time = CuTime::from_millis(100);
             left.tov = Tov::Time(tov_time);
             right.tov = Tov::Time(tov_time);
 


### PR DESCRIPTION
## Summary

As a CuTime is basically a CuDuration from the beginning of the start of the system it became semantically super fuzzy. This PR is to make that a like be cleaner and consistent.

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
