### PR TITLE
Fix cu-tuimon hostname lookup on Windows

### DIFF
--- a/components/libs/cu_tuimon/Cargo.toml
+++ b/components/libs/cu_tuimon/Cargo.toml
@@ -43,8 +43,8 @@ tui-widgets = { version = "0.7.0", default-features = false, features = [
 web-time = "1.1.0"
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
+hostname = "0.4.2"
 dotenvy = { version = "0.15.7", optional = true }
-libc = { workspace = true }
 libmacchina = { version = "8.1.0", optional = true }
 pfetch = { version = "2.11.1", optional = true }
 pfetch-logo-parser = { version = "0.1.1", optional = true }

--- a/components/libs/cu_tuimon/src/model.rs
+++ b/components/libs/cu_tuimon/src/model.rs
@@ -348,18 +348,13 @@ pub(crate) struct MonitorFooterIdentity {
 
 #[cfg(native)]
 fn cached_system_name() -> CompactString {
-    let mut buf = [0u8; 256];
-    let result = unsafe { libc::gethostname(buf.as_mut_ptr().cast(), buf.len()) };
-    if result == 0 {
-        let end = buf.iter().position(|byte| *byte == 0).unwrap_or(buf.len());
-        if let Ok(hostname) = core::str::from_utf8(&buf[..end]) {
-            let hostname = hostname.trim();
-            if !hostname.is_empty() {
-                return CompactString::from(hostname);
-            }
-        }
-    }
-    CompactString::from("unknown-host")
+    hostname::get()
+        .ok()
+        .and_then(|hostname| hostname.into_string().ok())
+        .map(|hostname| hostname.trim().to_string())
+        .filter(|hostname| !hostname.is_empty())
+        .map(CompactString::from)
+        .unwrap_or_else(|| CompactString::from("unknown-host"))
 }
 
 #[cfg(browser)]


### PR DESCRIPTION
## Summary
Fixes hostname retrieval in `cu-tuimon` for Windows/native builds.

The previous `native` implementation used `libc::gethostname`, which assumes a
Unix-style libc path. That works on Unix-like systems, but it does not match the
broader set of native platforms covered by Copper's `native` build path and
caused build issues on Windows.

## Changes
This change does the following:
- Replaces the `native` hostname lookup with the [`hostname`](https://crates.io/crates/hostname) crate
- Keeps the existing browser implementation unchanged
- Includes `hostname` only for native targets

## Reason
`cu-tuimon` currently has separate `native` and `browser` code paths.
The previous `native` implementation assumed a Unix-specific hostname API for all native targets. 
Using `hostname`, a cross-platform hostname crate, preserves the structure while avoiding platform-specific handling of hostname inside `cu-tuimon`.

## Validation
I validated the implementation with:
- `cargo check -p cu-tuimon`
- `cargo check -p cu-tuimon --target wasm32-unknown-unknown`

## Reminder
- [x] I have updated docs or examples where needed
