### PR TITLE
v1: Puts MSRV to 1.95.0

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -13,8 +13,34 @@ env:
   CARGO_PROFILE_DEV_CODEGEN_UNITS: "16"
   CARGO_PROFILE_TEST_CODEGEN_UNITS: "16"
   CARGO_INCREMENTAL: "0"
+  MSRV: "1.95.0"
 
 jobs:
+  msrv:
+    name: MSRV Check
+    runs-on: ubuntu-latest
+    env:
+      WORKSPACE_SCOPE: workspace
+    steps:
+      - uses: actions/checkout@v6
+      - id: rust_ci_setup
+        uses: ./.github/actions/rust-ci-setup
+        with:
+          toolchain: ${{ env.MSRV }}
+          linux_cargo_paths: true
+          cache_prefix: msrv
+          cache_shared_key: rust-ubuntu
+          install_nextest: "false"
+          sccache_key_suffix: msrv
+      - name: Detect embedded-only crates
+        run: |
+          EXCLUDES=$(python3 support/ci/embedded_crates.py excludes)
+          echo "EMBEDDED_EXCLUDES=$EXCLUDES" >> $GITHUB_ENV
+      - name: Check workspace on MSRV
+        run: cargo +${{ env.MSRV }} check --workspace --all-targets $EMBEDDED_EXCLUDES
+      - name: Check no_std default members on MSRV
+        run: cargo +${{ env.MSRV }} check --no-default-features
+
   Unit-Tests:
     name: Unit Tests
     uses: ./.github/workflows/reusable-unit-tests.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ First off, thank you for considering contributing to Copper-rs! We welcome contr
 
 ### Prerequisites
 
