### PR TITLE
fix: stackoverflows on handle decode 

### DIFF
--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -631,6 +631,7 @@ pub cu29_runtime::curuntime::CuExecutionStep::task_type: cu29_runtime::curuntime
 impl core::fmt::Debug for cu29_runtime::curuntime::CuExecutionStep
 pub fn cu29_runtime::curuntime::CuExecutionStep::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct cu29_runtime::curuntime::CuInputMsg
+pub cu29_runtime::curuntime::CuInputMsg::connection_order: usize
 pub cu29_runtime::curuntime::CuInputMsg::culist_index: u32
 pub cu29_runtime::curuntime::CuInputMsg::edge_id: usize
 pub cu29_runtime::curuntime::CuInputMsg::msg_type: alloc::string::String

--- a/api/v1/cu29-unifiedlog.txt
+++ b/api/v1/cu29-unifiedlog.txt
@@ -98,6 +98,7 @@ impl<S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S>>
 pub fn cu29_unifiedlog::LogStream<S, L>::drop(&mut self)
 pub struct cu29_unifiedlog::MainHeader
 pub cu29_unifiedlog::MainHeader::first_section_offset: u16
+pub cu29_unifiedlog::MainHeader::format_version: u8
 pub cu29_unifiedlog::MainHeader::magic: [u8; 4]
 pub cu29_unifiedlog::MainHeader::page_size: u16
 impl core::fmt::Display for cu29_unifiedlog::MainHeader
@@ -190,6 +191,7 @@ pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerWrite::status(&self) -> cu29_un
 pub const cu29_unifiedlog::MAIN_MAGIC: [u8; 4]
 pub const cu29_unifiedlog::SECTION_HEADER_COMPACT_SIZE: u16
 pub const cu29_unifiedlog::SECTION_MAGIC: [u8; 2]
+pub const cu29_unifiedlog::UNIFIED_LOG_FORMAT_VERSION: u8
 pub trait cu29_unifiedlog::SectionStorage: core::marker::Send + core::marker::Sync
 pub fn cu29_unifiedlog::SectionStorage::append<E: cu_bincode::enc::Encode>(&mut self, entry: &E) -> core::result::Result<usize, cu_bincode::error::EncodeError>
 pub fn cu29_unifiedlog::SectionStorage::flush(&mut self) -> cu29_traits::CuResult<usize>

--- a/components/payloads/cu_sensor_payloads/Cargo.toml
+++ b/components/payloads/cu_sensor_payloads/Cargo.toml
@@ -29,6 +29,9 @@ image = { workspace = true, default-features = false, optional = true }
 kornia-image = { version = "0.1.10", optional = true }
 serde = { workspace = true }
 
+[dev-dependencies]
+serde_json = { workspace = true }
+
 [features]
 default = ["std"]
 std = ["cu29/std", "cu29-clock/std"]

--- a/components/payloads/cu_sensor_payloads/src/handle_payload.rs
+++ b/components/payloads/cu_sensor_payloads/src/handle_payload.rs
@@ -18,6 +18,15 @@ pub trait CuHandlePayloadMeta {
 
 pub trait CuHandlePayloadInit: Debug + Send + Sync + 'static {
     fn boxed_init() -> Box<Self>;
+
+    fn decode_boxed<D>(decoder: &mut D) -> Result<Box<Self>, DecodeError>
+    where
+        Self: Decode<()>,
+        D: Decoder<Context = ()>,
+    {
+        let inner = Self::decode(decoder)?;
+        Ok(Box::new(inner))
+    }
 }
 
 #[derive(Reflect)]
@@ -156,11 +165,11 @@ where
 
 impl<T, M> Decode<()> for CuHandlePayload<T, M>
 where
-    T: Debug + Send + Sync + Decode<()> + 'static,
+    T: CuHandlePayloadInit + Decode<()>,
     M: CuHandlePayloadMeta + 'static,
 {
     fn decode<D: Decoder<Context = ()>>(decoder: &mut D) -> Result<Self, DecodeError> {
-        let inner = Box::<T>::decode(decoder)?;
+        let inner = T::decode_boxed(decoder)?;
         Ok(Self::from_box(inner))
     }
 }

