### PR TITLE
v1: tags a general log format version in header

### DIFF
--- a/components/libs/cu_sdlogger/src/logger.rs
+++ b/components/libs/cu_sdlogger/src/logger.rs
@@ -215,6 +215,7 @@ impl<BD: BlockDevice> EMMCLogger<BD> {
     pub fn new(bd: BD, start: BlockIdx, size: BlockCount) -> CuResult<Self> {
         let main_header = MainHeader {
             magic: MAIN_MAGIC,
+            format_version: UNIFIED_LOG_FORMAT_VERSION,
             first_section_offset: BLK as u16,
             page_size: BLK as u16,
         };

--- a/core/cu29_unifiedlog/src/lib.rs
+++ b/core/cu29_unifiedlog/src/lib.rs
@@ -42,12 +42,16 @@ pub const MAIN_MAGIC: [u8; 4] = [0xB4, 0xA5, 0x50, 0xFF]; // BRASS OFF
 /// ID to spot a section of Copper Log
 pub const SECTION_MAGIC: [u8; 2] = [0xFA, 0x57]; // FAST
 
+/// Version of the unified log file format.
+pub const UNIFIED_LOG_FORMAT_VERSION: u8 = 1;
+
 pub const SECTION_HEADER_COMPACT_SIZE: u16 = 512; // Usual minimum size for a disk sector.
 
 /// The main file header of the datalogger.
 #[derive(Encode, Decode, Debug)]
 pub struct MainHeader {
-    pub magic: [u8; 4],            // Magic number to identify the file.
+    pub magic: [u8; 4], // Magic number to identify the file.
+    pub format_version: u8,
     pub first_section_offset: u16, // This is to align with a page at write time.
     pub page_size: u16,
 }
@@ -59,6 +63,7 @@ impl Display for MainHeader {
             "  Magic -> {:2x}{:2x}{:2x}{:2x}",
             self.magic[0], self.magic[1], self.magic[2], self.magic[3]
         )?;
+        writeln!(f, "  format_version -> {}", self.format_version)?;
         writeln!(f, "  first_section_offset -> {}", self.first_section_offset)?;
         writeln!(f, "  page_size -> {}", self.page_size)
     }

--- a/core/cu29_unifiedlog/src/memmap.rs
+++ b/core/cu29_unifiedlog/src/memmap.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     AllocatedSection, MAIN_MAGIC, MainHeader, SECTION_MAGIC, SectionHandle, SectionHeader,
-    SectionStorage, UnifiedLogRead, UnifiedLogStatus, UnifiedLogWrite,
+    SectionStorage, UNIFIED_LOG_FORMAT_VERSION, UnifiedLogRead, UnifiedLogStatus, UnifiedLogWrite,
 };
 
 use crate::SECTION_HEADER_COMPACT_SIZE;
@@ -716,6 +716,7 @@ impl MmapUnifiedLoggerWrite {
         // This is the first slab so add the main header.
         let main_header = MainHeader {
             magic: MAIN_MAGIC,
+            format_version: UNIFIED_LOG_FORMAT_VERSION,
             first_section_offset: page_size as u16,
             page_size: page_size as u16,
         };
@@ -817,6 +818,15 @@ fn open_slab_index(
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Invalid magic number in main header",
+            ));
+        }
+        if main_header.format_version != UNIFIED_LOG_FORMAT_VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Unsupported unified log format version {} in main header; this reader supports version {}",
+                    main_header.format_version, UNIFIED_LOG_FORMAT_VERSION
+                ),
             ));
         }
         prolog = main_header.first_section_offset;
@@ -1089,6 +1099,7 @@ mod tests {
     use bincode::de::read::SliceReader;
     use bincode::{Decode, Encode, decode_from_reader, decode_from_slice};
     use cu29_traits::WriteStream;
+    use std::io::{Seek, SeekFrom, Write};
     use std::path::PathBuf;
     use std::sync::{Arc, Mutex};
     use tempfile::TempDir;
@@ -1153,6 +1164,52 @@ mod tests {
         //    file.metadata().unwrap().len(),
         //    (used + size_of::<SectionHeader>()) as u64
         //);
+    }
+
+    #[test]
+    fn test_unsupported_main_header_format_version_is_rejected() {
+        let tmp_dir = TempDir::new().expect("could not create a tmp dir");
+        let file_path = tmp_dir.path().join("test.bin");
+        {
+            let MmapUnifiedLogger::Write(_logger) = MmapUnifiedLoggerBuilder::new()
+                .write(true)
+                .create(true)
+                .file_base_name(&file_path)
+                .preallocated_size(100000)
+                .build()
+                .expect("Failed to create logger")
+            else {
+                panic!("Failed to create logger")
+            };
+        }
+
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(tmp_dir.path().join("test_0.bin"))
+            .expect("Could not reopen the slab");
+        let unsupported_version = UNIFIED_LOG_FORMAT_VERSION + 1;
+        file.seek(SeekFrom::Start(MAIN_MAGIC.len() as u64))
+            .expect("Could not seek to format version");
+        file.write_all(&[unsupported_version])
+            .expect("Could not write unsupported format version");
+        drop(file);
+
+        let err = match MmapUnifiedLoggerBuilder::new()
+            .file_base_name(&file_path)
+            .build()
+        {
+            Ok(_) => panic!("Reader accepted unsupported unified log format version"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "Unsupported unified log format version {unsupported_version} in main header; this reader supports version {UNIFIED_LOG_FORMAT_VERSION}"
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