-* **Rust:** Ensure you have a recent stable Rust toolchain installed. You can install it using [rustup](https://rustup.rs/).
+* **Rust:** Copper's minimum supported Rust version is 1.95. Install the latest stable Rust toolchain with [rustup](https://rustup.rs/).
     ```bash
     curl --proto '=https' --tlsv1.2 -sSf [https://sh.rustup.rs](https://sh.rustup.rs) | sh
     ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ soft_ratatui = { path = "vendor/soft_ratatui" }
 version = "0.15.0"
 authors = ["Guillaume Binet <gbin@gootz.net>"]
 edition = "2024"
+rust-version = "1.95"
 license = "Apache-2.0"
 keywords = ["robotics", "middleware", "copper", "real-time"]
 categories = ["science::robotics"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![copper](https://github.com/gbin/copper-project/actions/workflows/general.yml/badge.svg)](https://github.com/gbin/copper-project/actions/workflows/general.yml)
 ![GitHub last commit](https://img.shields.io/github/last-commit/copper-project/copper-rs)
-![](https://img.shields.io/badge/Rust-1.80+-orange.svg)
+![](https://img.shields.io/badge/Rust-1.95+-orange.svg)
 [![dependency status](https://deps.rs/repo/github/copper-project/copper-rs/status.svg)](https://deps.rs/repo/github/copper-project/copper-rs)
 [![Discord](https://img.shields.io/discord/1305916875741597826?logo=discord)](https://discord.gg/VkCG7Sb9Kw)
 [![Book](https://img.shields.io/badge/book-Docs-blue)](https://copper-project.github.io/copper-rs-book/)
@@ -77,6 +77,7 @@ Want to see more Copper in action? Watch the [community showcase video](https://
 
 ## Get Started
 
+- Requires Rust 1.95 or newer. The latest stable Rust toolchain is recommended.
 - Start a new project from templates: [Project Templates](https://copper-project.github.io/copper-rs/Project-Templates)
 - Browse the live component catalog: [Copper Component Catalog](https://cdn.copper-robotics.com/catalog/index.html)
   Community components are welcome there too; if you build a reusable Copper component, prefer publishing it as its own crate and adding it to the catalog.

--- a/components/bridges/cu_bdshot/Cargo.toml
+++ b/components/bridges/cu_bdshot/Cargo.toml
@@ -4,6 +4,7 @@ description = "Copper Bridge to Bidirectional DSHOT ESCs."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/bridges/cu_crsf/Cargo.toml
+++ b/components/bridges/cu_crsf/Cargo.toml
@@ -4,6 +4,7 @@ description = "A copper-rs bridge to communicate through CRSF. The initial motiv
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/bridges/cu_feetech/Cargo.toml
+++ b/components/bridges/cu_feetech/Cargo.toml
@@ -5,6 +5,7 @@ description = "A copper-rs bridge for Feetech STS/SCS serial bus servos (e.g. ST
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/bridges/cu_iceoryx2_bridge/Cargo.toml
+++ b/components/bridges/cu_iceoryx2_bridge/Cargo.toml
@@ -4,6 +4,7 @@ description = "Copper bridge for Iceoryx2 publish/subscribe services."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/bridges/cu_msp_bridge/Cargo.toml
+++ b/components/bridges/cu_msp_bridge/Cargo.toml
@@ -4,6 +4,7 @@ description = "Copper bridge to talk to MSP devices over serial."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/bridges/cu_ros2_bridge/Cargo.toml
+++ b/components/bridges/cu_ros2_bridge/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu-ros2-bridge"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/bridges/cu_zenoh_bridge/Cargo.toml
+++ b/components/bridges/cu_zenoh_bridge/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu-zenoh-bridge"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/codecs/cu_ffv1_codec/Cargo.toml
+++ b/components/codecs/cu_ffv1_codec/Cargo.toml
@@ -4,6 +4,7 @@ description = "FFV1 log codec for Copper image payloads"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/codecs/cu_png_codec/Cargo.toml
+++ b/components/codecs/cu_png_codec/Cargo.toml
@@ -4,6 +4,7 @@ description = "PNG log codec for Copper image payloads"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/libs/cu_msp_lib/Cargo.toml
+++ b/components/libs/cu_msp_lib/Cargo.toml
@@ -4,6 +4,7 @@ description = "This is the library side of an MSP (Multiwii Serial Protocol) ori
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/libs/cu_sdlogger/Cargo.toml
+++ b/components/libs/cu_sdlogger/Cargo.toml
@@ -4,6 +4,7 @@ description = "Shared SD/eMMC logging utilities for Copper targets"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/libs/cu_transform/Cargo.toml
+++ b/components/libs/cu_transform/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu-transform"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/libs/cu_tuimon/Cargo.toml
+++ b/components/libs/cu_tuimon/Cargo.toml
@@ -4,6 +4,7 @@ description = "Shared Ratatui TUI rendering for Copper monitors."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/libs/zed_sdk/Cargo.toml
+++ b/components/libs/zed_sdk/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zed-sdk"
 version = "0.15.0"
 edition = "2024"
+rust-version = "1.95"
 license = "Apache-2.0"
 description = "Safe Rust wrapper for the Stereolabs ZED C API"
 readme = "README.md"

--- a/components/libs/zed_sdk_sys/Cargo.toml
+++ b/components/libs/zed_sdk_sys/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zed-sdk-sys"
 version = "0.15.0"
 edition = "2024"
+rust-version = "1.95"
 license = "Apache-2.0"
 description = "Raw Rust FFI bindings for the Stereolabs ZED C API"
 repository = "https://github.com/copper-project/copper-rs"

--- a/components/monitors/cu_bevymon/Cargo.toml
+++ b/components/monitors/cu_bevymon/Cargo.toml
@@ -4,6 +4,7 @@ description = "A Bevy-backed Ratatui monitor for Copper."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/monitors/cu_consolemon/Cargo.toml
+++ b/components/monitors/cu_consolemon/Cargo.toml
@@ -4,6 +4,7 @@ description = "A monitoring TUI for Copper. See the main Copper repository for m
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/monitors/cu_logmon/Cargo.toml
+++ b/components/monitors/cu_logmon/Cargo.toml
@@ -4,6 +4,7 @@ description = "Lightweight Copper monitor that emits periodic stats over the sta
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/monitors/cu_safetymon/Cargo.toml
+++ b/components/monitors/cu_safetymon/Cargo.toml
@@ -4,6 +4,7 @@ description = "Safety monitor for Copper: watchdog, panic capture, fault latchin
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/payloads/cu_gnss_payloads/Cargo.toml
+++ b/components/payloads/cu_gnss_payloads/Cargo.toml
@@ -4,6 +4,7 @@ readme = "README.md"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/payloads/cu_ros2_payloads/Cargo.toml
+++ b/components/payloads/cu_ros2_payloads/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu-ros2-payloads"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/payloads/cu_sensor_payloads/Cargo.toml
+++ b/components/payloads/cu_sensor_payloads/Cargo.toml
@@ -4,6 +4,7 @@ readme = "README.md"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/payloads/cu_spatial_payloads/Cargo.toml
+++ b/components/payloads/cu_spatial_payloads/Cargo.toml
@@ -4,6 +4,7 @@ description = "Spatial payloads for the Copper."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/res/cu_linux_resources/Cargo.toml
+++ b/components/res/cu_linux_resources/Cargo.toml
@@ -4,6 +4,7 @@ description = "Linux/host resource bundle for serial, I2C and GPIO devices."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/res/cu_micoairh743/Cargo.toml
+++ b/components/res/cu_micoairh743/Cargo.toml
@@ -4,6 +4,7 @@ description = "Copper resource bundle for the MicoAir H743 flight controller."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sinks/cu_lewansoul/Cargo.toml
+++ b/components/sinks/cu_lewansoul/Cargo.toml
@@ -5,6 +5,7 @@ description = "This is a driver for the Lewansoul serial servos."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sinks/cu_rp_gpio/Cargo.toml
+++ b/components/sinks/cu_rp_gpio/Cargo.toml
@@ -4,6 +4,7 @@ description = "This is a simple driver example for the Raspberry Pi GPIOs for Co
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sinks/cu_rp_sn754410/Cargo.toml
+++ b/components/sinks/cu_rp_sn754410/Cargo.toml
@@ -4,6 +4,7 @@ description = "Rust library for controlling the SN754410 motor driver on the Ras
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sinks/cu_zenoh_sink/Cargo.toml
+++ b/components/sinks/cu_zenoh_sink/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu-zenoh-sink"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sources/cu_ads7883/Cargo.toml
+++ b/components/sources/cu_ads7883/Cargo.toml
@@ -4,6 +4,7 @@ description = "This is a driver for the TI ADS7883 for Copper."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sources/cu_bmi088/Cargo.toml
+++ b/components/sources/cu_bmi088/Cargo.toml
@@ -4,6 +4,7 @@ description = "Copper source driver for the BMI088 6-axis IMU (accelerometer + g
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sources/cu_dps310/Cargo.toml
+++ b/components/sources/cu_dps310/Cargo.toml
@@ -4,6 +4,7 @@ description = "Copper source driver for the DPS310 digital barometric pressure s
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sources/cu_gnss_ublox/Cargo.toml
+++ b/components/sources/cu_gnss_ublox/Cargo.toml
@@ -5,6 +5,7 @@ readme = "README.md"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sources/cu_gstreamer/Cargo.toml
+++ b/components/sources/cu_gstreamer/Cargo.toml
@@ -5,6 +5,7 @@ description = "This is a Copper GStreamer sink."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sources/cu_hesai/Cargo.toml
+++ b/components/sources/cu_hesai/Cargo.toml
@@ -5,6 +5,7 @@ readme = "README.md"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sources/cu_ist8310/Cargo.toml
+++ b/components/sources/cu_ist8310/Cargo.toml
@@ -4,6 +4,7 @@ description = "Copper source driver for the IST8310 digital magnetometer."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sources/cu_livox/Cargo.toml
+++ b/components/sources/cu_livox/Cargo.toml
@@ -4,6 +4,7 @@ description = "Copper driver for Livox Tele15. Note: the actual parsing is usabl
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sources/cu_mpu9250/Cargo.toml
+++ b/components/sources/cu_mpu9250/Cargo.toml
@@ -4,6 +4,7 @@ description = "Copper source driver for the MPU9250 IMU."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sources/cu_rp_encoder/Cargo.toml
+++ b/components/sources/cu_rp_encoder/Cargo.toml
@@ -4,6 +4,7 @@ description = "This is a driver for the Raspberry Pi to decode a directional enc
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sources/cu_sen0682/Cargo.toml
+++ b/components/sources/cu_sen0682/Cargo.toml
@@ -4,6 +4,7 @@ description = "Copper source for the DFRobot SEN0682 / Wanyee WY6005 ToF lidar."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sources/cu_v4l/Cargo.toml
+++ b/components/sources/cu_v4l/Cargo.toml
@@ -4,6 +4,7 @@ description = "This is a source task that captures video from a V4L2 device."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sources/cu_vlp16/Cargo.toml
+++ b/components/sources/cu_vlp16/Cargo.toml
@@ -4,6 +4,7 @@ description = "This is a driver for the Velodyne VLP-16 for the Copper engine."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sources/cu_wt901/Cargo.toml
+++ b/components/sources/cu_wt901/Cargo.toml
@@ -5,6 +5,7 @@ description = "This is a driver for the WT901 IMU."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/sources/cu_zed/Cargo.toml
+++ b/components/sources/cu_zed/Cargo.toml
@@ -4,6 +4,7 @@ description = "Copper source task for Stereolabs ZED stereo cameras."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/tasks/cu_ahrs/Cargo.toml
+++ b/components/tasks/cu_ahrs/Cargo.toml
@@ -4,6 +4,7 @@ description = "Copper task that fuses IMU payloads into roll, pitch, yaw."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/tasks/cu_aligner/Cargo.toml
+++ b/components/tasks/cu_aligner/Cargo.toml
@@ -4,6 +4,7 @@ description = "A Copper component to align messages in time."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/tasks/cu_apriltag/Cargo.toml
+++ b/components/tasks/cu_apriltag/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu-apriltag"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/tasks/cu_dynthreshold/Cargo.toml
+++ b/components/tasks/cu_dynthreshold/Cargo.toml
@@ -5,6 +5,7 @@ description = "Image Dynamic thresholding for Copper."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/tasks/cu_pid/Cargo.toml
+++ b/components/tasks/cu_pid/Cargo.toml
@@ -4,6 +4,7 @@ description = "A PID controller for the Copper project."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/tasks/cu_python_task/Cargo.toml
+++ b/components/tasks/cu_python_task/Cargo.toml
@@ -5,6 +5,7 @@ readme = "README.md"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/tasks/cu_ratelimit/Cargo.toml
+++ b/components/tasks/cu_ratelimit/Cargo.toml
@@ -4,6 +4,7 @@ description = "A simple generic rate limiter for Copper"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/components/testing/cu_udp_inject/Cargo.toml
+++ b/components/testing/cu_udp_inject/Cargo.toml
@@ -4,6 +4,7 @@ description = "A simple UDP packet injector that takes a PCAP file and sends it 
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/core/cu29/Cargo.toml
+++ b/core/cu29/Cargo.toml
@@ -5,6 +5,7 @@ documentation = "https://docs.rs/cu29"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/core/cu29_clock/Cargo.toml
+++ b/core/cu29_clock/Cargo.toml
@@ -5,6 +5,7 @@ documentation = "https://docs.rs/cu29-clock"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/core/cu29_derive/Cargo.toml
+++ b/core/cu29_derive/Cargo.toml
@@ -5,6 +5,7 @@ documentation = "https://docs.rs/cu29-derive"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/core/cu29_export/Cargo.toml
+++ b/core/cu29_export/Cargo.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/core/cu29_helpers/Cargo.toml
+++ b/core/cu29_helpers/Cargo.toml
@@ -5,6 +5,7 @@ documentation = "https://docs.rs/cu29-helpers"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/core/cu29_intern_strs/Cargo.toml
+++ b/core/cu29_intern_strs/Cargo.toml
@@ -5,6 +5,7 @@ documentation = "https://docs.rs/cu29-intern-strs"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/core/cu29_log/Cargo.toml
+++ b/core/cu29_log/Cargo.toml
@@ -5,6 +5,7 @@ documentation = "https://docs.rs/cu29-log"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/core/cu29_log_derive/Cargo.toml
+++ b/core/cu29_log_derive/Cargo.toml
@@ -5,6 +5,7 @@ documentation = "https://docs.rs/cu29-log-derive"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/core/cu29_log_runtime/Cargo.toml
+++ b/core/cu29_log_runtime/Cargo.toml
@@ -5,6 +5,7 @@ documentation = "https://docs.rs/cu29-log-runtime"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/core/cu29_logviz/Cargo.toml
+++ b/core/cu29_logviz/Cargo.toml
@@ -5,6 +5,7 @@ readme = "README.md"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/core/cu29_reflect_derive/Cargo.toml
+++ b/core/cu29_reflect_derive/Cargo.toml
@@ -5,6 +5,7 @@ readme = "README.md"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/core/cu29_runtime/Cargo.toml
+++ b/core/cu29_runtime/Cargo.toml
@@ -5,6 +5,7 @@ documentation = "https://docs.rs/cu29"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/core/cu29_soa_derive/Cargo.toml
+++ b/core/cu29_soa_derive/Cargo.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/core/cu29_traits/Cargo.toml
+++ b/core/cu29_traits/Cargo.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/core/cu29_unifiedlog/Cargo.toml
+++ b/core/cu29_unifiedlog/Cargo.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/core/cu29_units/Cargo.toml
+++ b/core/cu29_units/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu29-units"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/core/cu29_value/Cargo.toml
+++ b/core/cu29_value/Cargo.toml
@@ -4,6 +4,7 @@ description = "This is a fork of Value with custom types added for Copper like t
 
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
 

--- a/examples/cu_async_cl_io_bench/Cargo.toml
+++ b/examples/cu_async_cl_io_bench/Cargo.toml
@@ -4,6 +4,7 @@ description = "Host benchmark for CopperList logging latency and async CL I/O ex
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_background_task/Cargo.toml
+++ b/examples/cu_background_task/Cargo.toml
@@ -4,6 +4,7 @@ description = "This is an example for the Copper project to show how to set up a
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_bevymon_demo/Cargo.toml
+++ b/examples/cu_bevymon_demo/Cargo.toml
@@ -4,6 +4,7 @@ description = "Minimal side-by-side Bevy sim and Copper monitor demo."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_bridge_test/Cargo.toml
+++ b/examples/cu_bridge_test/Cargo.toml
@@ -4,6 +4,7 @@ description = "Mini test app to validate bridge scheduling semantics"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_caterpillar/Cargo.toml
+++ b/examples/cu_caterpillar/Cargo.toml
@@ -6,6 +6,7 @@ description = "This is an example for the Copper project to measure a base laten
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_config_gen/Cargo.toml
+++ b/examples/cu_config_gen/Cargo.toml
@@ -4,6 +4,7 @@ description = "This is an example for the Copper project to show how to programm
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_config_variation/Cargo.toml
+++ b/examples/cu_config_variation/Cargo.toml
@@ -4,6 +4,7 @@ description = "Example of a Copper configuration with programmatic multiple vari
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_debug_session/Cargo.toml
+++ b/examples/cu_debug_session/Cargo.toml
@@ -4,6 +4,7 @@ description = "Demonstrates CuDebug time-travel API on recorded Copper logs"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_distributed_resim_demo/Cargo.toml
+++ b/examples/cu_distributed_resim_demo/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu-distributed-resim-demo"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_dorabench/Cargo.toml
+++ b/examples/cu_dorabench/Cargo.toml
@@ -6,6 +6,7 @@ description = "This is the matching benchmark for https://github.com/dora-rs/dor
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_elrs_bdshot_demo/Cargo.toml
+++ b/examples/cu_elrs_bdshot_demo/Cargo.toml
@@ -4,6 +4,7 @@ description = "Example Copper app driving BDShot ESCs from an ELRS throttle comm
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_feetech_demo/Cargo.toml
+++ b/examples/cu_feetech_demo/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu-feetech-demo"
 description = "An example application demonstrating the cu_feetech bridge with a SO-100/SO-101 Feetech servo arm."
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_flight_controller/Cargo.toml
+++ b/examples/cu_flight_controller/Cargo.toml
@@ -4,6 +4,7 @@ description = "This is a basic quadcopter Flight Controller implemented end to e
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_gnss_ublox_demo/Cargo.toml
+++ b/examples/cu_gnss_ublox_demo/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu-gnss-ublox-demo"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 publish = false
 

--- a/examples/cu_human_pose/Cargo.toml
+++ b/examples/cu_human_pose/Cargo.toml
@@ -4,6 +4,7 @@ description = "Pose estimation demo using Candle and GStreamer camera input"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_iceoryx2_bridge_demo/Cargo.toml
+++ b/examples/cu_iceoryx2_bridge_demo/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu-iceoryx2-bridge-demo"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_image_aligner/Cargo.toml
+++ b/examples/cu_image_aligner/Cargo.toml
@@ -4,6 +4,7 @@ description = "Example showing image alignment using cu-aligner with pooled buff
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_image_codec_demo/Cargo.toml
+++ b/examples/cu_image_codec_demo/Cargo.toml
@@ -4,6 +4,7 @@ description = "Example comparing PNG and FFV1 image log codecs."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_instance_overrides_demo/Cargo.toml
+++ b/examples/cu_instance_overrides_demo/Cargo.toml
@@ -4,6 +4,7 @@ description = "Example showing instance-specific config overlays resolved from m
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_logging_size/Cargo.toml
+++ b/examples/cu_logging_size/Cargo.toml
@@ -4,6 +4,7 @@ description = "This is an example for the Copper project to show how to set cust
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_logviz_demo/Cargo.toml
+++ b/examples/cu_logviz_demo/Cargo.toml
@@ -4,6 +4,7 @@ description = "Example demonstrating Copper logviz with Rerun."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_min_baremetal/Cargo.toml
+++ b/examples/cu_min_baremetal/Cargo.toml
@@ -6,6 +6,7 @@ description = "This is a minimal example/smoke test of a baremetal (no_std) appl
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_missions/Cargo.toml
+++ b/examples/cu_missions/Cargo.toml
@@ -4,6 +4,7 @@ description = "This shows how to build a multimission configuration and switch f
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_monitoring/Cargo.toml
+++ b/examples/cu_monitoring/Cargo.toml
@@ -4,6 +4,7 @@ description = "This is an example for the Copper project to show how to implemwn
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_msp_bridge_loopback/Cargo.toml
+++ b/examples/cu_msp_bridge_loopback/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu-msp-bridge-loopback"
 description = "An example application that demonstrates a loopback using the cu_msp_bridge component."
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_multi_output/Cargo.toml
+++ b/examples/cu_multi_output/Cargo.toml
@@ -4,6 +4,7 @@ description = "Example demonstrating multi-output tasks."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_multisources/Cargo.toml
+++ b/examples/cu_multisources/Cargo.toml
@@ -4,6 +4,7 @@ description = "This is an example for the Copper project to show more advanced t
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_multisources_structs/Cargo.toml
+++ b/examples/cu_multisources_structs/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu-multisources-structs"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_nologging_task/Cargo.toml
+++ b/examples/cu_nologging_task/Cargo.toml
@@ -4,6 +4,7 @@ description = "This is an example for the Copper project to show how to stop the
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_parallel_mandelbrot/Cargo.toml
+++ b/examples/cu_parallel_mandelbrot/Cargo.toml
@@ -4,6 +4,7 @@ description = "Host-side zooming Mandelbrot benchmark for Copper's pipelined run
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_pointclouds/Cargo.toml
+++ b/examples/cu_pointclouds/Cargo.toml
@@ -4,6 +4,7 @@ description = "This is small sink example to display a Copper pointcloud in reru
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_python_task_demo/Cargo.toml
+++ b/examples/cu_python_task_demo/Cargo.toml
@@ -4,6 +4,7 @@ description = "Demonstrates Python-backed Copper tasks in process and embedded m
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_rate_target/Cargo.toml
+++ b/examples/cu_rate_target/Cargo.toml
@@ -4,6 +4,7 @@ description = "Example showing how to set a runtime rate target for the Copper a
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_reflect_demo/Cargo.toml
+++ b/examples/cu_reflect_demo/Cargo.toml
@@ -4,6 +4,7 @@ description = "Standalone demo for reflected task introspection through CuDebugS
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_remote_debug_session/Cargo.toml
+++ b/examples/cu_remote_debug_session/Cargo.toml
@@ -4,6 +4,7 @@ description = "Demonstrates the Zenoh remote debug API by exercising all endpoin
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_resources_test/Cargo.toml
+++ b/examples/cu_resources_test/Cargo.toml
@@ -4,6 +4,7 @@ description = "Resource-heavy Copper demo covering bundles, missions, owned vs s
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_ros2_bridge_demo/Cargo.toml
+++ b/examples/cu_ros2_bridge_demo/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu-ros2-bridge-demo"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_rp2350_skeleton/Cargo.toml
+++ b/examples/cu_rp2350_skeleton/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cu-rp2350-skeleton"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.95"
 description = "A minimal example of using Copper on a RP2350 microcontroller"
 authors = ["Guillaume Binet <gbin@gootz.net>"]
 default-run = "main"

--- a/examples/cu_rp_balancebot/Cargo.toml
+++ b/examples/cu_rp_balancebot/Cargo.toml
@@ -4,6 +4,7 @@ description = "This is a full robot example for the Copper project. It runs on t
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_run_in_sim/Cargo.toml
+++ b/examples/cu_run_in_sim/Cargo.toml
@@ -4,6 +4,7 @@ description = "Example for forcing Copper to compile in and run a source or a si
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_runtime_matrix/Cargo.toml
+++ b/examples/cu_runtime_matrix/Cargo.toml
@@ -4,6 +4,7 @@ description = "Deterministic scheduler/runtime matrix coverage for async-cl-io, 
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_standalone_structlog/Cargo.toml
+++ b/examples/cu_standalone_structlog/Cargo.toml
@@ -4,6 +4,7 @@ description = "Example of using structlog in a standalone application"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_zenoh/Cargo.toml
+++ b/examples/cu_zenoh/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu-zenoh"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_zenoh_bridge_bench/Cargo.toml
+++ b/examples/cu_zenoh_bridge_bench/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu-zenoh-bridge-bench"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/examples/cu_zenoh_bridge_demo/Cargo.toml
+++ b/examples/cu_zenoh_bridge_demo/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu-zenoh-bridge-demo"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/justfile
+++ b/justfile
@@ -1,6 +1,7 @@
 # CI-aligned helpers mirroring .github/workflows/general.yml
 BASE_FEATURES := "mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug"
 WINDOWS_BASE_FEATURES := "mock,cu-sensor-payloads/image,kornia,python,gst,faer,nalgebra,glam,debug_pane,bincode"
+MSRV := "1.95.0"
 export ROOT := `git rev-parse --show-toplevel`
 EMBEDDED_EXCLUDES := shell('python3 $1/support/ci/embedded_crates.py excludes', ROOT)
 PREK_FMT_FIX_HOOKS := "trailing-whitespace mixed-line-ending"
@@ -109,6 +110,14 @@ test:
 
 	cargo +stable nextest run --all-targets --workspace {{EMBEDDED_EXCLUDES}}
 	cargo +stable nextest run --no-default-features
+
+# Verify the declared minimum supported Rust version.
+msrv-check:
+	#!/usr/bin/env bash
+	set -euo pipefail
+
+	cargo +{{MSRV}} check --workspace --all-targets {{EMBEDDED_EXCLUDES}}
+	cargo +{{MSRV}} check --no-default-features
 
 # Run the no_std/embedded CI flow locally.
 nostd-ci:

--- a/support/cargo_cubuild/Cargo.toml
+++ b/support/cargo_cubuild/Cargo.toml
@@ -3,6 +3,7 @@ name = "cargo-cubuild"
 description = "A cargo tool to help with copper macro expansion errors."
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.95"
 license = "Apache-2.0"
 repository = "https://github.com/copper-project/copper-rs"
 

--- a/support/cu_catalog/Cargo.toml
+++ b/support/cu_catalog/Cargo.toml
@@ -3,6 +3,7 @@ name = "cu-catalog"
 description = "Generate the Copper component catalog from RON source entries."
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.95"
 license = "Apache-2.0"
 repository = "https://github.com/copper-project/copper-rs"
 

--- a/support/vendor/tui-nodes/Cargo.toml
+++ b/support/vendor/tui-nodes/Cargo.toml
@@ -11,6 +11,7 @@
 
 [package]
 edition = "2024"
+rust-version = "1.95"
 name = "tui-nodes"
 version = "0.9.0"
 authors = ["jaxter184 <jaxter184@gmail.com>"]

--- a/vendor/soft_ratatui/Cargo.toml
+++ b/vendor/soft_ratatui/Cargo.toml
@@ -2,6 +2,7 @@
 name = "soft_ratatui"
 version = "0.2.0"
 edition = "2024"
+rust-version = "1.95"
 authors = ["gold-silver-copper"]
 
 include = ["LICENSE-APACHE", "LICENSE-MIT", "**/*.rs", "Cargo.toml"]


### PR DESCRIPTION
## Summary

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
