### PR TITLE
bug(example): cu_missions - show bug in includes

### DIFF
--- a/examples/cu_missions/copperconfig.ron
+++ b/examples/cu_missions/copperconfig.ron
@@ -17,6 +17,21 @@
             config: {"label": "Mission B"},
             missions: ["B"],
         ),
+        // (
+        //     id: "sink_1",
+        //     type: "tasks::ExampleSink",
+        //     config: {"label": "Multi sink"},
+        // ),
+        // (
+        //     id: "src_multi_1",
+        //     type: "tasks::ExampleMultiSrc",
+        //     config: {"label": "Multi src"},
+        // ),
+        // (
+        //     id: "multi_input_1",
+        //     type: "tasks::MultiInputTask",
+        //     config: {"label": "Multi input"},
+        // ),
     ],
     cnx: [
         (
@@ -43,5 +58,32 @@
             msg: "i32",
             missions: ["B"],
         ),
+        // This works when not used in `includes`
+        // (
+        //     src: "src_multi_1",
+        //     dst: "multi_input_1",
+        //     msg: "i32",
+        // ),
+        // (
+        //     src: "src_multi_1",
+        //     dst: "multi_input_1",
+        //     msg: "u32",
+        // ),
+        // (
+        //     src: "multi_input_1",
+        //     // dst: "__nc__",
+        //     dst: "sink_1",
+        //     msg: "i32",
+        // ),
+
     ],
+    includes: [
+        // same code, w/ index param, results in errors
+        (
+            path: "template_task.ron",
+            params: {
+                "index": 0,
+            },
+        ),
+    ]
 )

--- a/examples/cu_missions/src/tasks.rs
+++ b/examples/cu_missions/src/tasks.rs
@@ -55,3 +55,83 @@ impl CuTask for ExampleTask {
         Ok(())
     }
 }
+
+#[derive(Reflect)]
+pub struct ExampleSink;
+
+impl Freezable for ExampleSink {}
+
+impl CuSinkTask for ExampleSink {
+    type Resources<'r> = ();
+    type Input<'m> = input_msg!(i32);
+
+    fn new(_config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self)
+    }
+
+    fn process(&mut self, _ctx: &CuContext, _input: &Self::Input<'_>) -> CuResult<()> {
+        Ok(())
+    }
+}
+
+#[derive(Reflect)]
+pub struct ExampleMultiSrc;
+
+impl Freezable for ExampleMultiSrc {}
+
+impl CuSrcTask for ExampleMultiSrc {
+    type Resources<'r> = ();
+    type Output<'m> = output_msg!(i32, u32);
+
+    fn new(_config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self)
+    }
+
+    fn process(&mut self, _ctx: &CuContext, new_msg: &mut Self::Output<'_>) -> CuResult<()> {
+        new_msg.0.set_payload(42);
+        new_msg.1.set_payload(42);
+        Ok(())
+    }
+}
+
+#[derive(Reflect)]
+pub struct MultiInputTask {
+    label: String,
+}
+
+impl Freezable for MultiInputTask {}
+
+impl CuTask for MultiInputTask {
+    type Resources<'r> = ();
+    type Input<'m> = input_msg!('m, i32, u32);
+    type Output<'o> = output_msg!(i32);
+
+    fn new(config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self>
+    where
+        Self: Sized,
+    {
+        let label = config
+            .and_then(|cfg| cfg.get::<String>("label").ok().flatten())
+            .unwrap_or_else(|| "Mission".to_string());
+        Ok(Self { label })
+    }
+
+    fn process(
+        &mut self,
+        _ctx: &CuContext,
+        input: &Self::Input<'_>,
+        output: &mut Self::Output<'_>,
+    ) -> CuResult<()> {
+        debug!("Processing from {}.", &self.label);
+        if let Some(payload) = input.0.payload() {
+            output.set_payload(payload.wrapping_add(1));
+        }
+        Ok(())
+    }
+}

--- a/examples/cu_missions/template_task.ron
+++ b/examples/cu_missions/template_task.ron
@@ -1,0 +1,43 @@
+(
+    tasks: [
+        (
+            id: "src_multi_{{index}}",
+            type: "tasks::ExampleMultiSrc",
+            config: {"label": "Multi src"},
+
+        ),
+        (
+            id: "multi_input_{{index}}",
+            type: "tasks::MultiInputTask",
+            config: {"label": "Multi input"},
+
+        ),
+        (
+            id: "sink_{{index}}",
+            type: "tasks::ExampleSink",
+            config: {"label": "Sink"},
+        ),
+    ],
+    cnx: [
+        (
+            src: "src_multi_{{index}}",
+            dst: "multi_input_{{index}}",
+            msg: "i32",
+        ),
+        (
+            src: "src_multi_{{index}}",
+            dst: "multi_input_{{index}}",
+            msg: "u32",
+        ),
+        // causes: error[E0277]: the trait bound `CuStampedData<i32, ...>: __CuOutputSlotMustMatchTaskOutput__Task_src_multi_0__Add_dst___nc___connections_for_unused_outputs<...>` is not satisfied
+        //     = note: expected reference `&(&CuStampedData<i32, CuMsgMetadata>, &CuStampedData<u32, CuMsgMetadata>)`
+        //    found reference `&CuStampedData<i32, CuMsgMetadata>`
+        // for both __nc__ and sink_{{index}}
+        (
+            src: "multi_input_{{index}}",
+            // dst: "__nc__",
+            dst: "sink_{{index}}",
+            msg: "i32",
+        ),
+    ],
+)


### PR DESCRIPTION
## Summary

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
