### PR TITLE
Bug: sequencing of the restoration of the keyframes were wrong

### DIFF
--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -963,6 +963,7 @@ pub fn cu29_runtime::debug::CuDebugSession<App, P, CB, TF, S, L>::from_log(log_b
 pub fn cu29_runtime::debug::CuDebugSession<App, P, CB, TF, S, L>::from_log_with_cache_cap(log_base: &std::path::Path, app: App, robot_clock: cu29_clock::RobotClock, clock_mock: cu29_clock::RobotClockMock, build_callback: CB, time_of: TF, cache_cap: usize) -> cu29_traits::CuResult<Self>
 pub fn cu29_runtime::debug::CuDebugSession<App, P, CB, TF, S, L>::goto_cl(&mut self, culistid: u64) -> cu29_traits::CuResult<cu29_runtime::debug::JumpOutcome> where App: cu29_runtime::app::CurrentRuntimeCopperList<P>
 pub fn cu29_runtime::debug::CuDebugSession<App, P, CB, TF, S, L>::goto_time(&mut self, ts: cu29_clock::CuTime) -> cu29_traits::CuResult<cu29_runtime::debug::JumpOutcome> where App: cu29_runtime::app::CurrentRuntimeCopperList<P>
+pub fn cu29_runtime::debug::CuDebugSession<App, P, CB, TF, S, L>::is_keyframe_culistid(&self, target_culistid: u64) -> bool
 pub fn cu29_runtime::debug::CuDebugSession<App, P, CB, TF, S, L>::nearest_keyframe_culistid(&self, target_culistid: u64) -> core::option::Option<u64>
 pub fn cu29_runtime::debug::CuDebugSession<App, P, CB, TF, S, L>::section_cache_stats(&self) -> cu29_runtime::debug::SectionCacheStats
 pub fn cu29_runtime::debug::CuDebugSession<App, P, CB, TF, S, L>::step(&mut self, delta: i32) -> cu29_traits::CuResult<cu29_runtime::debug::JumpOutcome> where App: cu29_runtime::app::CurrentRuntimeCopperList<P>

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -1336,8 +1336,96 @@ fn gen_recorded_replay_support(
             CuExecutionUnit::Loop(_) => None,
         })
         .collect();
+    let debug_replay_arms: Vec<proc_macro2::TokenStream> =
+        runtime_plan
+            .steps
+            .iter()
+            .filter_map(|unit| match unit {
+                CuExecutionUnit::Step(step) => match &exec_entities[step.node_id as usize].kind {
+                    ExecutionEntityKind::Task { .. } => {
+                        if step.task_type == CuTaskType::Regular {
+                            return None;
+                        }
+                        let enum_entry_name = config_id_to_enum(step.node.get_id().as_str());
+                        let enum_ident = Ident::new(&enum_entry_name, Span::call_site());
+                        let output_pack = step
+                            .output_msg_pack
+                            .as_ref()
+                            .expect("Task step missing output pack for recorded debug replay");
+                        let culist_index = int2sliceindex(output_pack.culist_index);
+                        Some(quote! {
+                            SimStep::#enum_ident(CuTaskCallbackState::Process(_, output)) => {
+                                *output = recorded.msgs.0.#culist_index.clone();
+                                SimOverride::ExecutedBySim
+                            }
+                        })
+                    }
+                    ExecutionEntityKind::BridgeRx {
+                        bridge_index,
+                        channel_index,
+                    } => {
+                        let bridge_spec = &bridge_specs[*bridge_index];
+                        let channel = &bridge_spec.rx_channels[*channel_index];
+                        let enum_entry_name =
+                            config_id_to_enum(&format!("{}_rx_{}", bridge_spec.id, channel.id));
+                        let enum_ident = Ident::new(&enum_entry_name, Span::call_site());
+                        let output_pack = step.output_msg_pack.as_ref().expect(
+                            "Bridge Rx channel missing output pack for recorded debug replay",
+                        );
+                        let port_index = output_pack
+                            .msg_types
+                            .iter()
+                            .position(|msg| msg == &channel.msg_type_name)
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "Bridge Rx channel '{}' missing output port for '{}'",
+                                    channel.id, channel.msg_type_name
+                                )
+                            });
+                        let culist_index = int2sliceindex(output_pack.culist_index);
+                        let recorded_slot = if output_pack.msg_types.len() == 1 {
+                            quote! { recorded.msgs.0.#culist_index.clone() }
+                        } else {
+                            let port_index = syn::Index::from(port_index);
+                            quote! { recorded.msgs.0.#culist_index.#port_index.clone() }
+                        };
+                        Some(quote! {
+                            SimStep::#enum_ident { msg, .. } => {
+                                *msg = #recorded_slot;
+                                SimOverride::ExecutedBySim
+                            }
+                        })
+                    }
+                    ExecutionEntityKind::BridgeTx {
+                        bridge_index,
+                        channel_index,
+                    } => {
+                        let bridge_spec = &bridge_specs[*bridge_index];
+                        let channel = &bridge_spec.tx_channels[*channel_index];
+                        let enum_entry_name =
+                            config_id_to_enum(&format!("{}_tx_{}", bridge_spec.id, channel.id));
+                        let enum_ident = Ident::new(&enum_entry_name, Span::call_site());
+                        let output_pack = step.output_msg_pack.as_ref().expect(
+                            "Bridge Tx channel missing output pack for recorded debug replay",
+                        );
+                        let culist_index = int2sliceindex(output_pack.culist_index);
+                        Some(quote! {
+                            SimStep::#enum_ident { output, .. } => {
+                                *output = recorded.msgs.0.#culist_index.clone();
+                                SimOverride::ExecutedBySim
+                            }
+                        })
+                    }
+                },
+                CuExecutionUnit::Loop(_) => None,
+            })
+            .collect();
 
     quote! {
+        /// Exact-output replay callback: every recorded task and bridge output is
+        /// copied from the CopperList and the runtime implementation is skipped.
+        ///
+        /// This is for deterministic log reproduction, not for debugger state replay.
         #[allow(dead_code)]
         pub fn recorded_replay_step<'a>(
             step: SimStep<'a>,
@@ -1345,6 +1433,22 @@ fn gen_recorded_replay_support(
         ) -> SimOverride {
             match step {
                 #(#replay_arms),*,
+                _ => SimOverride::ExecuteByRuntime,
+            }
+        }
+
+        /// Debugger state replay callback: recorded external inputs are injected,
+        /// regular Copper tasks execute normally, and external sink/bridge effects
+        /// are suppressed.
+        ///
+        /// This preserves task-state evolution after restoring an intra-CL keyframe.
+        #[allow(dead_code)]
+        pub fn recorded_debug_replay_step<'a>(
+            step: SimStep<'a>,
+            recorded: &CopperList<CuStampedDataSet>,
+        ) -> SimOverride {
+            match step {
+                #(#debug_replay_arms),*,
                 _ => SimOverride::ExecuteByRuntime,
             }
         }

