### PR TITLE
feat: monitor for custom memory (heap) allocator

### DIFF
--- a/.github/actions/rust-ci-setup/action.yml
+++ b/.github/actions/rust-ci-setup/action.yml
@@ -107,6 +107,17 @@ runs:
       if: inputs.install_nextest == 'true'
       uses: taiki-e/install-action@nextest
 
+    # The justfile uses just's `shell(...)` function which was added in 1.27.0.
+    # Linux host runners get just 1.21 from apt, which fails to parse the
+    # justfile. Install a current just binary from the upstream release feed;
+    # taiki places it in ~/.cargo/bin which precedes /usr/bin on PATH so this
+    # also overrides any apt-installed just inside prebaked images.
+    - name: Install recent just (Linux)
+      if: runner.os == 'Linux'
+      uses: taiki-e/install-action@v2
+      with:
+        tool: just
+
     - name: Set workspace scope
       if: inputs.set_workspace_flag == 'true'
       shell: bash

--- a/.github/actions/rust-ci-setup/action.yml
+++ b/.github/actions/rust-ci-setup/action.yml
@@ -107,17 +107,6 @@ runs:
       if: inputs.install_nextest == 'true'
       uses: taiki-e/install-action@nextest
 
-    # The justfile uses just's `shell(...)` function which was added in 1.27.0.
-    # Linux host runners get just 1.21 from apt, which fails to parse the
-    # justfile. Install a current just binary from the upstream release feed;
-    # taiki places it in ~/.cargo/bin which precedes /usr/bin on PATH so this
-    # also overrides any apt-installed just inside prebaked images.
-    - name: Install recent just (Linux)
-      if: runner.os == 'Linux'
-      uses: taiki-e/install-action@v2
-      with:
-        tool: just
-
     - name: Set workspace scope
       if: inputs.set_workspace_flag == 'true'
       shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
   "components/monitors/cu_consolemon",
   "components/monitors/cu_bevymon",
   "components/monitors/cu_logmon",
+  "components/monitors/cu_memmon",
   "components/monitors/cu_safetymon",
   "components/payloads/cu_ros2_payloads",
   "components/payloads/cu_gnss_payloads",

--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -1275,6 +1275,7 @@ pub cu29_runtime::monitoring::MonitorTopology::nodes: alloc::vec::Vec<cu29_runti
 pub struct cu29_runtime::monitoring::NoMonitor
 impl cu29_runtime::monitoring::CuMonitor for cu29_runtime::monitoring::NoMonitor
 pub fn cu29_runtime::monitoring::NoMonitor::new(_metadata: cu29_runtime::monitoring::CuMonitoringMetadata, _runtime: cu29_runtime::monitoring::CuMonitoringRuntime) -> cu29_traits::CuResult<Self>
