### PR TITLE
Docs/catalog link refresh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,6 +172,18 @@ cargo nextest run --workspace --all-targets --features mock,image,kornia,python,
     ```
 7. **Create a Pull Request**: Open a pull request (PR) from your branch to the master branch of the main copper-rs repository. Provide a clear description of your changes in the PR.
 
+## Contributing Components
+
+Reusable Copper components are welcome, but they do not always need to live inside the main `copper-rs` repository.
+
+If you are building a driver, task, bridge, or other generally useful component, the preferred path is usually:
+
+1. Publish it as its own crate or repository so it can evolve on its own release cycle.
+2. Make sure it is documented clearly and works well as a standalone Copper component.
+3. Add it to the [Copper Component Catalog](https://cdn.copper-robotics.com/catalog/index.html) so users can discover it easily.
+
+This keeps the core repository focused while still growing the Copper ecosystem. If you are unsure whether a component belongs in the main workspace or should live as an external package, open an issue or start a discussion first.
+
 ## Dependency Management
 
 We keep our dependencies minimal and up-to-date.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Want to see more Copper in action? Watch the [community showcase video](https://
 ## Get Started
 
 - Start a new project from templates: [Project Templates](https://copper-project.github.io/copper-rs/Project-Templates)
+- Browse the live component catalog: [Copper Component Catalog](https://cdn.copper-robotics.com/catalog/index.html)
 - See a full task graph + runtime walkthrough: [Copper Application Overview](https://copper-project.github.io/copper-rs/Copper-Application-Overview)
 - Build and deploy an application: [Build and Deploy a Copper Application](https://copper-project.github.io/copper-rs/Build-and-Deploy-a-Copper-Application)
 - RON configuration reference: [Copper RON Configuration Reference](https://copper-project.github.io/copper-rs/Copper-RON-Configuration-Reference)
@@ -92,7 +93,7 @@ Want to see more Copper in action? Watch the [community showcase video](https://
 - Task automation: [Task Automation with just](https://copper-project.github.io/copper-rs/Task-Automation-with-Just)
 - Supported platforms: [Supported Platforms](https://copper-project.github.io/copper-rs/Supported-Platforms)
 - Bare-metal development: [Baremetal Development](https://copper-project.github.io/copper-rs/Baremetal-Development)
-- Available components: [Available Components](https://cdn.copper-robotics.com/catalog/index.html)
+- Component catalog: [Copper Component Catalog](https://cdn.copper-robotics.com/catalog/index.html)
 - FAQ: [FAQ](https://copper-project.github.io/copper-rs/FAQ)
 - Release notes: [Copper Release Notes](https://copper-project.github.io/copper-rs/Copper-Release-Notes)
 - Roadmap: [Roadmap](https://copper-project.github.io/copper-rs/Roadmap)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Want to see more Copper in action? Watch the [community showcase video](https://
 
 - Start a new project from templates: [Project Templates](https://copper-project.github.io/copper-rs/Project-Templates)
 - Browse the live component catalog: [Copper Component Catalog](https://cdn.copper-robotics.com/catalog/index.html)
+  Community components are welcome there too; if you build a reusable Copper component, prefer publishing it as its own crate and adding it to the catalog.
 - See a full task graph + runtime walkthrough: [Copper Application Overview](https://copper-project.github.io/copper-rs/Copper-Application-Overview)
 - Build and deploy an application: [Build and Deploy a Copper Application](https://copper-project.github.io/copper-rs/Build-and-Deploy-a-Copper-Application)
 - RON configuration reference: [Copper RON Configuration Reference](https://copper-project.github.io/copper-rs/Copper-RON-Configuration-Reference)


### PR DESCRIPTION
## Summary

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
