### PR TITLE
chore(deps): bump candle-core and candle-nn to 0.11.0 together

### DIFF
--- a/examples/cu_human_pose/Cargo.toml
+++ b/examples/cu_human_pose/Cargo.toml
@@ -29,8 +29,8 @@ cu-sensor-payloads = { workspace = true }
 cu-logmon = { workspace = true }
 
 # Candle ML framework
-candle-core = "0.10.2"
-candle-nn = "0.10.2"
+candle-core = "0.11.0"
+candle-nn = "0.11.0"
 # Visualization
 rerun = { workspace = true }
 


### PR DESCRIPTION
## Summary

- Bumps both `candle-core` and `candle-nn` from 0.10.2 → 0.11.0 in `examples/cu_human_pose/Cargo.toml`.
- Replaces dependabot PRs #1166 (candle-core only) and #1167 (candle-nn only), which each fail CI because bumping only one of the two leaves two versions of `candle-core` in the dependency graph (the unchanged crate pulls in the older `candle-core` transitively). The trait/type mismatches in `cu-human-pose` (`expected candle_core::Tensor, found candle_core::tensor::Tensor`) all come from that duplication.

No source changes were needed for the 0.10 → 0.11 bump; `cargo check -p cu-human-pose` passes locally and `cargo tree -i candle-core` shows a single `candle-core v0.11.0` in the graph.

Closes #1166
Closes #1167

## Test plan

- [x] `cargo update -p candle-core -p candle-nn` resolves to 0.11.0 for both
- [x] `cargo tree -p cu-human-pose -i candle-core` shows a single version
- [x] `cargo check -p cu-human-pose` succeeds locally
- [ ] CI green