### PR TITLE
fix: capture arguments in logging

### DIFF
--- a/core/cu29_log/src/lib.rs
+++ b/core/cu29_log/src/lib.rs
@@ -198,14 +198,14 @@ pub fn format_logline(
             }
             formatted = formatted.replacen("{}", param, 1);
         }
-        if formatted.contains("{}") && !named_params.is_empty() {
+        if !named_params.is_empty() {
             let mut named = named_params.iter().collect::<Vec<_>>();
             named.sort_by(|a, b| a.0.cmp(b.0));
-            for (_, value) in named {
-                if !formatted.contains("{}") {
-                    break;
+            for (name, value) in named {
+                if formatted.contains("{}") {
+                    formatted = formatted.replacen("{}", value, 1);
                 }
-                formatted = formatted.replacen("{}", value, 1);
+                formatted = formatted.replace(&format!("{{{name}}}"), value);
             }
         }
         return Ok(format!("{time} [{level:?}]: {formatted}"));
@@ -408,5 +408,26 @@ mod tests {
         let entry = CuLogEntry::new(42, CuLogLevel::Warning);
         assert_eq!(entry.level, CuLogLevel::Warning);
         assert_eq!(entry.msg_index, 42);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_rebuild_logline_mixes_named_and_positional_placeholders() {
+        let all_interned_strings = vec![
+            "File closed after hash was calculated Hash: {hash}, size: {size};\n{}".to_string(),
+            "hash".to_string(),
+            "size".to_string(),
+        ];
+        let mut entry = CuLogEntry::new(0, CuLogLevel::Debug);
+        entry.add_param(ANONYMOUS, Value::String("event payload".to_string()));
+        entry.add_param(1, Value::String("0x000000000".to_string()));
+        entry.add_param(2, Value::U64(420));
+
+        let line = rebuild_logline(&all_interned_strings, &entry).unwrap();
+
+        assert_eq!(
+            line,
+            "0 ns [Debug]: File closed after hash was calculated Hash: 0x000000000, size: 420;\nevent payload"
+        );
     }
 }

--- a/core/cu29_log_runtime/src/lib.rs
+++ b/core/cu29_log_runtime/src/lib.rs
@@ -73,14 +73,14 @@ pub fn format_message_only(
             }
             formatted = formatted.replacen("{}", param, 1);
         }
-        if formatted.contains("{}") && !named_params.is_empty() {
+        if !named_params.is_empty() {
             let mut named = named_params.iter().collect::<Vec<_>>();
             named.sort_by(|a, b| a.0.cmp(b.0));
-            for (_, value) in named {
-                if !formatted.contains("{}") {
-                    break;
+            for (name, value) in named {
+                if formatted.contains("{}") {
+                    formatted = formatted.replacen("{}", value, 1);
                 }
-                formatted = formatted.replacen("{}", value, 1);
+                formatted = formatted.replace(&format!("{{{name}}}"), value);
             }
         }
         return Ok(formatted);
@@ -172,11 +172,16 @@ impl LoggerRuntime {
             register_live_log_listener(move |entry, format_str, param_names| {
                 // Build a text line from structured data—no parsing.
                 let params: Vec<String> = entry.params.iter().map(|v| v.to_string()).collect();
-                let named_params: HashMap<String, String> = param_names
-                    .iter()
-                    .zip(params.iter())
-                    .map(|(name, value)| (name.to_string(), value.clone()))
-                    .collect();
+                let mut named_params = HashMap::new();
+                let mut param_names_iter = param_names.iter();
+                for (name_index, value) in entry.paramname_indexes.iter().zip(params.iter()) {
+                    if *name_index != cu29_log::ANONYMOUS {
+                        let Some(name) = param_names_iter.next() else {
+                            continue;
+                        };
+                        named_params.insert(name.to_string(), value.clone());
+                    }
+                }
                 if let Ok(line) = format_message_only(format_str, params.as_slice(), &named_params)
                 {
                     logger.log(
@@ -438,5 +443,26 @@ mod tests {
         let decoded_tuple: (CuLogEntry, usize) =
             bincode::decode_from_slice(&encoded, standard()).unwrap();
         assert_eq!(log_entry, decoded_tuple.0);
+    }
+
+    #[cfg(all(feature = "std", debug_assertions))]
+    #[test]
+    fn test_format_message_only_mixes_named_and_positional_placeholders() {
+        let params = vec!["event payload".to_string()];
+        let mut named_params = std::collections::HashMap::new();
+        named_params.insert("hash".to_string(), "0x000000000".to_string());
+        named_params.insert("size".to_string(), "420".to_string());
+
+        let formatted = crate::format_message_only(
+            "File closed after hash was calculated Hash: {hash}, size: {size};\n{}",
+            &params,
+            &named_params,
+        )
+        .unwrap();
+
+        assert_eq!(
+            formatted,
+            "File closed after hash was calculated Hash: 0x000000000, size: 420;\nevent payload"
+        );
     }
 }


### PR DESCRIPTION
 ## Summary

  Fix structured text log formatting when a log message mixes named placeholders like `{hash}` with positional placeholders like `{}`.

  ## Related issues
  - Closes #962

  ## Changes

  - Replace named placeholders in the existing positional-formatting path for rebuilt text logs.
  - Apply the same minimal formatting fix to debug live-text log formatting.
  - Correct debug live-text named parameter mapping so anonymous parameters are not accidentally paired with named parameter labels.
  - Add regression tests for mixed named and positional placeholders.

  ## Reminder
  - [x] I ran `just` from the repo root
  - [x] I have updated docs or examples where needed
