### PR TITLE
Fix: encoding on ROS2 plus full end2end non-regression

### DIFF
--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -96,6 +96,23 @@ jobs:
       - name: Set features (Linux)
         run: |
           echo "FEATURES_FLAG=--features $BASE_FEATURES,python" >> $GITHUB_ENV
+      - name: Source ROS 2 (if present)
+        if: matrix.task == 'test'
+        run: |
+          if [ -f "/opt/ros/lyrical/setup.bash" ]; then
+            source /opt/ros/lyrical/setup.bash
+            {
+              echo "AMENT_PREFIX_PATH=${AMENT_PREFIX_PATH:-}"
+              echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-}"
+              echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}"
+              echo "PYTHONPATH=${PYTHONPATH:-}"
+              echo "PATH=$PATH"
+              echo "ROS_DISTRO=${ROS_DISTRO:-lyrical}"
+              echo "ROS_VERSION=${ROS_VERSION:-2}"
+              echo "ROS_PYTHON_VERSION=${ROS_PYTHON_VERSION:-3}"
+              echo "RMW_IMPLEMENTATION=rmw_zenoh_cpp"
+            } >> "$GITHUB_ENV"
+          fi
       - name: Detect default workspace exclusions
         run: |
           EXCLUDES=$(python3 support/ci/workspace_excludes.py excludes --toolchain ${{ inputs.toolchain }})
@@ -159,6 +176,22 @@ jobs:
       - name: Set features (Linux)
         run: |
           echo "FEATURES_FLAG=--features $BASE_FEATURES,python" >> $GITHUB_ENV
+      - name: Source ROS 2 (if present)
+        run: |
+          if [ -f "/opt/ros/lyrical/setup.bash" ]; then
+            source /opt/ros/lyrical/setup.bash
+            {
+              echo "AMENT_PREFIX_PATH=${AMENT_PREFIX_PATH:-}"
+              echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-}"
+              echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}"
+              echo "PYTHONPATH=${PYTHONPATH:-}"
+              echo "PATH=$PATH"
+              echo "ROS_DISTRO=${ROS_DISTRO:-lyrical}"
+              echo "ROS_VERSION=${ROS_VERSION:-2}"
+              echo "ROS_PYTHON_VERSION=${ROS_PYTHON_VERSION:-3}"
+              echo "RMW_IMPLEMENTATION=rmw_zenoh_cpp"
+            } >> "$GITHUB_ENV"
+          fi
       - name: Detect default workspace exclusions
         run: |
           EXCLUDES=$(python3 support/ci/workspace_excludes.py excludes --toolchain ${{ inputs.toolchain }})
@@ -471,6 +504,22 @@ jobs:
       - name: Set features (Linux)
         run: |
           echo "FEATURES_FLAG=--features $BASE_FEATURES,python" >> $GITHUB_ENV
+      - name: Source ROS 2 (if present)
+        run: |
+          if [ -f "/opt/ros/lyrical/setup.bash" ]; then
+            source /opt/ros/lyrical/setup.bash
+            {
+              echo "AMENT_PREFIX_PATH=${AMENT_PREFIX_PATH:-}"
+              echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-}"
+              echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}"
+              echo "PYTHONPATH=${PYTHONPATH:-}"
+              echo "PATH=$PATH"
+              echo "ROS_DISTRO=${ROS_DISTRO:-lyrical}"
+              echo "ROS_VERSION=${ROS_VERSION:-2}"
+              echo "ROS_PYTHON_VERSION=${ROS_PYTHON_VERSION:-3}"
+              echo "RMW_IMPLEMENTATION=rmw_zenoh_cpp"
+            } >> "$GITHUB_ENV"
+          fi
       - name: Detect default workspace exclusions
         run: |
           EXCLUDES=$(python3 support/ci/workspace_excludes.py excludes --toolchain ${{ inputs.toolchain }})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,7 @@ Implications:
 - When touching Rust code, avoid clippy-denied cleanup mistakes that keep recurring here:
   - do not keep redundant same-type casts such as `u64` to `u64`
   - prefer `.is_multiple_of(...)` over `% ... == 0` when checking divisibility
