### PR TITLE
fix: byte accounting for codecs in monitors

### DIFF
--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -1293,6 +1293,7 @@ pub fn (M0, M1)::stop(&mut self, ctx: &cu29_runtime::context::CuContext) -> cu29
 pub fn cu29_runtime::monitoring::build_monitor_topology(config: &cu29_runtime::config::CuConfig, mission: &str) -> cu29_traits::CuResult<cu29_runtime::monitoring::MonitorTopology>
 pub fn cu29_runtime::monitoring::panic_payload_to_string(payload: &(dyn core::any::Any + core::marker::Send)) -> alloc::string::String
 pub fn cu29_runtime::monitoring::payload_io_stats<T>(payload: &T) -> cu29_traits::CuResult<cu29_runtime::monitoring::PayloadIoStats> where T: cu_bincode::enc::Encode
+pub fn cu29_runtime::monitoring::record_payload_handle_bytes(bytes: usize)
 pub fn cu29_runtime::monitoring::runtime_panic_hook_active() -> bool
 pub fn cu29_runtime::monitoring::start_copperlist_io_capture<const N: usize>(cache: &cu29_runtime::monitoring::CuMsgIoCache<N>) -> cu29_runtime::monitoring::CuMsgIoCaptureGuard
 pub fn cu29_runtime::monitoring::take_last_completed_handle_bytes() -> u64

--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -1003,7 +1003,7 @@ pub type cu29_runtime::logcodec::CuLogCodec::Config: serde_core::de::Deserialize
 pub fn cu29_runtime::logcodec::CuLogCodec::decode_payload<D: cu_bincode::de::Decoder<Context = ()>>(&mut self, decoder: &mut D) -> core::result::Result<P, cu_bincode::error::DecodeError>
 pub fn cu29_runtime::logcodec::CuLogCodec::encode_payload<E: cu_bincode::enc::Encoder>(&mut self, payload: &P, encoder: &mut E) -> core::result::Result<(), cu_bincode::error::EncodeError>
 pub fn cu29_runtime::logcodec::CuLogCodec::new(config: Self::Config) -> cu29_traits::CuResult<Self> where Self: core::marker::Sized
-pub fn cu29_runtime::logcodec::CuLogCodec::source_payload_handle_bytes(&self, _payload: &P) -> usize
+pub fn cu29_runtime::logcodec::CuLogCodec::source_payload_handle_bytes(&self, payload: &P) -> usize
 pub fn cu29_runtime::logcodec::decode_msg_with_codec<T, C, D>(decoder: &mut D, codec: &mut C) -> core::result::Result<cu29_runtime::cutask::CuMsg<T>, cu_bincode::error::DecodeError> where T: cu29_runtime::cutask::CuMsgPayload, C: cu29_runtime::logcodec::CuLogCodec<T>, D: cu_bincode::de::Decoder<Context = ()>
 pub fn cu29_runtime::logcodec::deserialize_codec_config<C, P>(config: core::option::Option<&cu29_runtime::config::ComponentConfig>) -> cu29_traits::CuResult<<C as cu29_runtime::logcodec::CuLogCodec>::Config> where C: cu29_runtime::logcodec::CuLogCodec<P>, P: cu29_runtime::cutask::CuMsgPayload
 pub fn cu29_runtime::logcodec::effective_config_entry<T: 'static>(default_ron: &str) -> &'static cu29_runtime::logcodec::EffectiveConfigEntry

--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -1003,6 +1003,7 @@ pub type cu29_runtime::logcodec::CuLogCodec::Config: serde_core::de::Deserialize
 pub fn cu29_runtime::logcodec::CuLogCodec::decode_payload<D: cu_bincode::de::Decoder<Context = ()>>(&mut self, decoder: &mut D) -> core::result::Result<P, cu_bincode::error::DecodeError>
 pub fn cu29_runtime::logcodec::CuLogCodec::encode_payload<E: cu_bincode::enc::Encoder>(&mut self, payload: &P, encoder: &mut E) -> core::result::Result<(), cu_bincode::error::EncodeError>
 pub fn cu29_runtime::logcodec::CuLogCodec::new(config: Self::Config) -> cu29_traits::CuResult<Self> where Self: core::marker::Sized
