### PR TITLE
Pin the nightly toolchain for API checks.

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -445,11 +445,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PUBLIC_API_VERSION: "0.51.0"
-      PUBLIC_API_TOOLCHAIN: nightly
+      PUBLIC_API_TOOLCHAIN: nightly-2026-06-25
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
-      - uses: dtolnay/rust-toolchain@nightly
+      - name: Install public API Rust toolchain
+        run: rustup toolchain install "${PUBLIC_API_TOOLCHAIN}" --profile minimal
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: api-check

--- a/api/v1/cu29-unifiedlog.txt
+++ b/api/v1/cu29-unifiedlog.txt
@@ -21,7 +21,7 @@ pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerWrite::flush_section(&mut self,
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerWrite::status(&self) -> cu29_unifiedlog::UnifiedLogStatus
 pub struct cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder
 impl cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder
-pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::build(self) -> core::io::error::Result<cu29_unifiedlog::memmap::MmapUnifiedLogger>
+pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::build(self) -> std::io::error::Result<cu29_unifiedlog::memmap::MmapUnifiedLogger>
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::create(self, create: bool) -> Self
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::file_base_name(self, file_path: &std::path::Path) -> Self
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::new() -> Self
@@ -31,7 +31,7 @@ impl core::default::Default for cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilde
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::default() -> Self
 pub struct cu29_unifiedlog::memmap::MmapUnifiedLoggerRead
 impl cu29_unifiedlog::memmap::MmapUnifiedLoggerRead
-pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::new(base_file_path: &std::path::Path) -> core::io::error::Result<Self>
+pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::new(base_file_path: &std::path::Path) -> std::io::error::Result<Self>
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::position(&self) -> cu29_unifiedlog::memmap::LogPosition
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::raw_main_header(&self) -> &cu29_unifiedlog::MainHeader
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::scan_section_bytes(&mut self, datalogtype: cu29_traits::UnifiedLogType) -> cu29_traits::CuResult<u64>
@@ -52,7 +52,7 @@ pub struct cu29_unifiedlog::memmap::UnifiedLoggerIOReader
 impl cu29_unifiedlog::memmap::UnifiedLoggerIOReader
 pub fn cu29_unifiedlog::memmap::UnifiedLoggerIOReader::new(logger: cu29_unifiedlog::memmap::MmapUnifiedLoggerRead, log_type: cu29_traits::UnifiedLogType) -> Self
 impl std::io::Read for cu29_unifiedlog::memmap::UnifiedLoggerIOReader
-pub fn cu29_unifiedlog::memmap::UnifiedLoggerIOReader::read(&mut self, buf: &mut [u8]) -> core::io::error::Result<usize>
+pub fn cu29_unifiedlog::memmap::UnifiedLoggerIOReader::read(&mut self, buf: &mut [u8]) -> std::io::error::Result<usize>
 pub mod cu29_unifiedlog::noop
 pub struct cu29_unifiedlog::noop::NoopLogger
 impl cu29_unifiedlog::noop::NoopLogger
@@ -156,7 +156,7 @@ pub cu29_unifiedlog::UnifiedLogStatus::total_allocated_space: usize
 pub cu29_unifiedlog::UnifiedLogStatus::total_used_space: usize
 pub struct cu29_unifiedlog::UnifiedLoggerBuilder
 impl cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder
-pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::build(self) -> core::io::error::Result<cu29_unifiedlog::memmap::MmapUnifiedLogger>
+pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::build(self) -> std::io::error::Result<cu29_unifiedlog::memmap::MmapUnifiedLogger>
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::create(self, create: bool) -> Self
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::file_base_name(self, file_path: &std::path::Path) -> Self
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::new() -> Self
@@ -168,10 +168,10 @@ pub struct cu29_unifiedlog::UnifiedLoggerIOReader
 impl cu29_unifiedlog::memmap::UnifiedLoggerIOReader
 pub fn cu29_unifiedlog::memmap::UnifiedLoggerIOReader::new(logger: cu29_unifiedlog::memmap::MmapUnifiedLoggerRead, log_type: cu29_traits::UnifiedLogType) -> Self
 impl std::io::Read for cu29_unifiedlog::memmap::UnifiedLoggerIOReader
-pub fn cu29_unifiedlog::memmap::UnifiedLoggerIOReader::read(&mut self, buf: &mut [u8]) -> core::io::error::Result<usize>
+pub fn cu29_unifiedlog::memmap::UnifiedLoggerIOReader::read(&mut self, buf: &mut [u8]) -> std::io::error::Result<usize>
 pub struct cu29_unifiedlog::UnifiedLoggerRead
 impl cu29_unifiedlog::memmap::MmapUnifiedLoggerRead
-pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::new(base_file_path: &std::path::Path) -> core::io::error::Result<Self>
+pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::new(base_file_path: &std::path::Path) -> std::io::error::Result<Self>
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::position(&self) -> cu29_unifiedlog::memmap::LogPosition
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::raw_main_header(&self) -> &cu29_unifiedlog::MainHeader
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::scan_section_bytes(&mut self, datalogtype: cu29_traits::UnifiedLogType) -> cu29_traits::CuResult<u64>

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ BASE_FEATURES := "mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,de
 WINDOWS_BASE_FEATURES := "mock,cu-sensor-payloads/image,kornia,python,gst,faer,nalgebra,glam,debug_pane,bincode"
 MSRV := "1.95.0"
 PUBLIC_API_VERSION := "0.51.0"
-PUBLIC_API_TOOLCHAIN := "nightly"
+PUBLIC_API_TOOLCHAIN := "nightly-2026-06-25"
 export ROOT := justfile_directory()
 WORKSPACE_EXCLUDES := shell('python3 $1/support/ci/workspace_excludes.py excludes --toolchain stable', ROOT)
 PREK_FMT_FIX_HOOKS := "trailing-whitespace mixed-line-ending"
@@ -87,11 +87,11 @@ check-public-api:
 
 # Check the V1 public API snapshot baseline.
 api-check: check-public-api
-	@support/ci/check_public_api.sh
+	@PUBLIC_API_TOOLCHAIN={{PUBLIC_API_TOOLCHAIN}} support/ci/check_public_api.sh
 
 # Refresh the V1 public API snapshot baseline after an intentional API change.
 api-update: check-public-api
-	@UPDATE_PUBLIC_API=1 support/ci/check_public_api.sh
+	@UPDATE_PUBLIC_API=1 PUBLIC_API_TOOLCHAIN={{PUBLIC_API_TOOLCHAIN}} support/ci/check_public_api.sh
 
 # Std clippy checks aligned with reusable unit-test workflow defaults.
 clippy-std:

--- a/support/ci/check_public_api.sh
+++ b/support/ci/check_public_api.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT="${ROOT:-$(git rev-parse --show-toplevel)}"
 BASELINE_DIR="${ROOT}/api/v1"
 UPDATE="${UPDATE_PUBLIC_API:-0}"
-PUBLIC_API_TOOLCHAIN="${PUBLIC_API_TOOLCHAIN:-nightly}"
+PUBLIC_API_TOOLCHAIN="${PUBLIC_API_TOOLCHAIN:-nightly-2026-06-25}"
 CARGO_PUBLIC_API=(cargo "+${PUBLIC_API_TOOLCHAIN}" public-api)
 
 CRATES=(


### PR DESCRIPTION
## Summary

The nightly we were using stating to flip flop with type alias resolutions between core and std which is a pain when you want to check for API change leakages.

This pins a nightly version for the time being that is aliasing to std::. 

Updated the API def.

## Related issues
- Closes #

## Changes

## Reminder
- [ ] I ran `just` from the repo root
- [ ] I have updated docs or examples where needed

## Additional context