--- a/components/payloads/cu_sensor_payloads/src/pointcloud.rs
+++ b/components/payloads/cu_sensor_payloads/src/pointcloud.rs
@@ -1,6 +1,8 @@
 use crate::{CuHandlePayload, CuHandlePayloadInit, CuHandlePayloadMeta};
 use alloc::alloc::{Layout, alloc_zeroed, handle_alloc_error};
 use alloc::boxed::Box;
+use bincode::de::Decoder;
+use bincode::error::DecodeError;
 use bincode::{Decode, Encode};
 use cu29::prelude::*;
 use cu29::units::si::f32::{Length, Ratio};
@@ -135,6 +137,41 @@ impl<const N: usize> PointCloudSoa<N> {
 impl<const N: usize> CuHandlePayloadInit for PointCloudSoa<N> {
     fn boxed_init() -> Box<Self> {
         Self::boxed_zeroed()
+    }
+
+    fn decode_boxed<D>(decoder: &mut D) -> Result<Box<Self>, DecodeError>
+    where
+        D: Decoder<Context = ()>,
+    {
+        let mut result = Self::boxed_zeroed();
+        result.len = Decode::decode(decoder)?;
+        if result.len > N {
+            return Err(DecodeError::ArrayLengthMismatch {
+                required: N,
+                found: result.len,
+            });
+        }
+
+        for idx in 0..result.len {
+            result.tov[idx] = Decode::decode(decoder)?;
+        }
+        for idx in 0..result.len {
+            result.x[idx] = Decode::decode(decoder)?;
+        }
+        for idx in 0..result.len {
+            result.y[idx] = Decode::decode(decoder)?;
+        }
+        for idx in 0..result.len {
+            result.z[idx] = Decode::decode(decoder)?;
+        }
+        for idx in 0..result.len {
+            result.i[idx] = Decode::decode(decoder)?;
+        }
+        for idx in 0..result.len {
+            result.return_order[idx] = Decode::decode(decoder)?;
+        }
+
+        Ok(result)
     }
 }
 

--- a/components/payloads/cu_sensor_payloads/tests/pointcloud_soa_handle_export.rs
+++ b/components/payloads/cu_sensor_payloads/tests/pointcloud_soa_handle_export.rs
@@ -1,0 +1,94 @@
+use std::process::Command;
+use std::thread;
+
+use bincode::de::Decoder;
+use bincode::error::DecodeError;
+use bincode::{Decode, Encode};
+use cu_sensor_payloads::PointCloudSoaHandle;
+use cu29::prelude::{
+    CopperList, CuMsgMetadata, CuStampedData, ErasedCuStampedData, ErasedCuStampedDataSet,
+    MatchingTasks,
+};
+use serde::{Deserialize, Serialize};
+
+const HELPER_ENV: &str = "CU_SENSOR_POINTCLOUD_EXPORT_STACK_HELPER";
+const LARGE_POINTS: usize = 100_000;
+const SMALL_STACK_BYTES: usize = 256 * 1024;
+
+#[derive(Debug, Default, Encode, Serialize, Deserialize)]
+struct PointCloudMsgs(CuStampedData<PointCloudSoaHandle<LARGE_POINTS>, CuMsgMetadata>);
+
+impl Decode<()> for PointCloudMsgs {
+    fn decode<D: Decoder<Context = ()>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        Ok(Self(Decode::decode(decoder)?))
+    }
+}
+
+impl ErasedCuStampedDataSet for PointCloudMsgs {
+    fn cumsgs(&self) -> Vec<&dyn ErasedCuStampedData> {
+        vec![&self.0]
+    }
+}
+
+impl MatchingTasks for PointCloudMsgs {
+    fn get_all_task_ids() -> &'static [&'static str] {
+        &["points"]
+    }
+}
+
+fn encoded_copperlist() -> Vec<u8> {
+    let mut payload = PointCloudSoaHandle::<LARGE_POINTS>::default();
+    payload.with_inner_mut(|cloud| {
+        cloud.len = LARGE_POINTS;
+        cloud.return_order[0] = 1;
+        cloud.return_order[LARGE_POINTS - 1] = 2;
+    });
+
+    let mut msgs = PointCloudMsgs::default();
+    msgs.0.set_payload(payload);
+    let cl = CopperList::new(7, msgs);
+
+    bincode::encode_to_vec(cl, bincode::config::standard()).expect("encode CopperList")
+}
+
+fn run_json_export_on_small_stack() {
+    let encoded = encoded_copperlist();
+    thread::Builder::new()
+        .stack_size(SMALL_STACK_BYTES)
+        .spawn(move || {
+            let (entry, read): (CopperList<PointCloudMsgs>, usize) =
+                bincode::decode_from_slice(&encoded, bincode::config::standard())
+                    .expect("decode CopperList");
+            assert_eq!(read, encoded.len());
+
+            let json = serde_json::to_vec(&entry).expect("serialize CopperList JSON");
+            assert!(!json.is_empty());
+        })
+        .expect("thread spawn should succeed")
+        .join()
+        .expect("JSON export thread should not panic");
+}
+
+fn run_self(test_name: &str, helper_mode: &str) -> std::process::ExitStatus {
+    Command::new(std::env::current_exe().expect("current_exe should succeed"))
+        .arg("--exact")
+        .arg(test_name)
+        .env(HELPER_ENV, helper_mode)
+        .status()
+        .expect("child test process should launch")
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn pointcloud_handle_json_export_survives_small_stack() {
+    if std::env::var(HELPER_ENV).ok().as_deref() == Some("json") {
+        run_json_export_on_small_stack();
+        return;
+    }
+
+    let status = run_self("pointcloud_handle_json_export_survives_small_stack", "json");
+    assert!(
+        status.success(),
+        "JSON export child should succeed, got {status:?}"
+    );
+}

--- a/core/cu29_export/Cargo.toml
+++ b/core/cu29_export/Cargo.toml
@@ -39,6 +39,7 @@ erased-serde = { version = "0.4", optional = true, default-features = false }
 
 
 [dev-dependencies]
+cu-sensor-payloads = { workspace = true }
 tempfile = { workspace = true }
 jsonschema = { version = "0.46", default-features = false }
 

--- a/core/cu29_export/src/mcap_export.rs
+++ b/core/cu29_export/src/mcap_export.rs
@@ -666,7 +666,10 @@ pub fn mcap_info(mcap_path: &Path, show_schemas: bool, sample_messages: usize) -
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bincode::de::Decoder;
+    use bincode::error::DecodeError;
     use bincode::{Decode, Encode, config::standard, encode_into_slice};
+    use cu_sensor_payloads::PointCloudSoaHandle;
     use cu29::prelude::{
         CopperList, CuMsgMetadata, CuStampedData, ErasedCuStampedData, ErasedCuStampedDataSet,
         MatchingTasks, Reflect,
@@ -674,6 +677,8 @@ mod tests {
     use cu29_clock::OptionCuTime;
     use serde::{Deserialize, Serialize};
     use std::io::Cursor;
+    use std::process::Command;
+    use std::thread;
     use tempfile::tempdir;
 
     // Test payload types
@@ -696,6 +701,13 @@ mod tests {
         CuStampedData<TestPayloadB, CuMsgMetadata>,
     );
 
+    const HELPER_ENV: &str = "CU29_EXPORT_POINTCLOUD_STACK_HELPER";
+    const LARGE_POINTS: usize = 100_000;
+    const SMALL_STACK_BYTES: usize = 256 * 1024;
+
+    #[derive(Debug, Default, Encode, Serialize, Deserialize)]
+    struct LargePointCloudMsgs(CuStampedData<PointCloudSoaHandle<LARGE_POINTS>, CuMsgMetadata>);
+
     impl ErasedCuStampedDataSet for TestMsgs {
         fn cumsgs(&self) -> Vec<&dyn ErasedCuStampedData> {
             vec![&self.0, &self.1]
@@ -705,6 +717,24 @@ mod tests {
     impl MatchingTasks for TestMsgs {
         fn get_all_task_ids() -> &'static [&'static str] {
             &["task_a", "task_b"]
+        }
+    }
+
+    impl ErasedCuStampedDataSet for LargePointCloudMsgs {
+        fn cumsgs(&self) -> Vec<&dyn ErasedCuStampedData> {
+            vec![&self.0]
+        }
+    }
+
+    impl MatchingTasks for LargePointCloudMsgs {
+        fn get_all_task_ids() -> &'static [&'static str] {
+            &["points"]
+        }
+    }
+
+    impl Decode<()> for LargePointCloudMsgs {
+        fn decode<D: Decoder<Context = ()>>(decoder: &mut D) -> Result<Self, DecodeError> {
+            Ok(Self(Decode::decode(decoder)?))
         }
     }
 
@@ -724,6 +754,61 @@ mod tests {
         }
     }
 
+    impl PayloadSchemas for LargePointCloudMsgs {
+        fn get_payload_schemas() -> Vec<(&'static str, String)> {
+            vec![("points", "{}".to_string())]
+        }
+    }
+
+    fn encoded_pointcloud_copperlist() -> Vec<u8> {
+        let mut payload = PointCloudSoaHandle::<LARGE_POINTS>::default();
+        payload.with_inner_mut(|cloud| {
+            cloud.len = LARGE_POINTS;
+            cloud.return_order[0] = 1;
+            cloud.return_order[LARGE_POINTS - 1] = 2;
+        });
+
+        let mut msgs = LargePointCloudMsgs::default();
+        msgs.0.set_payload(payload);
+        let cl = CopperList::new(42, msgs);
+
+        bincode::encode_to_vec(cl, standard()).expect("encode CopperList")
+    }
+
+    fn run_mcap_export_on_small_stack() {
+        let encoded = encoded_pointcloud_copperlist();
+        let dir = tempdir().expect("create temp dir");
+        let mcap_path = dir.path().join("pointcloud.mcap");
+
+        thread::Builder::new()
+            .stack_size(SMALL_STACK_BYTES)
+            .spawn({
+                let mcap_path = mcap_path.clone();
+                move || {
+                    let stats =
+                        export_to_mcap::<LargePointCloudMsgs, _>(Cursor::new(encoded), &mcap_path)
+                            .expect("export MCAP");
+
+                    assert_eq!(stats.copperlists_read, 1);
+                    assert_eq!(stats.messages_written, 1);
+                }
+            })
+            .expect("thread spawn should succeed")
+            .join()
+            .expect("MCAP export thread should not panic");
+
+        assert!(mcap_path.exists());
+    }
+
+    fn run_self(test_name: &str, helper_mode: &str) -> std::process::ExitStatus {
+        Command::new(std::env::current_exe().expect("current_exe should succeed"))
+            .arg("--exact")
+            .arg(test_name)
+            .env(HELPER_ENV, helper_mode)
+            .status()
+            .expect("child test process should launch")
+    }
+
     #[test]
     fn test_tov_to_nanos() {
         assert_eq!(tov_to_nanos(&Tov::None), 0);
@@ -739,6 +824,21 @@ mod tests {
 
         let some_time = OptionCuTime::from(CuTime::from(500_000_000u64));
         assert_eq!(option_cutime_to_nanos(&some_time), 500_000_000);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn mcap_export_pointcloud_handle_survives_small_stack() {
+        if std::env::var(HELPER_ENV).ok().as_deref() == Some("mcap") {
+            run_mcap_export_on_small_stack();
+            return;
+        }
+
+        let status = run_self("mcap_export_pointcloud_handle_survives_small_stack", "mcap");
+        assert!(
+            status.success(),
+            "MCAP export child should succeed, got {status:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