+pub fn cu29_runtime::logcodec::CuLogCodec::source_payload_handle_bytes(&self, _payload: &P) -> usize
 pub fn cu29_runtime::logcodec::decode_msg_with_codec<T, C, D>(decoder: &mut D, codec: &mut C) -> core::result::Result<cu29_runtime::cutask::CuMsg<T>, cu_bincode::error::DecodeError> where T: cu29_runtime::cutask::CuMsgPayload, C: cu29_runtime::logcodec::CuLogCodec<T>, D: cu_bincode::de::Decoder<Context = ()>
 pub fn cu29_runtime::logcodec::deserialize_codec_config<C, P>(config: core::option::Option<&cu29_runtime::config::ComponentConfig>) -> cu29_traits::CuResult<<C as cu29_runtime::logcodec::CuLogCodec>::Config> where C: cu29_runtime::logcodec::CuLogCodec<P>, P: cu29_runtime::cutask::CuMsgPayload
 pub fn cu29_runtime::logcodec::effective_config_entry<T: 'static>(default_ron: &str) -> &'static cu29_runtime::logcodec::EffectiveConfigEntry
@@ -1293,7 +1294,6 @@ pub fn (M0, M1)::stop(&mut self, ctx: &cu29_runtime::context::CuContext) -> cu29
 pub fn cu29_runtime::monitoring::build_monitor_topology(config: &cu29_runtime::config::CuConfig, mission: &str) -> cu29_traits::CuResult<cu29_runtime::monitoring::MonitorTopology>
 pub fn cu29_runtime::monitoring::panic_payload_to_string(payload: &(dyn core::any::Any + core::marker::Send)) -> alloc::string::String
 pub fn cu29_runtime::monitoring::payload_io_stats<T>(payload: &T) -> cu29_traits::CuResult<cu29_runtime::monitoring::PayloadIoStats> where T: cu_bincode::enc::Encode
-pub fn cu29_runtime::monitoring::record_payload_handle_bytes(bytes: usize)
 pub fn cu29_runtime::monitoring::runtime_panic_hook_active() -> bool
 pub fn cu29_runtime::monitoring::start_copperlist_io_capture<const N: usize>(cache: &cu29_runtime::monitoring::CuMsgIoCache<N>) -> cu29_runtime::monitoring::CuMsgIoCaptureGuard
 pub fn cu29_runtime::monitoring::take_last_completed_handle_bytes() -> u64

--- a/components/codecs/cu_ffv1_codec/src/lib.rs
+++ b/components/codecs/cu_ffv1_codec/src/lib.rs
@@ -222,6 +222,10 @@ impl CuLogCodec<CuImage<Vec<u8>>> for CuFfv1Codec {
         }
     }
 
+    fn source_payload_handle_bytes(&self, payload: &CuImage<Vec<u8>>) -> usize {
+        payload.format.byte_size()
+    }
+
     fn encode_payload<E: Encoder>(
         &mut self,
         payload: &CuImage<Vec<u8>>,
@@ -268,7 +272,6 @@ impl CuFfv1Codec {
         payload: &CuImage<Vec<u8>>,
         encoder: &mut E,
     ) -> Result<(), EncodeError> {
-        cu29::monitoring::record_payload_handle_bytes(payload.format.byte_size());
         let wire = encoded_frame_from_payload(payload, &self.config, &mut self.encoder)
             .map_err(|err| Self::encode_error(err.to_string()))?;
 

--- a/components/codecs/cu_ffv1_codec/src/lib.rs
+++ b/components/codecs/cu_ffv1_codec/src/lib.rs
@@ -268,6 +268,7 @@ impl CuFfv1Codec {
         payload: &CuImage<Vec<u8>>,
         encoder: &mut E,
     ) -> Result<(), EncodeError> {
+        cu29::monitoring::record_payload_handle_bytes(payload.format.byte_size());
         let wire = encoded_frame_from_payload(payload, &self.config, &mut self.encoder)
             .map_err(|err| Self::encode_error(err.to_string()))?;
 
@@ -1212,6 +1213,31 @@ mod tests {
                 bytes.to_vec()
             });
             assert_eq!(decoded_bytes, original_bytes);
+        }
+
+        #[test]
+        fn ffv1_codec_reports_handle_backed_source_bytes_to_monitoring() {
+            let image = sample_rgb3_padded();
+            let cache = cu29::monitoring::CuMsgIoCache::<1>::default();
+
+            {
+                let capture = cu29::monitoring::start_copperlist_io_capture(&cache);
+                capture.select_slot(0);
+                let _ = encode_to_vec(
+                    EncodedWithCodec {
+                        image: &image,
+                        codec: std::cell::RefCell::new(
+                            CuFfv1Codec::new(CuFfv1CodecConfig::default()).expect("codec"),
+                        ),
+                    },
+                    standard(),
+                )
+                .expect("encode");
+            }
+
+            let io = cache.get(0);
+            assert!(io.present);
+            assert_eq!(io.handle_bytes, image.format.byte_size() as u64);
         }
     }
 }

