### PR TITLE
Ease on the bureaucracy again.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,24 +5,8 @@
 
 ## Changes
 
-## Testing
-- [ ] `just fmt`
-- [ ] `just lint`
-- [ ] `just api-check`
-- [ ] `just test`
-- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
-- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
-- [ ] Other (please specify):
-
-pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, `just api-check`, and `just test`.
-
-## Checklist
+## Reminder
+- [ ] I ran `just` from the repo root
 - [ ] I have updated docs or examples where needed
-- [ ] I have added or updated tests where needed
-- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
-- [ ] I have considered config/logging changes (if applicable)
-- [ ] This change is not a breaking change (or I documented it below)
-
-## Breaking changes (if any)
 
 ## Additional context

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,4 +1,4 @@
-name: Pull Request Labels
+name: Pull Request Guardrails
 
 on:
   pull_request_target:
@@ -14,7 +14,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  label:
+  do-not-merge:
     runs-on: ubuntu-latest
     steps:
       - name: Check for a "do-not-merge" label
@@ -23,10 +23,3 @@ jobs:
           mode: exactly
           count: 0
           labels: "do-not-merge"
-
-      - name: Require label "include in changelog" or "exclude from changelog"
-        uses: mheap/github-action-required-labels@v5
-        with:
-          mode: minimum
-          count: 1
-          labels: "exclude from changelog, include in changelog"


### PR DESCRIPTION
There is label fatigue, people contributing just ignore them and don't understand them. It is easy to go through a set of changes between version and cherry pick the important stuff.

## Summary

## Related issues
- Closes #

## Changes

## Testing
- [ ] `just fmt`
- [ ] `just lint`
- [ ] `just api-check`
- [ ] `just test`
- [ ] optional full `just std-ci` (if std/runtime paths are impacted)
- [ ] optional full `just nostd-ci` (if embedded/no_std paths are impacted)
- [ ] Other (please specify):

pro-tip: `just` with no parameters in the root defaults to `just fmt`, `just lint`, `just api-check`, and `just test`.

## Checklist
- [ ] I have updated docs or examples where needed
- [ ] I have added or updated tests where needed
- [ ] I have considered platform impact (Linux/macOS/Windows/embedded)
- [ ] I have considered config/logging changes (if applicable)
- [ ] This change is not a breaking change (or I documented it below)

## Breaking changes (if any)

## Additional context
