### PR TITLE
fix: runtime: Bundle resolved configuration preserving order

### DIFF
--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -1,7 +1,6 @@
 use proc_macro::TokenStream;
 use quote::{ToTokens, format_ident, quote};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::fs::read_to_string;
 use std::path::Path;
 use std::process::Command;
 use syn::Fields::{Named, Unnamed};
@@ -17,7 +16,7 @@ use crate::utils::{config_id_to_bridge_const, config_id_to_enum, config_id_to_st
 use cu29_runtime::config::CuConfig;
 use cu29_runtime::config::{
     BridgeChannelConfigRepresentation, ConfigGraphs, CuGraph, Flavor, HandleContent, Node, NodeId,
-    RT_POOL, ResourceBundleConfig, read_configuration,
+    RT_POOL, ResourceBundleConfig, read_configuration, read_configuration_with_resolved_ron,
 };
 use cu29_runtime::curuntime::{
     CuExecutionLoop, CuExecutionStep, CuExecutionUnit, CuTaskType, compute_runtime_plan,
@@ -5745,30 +5744,29 @@ fn resolve_runtime_config_with_root(
                 args.config_path
             ))
         })?;
-        let bundled_local_config_content = read_to_string(&subsystem.config_path).map_err(|e| {
-            CuError::from(format!(
-                "Failed to read bundled local configuration for subsystem '{subsystem_id}' from '{}'.",
-                subsystem.config_path
-            ))
-            .add_cause(e.to_string().as_str())
-        })?;
+        // Bundle the include-expanded source representation. Serializing the lowered
+        // mission graphs would lose the source task order because missions use hash maps.
+        let (local_config, bundled_local_config_content) =
+            read_configuration_with_resolved_ron(&subsystem.config_path).map_err(|e| {
+                CuError::from(format!(
+                    "Failed to prepare bundled local configuration for subsystem '{subsystem_id}' from '{}'.",
+                    subsystem.config_path
+                ))
+                .add_cause(e.to_string().as_str())
+            })?;
 
         Ok(ResolvedRuntimeConfig {
-            local_config: subsystem.config.clone(),
+            local_config,
             bundled_local_config_content,
             subsystem_id: Some(subsystem_id.to_string()),
             subsystem_code: subsystem.subsystem_code,
         })
     } else {
+        let (local_config, bundled_local_config_content) =
+            read_configuration_with_resolved_ron(filename.as_str())?;
         Ok(ResolvedRuntimeConfig {
-            local_config: read_configuration(filename.as_str())?,
-            bundled_local_config_content: read_to_string(&filename).map_err(|e| {
-                CuError::from(format!(
-                    "Could not read the configuration file '{}'.",
-                    args.config_path
-                ))
-                .add_cause(e.to_string().as_str())
-            })?,
+            local_config,
+            bundled_local_config_content,
             subsystem_id: None,
             subsystem_code: 0,
         })
@@ -9714,6 +9712,7 @@ mod tests {
 
         let root = unique_test_dir("multi_runtime_resolve");
         let alpha_config = root.join("alpha.ron");
+        let beta_base_config = root.join("beta_base.ron");
         let beta_config = root.join("beta.ron");
         let network_config = root.join("multi.ron");
 
@@ -9732,11 +9731,23 @@ mod tests {
 "#,
         );
         write_file(
-            &beta_config,
+            &beta_base_config,
             r#"
 (
     tasks: [
         (id: "src", type: "BetaSource", run_in_sim: true),
+    ],
+)
+"#,
+        );
+        write_file(
+            &beta_config,
+            r#"
+(
+    includes: [
+        (path: "beta_base.ron", params: {}),
+    ],
+    tasks: [
         (id: "sink", type: "BetaSink", run_in_sim: true),
     ],
     cnx: [
@@ -9776,6 +9787,149 @@ mod tests {
             .expect("resolved local config graph");
         assert!(graph.get_node_id_by_name("src").is_some());
         assert!(resolved.bundled_local_config_content.contains("BetaSource"));
+        assert!(
+            !resolved
+                .bundled_local_config_content
+                .contains("beta_base.ron")
+        );
+
+        let bundled = CuConfig::deserialize_ron(&resolved.bundled_local_config_content)
+            .expect("bundled subsystem config must not need include path resolution");
+        let bundled_graph = bundled.get_graph(None).expect("bundled graph");
+        assert!(bundled_graph.get_node_id_by_name("src").is_some());
+        assert!(bundled_graph.get_node_id_by_name("sink").is_some());
+        assert_eq!(bundled_graph.edge_count(), 1);
+    }
+
+    #[test]
+    fn resolve_runtime_config_bundles_resolved_single_config() {
+        use super::*;
+
+        let root = unique_test_dir("single_runtime_resolve");
+        let base_config = root.join("base.ron");
+        let app_config = root.join("app.ron");
+
+        write_file(
+            &base_config,
+            r#"
+(
+    tasks: [
+        (id: "src", type: "IncludedSource", run_in_sim: true),
+    ],
+)
+"#,
+        );
+        write_file(
+            &app_config,
+            r#"
+(
+    includes: [
+        (path: "base.ron", params: {}),
+    ],
+    tasks: [
+        (id: "sink", type: "LocalSink", run_in_sim: true),
+    ],
+    cnx: [
+        (src: "src", dst: "sink", msg: "u32"),
+    ],
+)
+"#,
+        );
+
+        let args = CopperRuntimeArgs {
+            config_path: "app.ron".to_string(),
+            subsystem_id: None,
+            sim_mode: false,
+            ignore_resources: false,
+        };
+
+        let resolved =
+            resolve_runtime_config_with_root(&args, &root).expect("resolve single runtime config");
+
+        assert!(
+            resolved
+                .bundled_local_config_content
+                .contains("IncludedSource")
+        );
+        assert!(!resolved.bundled_local_config_content.contains("base.ron"));
+        let bundled = CuConfig::deserialize_ron(&resolved.bundled_local_config_content)
+            .expect("bundled config must not need include path resolution");
+        let graph = bundled.get_graph(None).expect("bundled graph");
+        assert!(graph.get_node_id_by_name("src").is_some());
+        assert!(graph.get_node_id_by_name("sink").is_some());
+        assert_eq!(graph.edge_count(), 1);
+    }
+
+    #[test]
+    fn resolve_runtime_config_preserves_mission_task_order_in_bundle() {
+        use super::*;
+
+        let root = unique_test_dir("mission_runtime_resolve_order");
+        let base_config = root.join("base.ron");
+        let app_config = root.join("app.ron");
+
+        write_file(
+            &base_config,
+            r#"
+(
+    tasks: [
+        (id: "c", type: "TaskC", missions: ["one", "two"]),
+    ],
+)
+"#,
+        );
+        write_file(
+            &app_config,
+            r#"
+(
+    includes: [
+        (path: "base.ron", params: {}),
+    ],
+    missions: [
+        (id: "one"),
+        (id: "two"),
+    ],
+    tasks: [
+        (id: "a", type: "TaskA", missions: ["two"]),
+        (id: "b", type: "TaskB", missions: ["one"]),
+    ],
+)
+"#,
+        );
+
+        let args = CopperRuntimeArgs {
+            config_path: "app.ron".to_string(),
+            subsystem_id: None,
+            sim_mode: false,
+            ignore_resources: false,
+        };
+        let resolved = resolve_runtime_config_with_root(&args, &root)
+            .expect("resolve mission config with includes");
+        let bundled = CuConfig::deserialize_ron(&resolved.bundled_local_config_content)
+            .expect("bundled mission config");
+
+        let task_order = |config: &CuConfig, mission: &str| {
+            config
+                .get_graph(Some(mission))
+                .expect("mission graph")
+                .get_all_nodes()
+                .into_iter()
+                .filter(|(_, node)| node.get_flavor() == Flavor::Task)
+                .map(|(_, node)| node.get_id())
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(task_order(&resolved.local_config, "one"), vec!["b", "c"]);
+        assert_eq!(task_order(&resolved.local_config, "two"), vec!["a", "c"]);
+        assert_eq!(
+            task_order(&bundled, "one"),
+            task_order(&resolved.local_config, "one")
+        );
+        assert_eq!(
+            task_order(&bundled, "two"),
+            task_order(&resolved.local_config, "two")
+        );
+        assert!(!resolved.bundled_local_config_content.contains("base.ron"));
     }
 
     #[test]

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -4075,14 +4075,19 @@ fn validate_multi_config_representation(
 /// Read a copper configuration from a file.
 #[cfg(feature = "std")]
 pub fn read_configuration(config_filename: &str) -> CuResult<CuConfig> {
-    let config_content = read_to_string(config_filename).map_err(|e| {
+    let config_content = read_configuration_content(config_filename)?;
+    read_configuration_str(config_content, Some(config_filename))
+}
+
+#[cfg(feature = "std")]
+fn read_configuration_content(config_filename: &str) -> CuResult<String> {
+    read_to_string(config_filename).map_err(|e| {
         CuError::from(format!(
             "Failed to read configuration file: {:?}",
             config_filename
         ))
         .add_cause(e.to_string().as_str())
-    })?;
-    read_configuration_str(config_content, Some(config_filename))
+    })
 }
 
 /// Read a copper configuration from a String.
@@ -4119,12 +4124,12 @@ fn config_representation_to_config(representation: CuConfigRepresentation) -> Cu
 }
 
 #[allow(unused_variables)]
-pub fn read_configuration_str(
-    config_content: String,
+fn resolve_configuration_representation(
+    config_content: &str,
     file_path: Option<&str>,
-) -> CuResult<CuConfig> {
+) -> CuResult<CuConfigRepresentation> {
     // Parse the configuration string
-    let representation = parse_config_string(&config_content)?;
+    let representation = parse_config_string(config_content)?;
 
     // Process includes and generate a merged configuration if a file path is provided
     // includes are only available with std.
@@ -4134,6 +4139,33 @@ pub fn read_configuration_str(
     } else {
         representation
     };
+
+    Ok(representation)
+}
+
+/// Read a Copper configuration and return the include-expanded RON used by proc-macro bundling.
+///
+/// The RON is serialized from the ordered source representation before it is lowered into
+/// mission graph hash maps. This keeps task ordering aligned with generated runtime code.
+#[cfg(feature = "std")]
+#[doc(hidden)]
+#[allow(dead_code)]
+pub fn read_configuration_with_resolved_ron(config_filename: &str) -> CuResult<(CuConfig, String)> {
+    let config_content = read_configuration_content(config_filename)?;
+    let representation =
+        resolve_configuration_representation(&config_content, Some(config_filename))?;
+    let resolved_ron = CuConfig::get_options()
+        .to_string_pretty(&representation, ron::ser::PrettyConfig::default())
+        .map_err(|e| CuError::from(format!("Error serializing configuration: {e}")))?;
+    let config = config_representation_to_config(representation)?;
+    Ok((config, resolved_ron))
+}
+
+pub fn read_configuration_str(
+    config_content: String,
+    file_path: Option<&str>,
+) -> CuResult<CuConfig> {
+    let representation = resolve_configuration_representation(&config_content, file_path)?;
 
     // Convert the representation to a CuConfig and validate
     config_representation_to_config(representation)


### PR DESCRIPTION
## Summary

- Bundle fully resolved, include-expanded Copper configuration from the ordered source representation.
- Preserve mission task order so generated task configs remain positionally aligned.
- Make compiled-in defaults work when standalone or multi-Copper subsystem configs use relative `includes`.
- Add regression coverage for standalone, subsystem, and multi-mission ordering paths.

## Verification

- `just pr-check`
- `just nostd-ci`
- `cargo test -p cu-runtime-matrix missions_match_expected_async_traces -- --nocapture`