--- a/components/codecs/cu_png_codec/src/lib.rs
+++ b/components/codecs/cu_png_codec/src/lib.rs
@@ -294,6 +294,7 @@ impl CuLogCodec<CuImage<Vec<u8>>> for CuPngCodec {
 
         let byte_size = payload.format.byte_size();
         payload.seq.encode(encoder)?;
+        cu29::monitoring::record_payload_handle_bytes(byte_size);
         payload.buffer_handle.with_inner(|inner| {
             let image_bytes: &[u8] = inner;
             if image_bytes.len() < byte_size {
@@ -470,6 +471,31 @@ mod tests {
             bytes.to_vec()
         });
         assert_eq!(decoded_bytes, original_bytes);
+    }
+
+    #[test]
+    fn png_codec_reports_handle_backed_source_bytes_to_monitoring() {
+        let image = sample_image();
+        let cache = cu29::monitoring::CuMsgIoCache::<1>::default();
+
+        {
+            let capture = cu29::monitoring::start_copperlist_io_capture(&cache);
+            capture.select_slot(0);
+            let _ = encode_to_vec(
+                EncodedWithCodec {
+                    image: &image,
+                    codec: std::cell::RefCell::new(
+                        CuPngCodec::new(CuPngCodecConfig::default()).expect("codec"),
+                    ),
+                },
+                standard(),
+            )
+            .expect("encode");
+        }
+
+        let io = cache.get(0);
+        assert!(io.present);
+        assert_eq!(io.handle_bytes, image.format.byte_size() as u64);
     }
 
     #[test]

--- a/components/codecs/cu_png_codec/src/lib.rs
+++ b/components/codecs/cu_png_codec/src/lib.rs
@@ -272,6 +272,10 @@ impl CuLogCodec<CuImage<Vec<u8>>> for CuPngCodec {
         })
     }
 
