### PR TITLE
Fix missing external example references after PR #1053

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,10 +129,10 @@ Use these as the quickest way to regain context:
 - `examples/cu_caterpillar/`
   - Minimal but realistic Copper app.
   - Good reference for `#[copper_runtime]`, logger setup, determinism, resim, and justfile helpers.
-- `examples/cu_flight_controller/`
+- [`examples/cu_flight_controller/`](https://github.com/copper-project/extra-examples/tree/master/examples/cu_flight_controller)
   - Canonical higher-complexity integration example.
   - Good reference for resources, simulation mode, and real application structure.
-- `examples/cu_rp_balancebot/`
+- [`examples/cu_rp_balancebot/`](https://github.com/copper-project/extra-examples/tree/master/examples/cu_rp_balancebot)
   - Canonical simulation/demo app.
   - Good reference when validating the "try Copper without hardware" workflow.
 - `examples/cu_resources_test/`
@@ -144,8 +144,8 @@ Use these as the quickest way to regain context:
 Default canonical example set for orientation and regression thinking:
 
 - `examples/cu_caterpillar/`
-- `examples/cu_flight_controller/`
-- `examples/cu_rp_balancebot/`
+- [`examples/cu_flight_controller/`](https://github.com/copper-project/extra-examples/tree/master/examples/cu_flight_controller)
+- [`examples/cu_rp_balancebot/`](https://github.com/copper-project/extra-examples/tree/master/examples/cu_rp_balancebot)
 
 ## Commands That Match CI
 
@@ -288,7 +288,7 @@ This is how you selectively keep or suppress message logging at node level.
 
 Good references:
 
-- `examples/cu_flight_controller/copperconfig.ron`
+- [`examples/cu_flight_controller/copperconfig.ron`](https://github.com/copper-project/extra-examples/blob/master/examples/cu_flight_controller/copperconfig.ron)
   - selective `logging: (enabled: true|false)` on tasks and bridges
   - root logging block with `slab_size_mib`, `section_size_mib`, `enable_task_logging`
 - `examples/cu_caterpillar/copperconfig.ron`
@@ -313,7 +313,7 @@ For replaying failures:
 - This is a first-class debugging path for robot/algorithm failures.
 - Good references:
   - `examples/cu_caterpillar/src/resim.rs`
-  - `examples/cu_rp_balancebot/src/resim.rs`
+  - [`examples/cu_rp_balancebot/src/resim.rs`](https://github.com/copper-project/extra-examples/blob/master/examples/cu_rp_balancebot/src/resim.rs)
   - `examples/cu_bridge_test/src/resim.rs`
 - In practice, resim is done with the normal runtime macro in simulation mode:
   - `#[copper_runtime(config = "...", sim_mode = true)]`

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ These are not mockups: BalanceBot is the exact same application that runs on a R
       <strong><a href="https://cdn.copper-robotics.com/demo/balancebot/index.html">BalanceBot</a></strong>
       <br />
       Self-balancing robot sim with a live Copper DAG and latency monitor.
+      <br />
+      <a href="https://github.com/copper-project/extra-examples/tree/master/examples/cu_rp_balancebot">Source code</a>
     </td>
     <td width="50%" valign="top">
       <a href="https://cdn.copper-robotics.com/demo/flight-controller/index.html">
@@ -44,6 +46,8 @@ These are not mockups: BalanceBot is the exact same application that runs on a R
       <strong><a href="https://cdn.copper-robotics.com/demo/flight-controller/index.html">Flight Controller</a></strong>
       <br />
       Quadcopter flight sim with the same live Copper monitor.
+      <br />
+      <a href="https://github.com/copper-project/extra-examples/tree/master/examples/cu_flight_controller">Source code</a>
     </td>
   </tr>
 </table>

--- a/components/bridges/cu_bdshot/README.md
+++ b/components/bridges/cu_bdshot/README.md
@@ -52,4 +52,4 @@ Declare the bridge and wire tasks to it:
 )
 ```
 
-See `examples/cu_elrs_bdshot_demo` for a full mission wiring CRSF RC input into BDShot ESCs on the RP2350 reference board.
+See [`examples/cu_elrs_bdshot_demo`](https://github.com/copper-project/extra-examples/tree/master/examples/cu_elrs_bdshot_demo) for a full mission wiring CRSF RC input into BDShot ESCs on the RP2350 reference board.

--- a/components/bridges/cu_crsf/README.md
+++ b/components/bridges/cu_crsf/README.md
@@ -39,7 +39,7 @@ bridges: [
 
 Provide your own bundle that moves a UART into the `ResourceManager` (as an owned resource). If your UART type is not `Sync`, wrap it once at bundle registration time with `cu_linux_resources::Exclusive<T>`.
 
-The `resources` module in `examples/cu_elrs_bdshot_demo` shows a complete pattern:
+The `resources` module in [`examples/cu_elrs_bdshot_demo`](https://github.com/copper-project/extra-examples/tree/master/examples/cu_elrs_bdshot_demo) shows a complete pattern:
 
 ```ron
 resources: [
@@ -55,4 +55,4 @@ bridges: [
 ],
 ```
 
-See `examples/cu_elrs_bdshot_demo` for a full wiring that feeds CRSF RC channels into a BDShot bridge on the RP2350 reference board.
+See [`examples/cu_elrs_bdshot_demo`](https://github.com/copper-project/extra-examples/tree/master/examples/cu_elrs_bdshot_demo) for a full wiring that feeds CRSF RC channels into a BDShot bridge on the RP2350 reference board.

--- a/components/bridges/cu_feetech/README.md
+++ b/components/bridges/cu_feetech/README.md
@@ -20,4 +20,4 @@ cargo run -p cu-feetech --bin feetech-calibrate -- /dev/ttyACM0 1 2 3 4 5 6 cali
 
 ## Example
 
-See the [cu-feetech-demo](../../examples/cu_feetech_demo) example for a minimal app that reads and logs positions.
+See the [cu-feetech-demo](https://github.com/copper-project/extra-examples/tree/master/examples/cu_feetech_demo) example for a minimal app that reads and logs positions.

--- a/components/bridges/cu_msp_bridge/README.md
+++ b/components/bridges/cu_msp_bridge/README.md
@@ -28,4 +28,4 @@ bridges: [
 ],
 ```
 
-For embedded targets, provide your own bundle that moves the UART into the `ResourceManager` as an owned resource. If your UART type is not `Sync`, wrap it once at bundle registration time with `cu_linux_resources::Exclusive<T>`. See `examples/cu_elrs_bdshot_demo` and `examples/cu_msp_bridge_loopback` for end-to-end wiring and config mutation.
+For embedded targets, provide your own bundle that moves the UART into the `ResourceManager` as an owned resource. If your UART type is not `Sync`, wrap it once at bundle registration time with `cu_linux_resources::Exclusive<T>`. See [`examples/cu_elrs_bdshot_demo`](https://github.com/copper-project/extra-examples/tree/master/examples/cu_elrs_bdshot_demo) and `examples/cu_msp_bridge_loopback` for end-to-end wiring and config mutation.

--- a/components/libs/cu_sdlogger/README.md
+++ b/components/libs/cu_sdlogger/README.md
@@ -36,4 +36,4 @@ Notes:
 - `append` and `flush_section` use bincode encoding and update the section header to keep usage counters accurate.
 - `ForceSyncSend` does not provide locking; use it only with single-threaded or
   externally synchronized access.
-- See `examples/cu_rp2350_skeleton` and `examples/cu_elrs_bdshot_demo` for full RP2350 setups that hand the logger to a `CuApplication`.
+- See `examples/cu_rp2350_skeleton` and [`examples/cu_elrs_bdshot_demo`](https://github.com/copper-project/extra-examples/tree/master/examples/cu_elrs_bdshot_demo) for full RP2350 setups that hand the logger to a `CuApplication`.

--- a/components/monitors/cu_bevymon/README.md
+++ b/components/monitors/cu_bevymon/README.md
@@ -18,7 +18,7 @@ Design intent:
 
 - reuse the same Ratatui rendering as `cu_consolemon`
 - reuse the same shared `LOG` pane, including Copper live logs and optional `stderr` capture
-- integrate into existing Bevy sims like `cu_rp_balancebot` and `cu_flight_controller`
+- integrate into existing Bevy sims like [`cu_rp_balancebot`](https://github.com/copper-project/extra-examples/tree/master/examples/cu_rp_balancebot) and [`cu_flight_controller`](https://github.com/copper-project/extra-examples/tree/master/examples/cu_flight_controller)
 - keep the rendering/backend split clean enough for later browser / wasm work
 
 Recommended app structure:
@@ -83,7 +83,7 @@ commands.entity(layout.sim_panel).with_children(|panel| {
 });
 ```
 
-The `cu_bevymon_demo`, `cu_rp_balancebot`, and `cu_flight_controller` examples all use that shared split shell now. The main app-specific choice is how the left-side scene camera is produced.
+The `cu_bevymon_demo`, [`cu_rp_balancebot`](https://github.com/copper-project/extra-examples/tree/master/examples/cu_rp_balancebot), and [`cu_flight_controller`](https://github.com/copper-project/extra-examples/tree/master/examples/cu_flight_controller) examples all use that shared split shell now. The main app-specific choice is how the left-side scene camera is produced.
 
 Render strategy guidance:
 

--- a/components/tasks/cu_pid/README.md
+++ b/components/tasks/cu_pid/README.md
@@ -1,6 +1,6 @@
 ### This is a Generic PID Controller
 
-Check out cu_rp_balancebot for a full example of how to use it.
+Check out [`cu_rp_balancebot`](https://github.com/copper-project/extra-examples/tree/master/examples/cu_rp_balancebot) for a full example of how to use it.
 
 ### Compatibility
 

--- a/core/cu29_export/README.md
+++ b/core/cu29_export/README.md
@@ -50,9 +50,9 @@ The intended pattern is:
 3. call `copperlist_iterator_unified_typed_py::<YourGeneratedType>(...)`
 
 See
-[`examples/cu_flight_controller/src/python_module.rs`](/home/gbin/projects/copper/copper-rs.python/examples/cu_flight_controller/src/python_module.rs)
+[`examples/cu_flight_controller/src/python_module.rs`](https://github.com/copper-project/extra-examples/blob/master/examples/cu_flight_controller/src/python_module.rs)
 and
-[`examples/cu_flight_controller/python/print_gnss_from_log.py`](/home/gbin/projects/copper/copper-rs.python/examples/cu_flight_controller/python/print_gnss_from_log.py)
+[`examples/cu_flight_controller/python/print_gnss_from_log.py`](https://github.com/copper-project/extra-examples/blob/master/examples/cu_flight_controller/python/print_gnss_from_log.py)
 for the reference implementation.
 
 ## Feature Flags


### PR DESCRIPTION
## Summary
Add links to moved heavy examples in README/AGENTS/component docs and replace stale local paths with the corresponding extra-examples GitHub URLs introduced by PR #1053.


## Related issues


## Changes

## Reminder
- [ ] I ran `just` from the repo root
- [x] I have updated docs or examples where needed

## Additional context
