### PR TITLE
Remove blockquote description from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,6 @@
 [![Book](https://img.shields.io/badge/book-Docs-blue)](https://copper-project.github.io/copper-rs-book/)
 [![Documentation](https://img.shields.io/badge/docs-available-brightgreen)](https://copper-project.github.io/copper-rs)
 
-<blockquote>
-🤖&nbsp&nbsp&nbsp&nbsp
-  <em style="font-size: 1.2em;">
-    Copper is to robots what a game engine is to games - build, run, and replay your entire robot deterministically.
-  </em>
-</blockquote>
-
 ### Why Copper
 
 <p><strong style="color: #b87333;">Rust-first</strong> – ergonomic & safe


### PR DESCRIPTION
Removed the blockquote description of Copper.

## Summary

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just api-check`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, `just api-check`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