+    fn source_payload_handle_bytes(&self, payload: &CuImage<Vec<u8>>) -> usize {
+        payload.format.byte_size()
+    }
+
     fn encode_payload<E: Encoder>(
         &mut self,
         payload: &CuImage<Vec<u8>>,
@@ -294,7 +298,6 @@ impl CuLogCodec<CuImage<Vec<u8>>> for CuPngCodec {
 
         let byte_size = payload.format.byte_size();
         payload.seq.encode(encoder)?;
-        cu29::monitoring::record_payload_handle_bytes(byte_size);
         payload.buffer_handle.with_inner(|inner| {
             let image_bytes: &[u8] = inner;
             if image_bytes.len() < byte_size {

--- a/components/monitors/cu_consolemon/Cargo.toml
+++ b/components/monitors/cu_consolemon/Cargo.toml
@@ -29,7 +29,6 @@ compact_str = { workspace = true }
 ratatui = "0.30"
 ansi-to-tui = { version = "8.0.0", default-features = false }
 tui-widgets = "0.7.0"
-color-eyre = { version = "0.6.4", default-features = false }
 gag = "1.0.0"
 arboard = { version = "3.6.1", optional = true, default-features = false }
 

--- a/components/monitors/cu_consolemon/src/lib.rs
+++ b/components/monitors/cu_consolemon/src/lib.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "debug_pane")]
 use arboard::Clipboard;
-use color_eyre::config::HookBuilder;
 #[cfg(feature = "debug_pane")]
 use cu_tuimon::MonitorLogCapture;
 pub use cu_tuimon::{
@@ -24,10 +23,10 @@ use ratatui::crossterm::tty::IsTty;
 use ratatui::crossterm::{event, execute};
 use ratatui::{Terminal, TerminalOptions, Viewport};
 use std::io::{stdin, stdout};
+use std::sync::Arc;
 #[cfg(feature = "debug_pane")]
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, OnceLock};
 use std::thread::JoinHandle;
 use std::time::Duration;
 use std::{io, thread};
@@ -69,7 +68,6 @@ struct UI {
 
 impl UI {
     fn new(model: MonitorModel, quitting: Arc<AtomicBool>) -> Self {
-        init_error_hooks();
         Self {
             monitor_ui: MonitorUi::new(
                 model,
@@ -351,23 +349,6 @@ impl Drop for TerminalRestoreGuard {
     fn drop(&mut self) {
         let _ = restore_terminal();
     }
-}
-
-fn init_error_hooks() {
-    static ONCE: OnceLock<()> = OnceLock::new();
-    if ONCE.get().is_some() {
-        return;
-    }
-
-    let (_unused_panic_hook, error) = HookBuilder::default().into_hooks();
-    let error = error.into_eyre_hook();
-    color_eyre::eyre::set_hook(Box::new(move |err| {
-        let _ = restore_terminal();
-        error(err)
-    }))
-    .unwrap();
-
-    let _ = ONCE.set(());
 }
 
 fn setup_terminal() -> io::Result<()> {

--- a/core/cu29_runtime/src/logcodec.rs
+++ b/core/cu29_runtime/src/logcodec.rs
@@ -59,6 +59,14 @@ pub trait CuLogCodec<P: CuMsgPayload>: 'static {
     where
         Self: Sized;
 
+    /// Returns handle-backed source bytes read directly by the codec.
+    ///
+    /// This reports only extra handle-backed residency beyond the payload's
+    /// fixed `size_of::<P>()` footprint already accounted by runtime
+    /// monitoring. Codecs must implement this explicitly so they opt into the
+    /// correct accounting model for their payload type.
+    fn source_payload_handle_bytes(&self, payload: &P) -> usize;
+
     fn encode_payload<E: Encoder>(
         &mut self,
         payload: &P,
@@ -294,6 +302,10 @@ where
             1u8.encode(encoder)?;
             let encoded_start = observed_encode_bytes();
             let handle_start = crate::monitoring::current_payload_handle_bytes();
+            let source_handle_bytes = codec.source_payload_handle_bytes(payload);
+            if source_handle_bytes > 0 {
+                crate::monitoring::record_payload_handle_bytes(source_handle_bytes);
+            }
             codec.encode_payload(payload, encoder)?;
             let encoded_bytes = observed_encode_bytes().saturating_sub(encoded_start);
             let handle_bytes =

--- a/core/cu29_runtime/src/monitoring.rs
+++ b/core/cu29_runtime/src/monitoring.rs
@@ -1345,11 +1345,9 @@ fn current_payload_io_measurement() -> usize {
 /// Records handle-backed payload bytes for the active CopperList IO capture.
 ///
 /// This is called automatically by handle encoders such as `CuHandle::encode()`.
-/// Custom log codecs that read handle-backed buffers directly must call it
-/// explicitly so runtime monitoring can still account for the source payload
-/// residency even when the normal payload `Encode` path is bypassed.
+/// Custom log codecs report equivalent bytes via `CuLogCodec::source_payload_handle_bytes()`.
 #[cfg(feature = "std")]
-pub fn record_payload_handle_bytes(bytes: usize) {
+pub(crate) fn record_payload_handle_bytes(bytes: usize) {
     #[cfg(feature = "std")]
     PAYLOAD_HANDLE_BYTES.with(|total| {
         if let Some(current) = total.get() {

--- a/core/cu29_runtime/src/monitoring.rs
+++ b/core/cu29_runtime/src/monitoring.rs
@@ -1342,8 +1342,14 @@ fn current_payload_io_measurement() -> usize {
     }
 }
 
+/// Records handle-backed payload bytes for the active CopperList IO capture.
+///
+/// This is called automatically by handle encoders such as `CuHandle::encode()`.
+/// Custom log codecs that read handle-backed buffers directly must call it
+/// explicitly so runtime monitoring can still account for the source payload
+/// residency even when the normal payload `Encode` path is bypassed.
 #[cfg(feature = "std")]
-pub(crate) fn record_payload_handle_bytes(bytes: usize) {
+pub fn record_payload_handle_bytes(bytes: usize) {
     #[cfg(feature = "std")]
     PAYLOAD_HANDLE_BYTES.with(|total| {
         if let Some(current) = total.get() {

--- a/core/cu29_runtime/src/monitoring.rs
+++ b/core/cu29_runtime/src/monitoring.rs
@@ -1346,7 +1346,6 @@ fn current_payload_io_measurement() -> usize {
 ///
 /// This is called automatically by handle encoders such as `CuHandle::encode()`.
 /// Custom log codecs report equivalent bytes via `CuLogCodec::source_payload_handle_bytes()`.
-#[cfg(feature = "std")]
 pub(crate) fn record_payload_handle_bytes(bytes: usize) {
     #[cfg(feature = "std")]
     PAYLOAD_HANDLE_BYTES.with(|total| {


### PR DESCRIPTION
## Summary

The current implementation of the codecs did not register the size of the encoded data -> it was reporting basically zero which breaks the monitors

## Related issues
- Closes #1087

## Changes

## Reminder
- [ ] I ran `just` from the repo root
- [ ] I have updated docs or examples where needed

## Additional context
