### PR TITLE
Rust 1.95 changes

### DIFF
--- a/components/libs/cu_tuimon/src/ui.rs
+++ b/components/libs/cu_tuimon/src/ui.rs
@@ -227,23 +227,20 @@ impl MonitorUi {
 
     pub fn handle_key(&mut self, key: MonitorUiKey) -> MonitorUiAction {
         match key {
-            MonitorUiKey::Char(key) => {
-                if let Some(screen) = screen_for_tab_key(key) {
-                    self.active_screen = screen;
-                } else {
-                    match key {
-                        'r' if self.active_screen == MonitorScreen::Latency => {
-                            self.model.reset_latency();
-                        }
-                        'j' => self.scroll(ScrollDirection::Down, 1),
-                        'k' => self.scroll(ScrollDirection::Up, 1),
-                        'h' => self.scroll(ScrollDirection::Left, 5),
-                        'l' => self.scroll(ScrollDirection::Right, 5),
-                        'q' if self.show_quit_hint => return MonitorUiAction::QuitRequested,
-                        _ => {}
-                    }
-                }
+            MonitorUiKey::Char(key) if let Some(screen) = screen_for_tab_key(key) => {
+                self.active_screen = screen;
             }
+            MonitorUiKey::Char('r') if self.active_screen == MonitorScreen::Latency => {
+                self.model.reset_latency();
+            }
+            MonitorUiKey::Char('j') => self.scroll(ScrollDirection::Down, 1),
+            MonitorUiKey::Char('k') => self.scroll(ScrollDirection::Up, 1),
+            MonitorUiKey::Char('h') => self.scroll(ScrollDirection::Left, 5),
+            MonitorUiKey::Char('l') => self.scroll(ScrollDirection::Right, 5),
+            MonitorUiKey::Char('q') if self.show_quit_hint => {
+                return MonitorUiAction::QuitRequested;
+            }
+            MonitorUiKey::Char(_) => {}
             MonitorUiKey::Left => self.scroll(ScrollDirection::Left, 5),
             MonitorUiKey::Right => self.scroll(ScrollDirection::Right, 5),
             MonitorUiKey::Up => self.scroll(ScrollDirection::Up, 1),

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -5484,30 +5484,27 @@ fn extract_output_packs(runtime_plan: &CuExecutionLoop) -> Vec<OutputPack> {
         .steps
         .iter()
         .filter_map(|unit| match unit {
-            CuExecutionUnit::Step(step) => {
-                if let Some(output_pack) = &step.output_msg_pack {
-                    let msg_types: Vec<Type> = output_pack
-                        .msg_types
-                        .iter()
-                        .map(|output_msg_type| {
-                            parse_str::<Type>(output_msg_type.as_str()).unwrap_or_else(|_| {
-                                panic!(
-                                    "Could not transform {output_msg_type} into a message Rust type."
-                                )
-                            })
+            CuExecutionUnit::Step(step) if let Some(output_pack) = &step.output_msg_pack => {
+                let msg_types: Vec<Type> = output_pack
+                    .msg_types
+                    .iter()
+                    .map(|output_msg_type| {
+                        parse_str::<Type>(output_msg_type.as_str()).unwrap_or_else(|_| {
+                            panic!(
+                                "Could not transform {output_msg_type} into a message Rust type."
+                            )
                         })
-                        .collect();
-                    Some((
-                        output_pack.culist_index,
-                        OutputPack {
-                            msg_types,
-                            msg_type_names: output_pack.msg_types.clone(),
-                        },
-                    ))
-                } else {
-                    None
-                }
+                    })
+                    .collect();
+                Some((
+                    output_pack.culist_index,
+                    OutputPack {
+                        msg_types,
+                        msg_type_names: output_pack.msg_types.clone(),
+                    },
+                ))
             }
+            CuExecutionUnit::Step(_) => None,
             CuExecutionUnit::Loop(_) => todo!("Needs to be implemented"),
         })
         .collect();

--- a/core/cu29_export/src/logstats.rs
+++ b/core/cu29_export/src/logstats.rs
@@ -331,21 +331,20 @@ fn collect_output_packs_from_loop(
 ) -> CuResult<()> {
     for step in &loop_unit.steps {
         match step {
-            CuExecutionUnit::Step(step) => {
-                if let Some(output_pack) = &step.output_msg_pack {
-                    let node = graph
-                        .get_node(step.node_id)
-                        .ok_or_else(|| CuError::from("Missing node for output pack"))?;
-                    packs.push(OutputPackInfo {
-                        culist_index: output_pack.culist_index,
-                        src: node.get_id(),
-                        msg_types: output_pack.msg_types.clone(),
-                    });
-                }
+            CuExecutionUnit::Step(step) if let Some(output_pack) = &step.output_msg_pack => {
+                let node = graph
+                    .get_node(step.node_id)
+                    .ok_or_else(|| CuError::from("Missing node for output pack"))?;
+                packs.push(OutputPackInfo {
+                    culist_index: output_pack.culist_index,
+                    src: node.get_id(),
+                    msg_types: output_pack.msg_types.clone(),
+                });
             }
             CuExecutionUnit::Loop(inner) => {
                 collect_output_packs_from_loop(inner, graph, packs)?;
             }
+            CuExecutionUnit::Step(_) => {}
         }
     }
     Ok(())

--- a/core/cu29_runtime/src/curuntime.rs
+++ b/core/cu29_runtime/src/curuntime.rs
@@ -437,13 +437,9 @@ impl<P: CopperListTuple + Default, const NBCL: usize> SyncCopperListsManager<P, 
         for cl in self.inner.iter_mut() {
             if cl.id == culistid && cl.get_state() == CopperListState::Processing {
                 cl.change_state(CopperListState::DoneProcessing);
-                match () {
-                    #[cfg(feature = "remote-debug")]
-                    () => {
-                        *last_completed_encoded = Some(encode_completed_copperlist_snapshot(cl)?);
-                    }
-                    #[cfg(not(feature = "remote-debug"))]
-                    () => {}
+                #[cfg(feature = "remote-debug")]
+                {
+                    *last_completed_encoded = Some(encode_completed_copperlist_snapshot(cl)?);
                 }
             }
             if is_top && cl.get_state() == CopperListState::DoneProcessing {
@@ -1600,16 +1596,16 @@ fn find_output_pack_from_nodeid(
 ) -> Option<CuOutputPack> {
     for step in steps {
         match step {
-            CuExecutionUnit::Loop(loop_unit) => {
-                if let Some(output_pack) = find_output_pack_from_nodeid(node_id, &loop_unit.steps) {
-                    return Some(output_pack);
-                }
+            CuExecutionUnit::Loop(loop_unit)
+                if let Some(output_pack) =
+                    find_output_pack_from_nodeid(node_id, &loop_unit.steps) =>
+            {
+                return Some(output_pack);
             }
-            CuExecutionUnit::Step(step) => {
-                if step.node_id == node_id {
-                    return step.output_msg_pack.clone();
-                }
+            CuExecutionUnit::Step(step) if step.node_id == node_id => {
+                return step.output_msg_pack.clone();
             }
+            _ => {}
         }
     }
     None

--- a/core/cu29_runtime/src/monitoring.rs
+++ b/core/cu29_runtime/src/monitoring.rs
@@ -1567,15 +1567,13 @@ pub fn build_monitor_topology(config: &CuConfig, mission: &str) -> CuResult<Moni
 
         let mut inputs = Vec::new();
         let mut outputs = Vec::new();
-        if task_kind == ComponentType::Bridge {
-            if let Some(bridge) = bridge_lookup.get(node_id.as_str()) {
-                for ch in &bridge.channels {
-                    match ch {
-                        BridgeChannelConfigRepresentation::Rx { id, .. } => {
-                            outputs.push(id.clone())
-                        }
-                        BridgeChannelConfigRepresentation::Tx { id, .. } => inputs.push(id.clone()),
-                    }
+        if task_kind == ComponentType::Bridge
+            && let Some(bridge) = bridge_lookup.get(node_id.as_str())
+        {
+            for ch in &bridge.channels {
+                match ch {
+                    BridgeChannelConfigRepresentation::Rx { id, .. } => outputs.push(id.clone()),
+                    BridgeChannelConfigRepresentation::Tx { id, .. } => inputs.push(id.clone()),
                 }
             }
         } else {

--- a/core/cu29_runtime/src/parallel_queue.rs
+++ b/core/cu29_runtime/src/parallel_queue.rs
@@ -84,19 +84,19 @@ impl StageQueueShared {
 
     #[inline]
     fn wake_sender(&self) {
-        if self.sender_waiting.swap(false, Ordering::AcqRel) {
-            if let Some(thread) = self.sender_thread.get() {
-                thread.unpark();
-            }
+        if self.sender_waiting.swap(false, Ordering::AcqRel)
+            && let Some(thread) = self.sender_thread.get()
+        {
+            thread.unpark();
         }
     }
 
     #[inline]
     fn wake_receiver(&self) {
-        if self.receiver_waiting.swap(false, Ordering::AcqRel) {
-            if let Some(thread) = self.receiver_thread.get() {
-                thread.unpark();
-            }
+        if self.receiver_waiting.swap(false, Ordering::AcqRel)
+            && let Some(thread) = self.receiver_thread.get()
+        {
+            thread.unpark();
         }
     }
 }

--- a/examples/cu_flight_controller/src/tasks/vtx.rs
+++ b/examples/cu_flight_controller/src/tasks/vtx.rs
@@ -608,14 +608,12 @@ impl VtxOsd {
 
     fn format_relative_altitude(&self) -> alloc::string::String {
         match (self.takeoff_pressure_pa, self.last_pressure_pa) {
-            (Some(reference_pa), Some(pressure_pa)) => {
-                if let Some(altitude_m) = relative_altitude_m(reference_pa, pressure_pa) {
-                    let altitude_m = altitude_m.clamp(-999.9, 9999.9);
-                    let value = format_altitude_field_no_spaces(altitude_m);
-                    alloc::format!("{VTX_SYM_ALTITUDE}{value}{VTX_SYM_METER}")
-                } else {
-                    alloc::format!("{VTX_SYM_ALTITUDE}{VTX_ALT_UNKNOWN}{VTX_SYM_METER}")
-                }
+            (Some(reference_pa), Some(pressure_pa))
+                if let Some(altitude_m) = relative_altitude_m(reference_pa, pressure_pa) =>
+            {
+                let altitude_m = altitude_m.clamp(-999.9, 9999.9);
+                let value = format_altitude_field_no_spaces(altitude_m);
+                alloc::format!("{VTX_SYM_ALTITUDE}{value}{VTX_SYM_METER}")
             }
             _ => alloc::format!("{VTX_SYM_ALTITUDE}{VTX_ALT_UNKNOWN}{VTX_SYM_METER}"),
         }

--- a/examples/cu_runtime_matrix/src/lib.rs
+++ b/examples/cu_runtime_matrix/src/lib.rs
@@ -1187,11 +1187,11 @@ fn build_mission_app(
 }
 
 fn mode_label() -> &'static str {
-    match (cfg!(feature = "async-cl-io"), cfg!(feature = "parallel-rt")) {
-        (false, false) => "sync+serial",
-        (true, false) => "async-io+serial",
-        (false, true) => "sync+parallel",
-        (true, true) => "async-io+parallel",
+    std::cfg_select! {
+        all(feature = "async-cl-io", feature = "parallel-rt") => "async-io+parallel",
+        feature = "async-cl-io" => "async-io+serial",
+        feature = "parallel-rt" => "sync+parallel",
+        _ => "sync+serial",
     }
 }
 


### PR DESCRIPTION
## Summary

Uses the new Rust 1.95 new constructs in the codebase.

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
