### PR TITLE
Prelim safety coverage for monitors

### DIFF
--- a/components/monitors/cu_safetymon/Cargo.toml
+++ b/components/monitors/cu_safetymon/Cargo.toml
@@ -17,6 +17,15 @@ kind = "monitor"
 domains = ["monitor/safety"]
 environments = ["host", "embedded"]
 
+[package.metadata.copper-safety]
+scope = "monitor/safety"
+
+[[test]]
+name = "safety_ids"
+path = "tests/safety_ids.rs"
+harness = false
+required-features = ["safety-ids"]
+
 [lib]
 path = "src/lib.rs"
 
@@ -31,3 +40,4 @@ cu-logmon = { path = "../cu_logmon", version = "1.0.0-rc2", default-features = f
 [features]
 default = ["std"]
 std = ["cu29/std"]
+safety-ids = ["std", "cu29/safety-ids"]

--- a/components/monitors/cu_safetymon/src/lib.rs
+++ b/components/monitors/cu_safetymon/src/lib.rs
@@ -29,6 +29,8 @@ extern crate alloc;
 
 #[cfg(not(feature = "std"))]
 mod nostd_impl;
+#[cfg(all(feature = "std", any(test, feature = "safety-ids")))]
+mod safety_cases;
 #[cfg(feature = "std")]
 mod std_impl;
 
@@ -36,3 +38,9 @@ mod std_impl;
 pub use nostd_impl::CuSafetyMon;
 #[cfg(feature = "std")]
 pub use std_impl::CuSafetyMon;
+
+#[cfg(all(feature = "std", feature = "safety-ids"))]
+#[doc(hidden)]
+pub fn link_safety_ids() {
+    safety_cases::link_safety_ids();
+}

--- a/components/monitors/cu_safetymon/src/safety_cases.rs
+++ b/components/monitors/cu_safetymon/src/safety_cases.rs
@@ -1,0 +1,134 @@
+use crate::CuSafetyMon;
+use cu29::prelude::*;
+
+const MONITORED_COMPONENTS: &[MonitorComponentMetadata] = &[
+    MonitorComponentMetadata::new("planner", ComponentType::Task, None),
+    MonitorComponentMetadata::new("driver", ComponentType::Task, None),
+];
+const CULIST_COMPONENT_MAPPING: &[ComponentId] = &[ComponentId::new(0)];
+
+fn config_with_single_monitor(extra_config: &str) -> CuConfig {
+    let ron = format!(
+        r#"
+(
+    tasks: [],
+    cnx: [],
+    monitors: [(
+        type: "cu_safetymon::CuSafetyMon",
+        config: {{
+            {extra_config}
+        }},
+    )],
+)
+"#
+    );
+    CuConfig::deserialize_ron(&ron).expect("failed to parse monitor config")
+}
+
+fn monitor_metadata(config: &CuConfig) -> (CuMonitoringMetadata, CuMonitoringRuntime) {
+    let metadata = CuMonitoringMetadata::new(
+        DEFAULT_MISSION_ID.into(),
+        MONITORED_COMPONENTS,
+        CULIST_COMPONENT_MAPPING,
+        CopperListInfo::new(0, 0),
+        MonitorTopology::default(),
+        config
+            .get_monitor_configs()
+            .first()
+            .and_then(|entry| entry.get_config().cloned()),
+    )
+    .expect("valid monitor metadata");
+    let runtime = CuMonitoringRuntime::default();
+    (metadata, runtime)
+}
+
+fn new_monitor(extra_config: &str) -> CuResult<CuSafetyMon> {
+    let config = config_with_single_monitor(extra_config);
+    let (metadata, runtime) = monitor_metadata(&config);
+    CuSafetyMon::new(metadata, runtime)
+}
+
+#[cfg_attr(test, test)]
+#[safety_case("SMON-TEST-001")]
+fn safety_monitor_rejects_non_positive_watchdog_timing() {
+    let deadline_error = match new_monitor(r#""copperlist_deadline_ms": 0,"#) {
+        Ok(_) => panic!("expected invalid copperlist_deadline_ms to fail"),
+        Err(error) => error,
+    };
+    safety_check!(
+        "SMON-TEST-001-C1",
+        "SMON-REQ-001",
+        deadline_error
+            .to_string()
+            .contains("copperlist_deadline_ms must be > 0"),
+    );
+
+    let period_error = match new_monitor(
+        r#"
+        "copperlist_deadline_ms": 100,
+        "watchdog_period_ms": 0,
+    "#,
+    ) {
+        Ok(_) => panic!("expected invalid watchdog_period_ms to fail"),
+        Err(error) => error,
+    };
+    safety_check!(
+        "SMON-TEST-001-C2",
+        "SMON-REQ-001",
+        period_error
+            .to_string()
+            .contains("watchdog_period_ms must be > 0"),
+    );
+}
+
+#[cfg_attr(test, test)]
+#[safety_case("SMON-TEST-002")]
+fn safety_monitor_accepts_default_and_configured_fault_codes() {
+    safety_check!("SMON-TEST-002-C1", "SMON-REQ-002", new_monitor("").is_ok(),);
+
+    safety_check!(
+        "SMON-TEST-002-C2",
+        "SMON-REQ-002",
+        new_monitor(
+            r#"
+            "copperlist_deadline_ms": 10,
+            "watchdog_period_ms": 5,
+            "exit_code_shutdown": 65,
+            "exit_code_lock": 66,
+            "exit_code_panic": 67,
+        "#
+        )
+        .is_ok(),
+    );
+}
+
+#[cfg_attr(test, test)]
+#[safety_case("SMON-TEST-003")]
+fn safety_monitor_turns_runtime_errors_into_shutdown_decisions() {
+    let monitor = new_monitor(
+        r#"
+        "copperlist_deadline_ms": 1000,
+        "watchdog_period_ms": 100,
+        "exit_code_shutdown": 65,
+    "#,
+    )
+    .expect("safety monitor");
+
+    let decision = monitor.process_error(
+        ComponentId::new(1),
+        CuComponentState::Process,
+        &CuError::from("fault"),
+    );
+    safety_check!(
+        "SMON-TEST-003-C1",
+        "SMON-REQ-003",
+        matches!(decision, Decision::Shutdown),
+    );
+}
+
+#[cfg(feature = "safety-ids")]
+pub fn link_safety_ids() {
+    let _ = safety_monitor_rejects_non_positive_watchdog_timing as fn();
+    let _ = safety_monitor_accepts_default_and_configured_fault_codes as fn();
+    let _ = safety_monitor_turns_runtime_errors_into_shutdown_decisions as fn();
+}

--- a/components/monitors/cu_safetymon/tests/safety_ids.rs
+++ b/components/monitors/cu_safetymon/tests/safety_ids.rs
@@ -1,0 +1,21 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let out = parse_out_path();
+    cu_safetymon::link_safety_ids();
+    let index = cu29::safety::collect_package_index(env!("CARGO_PKG_NAME"));
+    cu29::safety::write_package_index_json(&out, &index).expect("failed to write safety ID dump");
+}
+
+fn parse_out_path() -> PathBuf {
+    let mut args = env::args().skip(1);
+    let flag = args.next().expect("expected '--out <path>'");
+    let path = args.next().expect("expected '--out <path>'");
+    assert_eq!(flag, "--out", "expected '--out <path>'");
+    assert!(
+        args.next().is_none(),
+        "unexpected extra arguments, expected only '--out <path>'",
+    );
+    PathBuf::from(path)
+}

--- a/examples/cu_baremetal_safety/Cargo.toml
+++ b/examples/cu_baremetal_safety/Cargo.toml
@@ -13,6 +13,9 @@ repository.workspace = true
 
 publish = false
 
+[package.metadata.copper-safety]
+scope = "bare-metal-no-std"
+
 [[test]]
 name = "safety_ids"
 path = "tests/safety_ids.rs"


### PR DESCRIPTION
## Summary

This is just linking ids for the safety case, no change in behavior.

## Related issues
- Closes #

## Changes

## Reminder
- [ ] I ran `just` from the repo root
- [ ] I have updated docs or examples where needed

## Additional context