--- a/core/cu29_runtime/src/debug.rs
+++ b/core/cu29_runtime/src/debug.rs
@@ -530,8 +530,22 @@ where
             }
 
             if target_idx >= current {
-                replay_start = current + 1;
-                keyframe_used = self.last_keyframe;
+                let nearest_keyframe = self.nearest_keyframe(target_culistid);
+                let nearest_keyframe_idx = nearest_keyframe
+                    .as_ref()
+                    .and_then(|kf| self.index_for_culistid(kf.culistid).ok());
+
+                if let (Some(kf), Some(kf_idx)) = (nearest_keyframe, nearest_keyframe_idx)
+                    && kf_idx > current
+                {
+                    self.restore_keyframe(&kf)?;
+                    self.clear_runtime_copperlist_snapshot();
+                    keyframe_used = Some(kf.culistid);
+                    replay_start = kf_idx;
+                } else {
+                    replay_start = current + 1;
+                    keyframe_used = self.last_keyframe;
+                }
             } else {
                 // Need to rewind to nearest keyframe
                 let Some(kf) = self.nearest_keyframe(target_culistid) else {

--- a/core/cu29_runtime/src/debug.rs
+++ b/core/cu29_runtime/src/debug.rs
@@ -641,6 +641,13 @@ where
         self.nearest_keyframe(target_culistid).map(|kf| kf.culistid)
     }
 
+    /// Whether the log contains an exact keyframe for this copperlist id.
+    pub fn is_keyframe_culistid(&self, target_culistid: u64) -> bool {
+        self.keyframes
+            .iter()
+            .any(|kf| kf.culistid == target_culistid)
+    }
+
     /// Returns section-cache statistics for this session.
     pub fn section_cache_stats(&self) -> SectionCacheStats {
         SectionCacheStats {

--- a/core/cu29_runtime/src/remote_debug.rs
+++ b/core/cu29_runtime/src/remote_debug.rs
@@ -654,6 +654,7 @@ struct QueryCursorSnapshot {
     idx: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     ts_ns: Option<u64>,
+    is_keyframe: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     keyframe_cl: Option<u64>,
 }
@@ -3098,6 +3099,7 @@ where
         cl: cl.id,
         idx: resolved.idx,
         ts_ns: time_of(cl.as_ref()).map(|t| t.as_nanos()),
+        is_keyframe: session.is_keyframe_culistid(cl.id),
         keyframe_cl: session.nearest_keyframe_culistid(cl.id),
     })
 }

--- a/core/cu29_runtime/src/simulation.rs
+++ b/core/cu29_runtime/src/simulation.rs
@@ -106,6 +106,17 @@
 //!   should be skipped.
 //! - **`ExecuteByRuntime`**: Indicates that the real implementation should proceed as normal.
 //!
+//! ## Recorded Replay Helpers
+//!
+//! Simulation-enabled generated runtimes expose two recorded replay callbacks:
+//!
+//! - `recorded_replay_step` is exact-output replay. It copies recorded outputs
+//!   from a CopperList and skips the runtime implementation for deterministic
+//!   log reproduction.
+//! - `recorded_debug_replay_step` is debugger state replay. It injects recorded
+//!   external inputs, suppresses external side effects, and lets regular Copper
+//!   tasks execute so restored keyframe state advances to the inspected CL.
+//!
 
 use crate::config::ComponentConfig;
 use crate::context::CuContext;

--- a/examples/cu_flight_controller/src/resim.rs
+++ b/examples/cu_flight_controller/src/resim.rs
@@ -82,7 +82,7 @@ fn build_callback<'a>(
     _process_clock: RobotClock,
     _clock_for_cb: RobotClockMock,
 ) -> Box<dyn for<'z> FnMut(gnss::SimStep<'z>) -> SimOverride + 'a> {
-    Box::new(move |step: gnss::SimStep<'_>| gnss::recorded_replay_step(step, copperlist))
+    Box::new(move |step: gnss::SimStep<'_>| gnss::recorded_debug_replay_step(step, copperlist))
 }
 
 fn extract_time(copperlist: &ReplayCopperList) -> Option<CuTime> {


### PR DESCRIPTION
## Summary

Keyframes are *spread* over the tasks so restoring them are delicate. This should fix this + we have an extensive test in the tiemtraveler to reproduce any issues like this now.

## Related issues
- Closes #

## Changes

## Reminder
- [ ] I ran `just` from the repo root
- [ ] I have updated docs or examples where needed

## Additional context