+pub fn cu29_runtime::monitoring::NoMonitor::observe_alloc(&self, _component_id: cu29_runtime::monitoring::ComponentId, _step: cu29_runtime::monitoring::CuComponentState, _allocated_bytes: usize, _deallocated_bytes: usize)
 pub fn cu29_runtime::monitoring::NoMonitor::observe_copperlist_io(&self, _stats: cu29_runtime::monitoring::CopperListIoStats)
 pub fn cu29_runtime::monitoring::NoMonitor::process_copperlist(&self, _ctx: &cu29_runtime::context::CuContext, _view: cu29_runtime::monitoring::CopperListView<'_>) -> cu29_traits::CuResult<()>
 pub fn cu29_runtime::monitoring::NoMonitor::process_error(&self, _component_id: cu29_runtime::monitoring::ComponentId, _step: cu29_runtime::monitoring::CuComponentState, _error: &cu29_traits::CuError) -> cu29_runtime::monitoring::Decision
@@ -1304,8 +1305,16 @@ pub fn cu29_runtime::monitoring::RuntimeExecutionProbe::record(&self, marker: cu
 pub fn cu29_runtime::monitoring::RuntimeExecutionProbe::sequence(&self) -> usize
 impl core::default::Default for cu29_runtime::monitoring::RuntimeExecutionProbe
 pub fn cu29_runtime::monitoring::RuntimeExecutionProbe::default() -> Self
+pub struct cu29_runtime::monitoring::ScopedAllocCounter
+impl cu29_runtime::monitoring::ScopedAllocCounter
+pub fn cu29_runtime::monitoring::ScopedAllocCounter::allocated(&self) -> usize
+pub fn cu29_runtime::monitoring::ScopedAllocCounter::deallocated(&self) -> usize
+pub fn cu29_runtime::monitoring::ScopedAllocCounter::new() -> Self
+impl core::default::Default for cu29_runtime::monitoring::ScopedAllocCounter
+pub fn cu29_runtime::monitoring::ScopedAllocCounter::default() -> Self
 pub trait cu29_runtime::monitoring::CuMonitor: core::marker::Sized
 pub fn cu29_runtime::monitoring::CuMonitor::new(metadata: cu29_runtime::monitoring::CuMonitoringMetadata, runtime: cu29_runtime::monitoring::CuMonitoringRuntime) -> cu29_traits::CuResult<Self> where Self: core::marker::Sized
+pub fn cu29_runtime::monitoring::CuMonitor::observe_alloc(&self, _component_id: cu29_runtime::monitoring::ComponentId, _step: cu29_runtime::monitoring::CuComponentState, _allocated_bytes: usize, _deallocated_bytes: usize)
 pub fn cu29_runtime::monitoring::CuMonitor::observe_copperlist_io(&self, _stats: cu29_runtime::monitoring::CopperListIoStats)
 pub fn cu29_runtime::monitoring::CuMonitor::process_copperlist(&self, _ctx: &cu29_runtime::context::CuContext, view: cu29_runtime::monitoring::CopperListView<'_>) -> cu29_traits::CuResult<()>
 pub fn cu29_runtime::monitoring::CuMonitor::process_error(&self, component_id: cu29_runtime::monitoring::ComponentId, step: cu29_runtime::monitoring::CuComponentState, error: &cu29_traits::CuError) -> cu29_runtime::monitoring::Decision
@@ -1314,6 +1323,7 @@ pub fn cu29_runtime::monitoring::CuMonitor::start(&mut self, _ctx: &cu29_runtime
 pub fn cu29_runtime::monitoring::CuMonitor::stop(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
 impl cu29_runtime::monitoring::CuMonitor for cu29_runtime::monitoring::NoMonitor
 pub fn cu29_runtime::monitoring::NoMonitor::new(_metadata: cu29_runtime::monitoring::CuMonitoringMetadata, _runtime: cu29_runtime::monitoring::CuMonitoringRuntime) -> cu29_traits::CuResult<Self>
+pub fn cu29_runtime::monitoring::NoMonitor::observe_alloc(&self, _component_id: cu29_runtime::monitoring::ComponentId, _step: cu29_runtime::monitoring::CuComponentState, _allocated_bytes: usize, _deallocated_bytes: usize)
 pub fn cu29_runtime::monitoring::NoMonitor::observe_copperlist_io(&self, _stats: cu29_runtime::monitoring::CopperListIoStats)
 pub fn cu29_runtime::monitoring::NoMonitor::process_copperlist(&self, _ctx: &cu29_runtime::context::CuContext, _view: cu29_runtime::monitoring::CopperListView<'_>) -> cu29_traits::CuResult<()>
 pub fn cu29_runtime::monitoring::NoMonitor::process_error(&self, _component_id: cu29_runtime::monitoring::ComponentId, _step: cu29_runtime::monitoring::CuComponentState, _error: &cu29_traits::CuError) -> cu29_runtime::monitoring::Decision
@@ -1322,6 +1332,7 @@ pub fn cu29_runtime::monitoring::NoMonitor::start(&mut self, _ctx: &cu29_runtime
 pub fn cu29_runtime::monitoring::NoMonitor::stop(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
 impl<M0: cu29_runtime::monitoring::CuMonitor, M1: cu29_runtime::monitoring::CuMonitor, M2: cu29_runtime::monitoring::CuMonitor, M3: cu29_runtime::monitoring::CuMonitor, M4: cu29_runtime::monitoring::CuMonitor, M5: cu29_runtime::monitoring::CuMonitor> cu29_runtime::monitoring::CuMonitor for (M0, M1, M2, M3, M4, M5)
 pub fn (M0, M1, M2, M3, M4, M5)::new(metadata: cu29_runtime::monitoring::CuMonitoringMetadata, runtime: cu29_runtime::monitoring::CuMonitoringRuntime) -> cu29_traits::CuResult<Self> where Self: core::marker::Sized
+pub fn (M0, M1, M2, M3, M4, M5)::observe_alloc(&self, component_id: cu29_runtime::monitoring::ComponentId, step: cu29_runtime::monitoring::CuComponentState, allocated_bytes: usize, deallocated_bytes: usize)
 pub fn (M0, M1, M2, M3, M4, M5)::observe_copperlist_io(&self, stats: cu29_runtime::monitoring::CopperListIoStats)
 pub fn (M0, M1, M2, M3, M4, M5)::process_copperlist(&self, ctx: &cu29_runtime::context::CuContext, view: cu29_runtime::monitoring::CopperListView<'_>) -> cu29_traits::CuResult<()>
 pub fn (M0, M1, M2, M3, M4, M5)::process_error(&self, component_id: cu29_runtime::monitoring::ComponentId, step: cu29_runtime::monitoring::CuComponentState, error: &cu29_traits::CuError) -> cu29_runtime::monitoring::Decision
@@ -1330,6 +1341,7 @@ pub fn (M0, M1, M2, M3, M4, M5)::start(&mut self, ctx: &cu29_runtime::context::C
 pub fn (M0, M1, M2, M3, M4, M5)::stop(&mut self, ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
 impl<M0: cu29_runtime::monitoring::CuMonitor, M1: cu29_runtime::monitoring::CuMonitor, M2: cu29_runtime::monitoring::CuMonitor, M3: cu29_runtime::monitoring::CuMonitor, M4: cu29_runtime::monitoring::CuMonitor> cu29_runtime::monitoring::CuMonitor for (M0, M1, M2, M3, M4)
 pub fn (M0, M1, M2, M3, M4)::new(metadata: cu29_runtime::monitoring::CuMonitoringMetadata, runtime: cu29_runtime::monitoring::CuMonitoringRuntime) -> cu29_traits::CuResult<Self> where Self: core::marker::Sized
+pub fn (M0, M1, M2, M3, M4)::observe_alloc(&self, component_id: cu29_runtime::monitoring::ComponentId, step: cu29_runtime::monitoring::CuComponentState, allocated_bytes: usize, deallocated_bytes: usize)
 pub fn (M0, M1, M2, M3, M4)::observe_copperlist_io(&self, stats: cu29_runtime::monitoring::CopperListIoStats)
 pub fn (M0, M1, M2, M3, M4)::process_copperlist(&self, ctx: &cu29_runtime::context::CuContext, view: cu29_runtime::monitoring::CopperListView<'_>) -> cu29_traits::CuResult<()>
 pub fn (M0, M1, M2, M3, M4)::process_error(&self, component_id: cu29_runtime::monitoring::ComponentId, step: cu29_runtime::monitoring::CuComponentState, error: &cu29_traits::CuError) -> cu29_runtime::monitoring::Decision
@@ -1338,6 +1350,7 @@ pub fn (M0, M1, M2, M3, M4)::start(&mut self, ctx: &cu29_runtime::context::CuCon
 pub fn (M0, M1, M2, M3, M4)::stop(&mut self, ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
 impl<M0: cu29_runtime::monitoring::CuMonitor, M1: cu29_runtime::monitoring::CuMonitor, M2: cu29_runtime::monitoring::CuMonitor, M3: cu29_runtime::monitoring::CuMonitor> cu29_runtime::monitoring::CuMonitor for (M0, M1, M2, M3)
 pub fn (M0, M1, M2, M3)::new(metadata: cu29_runtime::monitoring::CuMonitoringMetadata, runtime: cu29_runtime::monitoring::CuMonitoringRuntime) -> cu29_traits::CuResult<Self> where Self: core::marker::Sized
+pub fn (M0, M1, M2, M3)::observe_alloc(&self, component_id: cu29_runtime::monitoring::ComponentId, step: cu29_runtime::monitoring::CuComponentState, allocated_bytes: usize, deallocated_bytes: usize)
 pub fn (M0, M1, M2, M3)::observe_copperlist_io(&self, stats: cu29_runtime::monitoring::CopperListIoStats)
 pub fn (M0, M1, M2, M3)::process_copperlist(&self, ctx: &cu29_runtime::context::CuContext, view: cu29_runtime::monitoring::CopperListView<'_>) -> cu29_traits::CuResult<()>
 pub fn (M0, M1, M2, M3)::process_error(&self, component_id: cu29_runtime::monitoring::ComponentId, step: cu29_runtime::monitoring::CuComponentState, error: &cu29_traits::CuError) -> cu29_runtime::monitoring::Decision
@@ -1346,6 +1359,7 @@ pub fn (M0, M1, M2, M3)::start(&mut self, ctx: &cu29_runtime::context::CuContext
 pub fn (M0, M1, M2, M3)::stop(&mut self, ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
 impl<M0: cu29_runtime::monitoring::CuMonitor, M1: cu29_runtime::monitoring::CuMonitor, M2: cu29_runtime::monitoring::CuMonitor> cu29_runtime::monitoring::CuMonitor for (M0, M1, M2)
 pub fn (M0, M1, M2)::new(metadata: cu29_runtime::monitoring::CuMonitoringMetadata, runtime: cu29_runtime::monitoring::CuMonitoringRuntime) -> cu29_traits::CuResult<Self> where Self: core::marker::Sized
+pub fn (M0, M1, M2)::observe_alloc(&self, component_id: cu29_runtime::monitoring::ComponentId, step: cu29_runtime::monitoring::CuComponentState, allocated_bytes: usize, deallocated_bytes: usize)
 pub fn (M0, M1, M2)::observe_copperlist_io(&self, stats: cu29_runtime::monitoring::CopperListIoStats)
 pub fn (M0, M1, M2)::process_copperlist(&self, ctx: &cu29_runtime::context::CuContext, view: cu29_runtime::monitoring::CopperListView<'_>) -> cu29_traits::CuResult<()>
 pub fn (M0, M1, M2)::process_error(&self, component_id: cu29_runtime::monitoring::ComponentId, step: cu29_runtime::monitoring::CuComponentState, error: &cu29_traits::CuError) -> cu29_runtime::monitoring::Decision
@@ -1354,6 +1368,7 @@ pub fn (M0, M1, M2)::start(&mut self, ctx: &cu29_runtime::context::CuContext) ->
 pub fn (M0, M1, M2)::stop(&mut self, ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
 impl<M0: cu29_runtime::monitoring::CuMonitor, M1: cu29_runtime::monitoring::CuMonitor> cu29_runtime::monitoring::CuMonitor for (M0, M1)
 pub fn (M0, M1)::new(metadata: cu29_runtime::monitoring::CuMonitoringMetadata, runtime: cu29_runtime::monitoring::CuMonitoringRuntime) -> cu29_traits::CuResult<Self> where Self: core::marker::Sized
+pub fn (M0, M1)::observe_alloc(&self, component_id: cu29_runtime::monitoring::ComponentId, step: cu29_runtime::monitoring::CuComponentState, allocated_bytes: usize, deallocated_bytes: usize)
 pub fn (M0, M1)::observe_copperlist_io(&self, stats: cu29_runtime::monitoring::CopperListIoStats)
 pub fn (M0, M1)::process_copperlist(&self, ctx: &cu29_runtime::context::CuContext, view: cu29_runtime::monitoring::CopperListView<'_>) -> cu29_traits::CuResult<()>
 pub fn (M0, M1)::process_error(&self, component_id: cu29_runtime::monitoring::ComponentId, step: cu29_runtime::monitoring::CuComponentState, error: &cu29_traits::CuError) -> cu29_runtime::monitoring::Decision
@@ -1361,6 +1376,8 @@ pub fn (M0, M1)::process_panic(&self, panic_message: &str)
 pub fn (M0, M1)::start(&mut self, ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
 pub fn (M0, M1)::stop(&mut self, ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
 pub fn cu29_runtime::monitoring::build_monitor_topology(config: &cu29_runtime::config::CuConfig, mission: &str) -> cu29_traits::CuResult<cu29_runtime::monitoring::MonitorTopology>
+pub fn cu29_runtime::monitoring::global_allocated_bytes() -> core::option::Option<usize>
+pub fn cu29_runtime::monitoring::global_deallocated_bytes() -> core::option::Option<usize>
 pub fn cu29_runtime::monitoring::panic_payload_to_string(payload: &(dyn core::any::Any + core::marker::Send)) -> alloc::string::String
 pub fn cu29_runtime::monitoring::payload_io_stats<T>(payload: &T) -> cu29_traits::CuResult<cu29_runtime::monitoring::PayloadIoStats> where T: cu_bincode::enc::Encode
 pub fn cu29_runtime::monitoring::runtime_panic_hook_active() -> bool

--- a/components/monitors/cu_memmon/Cargo.toml
+++ b/components/monitors/cu_memmon/Cargo.toml
@@ -36,3 +36,7 @@ cu29 = { path = "../../../core/cu29", version = "1.0.0-rc2", default-features = 
 [features]
 default = ["std"]
 std = ["cu29/std"]
+# Passthrough that turns on per-task allocation accounting in the runtime and
+# the derive macro. Without this, the monitor compiles and runs but reports
+# zeros — and warns once at startup or on the first summary tick.
+memory_monitoring = ["cu29/memory_monitoring"]

--- a/components/monitors/cu_memmon/Cargo.toml
+++ b/components/monitors/cu_memmon/Cargo.toml
@@ -25,6 +25,7 @@ path = "src/lib.rs"
 
 [dependencies]
 cu29 = { path = "../../../core/cu29", version = "1.0.0-rc2", default-features = false }
+spin = { workspace = true }
 
 [dev-dependencies]
 serde = { workspace = true }

--- a/components/monitors/cu_memmon/Cargo.toml
+++ b/components/monitors/cu_memmon/Cargo.toml
@@ -25,7 +25,6 @@ path = "src/lib.rs"
 
 [dependencies]
 cu29 = { path = "../../../core/cu29", version = "1.0.0-rc2", default-features = false }
-spin = { workspace = true }
 
 [dev-dependencies]
 serde = { workspace = true }

--- a/components/monitors/cu_memmon/Cargo.toml
+++ b/components/monitors/cu_memmon/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "cu-memmon"
+description = "Copper monitor that tracks per-task heap allocations via the runtime's CountingAlloc and reports leaks and realtime violations."
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+build = "build.rs"
+
+[package.metadata.copper]
+kind = "monitor"
+domains = ["monitor/memory"]
+environments = ["host"]
+
+[package.metadata.cargo-shear]
+ignored = ["serde"]
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+cu29 = { path = "../../../core/cu29", version = "1.0.0-rc2", default-features = false }
+spin = { workspace = true }
+
+[dev-dependencies]
+serde = { workspace = true }
+cu29 = { path = "../../../core/cu29", version = "1.0.0-rc2", default-features = false, features = [
+  "log-level-info",
+] }
+
+[features]
+default = ["std"]
+std = ["cu29/std"]

--- a/components/monitors/cu_memmon/README.md
+++ b/components/monitors/cu_memmon/README.md
@@ -9,16 +9,24 @@ leaked at shutdown.
 ## How it works
 
 `cu29-runtime` ships a `CountingAlloc` global allocator (gated behind
-`cu29/memory_monitoring`) that bumps two atomic counters on every `alloc` /
-`dealloc`. With the feature on, the `#[copper_runtime]` macro wraps every
+`cu29/memory_monitoring`) that bumps two views of every `alloc` / `dealloc`:
+a process-wide pair of atomic counters and a pair of per-thread `Cell<usize>`
+counters. With the feature on, the `#[copper_runtime]` macro wraps every
 task and bridge lifecycle step in a `ScopedAllocCounter` and fans the delta
 out to all monitors via the `CuMonitor::observe_alloc` hook. `CuMemMon`
 collects those deltas, keeps per-`(component, step)` running totals, emits
 a throttled summary line every N copperlists, and reports leaks at `stop`.
 
+`ScopedAllocCounter` snapshots the **per-thread** counters, so under
+`parallel-rt` — where worker threads run monitored steps concurrently — a
+step's reported delta only includes allocations performed on the same thread
+that runs that step. Concurrent work on other worker threads does not
+contaminate the number.
+
 With the feature **off**, the macro emits no allocation scopes at all — zero
-runtime cost — and the monitor probes the runtime API at startup to detect
-this and warn once.
+runtime cost — and the monitor warns at startup if the runtime probe shows
+the allocator isn't installed, or on the first summary tick if the allocator
+is installed but no scopes have fired (the derive-side feature is off).
 
 Coverage in this release: task `start` / `stop` / `preprocess` / `process` /
 `postprocess`; bridge `start` / `stop` / `preprocess` / `process` (rx and tx) /
@@ -29,10 +37,11 @@ lifecycle steps from cu29 1.0.0-rc2 are observed.
 
 ```toml
 [dependencies]
-cu-memmon = { version = "*" }
-# Required for any non-zero numbers: installs the counting global allocator
-# and wires the macro to emit per-step allocation scopes.
-cu29 = { version = "*", features = ["memory_monitoring"] }
+# `memory_monitoring` is a passthrough that turns on both halves of the
+# feature — the counting allocator in cu29-runtime and the per-step scope
+# codegen in cu29-derive. Without it the monitor compiles and runs but
+# reports zeros.
+cu-memmon = { version = "*", features = ["memory_monitoring"] }
 ```
 
 In `copperconfig.ron`:
@@ -77,15 +86,18 @@ sibling task), which is worth knowing but not necessarily a bug.
 
 With `realtime_strict: true`, any non-zero allocation in `preprocess`,
 `process`, or `postprocess` is latched and surfaced as a `CuError` from the
-next `process_copperlist` call. The runtime treats that as a fatal monitor
-error and shuts the application down — so a violation reliably trips a CI
-smoke test regardless of whether any other component happens to error.
-Unrelated task errors are not escalated by this mode.
+following `process_copperlist` call — which in practice is the same iteration's
+`process_copperlist`, since it runs after every step. The runtime treats that
+as a fatal monitor error and shuts the application down, so a violation
+reliably trips a CI smoke test regardless of whether any other component
+happens to error. Unrelated task errors are not escalated by this mode. When
+multiple steps violate in the same iteration the *first* one wins; later
+violations are observed but don't overwrite the latched cause.
 
 ## Try it
 
 ```bash
-cargo run -p cu-memmon --example copper_app --features cu29/memory_monitoring
+cargo run -p cu-memmon --example copper_app --features memory_monitoring
 ```
 
 The intermediate `Step` task in the example allocates and drops a small `Vec`

--- a/components/monitors/cu_memmon/README.md
+++ b/components/monitors/cu_memmon/README.md
@@ -1,29 +1,37 @@
 # CuMemMon
 
 Per-task heap-allocation monitor for Copper. Tells you, for every monitored
-task: how many bytes were allocated/deallocated during each lifecycle step
-(`start` / `preprocess` / `process` / `postprocess` / `stop`), the lifetime
-balance, and whether anything leaked at shutdown.
+task and bridge: how many bytes were allocated/deallocated during each
+lifecycle step (`start` / `preprocess` / `process` / `postprocess` / `stop`),
+the per-call peak in `process`, the lifetime balance, and whether anything
+leaked at shutdown.
 
 ## How it works
 
 `cu29-runtime` ships a `CountingAlloc` global allocator (gated behind
 `cu29/memory_monitoring`) that bumps two atomic counters on every `alloc` /
-`dealloc`. The `#[copper_runtime]` macro now wraps every generated task step in
-a `ScopedAllocCounter` and fans the delta out to all monitors via the
-`CuMonitor::observe_alloc` hook. `CuMemMon` collects those deltas, keeps
-per-`(component, step)` running totals, and reports them at `stop`.
+`dealloc`. With the feature on, the `#[copper_runtime]` macro wraps every
+task and bridge lifecycle step in a `ScopedAllocCounter` and fans the delta
+out to all monitors via the `CuMonitor::observe_alloc` hook. `CuMemMon`
+collects those deltas, keeps per-`(component, step)` running totals, emits
+a throttled summary line every N copperlists, and reports leaks at `stop`.
 
-Without `cu29/memory_monitoring`, the runtime still calls `observe_alloc` but
-all deltas are zero. `CuMemMon` notices this once at startup and emits a single
-`warning!` so the build configuration is obvious from the log.
+With the feature **off**, the macro emits no allocation scopes at all — zero
+runtime cost — and the monitor probes the runtime API at startup to detect
+this and warn once.
+
+Coverage in this release: task `start` / `stop` / `preprocess` / `process` /
+`postprocess`; bridge `start` / `stop` / `preprocess` / `process` (rx and tx) /
+`postprocess`; and the parallel-rt counterparts of both. So all monitored
+lifecycle steps from cu29 1.0.0-rc2 are observed.
 
 ## Usage
 
 ```toml
 [dependencies]
 cu-memmon = { version = "*" }
-# Required for any non-zero numbers: installs the counting global allocator.
+# Required for any non-zero numbers: installs the counting global allocator
+# and wires the macro to emit per-step allocation scopes.
 cu29 = { version = "*", features = ["memory_monitoring"] }
 ```
 
@@ -32,21 +40,47 @@ In `copperconfig.ron`:
 ```ron
 monitor: (
     type: "cu_memmon::CuMemMon",
-    // Optional: when true, any non-zero allocation observed during
-    // preprocess/process/postprocess emits a one-shot warning. The next
-    // process_error() then escalates to Decision::Shutdown.
-    config: { "realtime_strict": false },
+    config: {
+        // When true, any non-zero allocation observed during
+        // preprocess/process/postprocess latches a violation that is
+        // surfaced from the next `process_copperlist` as a fatal CuError —
+        // the runtime then shuts down cleanly.
+        "realtime_strict": false,
+        // Emit a "[mem] task ..." summary every N copperlists. 0 disables.
+        "summary_every": 100,
+    },
 )
 ```
 
 ## Output
 
-At runtime shutdown you get a per-task line like:
+Periodic summary lines (every `summary_every` copperlists):
 
 ```
-cu_memmon: task task balanced (alloc 1024B, dealloc 1024B); process allocated 512B over 60 calls
+[mem] task start=+0B -0B | proc max=+64B over 60 calls | stop=+0B -0B | leak=0B
+```
+
+At runtime shutdown:
+
+```
+cu_memmon final report: total +3840B / -3840B
+cu_memmon: task task balanced (alloc 3840B, dealloc 3840B); process allocated 3840B over 60 calls
 cu_memmon: task leaky leak=256B (alloc 4096B, dealloc 3840B); process allocated 4096B over 60 calls
 ```
+
+Tasks that deallocate more than they allocate within their observed scopes
+are surfaced too — usually that means they're freeing memory that was
+allocated outside the lifecycle hooks (e.g. a payload passed in from a
+sibling task), which is worth knowing but not necessarily a bug.
+
+## Realtime-strict mode
+
+With `realtime_strict: true`, any non-zero allocation in `preprocess`,
+`process`, or `postprocess` is latched and surfaced as a `CuError` from the
+next `process_copperlist` call. The runtime treats that as a fatal monitor
+error and shuts the application down — so a violation reliably trips a CI
+smoke test regardless of whether any other component happens to error.
+Unrelated task errors are not escalated by this mode.
 
 ## Try it
 
@@ -55,10 +89,5 @@ cargo run -p cu-memmon --example copper_app --features cu29/memory_monitoring
 ```
 
 The intermediate `Step` task in the example allocates and drops a small `Vec`
-every iteration on purpose; lifetime totals should balance.
-
-## Status
-
-Stage 1 (this crate): task-level coverage of `start`/`preprocess`/`process`/
-`postprocess`/`stop`. Bridges and the `parallel-rt` execution engine are not
-instrumented yet — they will receive the same hook in a follow-up.
+every iteration on purpose; lifetime totals should balance and the per-call
+peak in `process` will read 64 bytes.

--- a/components/monitors/cu_memmon/README.md
+++ b/components/monitors/cu_memmon/README.md
@@ -1,0 +1,64 @@
+# CuMemMon
+
+Per-task heap-allocation monitor for Copper. Tells you, for every monitored
+task: how many bytes were allocated/deallocated during each lifecycle step
+(`start` / `preprocess` / `process` / `postprocess` / `stop`), the lifetime
+balance, and whether anything leaked at shutdown.
+
+## How it works
+
+`cu29-runtime` ships a `CountingAlloc` global allocator (gated behind
+`cu29/memory_monitoring`) that bumps two atomic counters on every `alloc` /
+`dealloc`. The `#[copper_runtime]` macro now wraps every generated task step in
+a `ScopedAllocCounter` and fans the delta out to all monitors via the
+`CuMonitor::observe_alloc` hook. `CuMemMon` collects those deltas, keeps
+per-`(component, step)` running totals, and reports them at `stop`.
+
+Without `cu29/memory_monitoring`, the runtime still calls `observe_alloc` but
+all deltas are zero. `CuMemMon` notices this once at startup and emits a single
+`warning!` so the build configuration is obvious from the log.
+
+## Usage
+
+```toml
+[dependencies]
+cu-memmon = { version = "*" }
+# Required for any non-zero numbers: installs the counting global allocator.
+cu29 = { version = "*", features = ["memory_monitoring"] }
+```
+
+In `copperconfig.ron`:
+
+```ron
+monitor: (
+    type: "cu_memmon::CuMemMon",
+    // Optional: when true, any non-zero allocation observed during
+    // preprocess/process/postprocess emits a one-shot warning. The next
+    // process_error() then escalates to Decision::Shutdown.
+    config: { "realtime_strict": false },
+)
+```
+
+## Output
+
+At runtime shutdown you get a per-task line like:
+
+```
+cu_memmon: task task balanced (alloc 1024B, dealloc 1024B); process allocated 512B over 60 calls
+cu_memmon: task leaky leak=256B (alloc 4096B, dealloc 3840B); process allocated 4096B over 60 calls
+```
+
+## Try it
+
+```bash
+cargo run -p cu-memmon --example copper_app --features cu29/memory_monitoring
+```
+
+The intermediate `Step` task in the example allocates and drops a small `Vec`
+every iteration on purpose; lifetime totals should balance.
+
+## Status
+
+Stage 1 (this crate): task-level coverage of `start`/`preprocess`/`process`/
+`postprocess`/`stop`. Bridges and the `parallel-rt` execution engine are not
+instrumented yet — they will receive the same hook in a follow-up.

--- a/components/monitors/cu_memmon/build.rs
+++ b/components/monitors/cu_memmon/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=LOG_INDEX_DIR={}",
+        std::env::var("OUT_DIR").unwrap()
+    );
+}

--- a/components/monitors/cu_memmon/copperconfig.ron
+++ b/components/monitors/cu_memmon/copperconfig.ron
@@ -24,7 +24,14 @@
     ],
     monitor: (
         type: "cu_memmon::CuMemMon",
-        config: { "realtime_strict": false },
+        config: {
+            // Set to true to abort the run on any non-zero allocation in
+            // preprocess/process/postprocess. Default is false: keep running
+            // and accumulate per-task totals reported at shutdown.
+            "realtime_strict": false,
+            // Emit a "[mem] task ..." summary every N copperlists. 0 disables.
+            "summary_every": 20,
+        },
     ),
     logging: (
         slab_size_mib: 16,

--- a/components/monitors/cu_memmon/copperconfig.ron
+++ b/components/monitors/cu_memmon/copperconfig.ron
@@ -25,11 +25,7 @@
     monitor: (
         type: "cu_memmon::CuMemMon",
         config: {
-            // Set to true to abort the run on any non-zero allocation in
-            // preprocess/process/postprocess. Default is false: keep running
-            // and accumulate per-task totals reported at shutdown.
             "realtime_strict": false,
-            // Emit a "[mem] task ..." summary every N copperlists. 0 disables.
             "summary_every": 20,
         },
     ),

--- a/components/monitors/cu_memmon/copperconfig.ron
+++ b/components/monitors/cu_memmon/copperconfig.ron
@@ -1,0 +1,35 @@
+(
+    tasks: [
+        (id: "src", type: "tasks::Src"),
+        (
+            id: "task",
+            type: "tasks::Step",
+        ),
+        (
+            id: "sink",
+            type: "tasks::Sink",
+        ),
+    ],
+    cnx: [
+        (
+            src: "src",
+            dst: "task",
+            msg: "u32",
+        ),
+        (
+            src: "task",
+            dst: "sink",
+            msg: "u32",
+        ),
+    ],
+    monitor: (
+        type: "cu_memmon::CuMemMon",
+        config: { "realtime_strict": false },
+    ),
+    logging: (
+        slab_size_mib: 16,
+        section_size_mib: 4,
+        enable_task_logging: false,
+    ),
+    runtime: (rate_target_hz: 20),
+)

--- a/components/monitors/cu_memmon/examples/copper_app.rs
+++ b/components/monitors/cu_memmon/examples/copper_app.rs
@@ -1,0 +1,134 @@
+//! Minimal end-to-end demo for `cu_memmon`.
+//!
+//! Build with `--features cu29/memory_monitoring` to install the counting
+//! allocator and see real per-task allocation totals at shutdown; without the
+//! feature, the monitor reports zeros and warns once at startup.
+//!
+//! The intermediate `Step` task deliberately allocates and immediately drops a
+//! small Vec on every iteration so a leaking pattern is easy to spot at the
+//! `stop` summary (alloc should equal dealloc -> "balanced").
+
+use cu29::prelude::*;
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+pub mod tasks {
+    use cu29::prelude::*;
+
+    #[derive(Reflect)]
+    pub struct Src {
+        counter: u32,
+    }
+
+    impl Freezable for Src {}
+
+    impl CuSrcTask for Src {
+        type Resources<'r> = ();
+        type Output<'m> = output_msg!(u32);
+
+        fn new(
+            _config: Option<&ComponentConfig>,
+            _resources: Self::Resources<'_>,
+        ) -> CuResult<Self> {
+            Ok(Self { counter: 0 })
+        }
+
+        fn process(&mut self, _ctx: &CuContext, new_msg: &mut Self::Output<'_>) -> CuResult<()> {
+            self.counter = self.counter.wrapping_add(1);
+            new_msg.set_payload(self.counter);
+            Ok(())
+        }
+    }
+
+    #[derive(Reflect)]
+    pub struct Step;
+
+    impl Freezable for Step {}
+
+    impl CuTask for Step {
+        type Resources<'r> = ();
+        type Input<'m> = input_msg!(u32);
+        type Output<'m> = output_msg!(u32);
+
+        fn new(
+            _config: Option<&ComponentConfig>,
+            _resources: Self::Resources<'_>,
+        ) -> CuResult<Self> {
+            Ok(Self)
+        }
+
+        fn process(
+            &mut self,
+            _ctx: &CuContext,
+            input: &Self::Input<'_>,
+            output: &mut Self::Output<'_>,
+        ) -> CuResult<()> {
+            // Deliberately allocate-and-drop to exercise the monitor: the
+            // lifetime alloc/dealloc totals should balance, but process()
+            // shows nonzero per-call allocation.
+            let scratch: Vec<u32> = (0..16).collect();
+            let payload = input.payload().copied().unwrap_or(0) + scratch.iter().sum::<u32>();
+            output.set_payload(payload);
+            Ok(())
+        }
+    }
+
+    #[derive(Reflect)]
+    pub struct Sink;
+
+    impl Freezable for Sink {}
+
+    impl CuSinkTask for Sink {
+        type Resources<'r> = ();
+        type Input<'m> = input_msg!(u32);
+
+        fn new(
+            _config: Option<&ComponentConfig>,
+            _resources: Self::Resources<'_>,
+        ) -> CuResult<Self> {
+            Ok(Self)
+        }
+
+        fn process(&mut self, _ctx: &CuContext, _input: &Self::Input<'_>) -> CuResult<()> {
+            Ok(())
+        }
+    }
+}
+
+#[copper_runtime(config = "copperconfig.ron")]
+struct App {}
+
+const SLAB_SIZE: Option<usize> = Some(16 * 1024 * 1024);
+
+fn main() {
+    let logger_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("logs/memmon_copper_app.copper");
+    if let Some(parent) = logger_path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    info!("Logger created at {}", &logger_path);
+
+    let mut application = App::builder()
+        .with_log_path(&logger_path, SLAB_SIZE)
+        .expect("Failed to setup logger.")
+        .build()
+        .expect("Failed to create runtime");
+    info!("Starting app at {}", application.clock().now());
+    application
+        .start_all_tasks()
+        .expect("Failed to start application.");
+
+    for _ in 0..60 {
+        application
+            .run_one_iteration()
+            .expect("Failed to run one iteration.");
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    application
+        .stop_all_tasks()
+        .expect("Failed to stop application.");
+    info!("App stopped at {}", application.clock().now());
+}

--- a/components/monitors/cu_memmon/src/lib.rs
+++ b/components/monitors/cu_memmon/src/lib.rs
@@ -268,9 +268,7 @@ impl CuMonitor for CuMemMon {
                 // copperlist are rare and a single trip-wire suffices.
                 let (component_id, viol) = drained[0];
                 let name = self.component_name(component_id);
-                let msg = format_rt_violation_message(name, viol);
-                error!(ctx, "{}", msg.as_str());
-                return Err(CuError::from(msg.as_str()));
+                return report_rt_violation(ctx, name, viol);
             }
         }
 
@@ -279,7 +277,7 @@ impl CuMonitor for CuMemMon {
             return Ok(());
         }
         let n = self.cl_counter.fetch_add(1, Ordering::Relaxed) + 1;
-        if n % self.summary_every != 0 {
+        if !n.is_multiple_of(self.summary_every) {
             return Ok(());
         }
         // Snapshot under the lock; format without holding it.
@@ -430,9 +428,7 @@ impl CuMonitor for CuMemMon {
     }
 }
 
-fn drain_rt_violations(
-    pending: &mut [Option<RtViolation>],
-) -> Vec<(ComponentId, RtViolation)> {
+fn drain_rt_violations(pending: &mut [Option<RtViolation>]) -> Vec<(ComponentId, RtViolation)> {
     let mut out = Vec::new();
     for (idx, slot) in pending.iter_mut().enumerate() {
         if let Some(v) = slot.take() {
@@ -453,13 +449,24 @@ fn format_rt_violation_message(name: &str, viol: RtViolation) -> String {
     )
 }
 
+#[cfg(feature = "std")]
+fn report_rt_violation(ctx: &CuContext, name: &str, viol: RtViolation) -> CuResult<()> {
+    let msg = format_rt_violation_message(name, viol);
+    error!(ctx, "{}", msg.as_str());
+    Err(CuError::from(msg.as_str()))
+}
+
 #[cfg(not(feature = "std"))]
-fn format_rt_violation_message(name: &str, viol: RtViolation) -> &'static str {
-    // In no_std builds we don't allocate the message; emit a fixed sentinel
-    // so the user still sees *that* a violation happened. The kind/component
-    // is already reported via error!(...) immediately before this is sent.
-    let _ = (name, viol);
-    "cu_memmon: realtime allocation violation"
+fn report_rt_violation(ctx: &CuContext, name: &str, viol: RtViolation) -> CuResult<()> {
+    error!(
+        ctx,
+        "cu_memmon: realtime violation: component {} allocated {} B (deallocated {} B) during {}",
+        name,
+        viol.allocated,
+        viol.deallocated,
+        step_label(viol.step),
+    );
+    Err(CuError::from("cu_memmon: realtime allocation violation"))
 }
 
 #[cfg(all(feature = "std", debug_assertions))]
@@ -527,19 +534,24 @@ mod tests {
 
         assert_eq!(c.lifetime_alloc(), 1024 + 256);
         assert_eq!(c.lifetime_dealloc(), 256 + 1024);
-        assert_eq!(
-            c.lifetime_alloc().saturating_sub(c.lifetime_dealloc()),
-            0
-        );
+        assert_eq!(c.lifetime_alloc().saturating_sub(c.lifetime_dealloc()), 0);
     }
 
     #[test]
     fn drain_rt_violations_takes_pending_only() {
         let mut pending = alloc::vec![
             None,
-            Some(RtViolation { step: CuComponentState::Process, allocated: 128, deallocated: 0 }),
+            Some(RtViolation {
+                step: CuComponentState::Process,
+                allocated: 128,
+                deallocated: 0
+            }),
             None,
-            Some(RtViolation { step: CuComponentState::Preprocess, allocated: 32, deallocated: 0 }),
+            Some(RtViolation {
+                step: CuComponentState::Preprocess,
+                allocated: 32,
+                deallocated: 0
+            }),
         ];
         let drained = drain_rt_violations(&mut pending);
         assert_eq!(drained.len(), 2);

--- a/components/monitors/cu_memmon/src/lib.rs
+++ b/components/monitors/cu_memmon/src/lib.rs
@@ -1,0 +1,370 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//! Per-task heap-allocation monitor for Copper.
+//!
+//! `CuMemMon` consumes the [`CuMonitor::observe_alloc`] hook the runtime emits
+//! around every task step and reports:
+//! - per-step allocation deltas (debug-only, throttled to avoid spam),
+//! - per-task lifetime balance (`alloc - dealloc` since the task's `start`),
+//! - a final per-task **leak report** at runtime shutdown.
+//!
+//! Optional realtime-strict mode (`realtime_strict: true` in the monitor's
+//! RON config) returns [`Decision::Shutdown`] from `process_error` whenever
+//! any non-zero allocation happens during `Preprocess`, `Process`, or
+//! `Postprocess`. This is intended for CI smoke tests that want to catch
+//! "task X allocated on the hot path" regressions deterministically.
+//!
+//! When the runtime is **not** built with `cu29/memory_monitoring`, the
+//! `observe_alloc` hook is still called but always reports zero. `CuMemMon`
+//! detects this once at startup, emits a single `warning!`, and from then on
+//! reports zeros without further noise.
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use cu29::prelude::*;
+
+#[cfg(feature = "std")]
+use std::sync::Mutex;
+#[cfg(feature = "std")]
+type MutexGuard<'a, T> = std::sync::MutexGuard<'a, T>;
+
+#[cfg(not(feature = "std"))]
+use spin::Mutex;
+#[cfg(not(feature = "std"))]
+type MutexGuard<'a, T> = spin::MutexGuard<'a, T, spin::relax::Spin>;
+
+/// One slot per (component, step). We collapse all five steps into separate
+/// counters per component for compact storage and O(1) updates.
+#[derive(Default, Clone, Copy)]
+struct StepCounters {
+    allocated: u64,
+    deallocated: u64,
+    calls: u64,
+}
+
+#[derive(Clone, Copy)]
+struct ComponentCounters {
+    start: StepCounters,
+    preprocess: StepCounters,
+    process: StepCounters,
+    postprocess: StepCounters,
+    stop: StepCounters,
+}
+
+impl ComponentCounters {
+    const fn new() -> Self {
+        const Z: StepCounters = StepCounters {
+            allocated: 0,
+            deallocated: 0,
+            calls: 0,
+        };
+        Self {
+            start: Z,
+            preprocess: Z,
+            process: Z,
+            postprocess: Z,
+            stop: Z,
+        }
+    }
+
+    fn slot(&mut self, step: CuComponentState) -> &mut StepCounters {
+        match step {
+            CuComponentState::Start => &mut self.start,
+            CuComponentState::Preprocess => &mut self.preprocess,
+            CuComponentState::Process => &mut self.process,
+            CuComponentState::Postprocess => &mut self.postprocess,
+            CuComponentState::Stop => &mut self.stop,
+        }
+    }
+
+    fn lifetime_alloc(&self) -> u64 {
+        self.start.allocated
+            + self.preprocess.allocated
+            + self.process.allocated
+            + self.postprocess.allocated
+            + self.stop.allocated
+    }
+
+    fn lifetime_dealloc(&self) -> u64 {
+        self.start.deallocated
+            + self.preprocess.deallocated
+            + self.process.deallocated
+            + self.postprocess.deallocated
+            + self.stop.deallocated
+    }
+}
+
+struct State {
+    per_component: Vec<ComponentCounters>,
+    /// True iff the runtime was compiled with `memory_monitoring`.
+    /// Probed in `start()` by reading the public counters from the runtime.
+    counters_available: bool,
+}
+
+pub struct CuMemMon {
+    components: &'static [MonitorComponentMetadata],
+    component_count: usize,
+    realtime_strict: bool,
+    state: Mutex<State>,
+    /// One-shot flag to avoid spamming the realtime-violation log.
+    rt_violation_logged: AtomicBool,
+    /// Total observed allocations / deallocations across the whole runtime
+    /// (cheap monotonic counters for the optional periodic summary).
+    total_alloc: AtomicU64,
+    total_dealloc: AtomicU64,
+}
+
+fn lock_state(state: &Mutex<State>) -> MutexGuard<'_, State> {
+    #[cfg(feature = "std")]
+    {
+        state.lock().unwrap_or_else(|poison| poison.into_inner())
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        state.lock()
+    }
+}
+
+fn parse_realtime_strict(cfg: Option<&ComponentConfig>) -> CuResult<bool> {
+    let Some(cfg) = cfg else { return Ok(false) };
+    if let Some(strict) = cfg.get::<bool>("realtime_strict")? {
+        return Ok(strict);
+    }
+    Ok(false)
+}
+
+fn step_label(step: CuComponentState) -> &'static str {
+    match step {
+        CuComponentState::Start => "start",
+        CuComponentState::Preprocess => "pre",
+        CuComponentState::Process => "process",
+        CuComponentState::Postprocess => "post",
+        CuComponentState::Stop => "stop",
+    }
+}
+
+#[inline]
+fn is_realtime_step(step: CuComponentState) -> bool {
+    matches!(
+        step,
+        CuComponentState::Preprocess | CuComponentState::Process | CuComponentState::Postprocess
+    )
+}
+
+impl CuMemMon {
+    fn component_name(&self, component_id: ComponentId) -> &'static str {
+        debug_assert!(component_id.index() < self.component_count);
+        self.components[component_id.index()].id()
+    }
+}
+
+impl CuMonitor for CuMemMon {
+    fn new(metadata: CuMonitoringMetadata, _runtime: CuMonitoringRuntime) -> CuResult<Self> {
+        let components = metadata.components();
+        let component_count = components.len();
+        let realtime_strict = parse_realtime_strict(metadata.monitor_config())?;
+
+        // Detect whether the runtime was built with the counting allocator.
+        // When the feature is off both getters return `None`.
+        let counters_available = cu29::monitoring::global_allocated_bytes().is_some();
+
+        let state = State {
+            per_component: alloc::vec![ComponentCounters::new(); component_count],
+            counters_available,
+        };
+
+        Ok(Self {
+            components,
+            component_count,
+            realtime_strict,
+            state: Mutex::new(state),
+            rt_violation_logged: AtomicBool::new(false),
+            total_alloc: AtomicU64::new(0),
+            total_dealloc: AtomicU64::new(0),
+        })
+    }
+
+    fn start(&mut self, ctx: &CuContext) -> CuResult<()> {
+        let state = lock_state(&self.state);
+        if !state.counters_available {
+            warning!(
+                ctx,
+                "cu_memmon enabled but cu29 was built without `memory_monitoring`. All reports will be zero."
+            );
+        } else {
+            info!(
+                ctx,
+                "cu_memmon started ({} components, realtime_strict={})",
+                self.component_count,
+                self.realtime_strict
+            );
+        }
+        Ok(())
+    }
+
+    fn process_copperlist(&self, _ctx: &CuContext, _view: CopperListView<'_>) -> CuResult<()> {
+        // Per-copperlist hook intentionally a no-op: all the interesting work
+        // happens in observe_alloc. A future revision can fold a throttled
+        // info!() summary in here.
+        Ok(())
+    }
+
+    fn observe_alloc(
+        &self,
+        component_id: ComponentId,
+        step: CuComponentState,
+        allocated_bytes: usize,
+        deallocated_bytes: usize,
+    ) {
+        // Cheap aggregate counters first — never block on the mutex if the
+        // runtime is hot and another thread is reporting.
+        let alloc_u64 = allocated_bytes as u64;
+        let dealloc_u64 = deallocated_bytes as u64;
+        self.total_alloc.fetch_add(alloc_u64, Ordering::Relaxed);
+        self.total_dealloc.fetch_add(dealloc_u64, Ordering::Relaxed);
+
+        let mut state = lock_state(&self.state);
+        let idx = component_id.index();
+        debug_assert!(
+            idx < state.per_component.len(),
+            "cu_memmon: component id {idx} out of bounds {}",
+            state.per_component.len()
+        );
+        if let Some(component) = state.per_component.get_mut(idx) {
+            let slot = component.slot(step);
+            slot.allocated = slot.allocated.saturating_add(alloc_u64);
+            slot.deallocated = slot.deallocated.saturating_add(dealloc_u64);
+            slot.calls = slot.calls.saturating_add(1);
+        }
+
+        // Realtime-strict warning is one-shot to keep the log clean; the actual
+        // shutdown happens via process_error() once a task surfaces an error,
+        // but most users will catch this via the warning first.
+        if self.realtime_strict
+            && is_realtime_step(step)
+            && allocated_bytes > 0
+            && !self.rt_violation_logged.swap(true, Ordering::Relaxed)
+        {
+            let name = self.component_name(component_id);
+            warning!(
+                "cu_memmon: realtime violation: component {} allocated {} B during {}",
+                name,
+                allocated_bytes as u64,
+                step_label(step)
+            );
+        }
+    }
+
+    fn process_error(
+        &self,
+        component_id: ComponentId,
+        step: CuComponentState,
+        error: &CuError,
+    ) -> Decision {
+        let component_name = self.component_name(component_id);
+        error!(
+            "cu_memmon: component {} errored at {}: {}",
+            component_name,
+            step_label(step),
+            error,
+        );
+        // We only escalate when realtime-strict mode actually flagged a
+        // violation; otherwise we stay out of the runtime's way.
+        if self.realtime_strict && self.rt_violation_logged.load(Ordering::Relaxed) {
+            Decision::Shutdown
+        } else {
+            Decision::Ignore
+        }
+    }
+
+    fn stop(&mut self, ctx: &CuContext) -> CuResult<()> {
+        let state = lock_state(&self.state);
+        if !state.counters_available {
+            return Ok(());
+        }
+        info!(
+            ctx,
+            "cu_memmon final report: total +{}B / -{}B",
+            self.total_alloc.load(Ordering::Relaxed),
+            self.total_dealloc.load(Ordering::Relaxed)
+        );
+        for (idx, counters) in state.per_component.iter().enumerate() {
+            let name = self.components[idx].id();
+            let lifetime_alloc = counters.lifetime_alloc();
+            let lifetime_dealloc = counters.lifetime_dealloc();
+            let leak = lifetime_alloc.saturating_sub(lifetime_dealloc);
+            let process_alloc = counters.process.allocated;
+            let process_calls = counters.process.calls;
+            if leak > 0 {
+                warning!(
+                    ctx,
+                    "cu_memmon: task {} leak={}B (alloc {}B, dealloc {}B); process allocated {}B over {} calls",
+                    name,
+                    leak,
+                    lifetime_alloc,
+                    lifetime_dealloc,
+                    process_alloc,
+                    process_calls
+                );
+            } else {
+                info!(
+                    ctx,
+                    "cu_memmon: task {} balanced (alloc {}B, dealloc {}B); process allocated {}B over {} calls",
+                    name,
+                    lifetime_alloc,
+                    lifetime_dealloc,
+                    process_alloc,
+                    process_calls
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn step_label_covers_all_states() {
+        assert_eq!(step_label(CuComponentState::Start), "start");
+        assert_eq!(step_label(CuComponentState::Preprocess), "pre");
+        assert_eq!(step_label(CuComponentState::Process), "process");
+        assert_eq!(step_label(CuComponentState::Postprocess), "post");
+        assert_eq!(step_label(CuComponentState::Stop), "stop");
+    }
+
+    #[test]
+    fn is_realtime_step_only_flags_hot_path_states() {
+        assert!(!is_realtime_step(CuComponentState::Start));
+        assert!(is_realtime_step(CuComponentState::Preprocess));
+        assert!(is_realtime_step(CuComponentState::Process));
+        assert!(is_realtime_step(CuComponentState::Postprocess));
+        assert!(!is_realtime_step(CuComponentState::Stop));
+    }
+
+    #[test]
+    fn component_counters_track_per_step_and_lifetime_totals() {
+        let mut c = ComponentCounters::new();
+        c.slot(CuComponentState::Start).allocated += 1024;
+        c.slot(CuComponentState::Process).allocated += 256;
+        c.slot(CuComponentState::Process).deallocated += 256;
+        c.slot(CuComponentState::Stop).deallocated += 1024;
+
+        assert_eq!(c.start.allocated, 1024);
+        assert_eq!(c.process.allocated, 256);
+        assert_eq!(c.process.deallocated, 256);
+        assert_eq!(c.stop.deallocated, 1024);
+
+        assert_eq!(c.lifetime_alloc(), 1024 + 256);
+        assert_eq!(c.lifetime_dealloc(), 256 + 1024);
+        // Net balanced over the lifetime: no leak.
+        assert_eq!(
+            c.lifetime_alloc().saturating_sub(c.lifetime_dealloc()),
+            0
+        );
+    }
+}

--- a/components/monitors/cu_memmon/src/lib.rs
+++ b/components/monitors/cu_memmon/src/lib.rs
@@ -3,37 +3,44 @@
 //! Per-task heap-allocation monitor for Copper.
 //!
 //! `CuMemMon` consumes the [`CuMonitor::observe_alloc`] hook the runtime emits
-//! around every task step and reports:
-//! - per-step allocation deltas (debug-only, throttled to avoid spam),
+//! around every task and bridge lifecycle step and reports:
+//! - per-step allocation deltas (running totals + per-call peak),
 //! - per-task lifetime balance (`alloc - dealloc` since the task's `start`),
+//! - a throttled `[mem]` one-liner from `process_copperlist`,
 //! - a final per-task **leak report** at runtime shutdown.
 //!
 //! Optional realtime-strict mode (`realtime_strict: true` in the monitor's
-//! RON config) returns [`Decision::Shutdown`] from `process_error` whenever
-//! any non-zero allocation happens during `Preprocess`, `Process`, or
-//! `Postprocess`. This is intended for CI smoke tests that want to catch
-//! "task X allocated on the hot path" regressions deterministically.
+//! RON config) latches any non-zero allocation observed during `Preprocess`,
+//! `Process`, or `Postprocess` and surfaces it from the *next*
+//! `process_copperlist` as a `CuError`. The runtime treats that as a fatal
+//! monitor error and shuts down cleanly — so a violation in
+//! e.g. `process` reliably aborts the run regardless of whether any other
+//! component errored, and unrelated task errors are not affected.
 //!
-//! When the runtime is **not** built with `cu29/memory_monitoring`, the
-//! `observe_alloc` hook is still called but always reports zero. `CuMemMon`
-//! detects this once at startup, emits a single `warning!`, and from then on
-//! reports zeros without further noise.
+//! When the runtime is **not** built with `cu29/memory_monitoring`, the macro
+//! emits no allocation scopes, so `observe_alloc` is never called.
+//! `CuMemMon` detects this at `start()` by probing the public counter API
+//! and emits a single `warning!` so the build configuration is obvious from
+//! the log.
 
 extern crate alloc;
 
 use alloc::vec::Vec;
 use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use cu29::__private::sync::Mutex;
 use cu29::prelude::*;
 
-#[cfg(feature = "std")]
-use std::sync::Mutex;
-#[cfg(feature = "std")]
-type MutexGuard<'a, T> = std::sync::MutexGuard<'a, T>;
+#[cfg(all(feature = "std", debug_assertions))]
+use alloc::string::String;
+#[cfg(all(feature = "std", debug_assertions))]
+use alloc::string::ToString;
+#[cfg(all(feature = "std", debug_assertions))]
+use std::collections::HashMap as StdHashMap;
 
-#[cfg(not(feature = "std"))]
-use spin::Mutex;
-#[cfg(not(feature = "std"))]
-type MutexGuard<'a, T> = spin::MutexGuard<'a, T, spin::relax::Spin>;
+/// Number of copperlists between throttled `[mem]` summary lines.
+/// Picked to be roughly once per second at 100 Hz; users that want quieter
+/// runs can disable via `summary_every: 0` in the monitor config.
+const DEFAULT_SUMMARY_EVERY: u64 = 100;
 
 /// One slot per (component, step). We collapse all five steps into separate
 /// counters per component for compact storage and O(1) updates.
@@ -42,6 +49,8 @@ struct StepCounters {
     allocated: u64,
     deallocated: u64,
     calls: u64,
+    /// Largest single-call allocation seen for this step.
+    max_allocated: u64,
 }
 
 #[derive(Clone, Copy)]
@@ -59,6 +68,7 @@ impl ComponentCounters {
             allocated: 0,
             deallocated: 0,
             calls: 0,
+            max_allocated: 0,
         };
         Self {
             start: Z,
@@ -96,27 +106,40 @@ impl ComponentCounters {
     }
 }
 
+#[derive(Clone, Copy)]
+struct RtViolation {
+    step: CuComponentState,
+    allocated: u64,
+    deallocated: u64,
+}
+
 struct State {
     per_component: Vec<ComponentCounters>,
     /// True iff the runtime was compiled with `memory_monitoring`.
-    /// Probed in `start()` by reading the public counters from the runtime.
+    /// Probed in `new()` by reading the public counters from the runtime.
     counters_available: bool,
+    /// Pending realtime-strict violations to surface from the next
+    /// `process_copperlist`. One slot per component; latest wins.
+    rt_pending: Vec<Option<RtViolation>>,
 }
 
 pub struct CuMemMon {
     components: &'static [MonitorComponentMetadata],
     component_count: usize,
     realtime_strict: bool,
+    summary_every: u64,
+    /// Monotonic copperlist counter, drives the throttled summary.
+    cl_counter: AtomicU64,
     state: Mutex<State>,
-    /// One-shot flag to avoid spamming the realtime-violation log.
-    rt_violation_logged: AtomicBool,
+    /// True once we've emitted the "feature off" warning, so we don't spam.
+    feature_off_warned: AtomicBool,
     /// Total observed allocations / deallocations across the whole runtime
-    /// (cheap monotonic counters for the optional periodic summary).
+    /// (cheap monotonic counters for the periodic summary header).
     total_alloc: AtomicU64,
     total_dealloc: AtomicU64,
 }
 
-fn lock_state(state: &Mutex<State>) -> MutexGuard<'_, State> {
+fn lock_state(state: &Mutex<State>) -> StateGuard<'_> {
     #[cfg(feature = "std")]
     {
         state.lock().unwrap_or_else(|poison| poison.into_inner())
@@ -127,12 +150,27 @@ fn lock_state(state: &Mutex<State>) -> MutexGuard<'_, State> {
     }
 }
 
+#[cfg(feature = "std")]
+type StateGuard<'a> = std::sync::MutexGuard<'a, State>;
+#[cfg(not(feature = "std"))]
+type StateGuard<'a> = spin::MutexGuard<'a, State, spin::relax::Spin>;
+
 fn parse_realtime_strict(cfg: Option<&ComponentConfig>) -> CuResult<bool> {
     let Some(cfg) = cfg else { return Ok(false) };
     if let Some(strict) = cfg.get::<bool>("realtime_strict")? {
         return Ok(strict);
     }
     Ok(false)
+}
+
+fn parse_summary_every(cfg: Option<&ComponentConfig>) -> CuResult<u64> {
+    let Some(cfg) = cfg else {
+        return Ok(DEFAULT_SUMMARY_EVERY);
+    };
+    if let Some(value) = cfg.get::<u32>("summary_every")? {
+        return Ok(value as u64);
+    }
+    Ok(DEFAULT_SUMMARY_EVERY)
 }
 
 fn step_label(step: CuComponentState) -> &'static str {
@@ -165,49 +203,112 @@ impl CuMonitor for CuMemMon {
         let components = metadata.components();
         let component_count = components.len();
         let realtime_strict = parse_realtime_strict(metadata.monitor_config())?;
+        let summary_every = parse_summary_every(metadata.monitor_config())?;
 
-        // Detect whether the runtime was built with the counting allocator.
-        // When the feature is off both getters return `None`.
+        // Probe the runtime API: when `memory_monitoring` is off, the macro
+        // never emits ScopedAllocCounter, so this hook would otherwise never
+        // fire — `start()` uses this to print a single warning.
         let counters_available = cu29::monitoring::global_allocated_bytes().is_some();
 
         let state = State {
             per_component: alloc::vec![ComponentCounters::new(); component_count],
             counters_available,
+            rt_pending: alloc::vec![None; component_count],
         };
 
         Ok(Self {
             components,
             component_count,
             realtime_strict,
+            summary_every,
+            cl_counter: AtomicU64::new(0),
             state: Mutex::new(state),
-            rt_violation_logged: AtomicBool::new(false),
+            feature_off_warned: AtomicBool::new(false),
             total_alloc: AtomicU64::new(0),
             total_dealloc: AtomicU64::new(0),
         })
     }
 
     fn start(&mut self, ctx: &CuContext) -> CuResult<()> {
+        // Mirror NoMonitor: tee every live structured log entry to stdout in
+        // std debug builds so apps that pick cu_memmon as their (only)
+        // monitor still see info!/warning!/error! on the console.
+        register_console_listener();
+
         let state = lock_state(&self.state);
         if !state.counters_available {
             warning!(
                 ctx,
-                "cu_memmon enabled but cu29 was built without `memory_monitoring`. All reports will be zero."
+                "cu_memmon enabled but cu29 was built without `memory_monitoring`. \
+                 No allocation scopes emitted; all reports will be zero."
             );
+            self.feature_off_warned.store(true, Ordering::Relaxed);
         } else {
             info!(
                 ctx,
-                "cu_memmon started ({} components, realtime_strict={})",
+                "cu_memmon started: {} components, realtime_strict={}, summary_every={}",
                 self.component_count,
-                self.realtime_strict
+                self.realtime_strict,
+                self.summary_every,
             );
         }
         Ok(())
     }
 
-    fn process_copperlist(&self, _ctx: &CuContext, _view: CopperListView<'_>) -> CuResult<()> {
-        // Per-copperlist hook intentionally a no-op: all the interesting work
-        // happens in observe_alloc. A future revision can fold a throttled
-        // info!() summary in here.
+    fn process_copperlist(&self, ctx: &CuContext, _view: CopperListView<'_>) -> CuResult<()> {
+        // 1) Surface realtime-strict violations: drain pending and return a
+        //    CuError. The runtime will treat this as fatal and shut down.
+        if self.realtime_strict {
+            let drained = {
+                let mut state = lock_state(&self.state);
+                drain_rt_violations(&mut state.rt_pending)
+            };
+            if !drained.is_empty() {
+                // Format only the first violation; multiples in the same
+                // copperlist are rare and a single trip-wire suffices.
+                let (component_id, viol) = drained[0];
+                let name = self.component_name(component_id);
+                let msg = format_rt_violation_message(name, viol);
+                error!(ctx, "{}", msg.as_str());
+                return Err(CuError::from(msg.as_str()));
+            }
+        }
+
+        // 2) Throttled summary. `summary_every == 0` disables the summary.
+        if self.summary_every == 0 {
+            return Ok(());
+        }
+        let n = self.cl_counter.fetch_add(1, Ordering::Relaxed) + 1;
+        if n % self.summary_every != 0 {
+            return Ok(());
+        }
+        // Snapshot under the lock; format without holding it.
+        let snapshot: Vec<(&'static str, ComponentCounters)> = {
+            let state = lock_state(&self.state);
+            if !state.counters_available {
+                return Ok(());
+            }
+            self.components
+                .iter()
+                .zip(state.per_component.iter())
+                .map(|(meta, counters)| (meta.id(), *counters))
+                .collect()
+        };
+        for (name, c) in snapshot.iter() {
+            let leak = c.lifetime_alloc().saturating_sub(c.lifetime_dealloc());
+            info!(
+                ctx,
+                "[mem] {} start=+{}B -{}B | proc max=+{}B over {} calls | stop=+{}B -{}B | leak={}B",
+                *name,
+                c.start.allocated,
+                c.start.deallocated,
+                c.process.max_allocated,
+                c.process.calls,
+                c.stop.allocated,
+                c.stop.deallocated,
+                leak,
+            );
+        }
         Ok(())
     }
 
@@ -218,10 +319,10 @@ impl CuMonitor for CuMemMon {
         allocated_bytes: usize,
         deallocated_bytes: usize,
     ) {
-        // Cheap aggregate counters first — never block on the mutex if the
-        // runtime is hot and another thread is reporting.
         let alloc_u64 = allocated_bytes as u64;
         let dealloc_u64 = deallocated_bytes as u64;
+        // Aggregate counters first — relaxed atomics suffice for an
+        // eventually-correct periodic summary header.
         self.total_alloc.fetch_add(alloc_u64, Ordering::Relaxed);
         self.total_dealloc.fetch_add(dealloc_u64, Ordering::Relaxed);
 
@@ -232,72 +333,60 @@ impl CuMonitor for CuMemMon {
             "cu_memmon: component id {idx} out of bounds {}",
             state.per_component.len()
         );
-        if let Some(component) = state.per_component.get_mut(idx) {
-            let slot = component.slot(step);
-            slot.allocated = slot.allocated.saturating_add(alloc_u64);
-            slot.deallocated = slot.deallocated.saturating_add(dealloc_u64);
-            slot.calls = slot.calls.saturating_add(1);
+        let Some(component) = state.per_component.get_mut(idx) else {
+            return;
+        };
+        let slot = component.slot(step);
+        slot.allocated = slot.allocated.saturating_add(alloc_u64);
+        slot.deallocated = slot.deallocated.saturating_add(dealloc_u64);
+        slot.calls = slot.calls.saturating_add(1);
+        if alloc_u64 > slot.max_allocated {
+            slot.max_allocated = alloc_u64;
         }
 
-        // Realtime-strict warning is one-shot to keep the log clean; the actual
-        // shutdown happens via process_error() once a task surfaces an error,
-        // but most users will catch this via the warning first.
-        if self.realtime_strict
-            && is_realtime_step(step)
-            && allocated_bytes > 0
-            && !self.rt_violation_logged.swap(true, Ordering::Relaxed)
-        {
-            let name = self.component_name(component_id);
-            warning!(
-                "cu_memmon: realtime violation: component {} allocated {} B during {}",
-                name,
-                allocated_bytes as u64,
-                step_label(step)
-            );
+        // Latch realtime violations: any non-zero alloc on a hot-path step
+        // becomes a pending error that the next process_copperlist surfaces.
+        if self.realtime_strict && is_realtime_step(step) && allocated_bytes > 0 {
+            state.rt_pending[idx] = Some(RtViolation {
+                step,
+                allocated: alloc_u64,
+                deallocated: dealloc_u64,
+            });
         }
     }
 
     fn process_error(
         &self,
-        component_id: ComponentId,
-        step: CuComponentState,
-        error: &CuError,
+        _component_id: ComponentId,
+        _step: CuComponentState,
+        _error: &CuError,
     ) -> Decision {
-        let component_name = self.component_name(component_id);
-        error!(
-            "cu_memmon: component {} errored at {}: {}",
-            component_name,
-            step_label(step),
-            error,
-        );
-        // We only escalate when realtime-strict mode actually flagged a
-        // violation; otherwise we stay out of the runtime's way.
-        if self.realtime_strict && self.rt_violation_logged.load(Ordering::Relaxed) {
-            Decision::Shutdown
-        } else {
-            Decision::Ignore
-        }
+        // cu_memmon is a passive observer for non-memory errors: hand the
+        // runtime's default policy back. Memory violations are escalated via
+        // process_copperlist returning Err, not through here.
+        Decision::Ignore
     }
 
     fn stop(&mut self, ctx: &CuContext) -> CuResult<()> {
         let state = lock_state(&self.state);
         if !state.counters_available {
+            unregister_console_listener();
             return Ok(());
         }
         info!(
             ctx,
             "cu_memmon final report: total +{}B / -{}B",
             self.total_alloc.load(Ordering::Relaxed),
-            self.total_dealloc.load(Ordering::Relaxed)
+            self.total_dealloc.load(Ordering::Relaxed),
         );
         for (idx, counters) in state.per_component.iter().enumerate() {
             let name = self.components[idx].id();
             let lifetime_alloc = counters.lifetime_alloc();
             let lifetime_dealloc = counters.lifetime_dealloc();
-            let leak = lifetime_alloc.saturating_sub(lifetime_dealloc);
             let process_alloc = counters.process.allocated;
             let process_calls = counters.process.calls;
-            if leak > 0 {
+            if lifetime_alloc > lifetime_dealloc {
+                let leak = lifetime_alloc - lifetime_dealloc;
                 warning!(
                     ctx,
                     "cu_memmon: task {} leak={}B (alloc {}B, dealloc {}B); process allocated {}B over {} calls",
@@ -306,7 +395,22 @@ impl CuMonitor for CuMemMon {
                     lifetime_alloc,
                     lifetime_dealloc,
                     process_alloc,
-                    process_calls
+                    process_calls,
+                );
+            } else if lifetime_alloc < lifetime_dealloc {
+                // Symmetric anomaly: the task freed more than it allocated
+                // within its own scopes. Usually means it returned memory
+                // originally allocated outside its observed lifecycle.
+                let excess = lifetime_dealloc - lifetime_alloc;
+                warning!(
+                    ctx,
+                    "cu_memmon: task {} dealloc excess={}B (alloc {}B, dealloc {}B); process allocated {}B over {} calls — task may free memory it didn't allocate within its own steps",
+                    name,
+                    excess,
+                    lifetime_alloc,
+                    lifetime_dealloc,
+                    process_alloc,
+                    process_calls,
                 );
             } else {
                 info!(
@@ -316,13 +420,75 @@ impl CuMonitor for CuMemMon {
                     lifetime_alloc,
                     lifetime_dealloc,
                     process_alloc,
-                    process_calls
+                    process_calls,
                 );
             }
         }
+        drop(state);
+        unregister_console_listener();
         Ok(())
     }
 }
+
+fn drain_rt_violations(
+    pending: &mut [Option<RtViolation>],
+) -> Vec<(ComponentId, RtViolation)> {
+    let mut out = Vec::new();
+    for (idx, slot) in pending.iter_mut().enumerate() {
+        if let Some(v) = slot.take() {
+            out.push((ComponentId::new(idx), v));
+        }
+    }
+    out
+}
+
+#[cfg(feature = "std")]
+fn format_rt_violation_message(name: &str, viol: RtViolation) -> String {
+    alloc::format!(
+        "cu_memmon: realtime violation: component {} allocated {} B (deallocated {} B) during {}",
+        name,
+        viol.allocated,
+        viol.deallocated,
+        step_label(viol.step),
+    )
+}
+
+#[cfg(not(feature = "std"))]
+fn format_rt_violation_message(name: &str, viol: RtViolation) -> &'static str {
+    // In no_std builds we don't allocate the message; emit a fixed sentinel
+    // so the user still sees *that* a violation happened. The kind/component
+    // is already reported via error!(...) immediately before this is sent.
+    let _ = (name, viol);
+    "cu_memmon: realtime allocation violation"
+}
+
+#[cfg(all(feature = "std", debug_assertions))]
+fn register_console_listener() {
+    use std::println;
+    register_live_log_listener(|entry, format_str, param_names| {
+        let params: Vec<String> = entry.params.iter().map(|v| v.to_string()).collect();
+        let named: StdHashMap<String, String> = param_names
+            .iter()
+            .zip(params.iter())
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect();
+
+        if let Ok(msg) = format_message_only(format_str, params.as_slice(), &named) {
+            println!("[{:?}] {}", entry.level, msg);
+        }
+    });
+}
+
+#[cfg(not(all(feature = "std", debug_assertions)))]
+fn register_console_listener() {}
+
+#[cfg(all(feature = "std", debug_assertions))]
+fn unregister_console_listener() {
+    unregister_live_log_listener();
+}
+
+#[cfg(not(all(feature = "std", debug_assertions)))]
+fn unregister_console_listener() {}
 
 #[cfg(test)]
 mod tests {
@@ -361,10 +527,29 @@ mod tests {
 
         assert_eq!(c.lifetime_alloc(), 1024 + 256);
         assert_eq!(c.lifetime_dealloc(), 256 + 1024);
-        // Net balanced over the lifetime: no leak.
         assert_eq!(
             c.lifetime_alloc().saturating_sub(c.lifetime_dealloc()),
             0
         );
+    }
+
+    #[test]
+    fn drain_rt_violations_takes_pending_only() {
+        let mut pending = alloc::vec![
+            None,
+            Some(RtViolation { step: CuComponentState::Process, allocated: 128, deallocated: 0 }),
+            None,
+            Some(RtViolation { step: CuComponentState::Preprocess, allocated: 32, deallocated: 0 }),
+        ];
+        let drained = drain_rt_violations(&mut pending);
+        assert_eq!(drained.len(), 2);
+        assert!(pending.iter().all(|s| s.is_none()));
+        // Second drain reports nothing.
+        assert!(drain_rt_violations(&mut pending).is_empty());
+
+        let indices: Vec<usize> = drained.iter().map(|(id, _)| id.index()).collect();
+        assert_eq!(indices, alloc::vec![1, 3]);
+        assert!(matches!(drained[0].1.step, CuComponentState::Process));
+        assert_eq!(drained[0].1.allocated, 128);
     }
 }

--- a/components/monitors/cu_memmon/src/lib.rs
+++ b/components/monitors/cu_memmon/src/lib.rs
@@ -11,17 +11,25 @@
 //!
 //! Optional realtime-strict mode (`realtime_strict: true` in the monitor's
 //! RON config) latches any non-zero allocation observed during `Preprocess`,
-//! `Process`, or `Postprocess` and surfaces it from the *next*
-//! `process_copperlist` as a `CuError`. The runtime treats that as a fatal
-//! monitor error and shuts down cleanly — so a violation in
-//! e.g. `process` reliably aborts the run regardless of whether any other
-//! component errored, and unrelated task errors are not affected.
+//! `Process`, or `Postprocess` and surfaces it from the *following*
+//! `process_copperlist` call as a `CuError`. In practice that is the very same
+//! iteration's `process_copperlist` (it runs after all the step hooks), so the
+//! violation aborts the run within the same tick it occurred in. The runtime
+//! treats the returned error as a fatal monitor error and shuts down cleanly
+//! — unrelated task errors are not escalated by this path. The first violating
+//! step in a copperlist wins (later violations in the same window are
+//! observed but don't overwrite the latched cause).
 //!
 //! When the runtime is **not** built with `cu29/memory_monitoring`, the macro
-//! emits no allocation scopes, so `observe_alloc` is never called.
-//! `CuMemMon` detects this at `start()` by probing the public counter API
-//! and emits a single `warning!` so the build configuration is obvious from
-//! the log.
+//! emits no allocation scopes, so `observe_alloc` is never called. `CuMemMon`
+//! detects this in two complementary ways:
+//! - At `start()` it probes the public counter API
+//!   ([`cu29::monitoring::global_allocated_bytes`]). If that returns `None`
+//!   the runtime side is off and we warn immediately.
+//! - If the runtime side is on but no `observe_alloc` ever fires (the macro
+//!   side was built without the feature — possible when features are wired
+//!   piecemeal instead of through the `cu29` umbrella), the first scheduled
+//!   summary tick emits a one-shot warning.
 
 extern crate alloc;
 
@@ -133,6 +141,14 @@ pub struct CuMemMon {
     state: Mutex<State>,
     /// True once we've emitted the "feature off" warning, so we don't spam.
     feature_off_warned: AtomicBool,
+    /// Set to true the first time `observe_alloc` fires. Combined with
+    /// `counters_available`, this catches the case where the runtime crate has
+    /// `memory_monitoring` enabled but the derive crate doesn't — the probe
+    /// would otherwise read as "active" while no scope ever runs.
+    first_observation_seen: AtomicBool,
+    /// True once we've warned that the macro side seems to be off despite the
+    /// runtime side being on. Prevents spamming the log every summary tick.
+    derive_off_warned: AtomicBool,
     /// Total observed allocations / deallocations across the whole runtime
     /// (cheap monotonic counters for the periodic summary header).
     total_alloc: AtomicU64,
@@ -224,6 +240,8 @@ impl CuMonitor for CuMemMon {
             cl_counter: AtomicU64::new(0),
             state: Mutex::new(state),
             feature_off_warned: AtomicBool::new(false),
+            first_observation_seen: AtomicBool::new(false),
+            derive_off_warned: AtomicBool::new(false),
             total_alloc: AtomicU64::new(0),
             total_dealloc: AtomicU64::new(0),
         })
@@ -292,6 +310,24 @@ impl CuMonitor for CuMemMon {
                 .map(|(meta, counters)| (meta.id(), *counters))
                 .collect()
         };
+        // Detect the derive-side-off misconfiguration: the runtime crate has
+        // the counting allocator installed (counters_available == true) but
+        // the proc-macro never emitted any ScopedAllocCounter scopes, so
+        // observe_alloc has never fired by the time the first summary fires.
+        // Warn once and continue; the summary lines will read all-zero on
+        // their own and that explains why.
+        if !self.first_observation_seen.load(Ordering::Relaxed)
+            && !self.derive_off_warned.swap(true, Ordering::Relaxed)
+        {
+            warning!(
+                ctx,
+                "cu_memmon: runtime allocator counters are active but no allocation \
+                 scopes have fired after {} copperlists. This usually means cu29-derive \
+                 was built without the `memory_monitoring` feature. Enable it via the \
+                 cu29 umbrella crate: `cu29 = {{ features = [\"memory_monitoring\"] }}`.",
+                n,
+            );
+        }
         for (name, c) in snapshot.iter() {
             let leak = c.lifetime_alloc().saturating_sub(c.lifetime_dealloc());
             info!(
@@ -323,6 +359,9 @@ impl CuMonitor for CuMemMon {
         // eventually-correct periodic summary header.
         self.total_alloc.fetch_add(alloc_u64, Ordering::Relaxed);
         self.total_dealloc.fetch_add(dealloc_u64, Ordering::Relaxed);
+        // Record that the macro side did wire up scopes, so the periodic
+        // probe in process_copperlist doesn't false-alarm.
+        self.first_observation_seen.store(true, Ordering::Relaxed);
 
         let mut state = lock_state(&self.state);
         let idx = component_id.index();
@@ -342,9 +381,16 @@ impl CuMonitor for CuMemMon {
             slot.max_allocated = alloc_u64;
         }
 
-        // Latch realtime violations: any non-zero alloc on a hot-path step
-        // becomes a pending error that the next process_copperlist surfaces.
-        if self.realtime_strict && is_realtime_step(step) && allocated_bytes > 0 {
+        // Latch realtime violations: first non-zero alloc on a hot-path step
+        // becomes a pending error that the following process_copperlist
+        // surfaces. First-wins: once a violation is latched we keep it, so
+        // the surfaced cause names the *earliest* offending step rather than
+        // whatever happened to fire last.
+        if self.realtime_strict
+            && is_realtime_step(step)
+            && allocated_bytes > 0
+            && state.rt_pending[idx].is_none()
+        {
             state.rt_pending[idx] = Some(RtViolation {
                 step,
                 allocated: alloc_u64,

--- a/core/cu29/Cargo.toml
+++ b/core/cu29/Cargo.toml
@@ -82,11 +82,15 @@ parallel-rt = ["std", "cu29-derive/parallel-rt", "cu29-runtime/parallel-rt"]
 rt-scheduling = ["std", "cu29-runtime/rt-scheduling"]
 mmap-fsync = ["std", "cu29-runtime/mmap-fsync", "cu29-unifiedlog/mmap-fsync"]
 # Install a heap-allocation-counting global allocator (cu29-runtime side) and
-# enable the cu29-runtime side of the per-task allocation observation pipeline.
-# Without this feature, `monitor.observe_alloc(...)` is still called by the
-# generated runtime code but always reports zero, so a monitor like `cu_memmon`
-# can detect and report "memory monitoring not compiled in".
-memory_monitoring = ["std", "cu29-runtime/memory_monitoring"]
+# emit per-task allocation scopes around every lifecycle step (cu29-derive
+# side). With this feature off, `cu29-derive` skips the scope codegen entirely,
+# so a monitor never sees the hook fire — there's zero runtime cost. With it
+# on, monitors receive observe_alloc(...) deltas around every step.
+memory_monitoring = [
+  "std",
+  "cu29-runtime/memory_monitoring",
+  "cu29-derive/memory_monitoring",
+]
 std = [
   "rayon",
   "cu29-clock/std",

--- a/core/cu29/Cargo.toml
+++ b/core/cu29/Cargo.toml
@@ -81,6 +81,12 @@ async-cl-io = ["std", "cu29-derive/async-cl-io", "cu29-runtime/async-cl-io"]
 parallel-rt = ["std", "cu29-derive/parallel-rt", "cu29-runtime/parallel-rt"]
 rt-scheduling = ["std", "cu29-runtime/rt-scheduling"]
 mmap-fsync = ["std", "cu29-runtime/mmap-fsync", "cu29-unifiedlog/mmap-fsync"]
+# Install a heap-allocation-counting global allocator (cu29-runtime side) and
+# enable the cu29-runtime side of the per-task allocation observation pipeline.
+# Without this feature, `monitor.observe_alloc(...)` is still called by the
+# generated runtime code but always reports zero, so a monitor like `cu_memmon`
+# can detect and report "memory monitoring not compiled in".
+memory_monitoring = ["std", "cu29-runtime/memory_monitoring"]
 std = [
   "rayon",
   "cu29-clock/std",

--- a/core/cu29_derive/Cargo.toml
+++ b/core/cu29_derive/Cargo.toml
@@ -42,6 +42,11 @@ macro_debug = ["cu29-runtime/macro_debug"]
 std = ["cu29-traits/std", "cu29-unifiedlog/std"]
 async-cl-io = ["cu29-runtime/async-cl-io"]
 parallel-rt = ["cu29-runtime/parallel-rt"]
+# Emit per-task allocation scopes around each task/bridge lifecycle step in the
+# generated runtime so a monitor can fan deltas out via `observe_alloc`. The
+# `cu29` umbrella crate's `memory_monitoring` feature forwards to this one; you
+# normally don't enable it directly on `cu29-derive`.
+memory_monitoring = ["cu29-runtime/memory_monitoring"]
 signal-handler = []
 rtsan = []
 

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -54,6 +54,44 @@ fn rtsan_guard_tokens() -> proc_macro2::TokenStream {
     }
 }
 
+/// Opens a heap-allocation accounting scope (binds `__cu_alloc_scope`) iff the
+/// `memory_monitoring` feature is enabled. Otherwise expands to nothing, so a
+/// default build emits zero extra code per task step.
+fn alloc_scope_open_tokens() -> proc_macro2::TokenStream {
+    if cfg!(feature = "memory_monitoring") {
+        quote! {
+            let __cu_alloc_scope = cu29::monitoring::ScopedAllocCounter::new();
+        }
+    } else {
+        quote! {}
+    }
+}
+
+/// Forwards the scope's accumulated delta to `monitor.observe_alloc(...)` and
+/// drops the scope. `monitor_expr` is whatever expression reaches the monitor
+/// in the current code block (`monitor` for preprocess/process/postprocess,
+/// `self.copper_runtime.monitor` for start/stop). `component_index` and `step`
+/// are the tokens to be passed through to `ComponentId::new(...)` and the
+/// `CuComponentState` variant.
+fn alloc_scope_close_tokens(
+    monitor_expr: proc_macro2::TokenStream,
+    component_index: proc_macro2::TokenStream,
+    step: proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    if cfg!(feature = "memory_monitoring") {
+        quote! {
+            #monitor_expr.observe_alloc(
+                cu29::monitoring::ComponentId::new(#component_index),
+                #step,
+                __cu_alloc_scope.allocated(),
+                __cu_alloc_scope.deallocated(),
+            );
+        }
+    } else {
+        quote! {}
+    }
+}
+
 fn git_output_trimmed(repo_root: &Path, args: &[&str]) -> Option<String> {
     let output = Command::new("git")
         .arg("-C")
@@ -2511,6 +2549,12 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         };
 
 
+                        let alloc_open = alloc_scope_open_tokens();
+                        let alloc_close = alloc_scope_close_tokens(
+                            quote! { self.copper_runtime.monitor },
+                            quote! { #index },
+                            quote! { CuComponentState::Start },
+                        );
                         quote! {
                             #call_sim_callback
                             if doit {
@@ -2523,15 +2567,9 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                 );
                                 let task = &mut self.copper_runtime.tasks.#task_index;
                                 ctx.set_current_task(#index);
-                                let __cu_alloc_scope = cu29::monitoring::ScopedAllocCounter::new();
+                                #alloc_open
                                 let __cu_step_result = task.start(&ctx);
-                                self.copper_runtime.monitor.observe_alloc(
-                                    cu29::monitoring::ComponentId::new(#index),
-                                    CuComponentState::Start,
-                                    __cu_alloc_scope.allocated(),
-                                    __cu_alloc_scope.deallocated(),
-                                );
-                                drop(__cu_alloc_scope);
+                                #alloc_close
                                 if let Err(error) = __cu_step_result {
                                     #monitoring_action
                                 }
@@ -2578,6 +2616,12 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                 let doit = true;  // in normal mode always execute the steps in the runtime.
                             }
                         };
+                        let alloc_open = alloc_scope_open_tokens();
+                        let alloc_close = alloc_scope_close_tokens(
+                            quote! { self.copper_runtime.monitor },
+                            quote! { #index },
+                            quote! { CuComponentState::Stop },
+                        );
                         quote! {
                             #call_sim_callback
                             if doit {
@@ -2590,15 +2634,9 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                 );
                                 let task = &mut self.copper_runtime.tasks.#task_index;
                                 ctx.set_current_task(#index);
-                                let __cu_alloc_scope = cu29::monitoring::ScopedAllocCounter::new();
+                                #alloc_open
                                 let __cu_step_result = task.stop(&ctx);
-                                self.copper_runtime.monitor.observe_alloc(
-                                    cu29::monitoring::ComponentId::new(#index),
-                                    CuComponentState::Stop,
-                                    __cu_alloc_scope.allocated(),
-                                    __cu_alloc_scope.deallocated(),
-                                );
-                                drop(__cu_alloc_scope);
+                                #alloc_close
                                 if let Err(error) = __cu_step_result {
                                     #monitoring_action
                                 }
@@ -2644,6 +2682,12 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                 let doit = true;  // in normal mode always execute the steps in the runtime.
                             }
                         };
+                        let alloc_open = alloc_scope_open_tokens();
+                        let alloc_close = alloc_scope_close_tokens(
+                            quote! { monitor },
+                            quote! { #index },
+                            quote! { CuComponentState::Preprocess },
+                        );
                         quote! {
                             #call_sim_callback
                             if doit {
@@ -2653,18 +2697,12 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                     culistid: None,
                                 });
                                 ctx.set_current_task(#index);
-                                let __cu_alloc_scope = cu29::monitoring::ScopedAllocCounter::new();
+                                #alloc_open
                                 let maybe_error = {
                                     #rt_guard
                                     tasks.#task_index.preprocess(&ctx)
                                 };
-                                monitor.observe_alloc(
-                                    cu29::monitoring::ComponentId::new(#index),
-                                    CuComponentState::Preprocess,
-                                    __cu_alloc_scope.allocated(),
-                                    __cu_alloc_scope.deallocated(),
-                                );
-                                drop(__cu_alloc_scope);
+                                #alloc_close
                                 if let Err(error) = maybe_error {
                                     #monitoring_action
                                 }
@@ -2710,6 +2748,12 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                 let doit = true;  // in normal mode always execute the steps in the runtime.
                             }
                         };
+                        let alloc_open = alloc_scope_open_tokens();
+                        let alloc_close = alloc_scope_close_tokens(
+                            quote! { monitor },
+                            quote! { #index },
+                            quote! { CuComponentState::Postprocess },
+                        );
                         quote! {
                             #call_sim_callback
                             if doit {
@@ -2719,18 +2763,12 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                     culistid: None,
                                 });
                                 ctx.set_current_task(#index);
-                                let __cu_alloc_scope = cu29::monitoring::ScopedAllocCounter::new();
+                                #alloc_open
                                 let maybe_error = {
                                     #rt_guard
                                     tasks.#task_index.postprocess(&ctx)
                                 };
-                                monitor.observe_alloc(
-                                    cu29::monitoring::ComponentId::new(#index),
-                                    CuComponentState::Postprocess,
-                                    __cu_alloc_scope.allocated(),
-                                    __cu_alloc_scope.deallocated(),
-                                );
-                                drop(__cu_alloc_scope);
+                                #alloc_close
                                 if let Err(error) = maybe_error {
                                     #monitoring_action
                                 }
@@ -2774,6 +2812,12 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 } else {
                     quote! { let doit = true; }
                 };
+                let alloc_open = alloc_scope_open_tokens();
+                let alloc_close = alloc_scope_close_tokens(
+                    quote! { self.copper_runtime.monitor },
+                    quote! { #monitor_index },
+                    quote! { CuComponentState::Start },
+                );
                 quote! {
                     {
                         #call_sim
@@ -2788,7 +2832,10 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         ctx.set_current_component(#monitor_index);
                         ctx.clear_current_task();
                         let bridge = &mut self.copper_runtime.bridges.#bridge_index;
-                        if let Err(error) = bridge.start(&ctx) {
+                        #alloc_open
+                        let __cu_step_result = bridge.start(&ctx);
+                        #alloc_close
+                        if let Err(error) = __cu_step_result {
                             let decision = self.copper_runtime.monitor.process_error(cu29::monitoring::ComponentId::new(#monitor_index), CuComponentState::Start, &error);
                             match decision {
                                 Decision::Abort => {
@@ -2842,6 +2889,12 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 } else {
                     quote! { let doit = true; }
                 };
+                let alloc_open = alloc_scope_open_tokens();
+                let alloc_close = alloc_scope_close_tokens(
+                    quote! { self.copper_runtime.monitor },
+                    quote! { #monitor_index },
+                    quote! { CuComponentState::Stop },
+                );
                 quote! {
                     {
                         #call_sim
@@ -2856,7 +2909,10 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         ctx.set_current_component(#monitor_index);
                         ctx.clear_current_task();
                         let bridge = &mut self.copper_runtime.bridges.#bridge_index;
-                        if let Err(error) = bridge.stop(&ctx) {
+                        #alloc_open
+                        let __cu_step_result = bridge.stop(&ctx);
+                        #alloc_close
+                        if let Err(error) = __cu_step_result {
                             let decision = self.copper_runtime.monitor.process_error(cu29::monitoring::ComponentId::new(#monitor_index), CuComponentState::Stop, &error);
                             match decision {
                                 Decision::Abort => {
@@ -2910,6 +2966,12 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 } else {
                     quote! { let doit = true; }
                 };
+                let alloc_open = alloc_scope_open_tokens();
+                let alloc_close = alloc_scope_close_tokens(
+                    quote! { monitor },
+                    quote! { #monitor_index },
+                    quote! { CuComponentState::Preprocess },
+                );
                 quote! {
                     {
                         #call_sim
@@ -2922,10 +2984,12 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                 step: CuComponentState::Preprocess,
                                 culistid: None,
                             });
+                            #alloc_open
                             let maybe_error = {
                                 #rt_guard
                                 bridge.preprocess(&ctx)
                             };
+                            #alloc_close
                             if let Err(error) = maybe_error {
                                 let decision = monitor.process_error(cu29::monitoring::ComponentId::new(#monitor_index), CuComponentState::Preprocess, &error);
                                 match decision {
@@ -2981,6 +3045,12 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 } else {
                     quote! { let doit = true; }
                 };
+                let alloc_open = alloc_scope_open_tokens();
+                let alloc_close = alloc_scope_close_tokens(
+                    quote! { monitor },
+                    quote! { #monitor_index },
+                    quote! { CuComponentState::Postprocess },
+                );
                 quote! {
                     {
                         #call_sim
@@ -2994,10 +3064,12 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                 step: CuComponentState::Postprocess,
                                 culistid: Some(clid),
                             });
+                            #alloc_open
                             let maybe_error = {
                                 #rt_guard
                                 bridge.postprocess(&ctx)
                             };
+                            #alloc_close
                             if let Err(error) = maybe_error {
                                 let decision = monitor.process_error(cu29::monitoring::ComponentId::new(#monitor_index), CuComponentState::Postprocess, &error);
                                 match decision {
@@ -8037,6 +8109,18 @@ fn parallel_task_lifecycle_tokens(
         CuTaskType::Regular => quote! { cu29::cutask::CuTask },
     };
 
+    let preprocess_alloc_open = alloc_scope_open_tokens();
+    let preprocess_alloc_close = alloc_scope_close_tokens(
+        quote! { monitor },
+        quote! { #component_index },
+        quote! { CuComponentState::Preprocess },
+    );
+    let postprocess_alloc_open = alloc_scope_open_tokens();
+    let postprocess_alloc_close = alloc_scope_close_tokens(
+        quote! { monitor },
+        quote! { #component_index },
+        quote! { CuComponentState::Postprocess },
+    );
     let preprocess = if placement.preprocess {
         quote! {
             execution_probe.record(cu29::monitoring::ExecutionMarker {
@@ -8045,10 +8129,12 @@ fn parallel_task_lifecycle_tokens(
                 culistid: Some(clid),
             });
             ctx.set_current_task(#component_index);
+            #preprocess_alloc_open
             let maybe_error = {
                 #rt_guard
                 <#task_type as #task_trait>::preprocess(&mut #task_instance, &ctx)
             };
+            #preprocess_alloc_close
             if let Err(error) = maybe_error {
                 let decision = monitor.process_error(
                     cu29::monitoring::ComponentId::new(#component_index),
@@ -8095,10 +8181,12 @@ fn parallel_task_lifecycle_tokens(
                 culistid: Some(clid),
             });
             ctx.set_current_task(#component_index);
+            #postprocess_alloc_open
             let maybe_error = {
                 #rt_guard
                 <#task_type as #task_trait>::postprocess(&mut #task_instance, &ctx)
             };
+            #postprocess_alloc_close
             if let Err(error) = maybe_error {
                 let decision = monitor.process_error(
                     cu29::monitoring::ComponentId::new(#component_index),
@@ -8147,6 +8235,18 @@ fn parallel_bridge_lifecycle_tokens(
     let rt_guard = rtsan_guard_tokens();
     let abort_process_step = abort_process_step_tokens(true);
 
+    let preprocess_alloc_open = alloc_scope_open_tokens();
+    let preprocess_alloc_close = alloc_scope_close_tokens(
+        quote! { monitor },
+        quote! { #component_index },
+        quote! { CuComponentState::Preprocess },
+    );
+    let postprocess_alloc_open = alloc_scope_open_tokens();
+    let postprocess_alloc_close = alloc_scope_close_tokens(
+        quote! { monitor },
+        quote! { #component_index },
+        quote! { CuComponentState::Postprocess },
+    );
     let preprocess = if placement.preprocess {
         quote! {
             execution_probe.record(cu29::monitoring::ExecutionMarker {
@@ -8156,10 +8256,12 @@ fn parallel_bridge_lifecycle_tokens(
             });
             ctx.set_current_component(#component_index);
             ctx.clear_current_task();
+            #preprocess_alloc_open
             let maybe_error = {
                 #rt_guard
                 <#bridge_type as cu29::cubridge::CuBridge>::preprocess(bridge, &ctx)
             };
+            #preprocess_alloc_close
             if let Err(error) = maybe_error {
                 let decision = monitor.process_error(
                     cu29::monitoring::ComponentId::new(#component_index),
@@ -8208,10 +8310,12 @@ fn parallel_bridge_lifecycle_tokens(
             });
             ctx.set_current_component(#component_index);
             ctx.clear_current_task();
+            #postprocess_alloc_open
             let maybe_error = {
                 #rt_guard
                 <#bridge_type as cu29::cubridge::CuBridge>::postprocess(bridge, &ctx)
             };
+            #postprocess_alloc_close
             if let Err(error) = maybe_error {
                 let decision = monitor.process_error(
                     cu29::monitoring::ComponentId::new(#component_index),
@@ -8463,6 +8567,12 @@ fn generate_task_execution_tokens(
             } else {
                 quote!()
             };
+            let alloc_open = alloc_scope_open_tokens();
+            let alloc_close = alloc_scope_close_tokens(
+                quote! { monitor },
+                quote! { #tid },
+                quote! { CuComponentState::Process },
+            );
             let source_process_tokens = quote! {
                 #[allow(non_camel_case_types)]
                 trait #source_slot_match_trait_ident<Expected> {
@@ -8486,7 +8596,7 @@ fn generate_task_execution_tokens(
                 }
 
                 #output_start_time
-                let __cu_alloc_scope = cu29::monitoring::ScopedAllocCounter::new();
+                #alloc_open
                 let result = {
                     let cumsg_output = #source_slot_match_fn_ident::<
                         _,
@@ -8497,13 +8607,7 @@ fn generate_task_execution_tokens(
                     #task_instance.process(&ctx, cumsg_output)
                 };
                 #output_end_time
-                monitor.observe_alloc(
-                    cu29::monitoring::ComponentId::new(#tid),
-                    CuComponentState::Process,
-                    __cu_alloc_scope.allocated(),
-                    __cu_alloc_scope.deallocated(),
-                );
-                drop(__cu_alloc_scope);
+                #alloc_close
                 result
             };
 
@@ -8592,6 +8696,12 @@ fn generate_task_execution_tokens(
                 quote! { let doit = true; }
             };
 
+            let alloc_open = alloc_scope_open_tokens();
+            let alloc_close = alloc_scope_close_tokens(
+                quote! { monitor },
+                quote! { #tid },
+                quote! { CuComponentState::Process },
+            );
             (
                 wrap_process_step_tokens(
                     wrap_process_step,
@@ -8611,20 +8721,14 @@ fn generate_task_execution_tokens(
                                 culistid: Some(clid),
                             });
                             #output_start_time
-                            let __cu_alloc_scope = cu29::monitoring::ScopedAllocCounter::new();
+                            #alloc_open
                             let result = {
                                 #rt_guard
                                 ctx.set_current_task(#tid);
                                 #task_instance.process(&ctx, cumsg_input)
                             };
                             #output_end_time
-                            monitor.observe_alloc(
-                                cu29::monitoring::ComponentId::new(#tid),
-                                CuComponentState::Process,
-                                __cu_alloc_scope.allocated(),
-                                __cu_alloc_scope.deallocated(),
-                            );
-                            drop(__cu_alloc_scope);
+                            #alloc_close
                             result
                         } else {
                             Ok(())
@@ -8702,6 +8806,12 @@ fn generate_task_execution_tokens(
             } else {
                 quote!()
             };
+            let alloc_open = alloc_scope_open_tokens();
+            let alloc_close = alloc_scope_close_tokens(
+                quote! { monitor },
+                quote! { #tid },
+                quote! { CuComponentState::Process },
+            );
             let regular_process_tokens = quote! {
                 #[allow(non_camel_case_types)]
                 trait #regular_slot_match_trait_ident<Expected> {
@@ -8725,7 +8835,7 @@ fn generate_task_execution_tokens(
                 }
 
                 #output_start_time
-                let __cu_alloc_scope = cu29::monitoring::ScopedAllocCounter::new();
+                #alloc_open
                 let result = {
                     let cumsg_output = #regular_slot_match_fn_ident::<
                         _,
@@ -8736,13 +8846,7 @@ fn generate_task_execution_tokens(
                     #task_instance.process(&ctx, cumsg_input, cumsg_output)
                 };
                 #output_end_time
-                monitor.observe_alloc(
-                    cu29::monitoring::ComponentId::new(#tid),
-                    CuComponentState::Process,
-                    __cu_alloc_scope.allocated(),
-                    __cu_alloc_scope.deallocated(),
-                );
-                drop(__cu_alloc_scope);
+                #alloc_close
                 result
             };
 
@@ -8875,6 +8979,12 @@ fn generate_bridge_rx_execution_tokens(
     } else {
         quote! { let doit = true; }
     };
+    let alloc_open = alloc_scope_open_tokens();
+    let alloc_close = alloc_scope_close_tokens(
+        quote! { monitor },
+        quote! { #monitor_index },
+        quote! { CuComponentState::Process },
+    );
     (
         wrap_process_step_tokens(
             wrap_process_step,
@@ -8890,6 +9000,7 @@ fn generate_bridge_rx_execution_tokens(
                         culistid: Some(clid),
                     });
                     cumsg_output.metadata.process_time.start = cu29::curuntime::perf_now(clock).into();
+                    #alloc_open
                     let maybe_error = {
                         #rt_guard
                         ctx.set_current_component(#monitor_index);
@@ -8901,6 +9012,7 @@ fn generate_bridge_rx_execution_tokens(
                         )
                     };
                     cumsg_output.metadata.process_time.end = cu29::curuntime::perf_now(clock).into();
+                    #alloc_close
                     if let Err(error) = maybe_error {
                         let decision = monitor.process_error(cu29::monitoring::ComponentId::new(#monitor_index), CuComponentState::Process, &error);
                         match decision {
@@ -9033,6 +9145,12 @@ fn generate_bridge_tx_execution_tokens(
     } else {
         quote! { let doit = true; }
     };
+    let alloc_open = alloc_scope_open_tokens();
+    let alloc_close = alloc_scope_close_tokens(
+        quote! { monitor },
+        quote! { #monitor_index },
+        quote! { CuComponentState::Process },
+    );
     (
         wrap_process_step_tokens(
             wrap_process_step,
@@ -9050,6 +9168,7 @@ fn generate_bridge_tx_execution_tokens(
                         culistid: Some(clid),
                     });
                     cumsg_output.metadata.process_time.start = cu29::curuntime::perf_now(clock).into();
+                    #alloc_open
                     let maybe_error = if bridge_channel.should_send(cumsg_input.payload().is_some()) {
                         {
                             #rt_guard
@@ -9064,6 +9183,7 @@ fn generate_bridge_tx_execution_tokens(
                     } else {
                         Ok(())
                     };
+                    #alloc_close
                     if let Err(error) = maybe_error {
                         let decision = monitor.process_error(cu29::monitoring::ComponentId::new(#monitor_index), CuComponentState::Process, &error);
                         match decision {

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -2523,7 +2523,16 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                 );
                                 let task = &mut self.copper_runtime.tasks.#task_index;
                                 ctx.set_current_task(#index);
-                                if let Err(error) = task.start(&ctx) {
+                                let __cu_alloc_scope = cu29::monitoring::ScopedAllocCounter::new();
+                                let __cu_step_result = task.start(&ctx);
+                                self.copper_runtime.monitor.observe_alloc(
+                                    cu29::monitoring::ComponentId::new(#index),
+                                    CuComponentState::Start,
+                                    __cu_alloc_scope.allocated(),
+                                    __cu_alloc_scope.deallocated(),
+                                );
+                                drop(__cu_alloc_scope);
+                                if let Err(error) = __cu_step_result {
                                     #monitoring_action
                                 }
                             }
@@ -2581,7 +2590,16 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                 );
                                 let task = &mut self.copper_runtime.tasks.#task_index;
                                 ctx.set_current_task(#index);
-                                if let Err(error) = task.stop(&ctx) {
+                                let __cu_alloc_scope = cu29::monitoring::ScopedAllocCounter::new();
+                                let __cu_step_result = task.stop(&ctx);
+                                self.copper_runtime.monitor.observe_alloc(
+                                    cu29::monitoring::ComponentId::new(#index),
+                                    CuComponentState::Stop,
+                                    __cu_alloc_scope.allocated(),
+                                    __cu_alloc_scope.deallocated(),
+                                );
+                                drop(__cu_alloc_scope);
+                                if let Err(error) = __cu_step_result {
                                     #monitoring_action
                                 }
                             }
@@ -2635,10 +2653,18 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                     culistid: None,
                                 });
                                 ctx.set_current_task(#index);
+                                let __cu_alloc_scope = cu29::monitoring::ScopedAllocCounter::new();
                                 let maybe_error = {
                                     #rt_guard
                                     tasks.#task_index.preprocess(&ctx)
                                 };
+                                monitor.observe_alloc(
+                                    cu29::monitoring::ComponentId::new(#index),
+                                    CuComponentState::Preprocess,
+                                    __cu_alloc_scope.allocated(),
+                                    __cu_alloc_scope.deallocated(),
+                                );
+                                drop(__cu_alloc_scope);
                                 if let Err(error) = maybe_error {
                                     #monitoring_action
                                 }
@@ -2693,10 +2719,18 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                     culistid: None,
                                 });
                                 ctx.set_current_task(#index);
+                                let __cu_alloc_scope = cu29::monitoring::ScopedAllocCounter::new();
                                 let maybe_error = {
                                     #rt_guard
                                     tasks.#task_index.postprocess(&ctx)
                                 };
+                                monitor.observe_alloc(
+                                    cu29::monitoring::ComponentId::new(#index),
+                                    CuComponentState::Postprocess,
+                                    __cu_alloc_scope.allocated(),
+                                    __cu_alloc_scope.deallocated(),
+                                );
+                                drop(__cu_alloc_scope);
                                 if let Err(error) = maybe_error {
                                     #monitoring_action
                                 }
@@ -8452,6 +8486,7 @@ fn generate_task_execution_tokens(
                 }
 
                 #output_start_time
+                let __cu_alloc_scope = cu29::monitoring::ScopedAllocCounter::new();
                 let result = {
                     let cumsg_output = #source_slot_match_fn_ident::<
                         _,
@@ -8462,6 +8497,13 @@ fn generate_task_execution_tokens(
                     #task_instance.process(&ctx, cumsg_output)
                 };
                 #output_end_time
+                monitor.observe_alloc(
+                    cu29::monitoring::ComponentId::new(#tid),
+                    CuComponentState::Process,
+                    __cu_alloc_scope.allocated(),
+                    __cu_alloc_scope.deallocated(),
+                );
+                drop(__cu_alloc_scope);
                 result
             };
 
@@ -8569,12 +8611,20 @@ fn generate_task_execution_tokens(
                                 culistid: Some(clid),
                             });
                             #output_start_time
+                            let __cu_alloc_scope = cu29::monitoring::ScopedAllocCounter::new();
                             let result = {
                                 #rt_guard
                                 ctx.set_current_task(#tid);
                                 #task_instance.process(&ctx, cumsg_input)
                             };
                             #output_end_time
+                            monitor.observe_alloc(
+                                cu29::monitoring::ComponentId::new(#tid),
+                                CuComponentState::Process,
+                                __cu_alloc_scope.allocated(),
+                                __cu_alloc_scope.deallocated(),
+                            );
+                            drop(__cu_alloc_scope);
                             result
                         } else {
                             Ok(())
@@ -8675,6 +8725,7 @@ fn generate_task_execution_tokens(
                 }
 
                 #output_start_time
+                let __cu_alloc_scope = cu29::monitoring::ScopedAllocCounter::new();
                 let result = {
                     let cumsg_output = #regular_slot_match_fn_ident::<
                         _,
@@ -8685,6 +8736,13 @@ fn generate_task_execution_tokens(
                     #task_instance.process(&ctx, cumsg_input, cumsg_output)
                 };
                 #output_end_time
+                monitor.observe_alloc(
+                    cu29::monitoring::ComponentId::new(#tid),
+                    CuComponentState::Process,
+                    __cu_alloc_scope.allocated(),
+                    __cu_alloc_scope.deallocated(),
+                );
+                drop(__cu_alloc_scope);
                 result
             };
 

--- a/core/cu29_runtime/src/monitoring.rs
+++ b/core/cu29_runtime/src/monitoring.rs
@@ -1700,6 +1700,26 @@ pub trait CuMonitor: Sized {
     /// Called when runtime finishes CopperList serialization/IO accounting.
     fn observe_copperlist_io(&self, _stats: CopperListIoStats) {}
 
+    /// Called after each monitored component step with the heap allocation delta
+    /// observed by the runtime around the call.
+    ///
+    /// `allocated_bytes` / `deallocated_bytes` are computed from the global
+    /// `CountingAlloc` counters when the runtime is built with
+    /// `feature = "memory_monitoring"`. Without that feature the runtime still
+    /// invokes this hook but always reports `0` — implementations can treat
+    /// that as "monitoring disabled at link time" and degrade gracefully (e.g.
+    /// log a one-shot warning).
+    ///
+    /// `component_id` is an index into [`CuMonitoringMetadata::components`].
+    fn observe_alloc(
+        &self,
+        _component_id: ComponentId,
+        _step: CuComponentState,
+        _allocated_bytes: usize,
+        _deallocated_bytes: usize,
+    ) {
+    }
+
     /// Called when a monitored component step fails; must return an immediate runtime decision.
     ///
     /// `component_id` is an index into [`CuMonitoringMetadata::components`].
@@ -1789,6 +1809,16 @@ macro_rules! impl_monitor_tuple {
 
             fn observe_copperlist_io(&self, stats: CopperListIoStats) {
                 $(self.$idx.observe_copperlist_io(stats);)+
+            }
+
+            fn observe_alloc(
+                &self,
+                component_id: ComponentId,
+                step: CuComponentState,
+                allocated_bytes: usize,
+                deallocated_bytes: usize,
+            ) {
+                $(self.$idx.observe_alloc(component_id, step, allocated_bytes, deallocated_bytes);)+
             }
 
             fn process_error(
@@ -1881,73 +1911,114 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for CountingAlloc<A> {
     }
 }
 
-/// A simple struct that counts the number of bytes allocated and deallocated in a scope.
-#[cfg(feature = "memory_monitoring")]
+/// Total bytes ever allocated through the `CountingAlloc` global allocator.
+///
+/// Returns `None` when the runtime was not built with `feature = "memory_monitoring"`
+/// (no counting allocator installed). Returns `Some(_)` otherwise.
+///
+/// Counters are monotonic and saturate at `usize::MAX`; subtract two snapshots
+/// to get a delta over a window.
+#[inline]
+pub fn global_allocated_bytes() -> Option<usize> {
+    #[cfg(all(feature = "std", feature = "memory_monitoring"))]
+    {
+        Some(GLOBAL.allocated())
+    }
+    #[cfg(not(all(feature = "std", feature = "memory_monitoring")))]
+    {
+        None
+    }
+}
+
+/// Total bytes ever returned to the `CountingAlloc` global allocator.
+///
+/// See [`global_allocated_bytes`] for availability semantics.
+#[inline]
+pub fn global_deallocated_bytes() -> Option<usize> {
+    #[cfg(all(feature = "std", feature = "memory_monitoring"))]
+    {
+        Some(GLOBAL.deallocated())
+    }
+    #[cfg(not(all(feature = "std", feature = "memory_monitoring")))]
+    {
+        None
+    }
+}
+
+/// Scoped helper that captures the global allocation counters on construction
+/// and exposes the delta accumulated by the time you query it.
+///
+/// When the runtime is built without `feature = "memory_monitoring"`, this
+/// becomes a zero-sized no-op: `allocated()`/`deallocated()` return `0`, the
+/// constructor performs no atomic load, and the type is fully eliminated by the
+/// optimizer. This lets the runtime macro emit the same code in both builds.
+///
+/// # Example
+/// ```
+/// use cu29_runtime::monitoring::ScopedAllocCounter;
+///
+/// let counter = ScopedAllocCounter::new();
+/// let _vec = vec![0u8; 1024];
+/// // With `memory_monitoring`: `counter.allocated() >= 1024`.
+/// // Without: `counter.allocated() == 0`.
+/// let _ = counter.allocated();
+/// ```
+#[must_use]
 pub struct ScopedAllocCounter {
+    #[cfg(all(feature = "std", feature = "memory_monitoring"))]
     bf_allocated: usize,
+    #[cfg(all(feature = "std", feature = "memory_monitoring"))]
     bf_deallocated: usize,
 }
 
-#[cfg(feature = "memory_monitoring")]
 impl Default for ScopedAllocCounter {
     fn default() -> Self {
         Self::new()
     }
 }
 
-#[cfg(feature = "memory_monitoring")]
 impl ScopedAllocCounter {
+    #[inline]
     pub fn new() -> Self {
-        ScopedAllocCounter {
-            bf_allocated: GLOBAL.allocated(),
-            bf_deallocated: GLOBAL.deallocated(),
+        #[cfg(all(feature = "std", feature = "memory_monitoring"))]
+        {
+            ScopedAllocCounter {
+                bf_allocated: GLOBAL.allocated(),
+                bf_deallocated: GLOBAL.deallocated(),
+            }
+        }
+        #[cfg(not(all(feature = "std", feature = "memory_monitoring")))]
+        {
+            ScopedAllocCounter {}
         }
     }
 
-    /// Returns the total number of bytes allocated in the current scope
-    /// since the creation of this `ScopedAllocCounter`.
-    ///
-    /// # Example
-    /// ```
-    /// use cu29_runtime::monitoring::ScopedAllocCounter;
-    ///
-    /// let counter = ScopedAllocCounter::new();
-    /// let _vec = vec![0u8; 1024];
-    /// println!("Bytes allocated: {}", counter.get_allocated());
-    /// ```
+    /// Bytes allocated since this counter was created.
+    /// Always `0` when `memory_monitoring` is not enabled.
+    #[inline]
     pub fn allocated(&self) -> usize {
-        GLOBAL.allocated() - self.bf_allocated
+        #[cfg(all(feature = "std", feature = "memory_monitoring"))]
+        {
+            GLOBAL.allocated().wrapping_sub(self.bf_allocated)
+        }
+        #[cfg(not(all(feature = "std", feature = "memory_monitoring")))]
+        {
+            0
+        }
     }
 
-    /// Returns the total number of bytes deallocated in the current scope
-    /// since the creation of this `ScopedAllocCounter`.
-    ///
-    /// # Example
-    /// ```
-    /// use cu29_runtime::monitoring::ScopedAllocCounter;
-    ///
-    /// let counter = ScopedAllocCounter::new();
-    /// let _vec = vec![0u8; 1024];
-    /// drop(_vec);
-    /// println!("Bytes deallocated: {}", counter.get_deallocated());
-    /// ```
+    /// Bytes deallocated since this counter was created.
+    /// Always `0` when `memory_monitoring` is not enabled.
+    #[inline]
     pub fn deallocated(&self) -> usize {
-        GLOBAL.deallocated() - self.bf_deallocated
-    }
-}
-
-/// Build a difference between the number of bytes allocated and deallocated in the scope at drop time.
-#[cfg(feature = "memory_monitoring")]
-impl Drop for ScopedAllocCounter {
-    fn drop(&mut self) {
-        let _allocated = GLOBAL.allocated() - self.bf_allocated;
-        let _deallocated = GLOBAL.deallocated() - self.bf_deallocated;
-        // TODO(gbin): Fix this when the logger is ready.
-        // debug!(
-        //     "Allocations: +{}B -{}B",
-        //     allocated = allocated,
-        //     deallocated = deallocated,
-        // );
+        #[cfg(all(feature = "std", feature = "memory_monitoring"))]
+        {
+            GLOBAL.deallocated().wrapping_sub(self.bf_deallocated)
+        }
+        #[cfg(not(all(feature = "std", feature = "memory_monitoring")))]
+        {
+            0
+        }
     }
 }
 
@@ -2228,6 +2299,9 @@ mod tests {
         decision: TestDecision,
         copperlist_calls: AtomicUsize,
         panic_calls: AtomicUsize,
+        alloc_calls: AtomicUsize,
+        last_alloc_bytes: AtomicUsize,
+        last_dealloc_bytes: AtomicUsize,
     }
 
     impl TestMonitor {
@@ -2236,6 +2310,9 @@ mod tests {
                 decision,
                 copperlist_calls: AtomicUsize::new(0),
                 panic_calls: AtomicUsize::new(0),
+                alloc_calls: AtomicUsize::new(0),
+                last_alloc_bytes: AtomicUsize::new(0),
+                last_dealloc_bytes: AtomicUsize::new(0),
             }
         }
     }
@@ -2284,6 +2361,20 @@ mod tests {
 
         fn process_panic(&self, _panic_message: &str) {
             self.panic_calls.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn observe_alloc(
+            &self,
+            _component_id: ComponentId,
+            _step: CuComponentState,
+            allocated_bytes: usize,
+            deallocated_bytes: usize,
+        ) {
+            self.alloc_calls.fetch_add(1, Ordering::SeqCst);
+            self.last_alloc_bytes
+                .store(allocated_bytes, Ordering::SeqCst);
+            self.last_dealloc_bytes
+                .store(deallocated_bytes, Ordering::SeqCst);
         }
     }
 
@@ -2367,6 +2458,48 @@ mod tests {
             two.process_error(ComponentId::new(0), CuComponentState::Process, &err),
             Decision::Abort
         ));
+    }
+
+    #[test]
+    fn scoped_alloc_counter_reports_zero_when_feature_off_and_nonzero_when_on() {
+        // We can't change link-time feature flags from a test, so we exercise
+        // both halves of the API contract regardless of feature state:
+        //
+        // * `global_allocated_bytes()` returns `Some` iff the feature is on.
+        // * `ScopedAllocCounter::allocated()` returns a sensible value either way
+        //   (0 when off, monotonically non-decreasing across a Vec alloc when on).
+        let availability_matches = match global_allocated_bytes() {
+            Some(_) => cfg!(all(feature = "std", feature = "memory_monitoring")),
+            None => !cfg!(all(feature = "std", feature = "memory_monitoring")),
+        };
+        assert!(availability_matches, "feature-gate cfg mismatch");
+
+        let counter = ScopedAllocCounter::new();
+        let _v = vec![0u8; 4096];
+        let allocated = counter.allocated();
+        if cfg!(all(feature = "std", feature = "memory_monitoring")) {
+            assert!(
+                allocated >= 4096,
+                "expected at least 4096 B allocated, got {allocated}"
+            );
+        } else {
+            assert_eq!(allocated, 0, "feature off must report 0");
+        }
+    }
+
+    #[test]
+    fn tuple_monitor_fans_out_observe_alloc() {
+        let monitors = <(TestMonitor, TestMonitor) as CuMonitor>::new(
+            test_metadata(),
+            CuMonitoringRuntime::unavailable(),
+        )
+        .expect("tuple new");
+        monitors.observe_alloc(ComponentId::new(0), CuComponentState::Process, 128, 64);
+
+        assert_eq!(monitors.0.alloc_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(monitors.1.alloc_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(monitors.0.last_alloc_bytes.load(Ordering::SeqCst), 128);
+        assert_eq!(monitors.1.last_dealloc_bytes.load(Ordering::SeqCst), 64);
     }
 
     #[test]

--- a/core/cu29_runtime/src/monitoring.rs
+++ b/core/cu29_runtime/src/monitoring.rs
@@ -1862,10 +1862,51 @@ pub fn panic_payload_to_string(payload: &(dyn core::any::Any + Send)) -> String 
 }
 
 /// A simple allocator that counts the number of bytes allocated and deallocated.
+///
+/// Tracks two views of the same activity:
+/// - Process-wide atomic counters (`allocated()`/`deallocated()`), suitable for
+///   probes like [`global_allocated_bytes`].
+/// - Per-thread `Cell<usize>` counters (when both `std` and `memory_monitoring`
+///   are enabled), used by [`ScopedAllocCounter`] so deltas under `parallel-rt`
+///   attribute only the calling thread's allocations to the calling thread's
+///   open scope.
 pub struct CountingAlloc<A: GlobalAlloc> {
     inner: A,
     allocated: AtomicUsize,
     deallocated: AtomicUsize,
+}
+
+#[cfg(all(feature = "std", feature = "memory_monitoring"))]
+thread_local! {
+    static THREAD_ALLOCATED: Cell<usize> = const { Cell::new(0) };
+    static THREAD_DEALLOCATED: Cell<usize> = const { Cell::new(0) };
+}
+
+#[cfg(all(feature = "std", feature = "memory_monitoring"))]
+#[inline]
+fn bump_thread_allocated(bytes: usize) {
+    // try_with is no-op during TLS teardown — we attribute nothing in that
+    // window, which is fine: monitored steps don't run while a worker thread is
+    // being torn down.
+    let _ = THREAD_ALLOCATED.try_with(|c| c.set(c.get().wrapping_add(bytes)));
+}
+
+#[cfg(all(feature = "std", feature = "memory_monitoring"))]
+#[inline]
+fn bump_thread_deallocated(bytes: usize) {
+    let _ = THREAD_DEALLOCATED.try_with(|c| c.set(c.get().wrapping_add(bytes)));
+}
+
+#[cfg(all(feature = "std", feature = "memory_monitoring"))]
+#[inline]
+fn read_thread_allocated() -> usize {
+    THREAD_ALLOCATED.try_with(|c| c.get()).unwrap_or(0)
+}
+
+#[cfg(all(feature = "std", feature = "memory_monitoring"))]
+#[inline]
+fn read_thread_deallocated() -> usize {
+    THREAD_DEALLOCATED.try_with(|c| c.get()).unwrap_or(0)
 }
 
 impl<A: GlobalAlloc> CountingAlloc<A> {
@@ -1899,6 +1940,8 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for CountingAlloc<A> {
         let p = unsafe { self.inner.alloc(layout) };
         if !p.is_null() {
             self.allocated.fetch_add(layout.size(), Ordering::SeqCst);
+            #[cfg(all(feature = "std", feature = "memory_monitoring"))]
+            bump_thread_allocated(layout.size());
         }
         p
     }
@@ -1908,6 +1951,8 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for CountingAlloc<A> {
         // SAFETY: Forwarding to the inner allocator preserves GlobalAlloc invariants.
         unsafe { self.inner.dealloc(ptr, layout) }
         self.deallocated.fetch_add(layout.size(), Ordering::SeqCst);
+        #[cfg(all(feature = "std", feature = "memory_monitoring"))]
+        bump_thread_deallocated(layout.size());
     }
 }
 
@@ -1945,13 +1990,24 @@ pub fn global_deallocated_bytes() -> Option<usize> {
     }
 }
 
-/// Scoped helper that captures the global allocation counters on construction
-/// and exposes the delta accumulated by the time you query it.
+/// Scoped helper that captures the calling thread's allocation counters on
+/// construction and exposes the delta accumulated by the time you query it.
+///
+/// Per-thread accounting matters under `parallel-rt`: multiple worker threads
+/// run monitored steps concurrently, and a delta computed from the
+/// process-wide counters would attribute every other thread's allocations to
+/// the local step. The counters this type snapshots are thread-local, so
+/// `allocated()` only reflects allocations performed on the same thread that
+/// constructed the counter.
 ///
 /// When the runtime is built without `feature = "memory_monitoring"`, this
 /// becomes a zero-sized no-op: `allocated()`/`deallocated()` return `0`, the
-/// constructor performs no atomic load, and the type is fully eliminated by the
+/// constructor performs no TLS load, and the type is fully eliminated by the
 /// optimizer. This lets the runtime macro emit the same code in both builds.
+///
+/// `ScopedAllocCounter` is intentionally pinned to the constructing thread —
+/// the macro always uses it as a stack-local within a single step, so this
+/// matches the only realistic usage pattern.
 ///
 /// # Example
 /// ```
@@ -1969,6 +2025,13 @@ pub struct ScopedAllocCounter {
     bf_allocated: usize,
     #[cfg(all(feature = "std", feature = "memory_monitoring"))]
     bf_deallocated: usize,
+    // Marker that pins the counter to the constructing thread: under
+    // `parallel-rt` it's a logic error to read the delta from another thread,
+    // since the TLS counters being read belong to the reading thread, not the
+    // thread the snapshot was taken on. `PhantomData<*const ()>` is a ZST so
+    // this doesn't change the type's footprint.
+    #[cfg(all(feature = "std", feature = "memory_monitoring"))]
+    _not_send_sync: core::marker::PhantomData<*const ()>,
 }
 
 impl Default for ScopedAllocCounter {
@@ -1983,8 +2046,9 @@ impl ScopedAllocCounter {
         #[cfg(all(feature = "std", feature = "memory_monitoring"))]
         {
             ScopedAllocCounter {
-                bf_allocated: GLOBAL.allocated(),
-                bf_deallocated: GLOBAL.deallocated(),
+                bf_allocated: read_thread_allocated(),
+                bf_deallocated: read_thread_deallocated(),
+                _not_send_sync: core::marker::PhantomData,
             }
         }
         #[cfg(not(all(feature = "std", feature = "memory_monitoring")))]
@@ -1993,13 +2057,13 @@ impl ScopedAllocCounter {
         }
     }
 
-    /// Bytes allocated since this counter was created.
-    /// Always `0` when `memory_monitoring` is not enabled.
+    /// Bytes allocated by the constructing thread since this counter was
+    /// created. Always `0` when `memory_monitoring` is not enabled.
     #[inline]
     pub fn allocated(&self) -> usize {
         #[cfg(all(feature = "std", feature = "memory_monitoring"))]
         {
-            GLOBAL.allocated().wrapping_sub(self.bf_allocated)
+            read_thread_allocated().wrapping_sub(self.bf_allocated)
         }
         #[cfg(not(all(feature = "std", feature = "memory_monitoring")))]
         {
@@ -2007,13 +2071,13 @@ impl ScopedAllocCounter {
         }
     }
 
-    /// Bytes deallocated since this counter was created.
-    /// Always `0` when `memory_monitoring` is not enabled.
+    /// Bytes deallocated by the constructing thread since this counter was
+    /// created. Always `0` when `memory_monitoring` is not enabled.
     #[inline]
     pub fn deallocated(&self) -> usize {
         #[cfg(all(feature = "std", feature = "memory_monitoring"))]
         {
-            GLOBAL.deallocated().wrapping_sub(self.bf_deallocated)
+            read_thread_deallocated().wrapping_sub(self.bf_deallocated)
         }
         #[cfg(not(all(feature = "std", feature = "memory_monitoring")))]
         {
@@ -2458,6 +2522,58 @@ mod tests {
             two.process_error(ComponentId::new(0), CuComponentState::Process, &err),
             Decision::Abort
         ));
+    }
+
+    #[cfg(all(feature = "std", feature = "memory_monitoring"))]
+    #[test]
+    fn scoped_alloc_counter_attributes_only_calling_threads_allocations() {
+        // Under parallel-rt, monitored steps run on different worker threads
+        // concurrently. ScopedAllocCounter must read per-thread counters so
+        // thread A's open scope is not contaminated by allocations made by
+        // thread B in the same wall-clock window.
+        use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+        use std::sync::{Arc, Barrier};
+
+        let barrier = Arc::new(Barrier::new(2));
+        let other_running = Arc::new(AtomicBool::new(true));
+
+        let b = barrier.clone();
+        let flag = other_running.clone();
+        let other = std::thread::spawn(move || {
+            // Wait until the main thread has opened its scope, then churn
+            // through allocations the entire time it is sampling.
+            b.wait();
+            let mut total: usize = 0;
+            while flag.load(AtomicOrdering::Relaxed) {
+                let v: Vec<u8> = vec![0u8; 1024 * 16];
+                total = total.wrapping_add(v.len());
+            }
+            total
+        });
+
+        let counter = ScopedAllocCounter::new();
+        barrier.wait();
+        // Sample for long enough that the other thread definitely allocates a
+        // lot more than the 1 KiB we deliberately allocate here.
+        let local_alloc_size = 1024;
+        let local = vec![0u8; local_alloc_size];
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        let observed = counter.allocated();
+        other_running.store(false, AtomicOrdering::Relaxed);
+        drop(local);
+        let _ = other.join();
+
+        // The other thread will have allocated megabytes during the sleep —
+        // an upper bound of ~1 MiB on this thread's delta is comfortably
+        // below that and well above the local allocation.
+        assert!(
+            observed >= local_alloc_size,
+            "expected at least {local_alloc_size} B, got {observed}"
+        );
+        assert!(
+            observed < 1024 * 1024,
+            "thread-local scope leaked across threads: observed {observed} B"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`core/cu29_runtime/src/monitoring.rs` already ships a `CountingAlloc` global allocator and a `ScopedAllocCounter` scope helper behind the `memory_monitoring` feature, but the feature is dead:

- No call site in the repo ever constructs a `ScopedAllocCounter`.
- Its `Drop` impl computes the delta and drops it on the floor (`TODO(gbin)`,`monitoring.rs:1945-1950`).
- The `CuMonitor` trait only sees post-copperlist views (`CuMsgMetadata` timings) — there is no hook for memory deltas, and no per-task lifecycle observation.

The maintainer wants users to know, in realtime-sensitive code, whether any of their tasks allocate on the heap between `start` and `stop`, and ideally to get heap-balance stats per lifecycle.

## Why "monitor + debug-only feature" is awkward

Two link-time constraints:

1. `#[global_allocator]` is a whole-binary decision. The counting allocator must live in `cu29_runtime` (or be opted in by the user's `main.rs`); a monitor selected by RON at runtime cannot install one.
2. Per-task allocation accounting must come from the proc-macro (`cu29_derive/src/lib.rs`) wrapping each generated `task.start/preprocess/process/postprocess/stop` call — the monitor cannot reach into those sites itself.

## Decision

- Keep allocator installation gated behind `memory_monitoring` → **zero cost when off**.
- Gate the macro emission of allocation scopes behind the same `cfg!(feature = "memory_monitoring")` → no overhead on default builds.
- Make `cu_memmon` a normal monitor crate sibling to `cu_logmon`/`cu_safetymon`, added via RON. When the feature is off it warns once at `start` and reports zeros; users never need `#[cfg]` in their code.
- `realtime_strict` mode is **opt-in via RON** — too dangerous as a default for users who allocate on purpose.
- Defer unifiedlog `MemSample` encoding until someone asks.

## Changes
1. **Expose counters** in `cu29_runtime::monitoring`: `global_allocated_bytes() / global_deallocated_bytes() -> Option<usize>` (`None` when the feature is off). Keep `CountingAlloc` `pub` for users who want to wrap their own allocator.
2. **Add `CuMonitor::observe_alloc`** with a default no-op: `fn observe_alloc(&self, _component_id: ComponentId, _step: CuComponentState, _allocated: usize, _deallocated: usize) {}`. Tuple impl fans out. Existing monitors compile unchanged.
3. **Wire the macro** (`cu29_derive/src/lib.rs`):
   - Wrap each `task.<step>()` call in a `ScopedAllocCounter`.
   - On return, forward the delta via `monitor.observe_alloc(...)`.
   - Gated on `cfg!(feature = "memory_monitoring")`.
4. **`components/monitors/cu_memmon`** (mirrors `cu_logmon` shape):
   - `observe_alloc`: per-`(component, step)` running totals + per-component lifetime balance since `start` returned.
   - `process_copperlist`: throttled `info!` one-liner, e.g. `[mem] foo start=+4KiB -0B | proc max=+0B | stop=+0B -4KiB | leak=0B`.
   - `stop`: final per-task `leak = alloc - dealloc` report. `warning!` on non-zero.
   - RON knob `realtime_strict: bool` → any non-zero alloc in `preprocess/process/postprocess` returns `Decision::Shutdown`.
   - Feature-off path: emit one `warning!` at `start` and stop there.
