### PR TITLE
tuimon: block_port OoB check

### DIFF
--- a/components/libs/cu_tuimon/src/tui_nodes/connection.rs
+++ b/components/libs/cu_tuimon/src/tui_nodes/connection.rs
@@ -261,6 +261,9 @@ impl ConnectionsLayout {
         if is_input {
             return;
         }
+        if coord.0 >= self.width || coord.1 >= self.height {
+            return;
+        }
         self.edge_field[(coord, Direction::North).into()] = Edge::Blocked;
         self.edge_field[(coord, Direction::South).into()] = Edge::Blocked;
     }


### PR DESCRIPTION
## Summary
When starting 8 parallels sources connected straight to sinks, I was getting the following panic:
```
CuConsoleMon panic: panicked at .cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cu-tuimon-0.15.0/src/tui_nodes/connection.rs:264:24:
index out of bounds: the len is 37 but the index is 38
Backtrace:
   0: <std::backtrace::Backtrace>::create
   1: cu_consolemon::init_error_hooks::{{closure}}
   2: std::panicking::panic_with_hook
   3: std::panicking::panic_handler::{closure#0}
   4: std::sys::backtrace::__rust_end_short_backtrace::<std::panicking::panic_handler::{closure#0}, !>
   5: __rustc::rust_begin_unwind
   6: core::panicking::panic_fmt
   7: core::panicking::panic_bounds_check
   8: cu_tuimon::tui_nodes::graph::NodeGraph::calculate
   9: cu_tuimon::ui::NodesScrollableWidgetState::build_graph
  10: <cu_tuimon::ui::NodesScrollableWidget as ratatui_core::widgets::stateful_widget::StatefulWidget>::render
  11: cu_tuimon::ui::MonitorUi::draw_content
  12: cu_tuimon::ui::MonitorUi::draw
  13: ratatui_core::terminal::terminal::Terminal<B>::try_draw
  14: cu_consolemon::UI::run_app
  15: std::sys::backtrace::__rust_begin_short_backtrace
  16: core::ops::function::FnOnce::call_once{{vtable.shim}}
  17: <std::sys::thread::unix::Thread>::new::thread_start
  18: <unknown>
  19: <unknown>
``` 

## Changes

Similar to what's done on `block_zone` above, `block_port` now checks for Out-of-Bound coordinates.
I think there might be some deeper issues in the way the graph is drawn (it's shifted a lot to the right and require to scroll horizontally to see it all) but at least this PR avoid panicking.

## Reminder
- [X] I ran `just` from the repo root
- [X] I have updated docs or examples where needed

## Additional context
