### PR TITLE
Feat: structured log live listener chaining + replay debug api

### DIFF
--- a/core/cu29/src/lib.rs
+++ b/core/cu29/src/lib.rs
@@ -360,7 +360,7 @@ mod tests {
         let runtime = LoggerRuntime::init(RobotClock::default(), CaptureStream, None::<NullLog>);
         let captured = Arc::new(Mutex::new(Vec::new()));
         let sink = captured.clone();
-        register_live_log_listener(move |entry, _, _| {
+        let _listener = scoped_live_log_listener(move |entry, _, _| {
             sink.lock()
                 .unwrap_or_else(|poison| poison.into_inner())
                 .push(entry.clone());
@@ -368,7 +368,6 @@ mod tests {
 
         emit();
 
-        unregister_live_log_listener();
         drop(runtime);
 
         let entries = captured.lock().unwrap_or_else(|poison| poison.into_inner());

--- a/core/cu29_log_derive/tests/implicit_capture.rs
+++ b/core/cu29_log_derive/tests/implicit_capture.rs
@@ -2,8 +2,7 @@ use cu29_clock::RobotClock;
 use cu29_log::{CuLogEntry, CuLogLevel};
 use cu29_log_derive::debug;
 use cu29_log_runtime::{
-    LoggerRuntime, NullLog, log_debug_mode, register_live_log_listener,
-    unregister_live_log_listener,
+    LoggerRuntime, NullLog, log_debug_mode, scoped_live_log_listener, unregister_live_log_listener,
 };
 use cu29_traits::{CuResult, WriteStream};
 use cu29_value::{Value, to_value};
@@ -33,7 +32,7 @@ fn debug_implicitly_captures_named_placeholders() {
     unregister_live_log_listener();
 
     let observed_clone = observed.clone();
-    register_live_log_listener(move |entry, format_str, param_names| {
+    let _listener = scoped_live_log_listener(move |entry, format_str, param_names| {
         *observed_clone.lock().unwrap() = Some((
             entry.clone(),
             format_str.to_string(),
@@ -46,7 +45,6 @@ fn debug_implicitly_captures_named_placeholders() {
 
     let hash = "0x000000000";
     debug!("Hash: {hash}");
-    unregister_live_log_listener();
 
     let entries = entries.lock().unwrap();
     assert_eq!(entries.len(), 1);

--- a/core/cu29_log_runtime/src/lib.rs
+++ b/core/cu29_log_runtime/src/lib.rs
@@ -16,6 +16,7 @@ use sync_compat::{Mutex, OnceLock, init_once, lock as lock_mutex};
 #[cfg(not(feature = "std"))]
 mod imp {
     pub use alloc::boxed::Box;
+    pub use alloc::vec::Vec;
 }
 
 #[cfg(feature = "std")]
@@ -53,6 +54,47 @@ type LogWriter = Box<dyn WriteStream<CuLogEntry> + Send + 'static>;
 
 /// Callback signature: receives the structured entry plus its format string and param names.
 pub type LiveLogListener = Box<dyn Fn(&CuLogEntry, &str, &[&str]) + Send + Sync + 'static>;
+
+pub type LiveLogListenerId = usize;
+
+struct LiveLogListeners {
+    next_id: LiveLogListenerId,
+    listeners: Vec<(LiveLogListenerId, LiveLogListener)>,
+}
+
+impl Default for LiveLogListeners {
+    fn default() -> Self {
+        Self {
+            next_id: 1,
+            listeners: Vec::new(),
+        }
+    }
+}
+
+impl LiveLogListeners {
+    fn insert(&mut self, listener: LiveLogListener) -> LiveLogListenerId {
+        let id = self.next_id;
+        self.next_id = self.next_id.saturating_add(1).max(1);
+        self.listeners.push((id, listener));
+        id
+    }
+
+    fn remove(&mut self, id: LiveLogListenerId) {
+        self.listeners.retain(|(listener_id, _)| *listener_id != id);
+    }
+}
+
+pub struct LiveLogListenerGuard {
+    id: Option<LiveLogListenerId>,
+}
+
+impl Drop for LiveLogListenerGuard {
+    fn drop(&mut self) {
+        if let Some(id) = self.id.take() {
+            unregister_live_log_listener_id(id);
+        }
+    }
+}
 
 #[cfg(all(feature = "std", debug_assertions))]
 pub fn format_message_only(
@@ -97,7 +139,7 @@ pub fn format_message_only(
 struct LoggerState {
     writer: Mutex<LogWriter>,
     clock: RobotClock,
-    live_listener: Mutex<Option<LiveLogListener>>,
+    live_listeners: Mutex<LiveLogListeners>,
 }
 
 impl core::fmt::Debug for LoggerState {
@@ -145,7 +187,7 @@ impl LoggerRuntime {
             let state = LoggerState {
                 writer: Mutex::new(Box::new(destination)),
                 clock,
-                live_listener: Mutex::new(None),
+                live_listeners: Mutex::new(LiveLogListeners::default()),
             };
             init_logger_state(state);
         }
@@ -279,30 +321,79 @@ fn extra_log(entry: &mut CuLogEntry, format_str: &str, param_names: &[&str]) -> 
     Ok(())
 }
 
-/// Register a live log listener; subsequent logs invoke `cb`. No-op if runtime not initialized.
-pub fn register_live_log_listener<F>(cb: F)
+/// Register a live log listener; subsequent logs invoke `cb`.
+pub fn register_live_log_listener<F>(cb: F) -> Option<LiveLogListenerId>
 where
     F: Fn(&CuLogEntry, &str, &[&str]) + Send + Sync + 'static,
 {
-    if let Some(state) = LOGGER_STATE.get() {
-        let mut guard = lock_mutex(&state.live_listener);
-        *guard = Some(Box::new(cb));
+    LOGGER_STATE.get().map(|state| {
+        let mut guard = lock_mutex(&state.live_listeners);
+        guard.insert(Box::new(cb))
+    })
+}
+
+/// Register a scoped live log listener and remove it when the returned guard is dropped.
+pub fn scoped_live_log_listener<F>(cb: F) -> LiveLogListenerGuard
+where
+    F: Fn(&CuLogEntry, &str, &[&str]) + Send + Sync + 'static,
+{
+    LiveLogListenerGuard {
+        id: register_live_log_listener(cb),
     }
 }
 
-/// Remove any registered live log listener. No-op if runtime not initialized.
+/// Remove a live log listener by id. No-op if runtime not initialized.
+pub fn unregister_live_log_listener_id(id: LiveLogListenerId) {
+    if let Some(state) = LOGGER_STATE.get() {
+        let mut guard = lock_mutex(&state.live_listeners);
+        guard.remove(id);
+    }
+}
+
+/// Remove all registered live log listeners. No-op if runtime not initialized.
 pub fn unregister_live_log_listener() {
     if let Some(state) = LOGGER_STATE.get() {
-        let mut guard = lock_mutex(&state.live_listener);
-        *guard = None;
+        let mut guard = lock_mutex(&state.live_listeners);
+        guard.listeners.clear();
     }
+}
+
+/// Capture structured log entries emitted while `f` runs.
+///
+/// This is a scoped tee: existing live listeners still receive entries while
+/// capture is active.
+#[cfg(feature = "std")]
+pub fn capture_live_logs<F, R>(f: F) -> (R, Vec<CuLogEntry>)
+where
+    F: FnOnce() -> R,
+{
+    let captured_logs = std::sync::Arc::new(std::sync::Mutex::new(Vec::<CuLogEntry>::new()));
+    let listener_guard = LOGGER_STATE.get().map(|_| {
+        let captured_logs_for_listener = captured_logs.clone();
+        scoped_live_log_listener(move |entry, _, _| {
+            captured_logs_for_listener
+                .lock()
+                .expect("live log capture poisoned")
+                .push(entry.clone());
+        })
+    });
+
+    let result = f();
+    drop(listener_guard);
+    let logs = captured_logs
+        .lock()
+        .expect("live log capture poisoned")
+        .clone();
+
+    (result, logs)
 }
 
 /// Notify registered listener if any.
 #[allow(clippy::collapsible_if)]
 pub(crate) fn notify_live_listeners(entry: &CuLogEntry, format_str: &str, param_names: &[&str]) {
     if let Some(state) = LOGGER_STATE.get() {
-        if let Some(cb) = lock_mutex(&state.live_listener).as_ref() {
+        let guard = lock_mutex(&state.live_listeners);
+        for (_, cb) in &guard.listeners {
             cb(entry, format_str, param_names);
         }
     }

--- a/core/cu29_runtime/src/monitoring.rs
+++ b/core/cu29_runtime/src/monitoring.rs
@@ -21,9 +21,7 @@ use cu29_clock::CuDuration;
 #[allow(unused_imports)]
 use cu29_log::CuLogLevel;
 #[cfg(all(feature = "std", debug_assertions))]
-use cu29_log_runtime::{
-    format_message_only, register_live_log_listener, unregister_live_log_listener,
-};
+use cu29_log_runtime::{LiveLogListenerGuard, format_message_only, scoped_live_log_listener};
 use cu29_traits::{
     CuError, CuResult, ObservedWriter, abort_observed_encode, begin_observed_encode,
     finish_observed_encode,
@@ -1721,27 +1719,37 @@ pub trait CuMonitor: Sized {
 
 /// A do nothing monitor if no monitor is provided.
 /// This is basically defining the default behavior of Copper in case of error.
-pub struct NoMonitor {}
+pub struct NoMonitor {
+    #[cfg(all(feature = "std", debug_assertions))]
+    live_log_listener: Option<LiveLogListenerGuard>,
+}
 impl CuMonitor for NoMonitor {
     fn new(_metadata: CuMonitoringMetadata, _runtime: CuMonitoringRuntime) -> CuResult<Self> {
-        Ok(NoMonitor {})
+        Ok(NoMonitor {
+            #[cfg(all(feature = "std", debug_assertions))]
+            live_log_listener: None,
+        })
     }
 
     fn start(&mut self, _ctx: &CuContext) -> CuResult<()> {
         #[cfg(all(feature = "std", debug_assertions))]
-        register_live_log_listener(|entry, format_str, param_names| {
-            let params: Vec<String> = entry.params.iter().map(|v| v.to_string()).collect();
-            let named: Map<String, String> = param_names
-                .iter()
-                .zip(params.iter())
-                .map(|(k, v)| (k.to_string(), v.clone()))
-                .collect();
+        {
+            self.live_log_listener = Some(scoped_live_log_listener(
+                |entry, format_str, param_names| {
+                    let params: Vec<String> = entry.params.iter().map(|v| v.to_string()).collect();
+                    let named: Map<String, String> = param_names
+                        .iter()
+                        .zip(params.iter())
+                        .map(|(k, v)| (k.to_string(), v.clone()))
+                        .collect();
 
-            if let Ok(msg) = format_message_only(format_str, params.as_slice(), &named) {
-                let ts = format_timestamp(entry.time.into());
-                println!("{} [{:?}] {}", ts, entry.level, msg);
-            }
-        });
+                    if let Ok(msg) = format_message_only(format_str, params.as_slice(), &named) {
+                        let ts = format_timestamp(entry.time.into());
+                        println!("{} [{:?}] {}", ts, entry.level, msg);
+                    }
+                },
+            ));
+        }
         Ok(())
     }
 
@@ -1762,7 +1770,9 @@ impl CuMonitor for NoMonitor {
 
     fn stop(&mut self, _ctx: &CuContext) -> CuResult<()> {
         #[cfg(all(feature = "std", debug_assertions))]
-        unregister_live_log_listener();
+        {
+            self.live_log_listener = None;
+        }
         Ok(())
     }
 }

--- a/core/cu29_runtime/src/remote_debug.rs
+++ b/core/cu29_runtime/src/remote_debug.rs
@@ -152,7 +152,7 @@
 //! | Method | Session required | Params | Result |
 //! | --- | --- | --- | --- |
 //! | `logs.strings` | yes | `{}` | interned string table and resolved index path |
-//! | `logs.list` | yes | `{ offset?, limit? }` | structured log entries + `next_offset` |
+//! | `logs.list` | yes | `{ source?, offset?, limit? }` | structured log entries + `next_offset` |
 //!
 //! ### Schema
 //!
@@ -246,7 +246,8 @@ use bincode::error::DecodeError;
 use cu29_clock::{
     CuTime, CuTimeRange, OptionCuTime, PartialCuTimeRange, RobotClock, RobotClockMock, Tov,
 };
-use cu29_log::{CuLogEntry, rebuild_logline};
+use cu29_log::CuLogEntry;
+use cu29_log_runtime::capture_live_logs;
 use cu29_traits::{
     CopperListTuple, CuCompactString, CuError, CuMsgMetadataTrait, CuMsgOrigin, CuResult,
     DebugFieldDescriptor, DebugFieldKind, DebugFieldSemantics, DebugScalarKind,
@@ -447,6 +448,16 @@ struct LogsListParams {
     offset: usize,
     #[serde(default)]
     limit: Option<usize>,
+    #[serde(default)]
+    source: LogsSource,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum LogsSource {
+    #[default]
+    Recorded,
+    Replay,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -687,6 +698,7 @@ where
     log_base: PathBuf,
     log_index_path: Option<PathBuf>,
     interned_strings: Option<Vec<String>>,
+    replay_structured_logs: Vec<CuLogEntry>,
     opened_at: Instant,
     last_touched_at: Instant,
     cursor_rev: u64,
@@ -1392,6 +1404,7 @@ where
                 log_base: path,
                 log_index_path: None,
                 interned_strings: None,
+                replay_structured_logs: Vec::new(),
                 opened_at: Instant::now(),
                 last_touched_at: Instant::now(),
                 cursor_rev: 0,
@@ -1509,10 +1522,13 @@ where
                 Err(e) => return err_response(request_id, "ResolveFailed", &e.to_string()),
             };
 
-        let jump = match seek_to_index(&mut state.session, resolved.idx) {
+        let (jump_result, captured_logs) =
+            capture_live_logs(|| seek_to_index(&mut state.session, resolved.idx));
+        let jump = match jump_result {
             Ok(v) => v,
             Err(e) => return err_response(request_id, "SeekFailed", &e.to_string()),
         };
+        state.replay_structured_logs.extend(captured_logs);
 
         update_after_jump(state, &jump);
         let cursor = match cursor_snapshot(state, &time_of) {
@@ -1558,10 +1574,13 @@ where
                 Err(e) => return err_response(request_id, "ResolveFailed", &e.to_string()),
             };
 
-        let jump = match seek_to_index(&mut state.session, resolved.idx) {
+        let (jump_result, captured_logs) =
+            capture_live_logs(|| seek_to_index(&mut state.session, resolved.idx));
+        let jump = match jump_result {
             Ok(v) => v,
             Err(e) => return err_response(request_id, "RunUntilFailed", &e.to_string()),
         };
+        state.replay_structured_logs.extend(captured_logs);
         update_after_jump(state, &jump);
 
         let cursor = match cursor_snapshot(state, &time_of) {
@@ -1614,10 +1633,12 @@ where
             Err(e) => return err_response(request_id, "SessionNotFound", &e.to_string()),
         };
 
-        let jump = match state.session.step(parsed.delta) {
+        let (jump_result, captured_logs) = capture_live_logs(|| state.session.step(parsed.delta));
+        let jump = match jump_result {
             Ok(v) => v,
             Err(e) => return err_response(request_id, "StepFailed", &e.to_string()),
         };
+        state.replay_structured_logs.extend(captured_logs);
         update_after_jump(state, &jump);
 
         let cursor = match cursor_snapshot(state, &time_of) {
@@ -1675,26 +1696,28 @@ where
                     Err(e) => return err_response(request_id, "ResolveFailed", &e.to_string()),
                 };
             resolved_at = Some(resolved.clone());
-            let jump = match seek_to_index(&mut state.session, resolved.idx) {
+            let (jump_result, captured_logs) =
+                capture_live_logs(|| seek_to_index(&mut state.session, resolved.idx));
+            let jump = match jump_result {
                 Ok(v) => v,
                 Err(e) => return err_response(request_id, "ReplayFailed", &e.to_string()),
             };
+            state.replay_structured_logs.extend(captured_logs);
             update_after_jump(state, &jump);
         }
 
         let mut items = Vec::with_capacity(parsed.limit as usize);
         for step_idx in 0..parsed.limit {
-            let replayed = if step_idx == 0 {
-                match replay_current_step(&mut state.session) {
-                    Ok(v) => v,
-                    Err(e) => return err_response(request_id, "ReplayFailed", &e.to_string()),
-                }
+            let (replay_result, captured_logs) = if step_idx == 0 {
+                capture_live_logs(|| replay_current_step(&mut state.session))
             } else {
-                match state.session.step(1) {
-                    Ok(v) => v,
-                    Err(e) => return err_response(request_id, "ReplayFailed", &e.to_string()),
-                }
+                capture_live_logs(|| state.session.step(1))
             };
+            let replayed = match replay_result {
+                Ok(v) => v,
+                Err(e) => return err_response(request_id, "ReplayFailed", &e.to_string()),
+            };
+            state.replay_structured_logs.extend(captured_logs);
             update_after_jump(state, &replayed);
 
             let item =
@@ -1999,6 +2022,35 @@ where
                 return err_response(request_id, "StructuredLogStringsFailed", &err.to_string());
             }
         };
+        if parsed.source == LogsSource::Replay {
+            let limit = parsed
+                .limit
+                .unwrap_or(MAX_LOG_PAGE_LIMIT)
+                .min(MAX_LOG_PAGE_LIMIT);
+            let total = state.replay_structured_logs.len();
+            let entries = state
+                .replay_structured_logs
+                .iter()
+                .enumerate()
+                .skip(parsed.offset)
+                .take(limit)
+                .map(|(index, entry)| structured_log_entry_json(index, &strings, entry))
+                .collect::<Vec<_>>();
+            let next_offset = parsed.offset.saturating_add(entries.len());
+
+            return ok_response(
+                request_id,
+                json!({
+                    "entries": entries,
+                    "next_offset": (next_offset < total).then_some(next_offset),
+                    "index_path": state.log_index_path.as_ref().map(|path| path.display().to_string()),
+                    "source": "replay",
+                }),
+                Some(state.cursor_rev),
+                None,
+            );
+        }
+
         let mut reader = match open_structured_log_reader(&state.log_base) {
             Ok(reader) => reader,
             Err(err) => {
@@ -2040,6 +2092,7 @@ where
                 "entries": entries,
                 "next_offset": (!reached_end).then_some(parsed.offset.saturating_add(emitted)),
                 "index_path": state.log_index_path.as_ref().map(|path| path.display().to_string()),
+                "source": "recorded",
             }),
             Some(state.cursor_rev),
             None,
@@ -3025,7 +3078,6 @@ fn structured_log_entry_json(index: usize, strings: &[String], entry: &CuLogEntr
         "level": format!("{:?}", entry.level),
         "msg_index": entry.msg_index,
         "message_template": strings.get(entry.msg_index as usize).cloned(),
-        "rendered": rebuild_logline(strings, entry).ok(),
         "culistid": entry.origin.culistid,
         "component_id": entry.origin.component_id,
         "task_index": entry.origin.task_index,


### PR DESCRIPTION
## Summary

This allows to get also the structured logging in the replay tab of the timetraveler

## Related issues
- Closes #

## Changes

## Reminder
- [ ] I ran `just` from the repo root
- [ ] I have updated docs or examples where needed

## Additional context
