### PR TITLE
fix: address Rust 1.97 Clippy lints

### DIFF
--- a/components/libs/cu_tuimon/src/tui_nodes/graph.rs
+++ b/components/libs/cu_tuimon/src/tui_nodes/graph.rs
@@ -161,7 +161,7 @@ impl<'a> NodeGraph<'a> {
         // Repeat the for loop until in runs all the way through without any
         // intersections. Surely there's a more efficient way to do this.
         'outer: loop {
-            for (_, ea_them) in self.placements.iter() {
+            for ea_them in self.placements.values() {
                 if rect_me.intersects(*ea_them) {
                     rect_me.y = rect_me.y.max(ea_them.bottom());
                     continue 'outer;

--- a/components/tasks/cu_pid/src/lib.rs
+++ b/components/tasks/cu_pid/src/lib.rs
@@ -283,7 +283,7 @@ where
                 }
                 output.metadata.set_status(format!(
                     "{:>5.2} {:>5.2} {:>5.2} {:>5.2}",
-                    &state.output, &state.p, &state.i, &state.d
+                    state.output, state.p, state.i, state.d
                 ));
                 output.set_payload(state);
             }

--- a/core/cu29_export/src/lib.rs
+++ b/core/cu29_export/src/lib.rs
@@ -608,12 +608,10 @@ pub fn textlog_dump(src: impl Read, index: &Path) -> CuResult<()> {
     })?;
 
     for result in structlog_reader(src) {
-        match result {
-            Ok(entry) => match rebuild_logline(&all_strings, &entry) {
-                Ok(line) => println!("{line}"),
-                Err(e) => println!("Failed to rebuild log line: {e:?}"),
-            },
-            Err(e) => return Err(e),
+        let entry = result?;
+        match rebuild_logline(&all_strings, &entry) {
+            Ok(line) => println!("{line}"),
+            Err(e) => println!("Failed to rebuild log line: {e:?}"),
         }
     }
 

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -4078,7 +4078,7 @@ pub fn read_configuration(config_filename: &str) -> CuResult<CuConfig> {
     let config_content = read_to_string(config_filename).map_err(|e| {
         CuError::from(format!(
             "Failed to read configuration file: {:?}",
-            &config_filename
+            config_filename
         ))
         .add_cause(e.to_string().as_str())
     })?;
@@ -4146,7 +4146,7 @@ pub fn read_multi_configuration(config_filename: &str) -> CuResult<MultiCopperCo
     let config_content = read_to_string(config_filename).map_err(|e| {
         CuError::from(format!(
             "Failed to read multi-Copper configuration file: {:?}",
-            &config_filename
+            config_filename
         ))
         .add_cause(e.to_string().as_str())
     })?;


### PR DESCRIPTION
## Summary

- remove redundant formatting borrows reported by Rust 1.97 Clippy
- iterate directly over map values in `cu-tuimon`
- use `?` to propagate structured-log reader errors

## Verification

- `just fmt`
- `just lint`
- `just api-check`
- `cargo +stable nextest run -p cu29-runtime -p cu29-export -p cu-tuimon -p cu-pid --features cu-tuimon/log_pane` (260 passed, 1 skipped)