### PR TITLE
RUSTSEC-2025-0140: this is not affecting us as it is through cargo-generate.

### DIFF
--- a/.config/deny.toml
+++ b/.config/deny.toml
@@ -8,4 +8,5 @@ ignore = [
   "RUSTSEC-2026-0041", # lz4_flex security vulnerability detected. https://rustsec.org/advisories/RUSTSEC-2026-0041
   "RUSTSEC-2025-0134", # rustls-pemfile is unmaintained. https://rustsec.org/advisories/RUSTSEC-2025-0134
   "RUSTSEC-2026-0110", # bare-metal is deprecated; stm32h7xx-hal 0.16.0 still depends on it and no safe upgrade is available.
+  "RUSTSEC-2025-0140", # gix-date UB advisory via cargo-cunew -> cargo-generate; no upstream release fixes it yet.
 ]


### PR DESCRIPTION
## Summary

## Related issues
- Closes #

## Changes

## Reminder
- [ ] I ran `just` from the repo root
- [ ] I have updated docs or examples where needed

## Additional context