+  - collapse nested `if` / `if let` statements into `if let` chains when clippy's `collapsible_if` lint applies
 - Use `cargo expand` when proc-macro behavior is unclear.
 - Lockfiles are intentionally not committed in this checkout. Before starting a work pass, remove any existing generated `Cargo.lock` files unless explicitly asked otherwise; do not remove lockfiles as final cleanup after the work is complete. Resolving without lockfiles matches remote/CI behavior.
 - Many examples/apps create logs under their own `logs/` directories.

--- a/components/bridges/cu_ros2_bridge/README.md
+++ b/components/bridges/cu_ros2_bridge/README.md
@@ -52,3 +52,23 @@ register it once at startup:
 ```rust
 cu_ros2_bridge::register_ros2_payload::<MyPayload>();
 ```
+
+## Wire encoding
+
+Copper -> ROS 2 samples are serialized as OMG CDR little-endian (`CdrLe`). Inbound samples use
+`cdr::deserialize`, which reads the CDR encapsulation header and accepts either endianness.
+
+## ROS 2 interop test
+
+The `ros2_interop` test auto-detects a sourced ROS 2 environment. If `ros2`, `std_msgs`, or
+`rmw_zenoh_cpp` are unavailable, the test prints a warning with the skip reason and returns
+success. The Linux CI image includes ROS 2 Lyrical and `rmw_zenoh_cpp`, so the same normal test
+flow exercises real ROS 2 bridge interoperability in CI.
+
+When available, the test starts `rmw_zenohd`, runs a real ROS 2 subscriber with
+`ros2 topic echo --once`, publishes an `std_msgs/msg/Int32` through `Ros2Bridge`, and requires
+the ROS 2 process to print `data: 42`.
+
+```bash
+cargo test -p cu-ros2-bridge --test ros2_interop -- --nocapture
+```

--- a/components/bridges/cu_ros2_bridge/src/lib.rs
+++ b/components/bridges/cu_ros2_bridge/src/lib.rs
@@ -6,7 +6,7 @@ mod node;
 mod topic;
 
 use attachment::encode_attachment;
-use cdr::{CdrBe, Infinite};
+use cdr::{CdrLe, Infinite};
 use cu_ros2_payloads::RosBridgeAdapter;
 use cu29::cubridge::{BridgeChannel, BridgeChannelConfig, BridgeChannelSet, CuBridge};
 use cu29::prelude::*;
@@ -89,7 +89,7 @@ where
         ))
     })?;
     let ros_payload = payload.to_ros_message();
-    cdr::serialize::<_, _, CdrBe>(&ros_payload, Infinite)
+    cdr::serialize::<_, _, CdrLe>(&ros_payload, Infinite)
         .map_err(|e| CuError::new_with_cause("Ros2Bridge: Failed to serialize payload", e))
 }
 
