### PR TITLE
Support multi-output source placeholders in simulation [0]

### DIFF
--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -875,6 +875,18 @@ pub fn cu29_runtime::cutask::CuSrcTask::register_debug_state_types(registry: &mu
 pub fn cu29_runtime::cutask::CuSrcTask::start(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
 pub fn cu29_runtime::cutask::CuSrcTask::stop(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
 pub fn cu29_runtime::cutask::CuSrcTask::with_debug_state<R>(&self, f: impl core::ops::function::FnOnce(&dyn cu29_runtime::reflect::Reflect) -> R) -> R where Self: core::marker::Sized
+impl<O: cu29_runtime::cutask::CuMsgPayload + 'static> cu29_runtime::cutask::CuSrcTask for cu29_runtime::simulation::CuSimSrcTaskPack<O>
+pub type cu29_runtime::simulation::CuSimSrcTaskPack<O>::Output<'m> = O
+pub type cu29_runtime::simulation::CuSimSrcTaskPack<O>::Resources<'r> = ()
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::debug_state_type_path() -> &'static str where Self: cu29_runtime::reflect::TypePath + core::marker::Sized
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::new(_config: core::option::Option<&cu29_runtime::config::ComponentConfig>, _resources: Self::Resources) -> cu29_traits::CuResult<Self> where Self: core::marker::Sized
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::postprocess(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::preprocess(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::process(&mut self, _ctx: &cu29_runtime::context::CuContext, _new_msg: &mut Self::Output) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::register_debug_state_types(registry: &mut cu29_runtime::reflect::TypeRegistry) where Self: cu29_runtime::reflect::GetTypeRegistration + core::marker::Sized
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::start(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::stop(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::with_debug_state<R>(&self, f: impl core::ops::function::FnOnce(&dyn cu29_runtime::reflect::Reflect) -> R) -> R where Self: core::marker::Sized
 impl<T, O> cu29_runtime::cutask::CuSrcTask for cu29_runtime::cuasynctask::CuAsyncSrcTask<T, O> where T: for<'m> cu29_runtime::cutask::CuSrcTask<Output<'m> = cu29_runtime::cutask::CuMsg<O>> + core::marker::Send + 'static, O: cu29_runtime::cutask::CuMsgPayload + core::marker::Send + 'static
 pub type cu29_runtime::cuasynctask::CuAsyncSrcTask<T, O>::Output<'m> = <T as cu29_runtime::cutask::CuSrcTask>::Output
 pub type cu29_runtime::cuasynctask::CuAsyncSrcTask<T, O>::Resources<'r> = cu29_runtime::cuasynctask::CuAsyncSrcTaskResources<'r, T>
@@ -931,6 +943,9 @@ pub fn cu29_runtime::cutask::Freezable::thaw<D: cu_bincode::de::Decoder>(&mut se
 impl<I> cu29_runtime::cutask::Freezable for cu29_runtime::simulation::CuSimSinkTask<I>
 pub fn cu29_runtime::simulation::CuSimSinkTask<I>::freeze<E: cu_bincode::enc::Encoder>(&self, encoder: &mut E) -> core::result::Result<(), cu_bincode::error::EncodeError>
 pub fn cu29_runtime::simulation::CuSimSinkTask<I>::thaw<D: cu_bincode::de::Decoder>(&mut self, _decoder: &mut D) -> core::result::Result<(), cu_bincode::error::DecodeError>
+impl<O> cu29_runtime::cutask::Freezable for cu29_runtime::simulation::CuSimSrcTaskPack<O>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::freeze<E: cu_bincode::enc::Encoder>(&self, encoder: &mut E) -> core::result::Result<(), cu_bincode::error::EncodeError>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::thaw<D: cu_bincode::de::Decoder>(&mut self, decoder: &mut D) -> core::result::Result<(), cu_bincode::error::DecodeError>
 impl<T, O> cu29_runtime::cutask::Freezable for cu29_runtime::cuasynctask::CuAsyncSrcTask<T, O> where T: for<'m> cu29_runtime::cutask::CuSrcTask<Output<'m> = cu29_runtime::cutask::CuMsg<O>> + core::marker::Send + 'static, O: cu29_runtime::cutask::CuMsgPayload + core::marker::Send + 'static
 pub fn cu29_runtime::cuasynctask::CuAsyncSrcTask<T, O>::freeze<E: cu_bincode::enc::Encoder>(&self, encoder: &mut E) -> core::result::Result<(), cu_bincode::error::EncodeError>
 pub fn cu29_runtime::cuasynctask::CuAsyncSrcTask<T, O>::thaw<D: cu_bincode::de::Decoder>(&mut self, decoder: &mut D) -> core::result::Result<(), cu_bincode::error::DecodeError>
@@ -1786,6 +1801,12 @@ pub fn cu29_runtime::simulation::CuSimSinkTask<I>::module_path() -> core::option
 pub fn cu29_runtime::simulation::CuSimSinkTask<I>::short_type_path() -> &'static str
 pub fn cu29_runtime::simulation::CuSimSinkTask<I>::type_ident() -> core::option::Option<&'static str>
 pub fn cu29_runtime::simulation::CuSimSinkTask<I>::type_path() -> &'static str
+impl<O: 'static> cu29_runtime::reflect::TypePath for cu29_runtime::simulation::CuSimSrcTaskPack<O>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::crate_name() -> core::option::Option<&'static str>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::module_path() -> core::option::Option<&'static str>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::short_type_path() -> &'static str
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::type_ident() -> core::option::Option<&'static str>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::type_path() -> &'static str
 impl<T, M> cu29_runtime::reflect::TypePath for cu29_runtime::cutask::CuStampedData<T, M> where T: cu29_runtime::cutask::CuMsgPayload, M: cu29_traits::Metadata
 pub fn cu29_runtime::cutask::CuStampedData<T, M>::crate_name() -> core::option::Option<&'static str>
 pub fn cu29_runtime::cutask::CuStampedData<T, M>::module_path() -> core::option::Option<&'static str>
@@ -2000,6 +2021,30 @@ pub fn cu29_runtime::simulation::CuSimSrcTask<T>::with_debug_state<R>(&self, f: 
 impl<T> cu29_runtime::cutask::Freezable for cu29_runtime::simulation::CuSimSrcTask<T>
 pub fn cu29_runtime::simulation::CuSimSrcTask<T>::freeze<E: cu_bincode::enc::Encoder>(&self, encoder: &mut E) -> core::result::Result<(), cu_bincode::error::EncodeError>
 pub fn cu29_runtime::simulation::CuSimSrcTask<T>::thaw<D: cu_bincode::de::Decoder>(&mut self, decoder: &mut D) -> core::result::Result<(), cu_bincode::error::DecodeError>
+pub struct cu29_runtime::simulation::CuSimSrcTaskPack<O>
+impl<O> cu29_runtime::simulation::CuSimSrcTaskPack<O>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::sim_tick(&mut self)
+impl<O: 'static> cu29_runtime::reflect::TypePath for cu29_runtime::simulation::CuSimSrcTaskPack<O>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::crate_name() -> core::option::Option<&'static str>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::module_path() -> core::option::Option<&'static str>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::short_type_path() -> &'static str
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::type_ident() -> core::option::Option<&'static str>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::type_path() -> &'static str
+impl<O: cu29_runtime::cutask::CuMsgPayload + 'static> cu29_runtime::cutask::CuSrcTask for cu29_runtime::simulation::CuSimSrcTaskPack<O>
+pub type cu29_runtime::simulation::CuSimSrcTaskPack<O>::Output<'m> = O
+pub type cu29_runtime::simulation::CuSimSrcTaskPack<O>::Resources<'r> = ()
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::debug_state_type_path() -> &'static str where Self: cu29_runtime::reflect::TypePath + core::marker::Sized
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::new(_config: core::option::Option<&cu29_runtime::config::ComponentConfig>, _resources: Self::Resources) -> cu29_traits::CuResult<Self> where Self: core::marker::Sized
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::postprocess(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::preprocess(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::process(&mut self, _ctx: &cu29_runtime::context::CuContext, _new_msg: &mut Self::Output) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::register_debug_state_types(registry: &mut cu29_runtime::reflect::TypeRegistry) where Self: cu29_runtime::reflect::GetTypeRegistration + core::marker::Sized
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::start(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::stop(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::with_debug_state<R>(&self, f: impl core::ops::function::FnOnce(&dyn cu29_runtime::reflect::Reflect) -> R) -> R where Self: core::marker::Sized
+impl<O> cu29_runtime::cutask::Freezable for cu29_runtime::simulation::CuSimSrcTaskPack<O>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::freeze<E: cu_bincode::enc::Encoder>(&self, encoder: &mut E) -> core::result::Result<(), cu_bincode::error::EncodeError>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::thaw<D: cu_bincode::de::Decoder>(&mut self, decoder: &mut D) -> core::result::Result<(), cu_bincode::error::DecodeError>
 pub trait cu29_runtime::simulation::CuSimSinkInput
 pub type cu29_runtime::simulation::CuSimSinkInput::With<'m> where Self: 'm: cu29_runtime::cutask::CuMsgPack
 impl<T1: cu29_runtime::cutask::CuMsgPayload, T2: cu29_runtime::cutask::CuMsgPayload, T3: cu29_runtime::cutask::CuMsgPayload, T4: cu29_runtime::cutask::CuMsgPayload, T5: cu29_runtime::cutask::CuMsgPayload, T6: cu29_runtime::cutask::CuMsgPayload, T7: cu29_runtime::cutask::CuMsgPayload, T8: cu29_runtime::cutask::CuMsgPayload, T9: cu29_runtime::cutask::CuMsgPayload, T10: cu29_runtime::cutask::CuMsgPayload, T11: cu29_runtime::cutask::CuMsgPayload, T12: cu29_runtime::cutask::CuMsgPayload> cu29_runtime::simulation::CuSimSinkInput for (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -5413,6 +5413,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 use cu29::simulation::SimOverride;
                 use cu29::simulation::CuTaskCallbackState;
                 use cu29::simulation::CuSimSrcTask;
+                use cu29::simulation::CuSimSrcTaskPack;
                 use cu29::simulation::CuSimSinkTask;
                 use cu29::simulation::CuSimBridge;
                 use cu29::prelude::app::CuSimApplication;
@@ -9350,12 +9351,23 @@ fn runtime_task_type_for_index(
     match task_specs.cutypes[index] {
         CuTaskType::Source => {
             if sim_mode && !run_in_sim {
-                let msg_type = graph.get_node_output_msg_type(task_id.as_str()).unwrap_or_else(|| {
-                    panic!(
-                        "CuSrcTask {task_id} should have an outgoing connection with a valid output msg type"
-                    )
-                });
-                let sim_task_name = format!("CuSimSrcTask<{msg_type}>");
+                let msg_types = graph
+                    .get_node_output_msg_types(task_id.as_str())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "CuSrcTask {task_id} should have an outgoing connection with a valid output msg type"
+                        )
+                    });
+                let sim_task_name = if msg_types.len() == 1 {
+                    format!("CuSimSrcTask<{}>", msg_types[0])
+                } else {
+                    let messages = msg_types
+                        .iter()
+                        .map(|msg_type| format!("cu29::prelude::CuMsg<{msg_type}>"))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!("CuSimSrcTaskPack<({messages})>")
+                };
                 parse_str(sim_task_name.as_str()).unwrap_or_else(|_| {
                     panic!("Could not build the placeholder for simulation: {sim_task_name}")
                 })

--- a/core/cu29_derive/tests/config/multi_output_source_subset_valid.ron
+++ b/core/cu29_derive/tests/config/multi_output_source_subset_valid.ron
@@ -3,7 +3,7 @@
         (
             id: "src",
             type: "MultiSource",
-            run_in_sim: true,
+            run_in_sim: false,
         ),
         (
             id: "sink",

--- a/core/cu29_runtime/src/simulation.rs
+++ b/core/cu29_runtime/src/simulation.rs
@@ -93,6 +93,7 @@
 //!
 //! - **`CuSimSrcTask<T>`**: A placeholder for a source task that simulates a sensor or data acquisition hardware.
 //!   This task provides the ability to simulate incoming data without requiring actual hardware initialization.
+//! - **`CuSimSrcTaskPack<O>`**: The corresponding placeholder for multi-output sources.
 //!
 //! - **`CuSimSinkTask<T>`**: A placeholder for a sink task that simulates sending data to hardware. It serves as a
 //!   mock for hardware actuators or output devices during simulations.
@@ -273,6 +274,74 @@ impl<T> CuSimSrcTask<T> {
     /// simulator is responsible for providing deterministic outputs and state
     /// snapshots are carried by the real task (when run_in_sim = true).
     /// Keeping this as a no-op avoids baking any fake behavior into keyframes.
+    pub fn sim_tick(&mut self) {}
+}
+
+/// Simulation placeholder preserving the complete output tuple of a multi-output source.
+#[derive(Reflect)]
+#[reflect(no_field_bounds, from_reflect = false, type_path = false)]
+pub struct CuSimSrcTaskPack<O> {
+    #[reflect(ignore)]
+    output: PhantomData<fn() -> O>,
+    state: bool,
+}
+
+impl<O: 'static> TypePath for CuSimSrcTaskPack<O> {
+    fn type_path() -> &'static str {
+        "cu29_runtime::simulation::CuSimSrcTaskPack"
+    }
+
+    fn short_type_path() -> &'static str {
+        "CuSimSrcTaskPack"
+    }
+
+    fn type_ident() -> Option<&'static str> {
+        Some("CuSimSrcTaskPack")
+    }
+
+    fn crate_name() -> Option<&'static str> {
+        Some("cu29_runtime")
+    }
+
+    fn module_path() -> Option<&'static str> {
+        Some("simulation")
+    }
+}
+
+impl<O> Freezable for CuSimSrcTaskPack<O> {
+    fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        Encode::encode(&self.state, encoder)
+    }
+
+    fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
+        self.state = Decode::decode(decoder)?;
+        Ok(())
+    }
+}
+
+impl<O: CuMsgPayload + 'static> CuSrcTask for CuSimSrcTaskPack<O> {
+    type Resources<'r> = ();
+    type Output<'m> = O;
+
+    fn new(_config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self {
+            output: PhantomData,
+            state: true,
+        })
+    }
+
+    fn process(&mut self, _ctx: &CuContext, _new_msg: &mut Self::Output<'_>) -> CuResult<()> {
+        unimplemented!(
+            "A placeholder for sim was called for a multi-output source, you need answer SimOverride to ExecutedBySim for the Process step."
+        )
+    }
+}
+
+impl<O> CuSimSrcTaskPack<O> {
+    /// Placeholder hook for simulation-driven multi-output sources.
     pub fn sim_tick(&mut self) {}
 }
 


### PR DESCRIPTION
## Summary

Allow simulation-mode applications to replace a multi-output source with a placeholder while preserving its complete output tuple. Previously the macro selected only one output type, so sources with `run_in_sim: false` could not generate the correct simulated runtime shape.

## Related issues

- None

## Changes

- Add `CuSimSrcTaskPack` as the tuple-aware placeholder for multi-output sources.
- Generate the single-output placeholder for one output and the tuple-aware placeholder for multiple outputs.
- Exercise the excluded multi-output source path in the existing compile-pass fixture.
- Update the V1 public API snapshot.

## Reminder

- [x] I ran `just` from the repo root (`just pr-check`).
- [x] I updated the module docs and API snapshot; no wiki/book changes are needed for this targeted fix.

## Additional context

Validation:

- `cargo test -p cu29-derive test_compile_fail -- --nocapture`
- `just api-check`
- `just pr-check` (638 standard tests and 329 no-default-feature tests passed)