@@ -710,18 +710,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn i8_payload_cdr_roundtrip() {
-        let mut src = CuMsg::<i8>::default();
-        src.set_payload(42);
+    fn scalar_payload_cdr_roundtrip_uses_little_endian_encapsulation() {
+        let mut src = CuMsg::<i32>::default();
+        src.set_payload(0x0102_0304);
 
         let codec =
-            Ros2Bridge::<crate::tests::DummyTx, crate::tests::DummyRx>::codec_for_payload::<i8>()
+            Ros2Bridge::<crate::tests::DummyTx, crate::tests::DummyRx>::codec_for_payload::<i32>()
                 .expect("codec should be registered");
         let bytes =
             Ros2Bridge::<crate::tests::DummyTx, crate::tests::DummyRx>::encode_payload(&src, codec)
                 .expect("encode should succeed");
 
-        let mut dst = CuMsg::<i8>::default();
+        assert_eq!(&bytes[..4], &[0, 1, 0, 0], "CDR_LE encapsulation");
+        assert_eq!(&bytes[4..8], &[4, 3, 2, 1], "little-endian i32 data");
+
+        let mut dst = CuMsg::<i32>::default();
         Ros2Bridge::<crate::tests::DummyTx, crate::tests::DummyRx>::decode_payload_into(
             bytes.as_slice(),
             &mut dst,
@@ -729,7 +732,7 @@ mod tests {
         )
         .expect("decode should succeed");
 
-        assert_eq!(dst.payload(), Some(&42));
+        assert_eq!(dst.payload(), Some(&0x0102_0304));
     }
 
     #[test]

--- a/components/bridges/cu_ros2_bridge/tests/ros2_interop.rs
+++ b/components/bridges/cu_ros2_bridge/tests/ros2_interop.rs
@@ -1,0 +1,293 @@
+use cu_ros2_bridge::Ros2Bridge;
+use cu29::prelude::*;
+use std::error::Error;
+use std::io;
+use std::net::TcpStream;
+use std::process::{Child, Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+tx_channels! {
+    struct InteropTxChannels : InteropTxId {
+        out => i32,
+    }
+}
+
+rx_channels! {
+    struct InteropRxChannels : InteropRxId {
+        unused => i32,
+    }
+}
+
+type InteropBridge = Ros2Bridge<InteropTxChannels, InteropRxChannels>;
+
+#[test]
+fn ros2_echo_reads_copper_published_std_msgs_int32_over_zenoh() -> Result<(), Box<dyn Error>> {
+    if let Err(reason) = probe_ros2_interop_dependencies() {
+        eprintln!(
+            "warning: skipping ROS 2 interop test: {reason}. Install ROS 2 with std_msgs and rmw_zenoh_cpp to exercise real ROS 2 bridge interoperability."
+        );
+        return Ok(());
+    }
+
+    run_ros2_interop()
+}
+
+fn run_ros2_interop() -> Result<(), Box<dyn Error>> {
+    let domain_id = env_u32("ROS_DOMAIN_ID", 0)?;
+    let endpoint = "tcp/127.0.0.1:7447";
+    let topic = format!("/copper_ros2_bridge_interop_{}", std::process::id());
+
+    stop_ros2_daemon();
+
+    let mut zenohd = ensure_zenoh_router(endpoint, domain_id)?;
+
+    let mut echo = spawn_ros2_echo(&topic, domain_id)?;
+    thread::sleep(Duration::from_millis(750));
+
+    let mut bridge_cfg = ComponentConfig::default();
+    bridge_cfg.set("domain_id", domain_id);
+    bridge_cfg.set("namespace", "copper".to_string());
+    bridge_cfg.set("node", "ros2_interop_test".to_string());
+    bridge_cfg.set("zenoh_config_json", zenoh_client_config_json(endpoint));
+
+    let tx_channels = [BridgeChannelConfig::from_static(
+        &InteropTxChannels::OUT,
+        Some(topic),
+        None,
+    )];
+    let mut bridge = <InteropBridge as CuBridge>::new(Some(&bridge_cfg), &tx_channels, &[], ())?;
+    let ctx = CuContext::new_with_clock();
+    bridge.start(&ctx)?;
+
+    let result = publish_until_echo_receives(&mut bridge, &ctx, &mut echo);
+    bridge.stop(&ctx)?;
+
+    if let Some(router) = zenohd.as_mut() {
+        router.kill_and_wait();
+    }
+
+    result
+}
+
+fn probe_ros2_interop_dependencies() -> Result<(), String> {
+    require_command_success(Command::new("ros2").arg("--help"), "ros2 --help")?;
+    require_command_success(
+        Command::new("ros2").args(["pkg", "prefix", "rmw_zenoh_cpp"]),
+        "ros2 pkg prefix rmw_zenoh_cpp",
+    )?;
+    require_command_success(
+        Command::new("ros2").args(["pkg", "prefix", "std_msgs"]),
+        "ros2 pkg prefix std_msgs",
+    )?;
+    Ok(())
+}
+
+fn require_command_success(command: &mut Command, label: &str) -> Result<(), String> {
+    let output = command
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|err| format!("{label} failed to spawn: {err}"))?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "{label} exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}
+
+fn ensure_zenoh_router(
+    endpoint: &str,
+    domain_id: u32,
+) -> Result<Option<ChildGuard>, Box<dyn Error>> {
+    if tcp_endpoint_reachable(endpoint) {
+        return Ok(None);
+    }
+
+    let mut command = Command::new("ros2");
+    command
+        .args(["run", "rmw_zenoh_cpp", "rmw_zenohd"])
+        .env("ROS_DOMAIN_ID", domain_id.to_string())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut guard = ChildGuard::spawn(command, "rmw_zenohd")?;
+    wait_for_tcp_endpoint(endpoint, Duration::from_secs(10), Some(&mut guard))?;
+    Ok(Some(guard))
+}
+
+fn spawn_ros2_echo(topic: &str, domain_id: u32) -> Result<ChildGuard, Box<dyn Error>> {
+    let mut command = Command::new("ros2");
+    command
+        .args(["topic", "echo", "--once", topic, "std_msgs/msg/Int32"])
+        .env("ROS_DOMAIN_ID", domain_id.to_string())
+        .env("RMW_IMPLEMENTATION", "rmw_zenoh_cpp")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    ChildGuard::spawn(command, "ros2 topic echo")
+}
+
+fn publish_until_echo_receives(
+    bridge: &mut InteropBridge,
+    ctx: &CuContext,
+    echo: &mut ChildGuard,
+) -> Result<(), Box<dyn Error>> {
+    let deadline = Instant::now() + Duration::from_secs(15);
+
+    while Instant::now() < deadline {
+        let msg = CuMsg::new(Some(42i32));
+        bridge.send(ctx, &InteropTxChannels::OUT, &msg)?;
+
+        if echo.try_wait()?.is_some() {
+            let output = echo.wait_with_output()?;
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+
+            if !output.status.success() {
+                return Err(boxed_error(format!(
+                    "ros2 topic echo exited with {}.\nstdout:\n{}\nstderr:\n{}",
+                    output.status, stdout, stderr
+                )));
+            }
+
+            if stdout.contains("data: 42") {
+                return Ok(());
+            }
+
+            return Err(boxed_error(format!(
+                "ros2 topic echo exited without the expected sample.\nstdout:\n{}\nstderr:\n{}",
+                stdout, stderr
+            )));
+        }
+
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    echo.kill_and_wait();
+    Err(boxed_error(
+        "timed out waiting for ros2 topic echo to receive data: 42",
+    ))
+}
+
+fn zenoh_client_config_json(endpoint: &str) -> String {
+    format!(
+        r#"{{
+            mode: "client",
+            connect: {{ endpoints: ["{endpoint}"] }},
+            scouting: {{ multicast: {{ enabled: false }}, gossip: {{ enabled: false }} }}
+        }}"#
+    )
+}
+
+fn wait_for_tcp_endpoint(
+    endpoint: &str,
+    timeout: Duration,
+    mut child: Option<&mut ChildGuard>,
+) -> Result<(), Box<dyn Error>> {
+    let addr = endpoint
+        .strip_prefix("tcp/")
+        .ok_or_else(|| boxed_error(format!("expected tcp/ endpoint, got {endpoint}")))?;
+    let deadline = Instant::now() + timeout;
+
+    while Instant::now() < deadline {
+        if TcpStream::connect(addr).is_ok() {
+            return Ok(());
+        }
+
+        if let Some(child) = child.as_deref_mut()
+            && let Some(status) = child.try_wait()?
+        {
+            let output = child.wait_with_output()?;
+            return Err(boxed_error(format!(
+                "{} exited before {endpoint} became reachable: {status}\nstdout:\n{}\nstderr:\n{}",
+                child.name,
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    Err(boxed_error(format!("timed out waiting for {endpoint}")))
+}
+
+fn tcp_endpoint_reachable(endpoint: &str) -> bool {
+    endpoint
+        .strip_prefix("tcp/")
+        .map(|addr| TcpStream::connect(addr).is_ok())
+        .unwrap_or(false)
+}
+
+fn stop_ros2_daemon() {
+    let _ = Command::new("ros2")
+        .args(["daemon", "stop"])
+        .env("RMW_IMPLEMENTATION", "rmw_zenoh_cpp")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+fn env_u32(name: &str, default: u32) -> Result<u32, Box<dyn Error>> {
+    match std::env::var(name) {
+        Ok(value) => value
+            .parse::<u32>()
+            .map_err(|err| boxed_error(format!("{name} must be a u32, got {value:?}: {err}"))),
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(err) => Err(boxed_error(format!("failed to read {name}: {err}"))),
+    }
+}
+
+fn boxed_error(message: impl Into<String>) -> Box<dyn Error> {
+    Box::new(io::Error::other(message.into()))
+}
+
+struct ChildGuard {
+    child: Option<Child>,
+    name: &'static str,
+}
+
+impl ChildGuard {
+    fn spawn(mut command: Command, name: &'static str) -> Result<Self, Box<dyn Error>> {
+        let child = command
+            .spawn()
+            .map_err(|err| boxed_error(format!("failed to spawn {name}: {err}")))?;
+        Ok(Self {
+            child: Some(child),
+            name,
+        })
+    }
+
+    fn try_wait(&mut self) -> io::Result<Option<std::process::ExitStatus>> {
+        match self.child.as_mut() {
+            Some(child) => child.try_wait(),
+            None => Ok(None),
+        }
+    }
+
+    fn wait_with_output(&mut self) -> io::Result<Output> {
+        self.child
+            .take()
+            .expect("child already consumed")
+            .wait_with_output()
+    }
+
+    fn kill_and_wait(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            if matches!(child.try_wait(), Ok(None)) {
+                let _ = child.kill();
+            }
+            let _ = child.wait();
+        }
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        self.kill_and_wait();
+    }
+}

--- a/components/payloads/cu_ros2_payloads/src/sensor_msgs.rs
+++ b/components/payloads/cu_ros2_payloads/src/sensor_msgs.rs
@@ -658,7 +658,7 @@ mod tests {
         let cloud = sample_pointcloud();
 
         let ros_value = cloud.to_ros_message();
-        let bytes = cdr::serialize::<_, _, cdr::CdrBe>(&ros_value, cdr::Infinite)
+        let bytes = cdr::serialize::<_, _, cdr::CdrLe>(&ros_value, cdr::Infinite)
             .expect("cdr encode should succeed");
         let decoded_ros: <PointCloudSoa<4> as RosBridgeAdapter>::RosMessage =
             cdr::deserialize(bytes.as_slice()).expect("cdr decode should succeed");
@@ -673,7 +673,7 @@ mod tests {
         let expected = sample_pointcloud();
         let cloud = PointCloudSoaHandle::from_box(Box::new(sample_pointcloud()));
         let ros_value = cloud.to_ros_message();
-        let bytes = cdr::serialize::<_, _, cdr::CdrBe>(&ros_value, cdr::Infinite)
+        let bytes = cdr::serialize::<_, _, cdr::CdrLe>(&ros_value, cdr::Infinite)
             .expect("cdr encode should succeed");
         let decoded_ros: <PointCloudSoaHandle<4> as RosBridgeAdapter>::RosMessage =
             cdr::deserialize(bytes.as_slice()).expect("cdr decode should succeed");
@@ -696,7 +696,7 @@ mod tests {
         image.seq = 0;
 
         let ros_value = image.to_ros_message();
-        let encoded = cdr::serialize::<_, _, cdr::CdrBe>(&ros_value, cdr::Infinite)
+        let encoded = cdr::serialize::<_, _, cdr::CdrLe>(&ros_value, cdr::Infinite)
             .expect("cdr encode should succeed");
         let decoded_ros: <CuImage<Vec<u8>> as RosBridgeAdapter>::RosMessage =
             cdr::deserialize(encoded.as_slice()).expect("cdr decode should succeed");
@@ -739,7 +739,7 @@ mod tests {
         let imu = ImuPayload::from_raw([9.8, -0.2, 0.5], [0.1, -0.2, 1.5], 0.0);
 
         let ros_value = imu.to_ros_message();
-        let encoded = cdr::serialize::<_, _, cdr::CdrBe>(&ros_value, cdr::Infinite)
+        let encoded = cdr::serialize::<_, _, cdr::CdrLe>(&ros_value, cdr::Infinite)
             .expect("cdr encode should succeed");
         let decoded_ros: <ImuPayload as RosBridgeAdapter>::RosMessage =
             cdr::deserialize(encoded.as_slice()).expect("cdr decode should succeed");
@@ -765,7 +765,7 @@ mod tests {
         let mag = MagnetometerPayload::from_raw([42.0, -13.0, 8.0]);
 
         let ros_value = mag.to_ros_message();
-        let encoded = cdr::serialize::<_, _, cdr::CdrBe>(&ros_value, cdr::Infinite)
+        let encoded = cdr::serialize::<_, _, cdr::CdrLe>(&ros_value, cdr::Infinite)
             .expect("cdr encode should succeed");
         let decoded_ros: <MagnetometerPayload as RosBridgeAdapter>::RosMessage =
             cdr::deserialize(encoded.as_slice()).expect("cdr decode should succeed");

--- a/components/payloads/cu_ros2_payloads/src/std_msgs.rs
+++ b/components/payloads/cu_ros2_payloads/src/std_msgs.rs
@@ -143,7 +143,7 @@ mod tests {
         T: RosBridgeAdapter + PartialEq + core::fmt::Debug,
     {
         let ros_value = value.to_ros_message();
-        let bytes = cdr::serialize::<_, _, cdr::CdrBe>(&ros_value, cdr::Infinite)
+        let bytes = cdr::serialize::<_, _, cdr::CdrLe>(&ros_value, cdr::Infinite)
             .expect("cdr encode should succeed");
         let decoded_ros: <T as RosBridgeAdapter>::RosMessage =
             cdr::deserialize(bytes.as_slice()).expect("cdr decode should succeed");

--- a/support/docker/Dockerfile.ci-ubuntu26
+++ b/support/docker/Dockerfile.ci-ubuntu26
@@ -1,5 +1,7 @@
 FROM ubuntu:26.04
 
+ARG ROS_DISTRO=lyrical
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
@@ -11,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     git \
     curl \
+    gnupg \
     just \
     sudo \
     python3 \
@@ -48,6 +51,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && dpkg-reconfigure -f noninteractive tzdata \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+        -o /usr/share/keyrings/ros-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") main" \
+        > /etc/apt/sources.list.d/ros2.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ros-${ROS_DISTRO}-ros-base \
+        ros-${ROS_DISTRO}-rmw-zenoh-cpp \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV ROS_DISTRO=${ROS_DISTRO}
 
 WORKDIR /workspaces/copper-rs
 

--- a/support/docker/README.md
+++ b/support/docker/README.md
@@ -13,7 +13,8 @@ Build and run the Copper development container images.
 
 The Linux CI image is published to `ghcr.io/copper-project/copper-rs-ci:ubuntu-26.04`
 by `.github/workflows/build-ci-images.yml`, which refreshes it nightly and on
-changes under `support/docker/`.
+changes under `support/docker/`. It includes ROS 2 Lyrical plus `rmw_zenoh_cpp` so
+ROS 2 interop tests can run in the normal Linux test job.
 The CUDA Linux CI image is published to
 `ghcr.io/copper-project/copper-rs-ci:cuda-12.6.1-ubuntu-24.04`
 by `.github/workflows/build-ci-images.yml`, which refreshes it nightly and on


### PR DESCRIPTION
## Summary

The existing was only testing with a loopback the ros2 bridge so it left an encoding issue open.

This PR adds a full end2end interoperability test so it never happens again.

## Related issues
- Closes #1175

## Changes

## Reminder
- [ ] I ran `just` from the repo root
- [ ] I have updated docs or examples where needed

## Additional context
