### PR TITLE
fc: Add distributed logging and safe simulator reset

### DIFF
--- a/examples/cu_flight_controller/Cargo.toml
+++ b/examples/cu_flight_controller/Cargo.toml
@@ -256,6 +256,7 @@ logreader = [
   "dep:cu-gnss-payloads",
   "cu-bdshot/messages-only",
 ]
+compute-logreader = ["logreader", "dep:cu-zed", "dep:cu-vitfly"]
 python-bindings = [
   "dep:cu29",
   "cu29/std",
@@ -325,6 +326,11 @@ path = "src/logreader.rs"
 required-features = ["logreader"]
 
 [[bin]]
+name = "quad-compute-logreader"
+path = "src/compute_logreader.rs"
+required-features = ["compute-logreader"]
+
+[[bin]]
 name = "quad-sim"
 path = "src/sim.rs"
 required-features = ["sim"]
@@ -338,3 +344,7 @@ required-features = ["sim-debug"]
 name = "quad-bevymon"
 path = "src/bevymon.rs"
 required-features = ["bevymon"]
+
+[dev-dependencies]
+cu29-export = { workspace = true }
+tempfile = { workspace = true }

--- a/examples/cu_flight_controller/README.md
+++ b/examples/cu_flight_controller/README.md
@@ -201,12 +201,13 @@ The split BevyMon path reuses the same `cu_bevymon::spawn_split_layout(...)` she
 `cu_rp_balancebot` and `cu_bevymon_demo`, but the left panel still runs the real flight-controller
 sim world, OSD, and help overlays.
 
-The simulated compute subsystem publishes ZED2i-compatible 320×180 stereo RGBA images, depth and
-confidence maps, calibration and rig transforms, plus IMU, magnetometer, barometer, and frame
-metadata. Bevy performs the camera rendering and GPU depth readback; the simulator injects those
-buffers into the preempted `cu_zed::Zed` source. The compute graph runs ViTFly inference on the CPU
-by default and draws its predicted velocity over the top-right depth inset. Use `just sim-cuda` to
-run the same graph with ViTFly inference on NVIDIA CUDA.
+The simulated compute subsystem publishes ZED2i-compatible 320×240 stereo RGBA images at a 100°
+vertical field of view, matching the 4:3 projection used to train and evaluate ViTFly. It also
+publishes depth and confidence maps, calibration and rig transforms, plus IMU, magnetometer,
+barometer, and frame metadata. Bevy performs the camera rendering and GPU depth readback; the
+simulator injects those buffers into the preempted `cu_zed::Zed` source. The compute graph runs
+ViTFly inference on the CPU by default and draws its predicted velocity over the top-right depth
+inset. Use `just sim-cuda` to run the same graph with ViTFly inference on NVIDIA CUDA.
 
 CPU runs use `RAYON_NUM_THREADS=8` from the checked-in `.cargo/config.toml`. Making the pool size
 explicit prevents Candle from repeatedly probing Linux CPU topology while retaining parallelism for
@@ -231,6 +232,9 @@ Notes:
 - If no compatible RC joystick is found, the sim falls back to keyboard controls.
 - When connected, the bottom-right help panel shows the selected device name and technical axis bindings (`ABS_X`, `ABS_RY`, etc.).
 - USB and Bluetooth radios both work if they appear as a joystick device on the host.
+- `R` resets the rigid body, controller/estimator state, AUTO mission, camera cache, and ViTFly
+  recurrent state. With a joystick, move ARM low and AUTO off after resetting before the interlock
+  permits rearming.
 
 ### Compatible TX/RX Notes
 

--- a/examples/cu_flight_controller/compute_vitfly_config.ron
+++ b/examples/cu_flight_controller/compute_vitfly_config.ron
@@ -7,6 +7,11 @@
             logging: (enabled: false),
         ),
         (
+            id: "vitfly_depth_log",
+            type: "tasks::VitFlyDepthLog",
+            logging: (enabled: true),
+        ),
+        (
             id: "vitfly_context",
             type: "tasks::VitFlyContextAdapter",
             logging: (enabled: true),
@@ -76,6 +81,11 @@
         ),
         (
             src: "zed",
+            dst: "vitfly_depth_log",
+            msg: "cu_zed::ZedDepthMap<Vec<f32>>",
+        ),
+        (
+            src: "vitfly_depth_log",
             dst: "vitfly",
             msg: "cu_zed::ZedDepthMap<Vec<f32>>",
         ),

--- a/examples/cu_flight_controller/justfile
+++ b/examples/cu_flight_controller/justfile
@@ -167,6 +167,28 @@ logreader log="logs/flight_controller_sim.copper":
   fi
   RUST_BACKTRACE=1 cargo run -p cu-flight-controller --no-default-features --features logreader --bin quad-logreader -- "$log" extract-copperlists --export-format json
 
+# Extract compute CopperLists, including depth and ViTFly predictions (JSON export).
+compute-logreader log="logs/flight_compute_sim.copper":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  log="{{log}}"
+  if [[ "$log" != /* ]]; then
+    log="{{ROOT}}/${log}"
+  fi
+  cd "{{ROOT}}"
+  RUST_BACKTRACE=1 cargo run -p cu-flight-controller --no-default-features --features compute-logreader --bin quad-compute-logreader -- "$log" extract-copperlists --export-format json
+
+# Run the compute-subsystem log reader fsck.
+compute-fsck log="logs/flight_compute_sim.copper":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  log="{{log}}"
+  if [[ "$log" != /* ]]; then
+    log="{{ROOT}}/${log}"
+  fi
+  cd "{{ROOT}}"
+  RUST_BACKTRACE=1 cargo run -p cu-flight-controller --no-default-features --features compute-logreader --bin quad-compute-logreader -- "$log" fsck
+
 # Build the cu_flight_controller Python extension module.
 py-build:
   #!/usr/bin/env bash

--- a/examples/cu_flight_controller/mcu_autonomy_config.ron
+++ b/examples/cu_flight_controller/mcu_autonomy_config.ron
@@ -4,6 +4,7 @@
             path: "mcu_graph.ron",
             params: {
                 "control_source": "mode_supervisor",
+                "attitude_kp": 10.0,
             },
         ),
     ],

--- a/examples/cu_flight_controller/mcu_config.ron
+++ b/examples/cu_flight_controller/mcu_config.ron
@@ -2,7 +2,10 @@
     includes: [
         (
             path: "mcu_graph.ron",
-            params: {"control_source": "mapper"},
+            params: {
+                "control_source": "mapper",
+                "attitude_kp": 1.0,
+            },
         ),
     ],
 )

--- a/examples/cu_flight_controller/mcu_graph.ron
+++ b/examples/cu_flight_controller/mcu_graph.ron
@@ -75,7 +75,7 @@
                 "rate_limit_dps": 210.0,
                 "acro_rate_dps": 500.0,
                 "acro_expo": 0.4,
-                "kp": 1.0,
+                "kp": {{attitude_kp}},
                 "ki": 0.0,
                 "kd": 0.0,
             },

--- a/examples/cu_flight_controller/src/compute_logreader.rs
+++ b/examples/cu_flight_controller/src/compute_logreader.rs
@@ -1,0 +1,14 @@
+extern crate cu29 as bevy;
+
+mod messages;
+
+use cu29::prelude::*;
+use cu29_export::run_cli;
+
+// The simulator records the compute subsystem independently from the MCU.
+// Keep this schema aligned with the compute side of `multi_copper_vitfly_sim.ron`.
+gen_cumsgs!("compute_vitfly_config.ron");
+
+fn main() {
+    run_cli::<CuStampedDataSet>().expect("Failed to run the compute export CLI");
+}

--- a/examples/cu_flight_controller/src/compute_tasks.rs
+++ b/examples/cu_flight_controller/src/compute_tasks.rs
@@ -11,6 +11,43 @@ use cu29::units::si::velocity::meter_per_second;
 #[cfg(any(feature = "sim", feature = "end2end"))]
 const MIN_FORWARD_SPEED_MPS: f32 = 1.0;
 
+/// Gives simulated depth its own logged Copper slot without copying the raster.
+///
+/// The ZED source remains unlogged so its unused stereo and confidence outputs do
+/// not inflate the compute log. Cloning `ZedDepthMap` only clones its `CuHandle`.
+#[cfg(feature = "sim")]
+#[derive(Reflect)]
+pub struct VitFlyDepthLog;
+
+#[cfg(feature = "sim")]
+impl Freezable for VitFlyDepthLog {}
+
+#[cfg(feature = "sim")]
+impl CuTask for VitFlyDepthLog {
+    type Resources<'r> = ();
+    type Input<'m> = input_msg!(cu_zed::ZedDepthMap<Vec<f32>>);
+    type Output<'m> = output_msg!(cu_zed::ZedDepthMap<Vec<f32>>);
+
+    fn new(_config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self> {
+        Ok(Self)
+    }
+
+    fn process(
+        &mut self,
+        _ctx: &CuContext,
+        input: &Self::Input<'_>,
+        output: &mut Self::Output<'_>,
+    ) -> CuResult<()> {
+        output.tov = input.tov;
+        if let Some(depth) = input.payload() {
+            output.set_payload(depth.clone());
+        } else {
+            output.clear_payload();
+        }
+        Ok(())
+    }
+}
+
 /// Adapts the fixed-size MCU context message to ViTFly's typed inputs.
 #[cfg(any(feature = "sim", feature = "end2end"))]
 #[derive(Reflect, Default)]

--- a/examples/cu_flight_controller/src/sim.rs
+++ b/examples/cu_flight_controller/src/sim.rs
@@ -30,6 +30,7 @@ use bevy::camera::RenderTarget;
 use bevy::core_pipeline::{Core3dSystems, Skybox, prepass::DepthPrepass, schedule::Core3d};
 use bevy::ecs::change_detection::DetectChanges;
 use bevy::ecs::schedule::IntoScheduleConfigs;
+use bevy::ecs::system::SystemParam;
 use bevy::image::{
     ImageCompareFunction, ImageSampler, ImageSamplerDescriptor, TextureFormatPixelInfo,
 };
@@ -91,6 +92,19 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 #[cfg(feature = "bevymon")]
 use std::sync::{Arc, Mutex};
+
+#[cfg(feature = "sim")]
+fn replace_reflected_task<A, T>(app: &mut A, task_id: &str, replacement: T) -> CuResult<()>
+where
+    A: cu29::reflect::ReflectTaskIntrospection,
+    T: cu29::reflect::Reflect,
+{
+    let task = cu29::reflect::ReflectTaskIntrospection::reflect_task_mut(app, task_id)
+        .and_then(|task| task.downcast_mut::<T>())
+        .ok_or_else(|| CuError::from(format!("sim reset cannot access task {task_id}")))?;
+    *task = replacement;
+    Ok(())
+}
 
 mod mcu_copper {
     use super::*;
@@ -172,6 +186,31 @@ mod mcu_copper {
 
         pub(super) fn log_shutdown_completed(&mut self) -> CuResult<()> {
             self.app.log_shutdown_completed()
+        }
+
+        #[cfg(feature = "sim")]
+        pub(super) fn reset_sim_state(&mut self) -> CuResult<()> {
+            replace_reflected_task(&mut self.app, "ahrs", cu_ahrs::CuAhrs::new_filter())?;
+            replace_reflected_task(
+                &mut self.app,
+                "navigation",
+                crate::tasks::autonomy::NavigationStateTask::default(),
+            )?;
+            replace_reflected_task(
+                &mut self.app,
+                "auto_mission",
+                crate::tasks::autonomy::AutoMission::default(),
+            )?;
+            replace_reflected_task(
+                &mut self.app,
+                "autonomy_context",
+                crate::tasks::autonomy::AutonomyContextTask::default(),
+            )?;
+            replace_reflected_task(
+                &mut self.app,
+                "auto_controller",
+                crate::tasks::autonomy::AutoVelocityController::default(),
+            )
         }
 
         #[cfg(feature = "bevymon")]
@@ -279,6 +318,13 @@ mod mcu_copper {
     fn default_callback(_step: default::SimStep) -> SimOverride {
         SimOverride::ExecuteByRuntime
     }
+
+    #[cfg(all(test, not(target_arch = "wasm32"), feature = "sim"))]
+    pub(super) fn register_distributed_replay(
+        builder: cu29::distributed_replay::DistributedReplayBuilder,
+    ) -> CuResult<cu29::distributed_replay::DistributedReplayBuilder> {
+        builder.register::<FlightControllerSim>("mcu")
+    }
 }
 
 mod compute_copper {
@@ -306,7 +352,32 @@ mod compute_copper {
         zed_static_state_sent: bool,
     }
 
+    #[cfg(test)]
+    pub(super) type RecordedDataSet = default::CuStampedDataSet;
+
     impl Runtime {
+        #[cfg(all(not(target_arch = "wasm32"), feature = "sim"))]
+        pub(super) fn with_log_path(
+            clock: &RobotClock,
+            zed_store: sim_zed::SimZedFrameStore,
+            logger_path: &Path,
+            log_slab_size: Option<usize>,
+        ) -> Self {
+            let app = default::FlightComputeSim::builder()
+                .with_clock(clock.clone())
+                .with_log_path(PathBuf::from(logger_path), log_slab_size)
+                .expect("failed to create compute logger")
+                .with_sim_callback(&mut default_callback)
+                .build()
+                .expect("failed to create compute runtime");
+            Self {
+                app,
+                zed_store,
+                zed_static_state_sent: false,
+            }
+        }
+
+        #[cfg(any(test, feature = "bevymon"))]
         pub(super) fn new(clock: &RobotClock, zed_store: sim_zed::SimZedFrameStore) -> Self {
             let app = default::FlightComputeSim::builder()
                 .with_clock(clock.clone())
@@ -360,11 +431,25 @@ mod compute_copper {
                     #[cfg(feature = "sim")]
                     default::SimStep::AutonomyTxCommand { msg, .. } => {
                         _autonomy_link.command = msg.clone();
+                        if let Some(command) = msg.payload() {
+                            // The upstream ViTFly preview draws the normalized
+                            // velocity command, not the raw network vector.
+                            zed_store.publish_vitfly_prediction([
+                                command.forward.get::<meter_per_second>(),
+                                command.left.get::<meter_per_second>(),
+                                command.up.get::<meter_per_second>(),
+                            ]);
+                        }
                         SimOverride::ExecutedBySim
                     }
                     #[cfg(feature = "sim")]
                     default::SimStep::VitflyListener(CuTaskCallbackState::Process(input, _)) => {
-                        if let Some(velocity) = input.payload() {
+                        // Keep an inference preview available while AUTO is
+                        // inactive. An active conditioned command published
+                        // above always takes precedence over this raw vector.
+                        if _autonomy_link.command.payload().is_none()
+                            && let Some(velocity) = input.payload()
+                        {
                             zed_store.publish_vitfly_prediction(
                                 velocity.map(|axis| axis.get::<meter_per_second>()),
                             );
@@ -388,10 +473,47 @@ mod compute_copper {
         pub(super) fn log_shutdown_completed(&mut self) -> CuResult<()> {
             self.app.log_shutdown_completed()
         }
+
+        #[cfg(feature = "sim")]
+        pub(super) fn reset_sim_state(&mut self) -> CuResult<()> {
+            replace_reflected_task(
+                &mut self.app,
+                "vitfly_context",
+                crate::compute_tasks::VitFlyContextAdapter::default(),
+            )?;
+
+            let vitfly =
+                cu29::reflect::ReflectTaskIntrospection::reflect_task_mut(&mut self.app, "vitfly")
+                    .and_then(|task| task.downcast_mut::<cu_vitfly::VitFlyTask>())
+                    .ok_or_else(|| CuError::from("sim reset cannot access task vitfly"))?;
+            let config = cu29::bincode::config::standard();
+            let encoded =
+                cu29::bincode::encode_to_vec(Option::<(Vec<f32>, Vec<f32>)>::None, config)
+                    .map_err(|err| {
+                        CuError::new_with_cause(
+                            "failed to encode empty ViTFly recurrent state",
+                            err,
+                        )
+                    })?;
+            let reader = cu29::bincode::de::read::SliceReader::new(&encoded);
+            let mut decoder = cu29::bincode::de::DecoderImpl::new(reader, config, ());
+            vitfly.thaw(&mut decoder).map_err(|err| {
+                CuError::new_with_cause("failed to clear ViTFly recurrent state", err)
+            })?;
+            self.zed_static_state_sent = false;
+            Ok(())
+        }
     }
 
     fn default_callback(_step: default::SimStep) -> SimOverride {
         SimOverride::ExecuteByRuntime
+    }
+
+    #[cfg(all(test, not(target_arch = "wasm32"), feature = "sim"))]
+    pub(super) fn register_distributed_replay(
+        builder: cu29::distributed_replay::DistributedReplayBuilder,
+    ) -> CuResult<cu29::distributed_replay::DistributedReplayBuilder> {
+        builder.register::<FlightComputeSim>("compute")
     }
 }
 
@@ -491,6 +613,48 @@ enum RcInputSource {
     #[default]
     Keyboard,
     Joystick,
+}
+
+#[derive(Resource, Default)]
+struct SimResetInterlock {
+    waiting_for_joystick_safe: bool,
+}
+
+impl SimResetInterlock {
+    fn begin(&mut self, source: RcInputSource, rc_input: &mut SimRcInput) {
+        match source {
+            RcInputSource::Keyboard => {
+                self.waiting_for_joystick_safe = false;
+                init_keyboard_rc(rc_input);
+            }
+            RcInputSource::Joystick => {
+                self.waiting_for_joystick_safe = true;
+                force_disarmed(rc_input);
+            }
+        }
+    }
+
+    fn apply_joystick_frame(&mut self, rc_input: &mut SimRcInput) {
+        if !self.waiting_for_joystick_safe {
+            return;
+        }
+
+        if !rc_input.armed && !rc_input.auto {
+            self.waiting_for_joystick_safe = false;
+            return;
+        }
+
+        force_disarmed(rc_input);
+    }
+}
+
+fn force_disarmed(rc_input: &mut SimRcInput) {
+    rc_input.roll = 0.0;
+    rc_input.pitch = 0.0;
+    rc_input.yaw = 0.0;
+    rc_input.throttle = 0.0;
+    rc_input.armed = false;
+    rc_input.auto = false;
 }
 
 #[derive(Resource, Default)]
@@ -1107,6 +1271,7 @@ fn setup_copper(mut commands: Commands, zed_store: Res<sim_zed::SimZedFrameStore
     const LOG_SLAB_SIZE: Option<usize> = Some(128 * 1024 * 1024);
     commands.insert_resource(build_sim_copper_state(
         Path::new("logs/flight_controller_sim.copper"),
+        Path::new("logs/flight_compute_sim.copper"),
         LOG_SLAB_SIZE,
         zed_store.clone(),
     ));
@@ -1114,19 +1279,27 @@ fn setup_copper(mut commands: Commands, zed_store: Res<sim_zed::SimZedFrameStore
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "sim"))]
 fn build_sim_copper_state(
-    logger_path: &Path,
+    mcu_logger_path: &Path,
+    compute_logger_path: &Path,
     log_slab_size: Option<usize>,
     zed_store: sim_zed::SimZedFrameStore,
 ) -> CopperState {
-    if let Some(parent) = logger_path.parent()
-        && !parent.exists()
-    {
-        fs::create_dir_all(parent).expect("failed to create logs directory");
+    for logger_path in [mcu_logger_path, compute_logger_path] {
+        if let Some(parent) = logger_path.parent()
+            && !parent.exists()
+        {
+            fs::create_dir_all(parent).expect("failed to create logs directory");
+        }
     }
 
     let (clock, clock_mock) = RobotClock::mock();
-    let mut mcu = mcu_copper::Runtime::with_log_path(&clock, logger_path, log_slab_size);
-    let mut compute = compute_copper::Runtime::new(&clock, zed_store);
+    let mut mcu = mcu_copper::Runtime::with_log_path(&clock, mcu_logger_path, log_slab_size);
+    let mut compute = compute_copper::Runtime::with_log_path(
+        &clock,
+        zed_store,
+        compute_logger_path,
+        log_slab_size,
+    );
 
     mcu.start().expect("failed to start tasks");
     compute.start().expect("failed to start compute tasks");
@@ -2032,6 +2205,7 @@ fn poll_joystick(
     mut joystick: ResMut<SimJoystickState>,
     mut rc_input: ResMut<SimRcInput>,
     mut rc_source: ResMut<RcInputSource>,
+    mut reset_interlock: ResMut<SimResetInterlock>,
 ) {
     let Some(reader) = joystick.reader.as_mut() else {
         return;
@@ -2043,6 +2217,7 @@ fn poll_joystick(
             let prev_mode = rc_input.mode;
             let prev_auto = rc_input.auto;
             apply_joystick_frame(&frame, &mut rc_input);
+            reset_interlock.apply_joystick_frame(&mut rc_input);
             *rc_source = RcInputSource::Joystick;
             if rc_input.armed != prev_armed
                 || rc_input.mode != prev_mode
@@ -2185,6 +2360,19 @@ fn adjust_keyboard_throttle(
         };
 }
 
+#[derive(SystemParam)]
+struct SimResetResources<'w> {
+    motors: ResMut<'w, SimMotorCommands>,
+    kinematics: ResMut<'w, SimKinematics>,
+    sim_state: ResMut<'w, SimState>,
+    rc_source: Res<'w, RcInputSource>,
+    rc_input: ResMut<'w, SimRcInput>,
+    interlock: ResMut<'w, SimResetInterlock>,
+    zed_store: Res<'w, sim_zed::SimZedFrameStore>,
+    #[cfg(feature = "sim")]
+    copper: ResMut<'w, CopperState>,
+}
+
 fn reset_vehicle(
     keyboard: Res<ButtonInput<KeyCode>>,
     mut query: Query<
@@ -2197,10 +2385,7 @@ fn reset_vehicle(
         ),
         With<Multicopter>,
     >,
-    mut motors: ResMut<SimMotorCommands>,
-    mut kin: ResMut<SimKinematics>,
-    rc_source: Res<RcInputSource>,
-    mut rc_input: ResMut<SimRcInput>,
+    mut reset: SimResetResources,
     _layout: Res<WorldLayout>,
     #[cfg(feature = "bevymon")] focus: Option<Res<CuBevyMonFocus>>,
 ) {
@@ -2225,12 +2410,29 @@ fn reset_vehicle(
         *ang_vel = spawn_ang_vel;
     }
 
-    motors.dshot = [0; 4];
-    kin.prev_linear_velocity = None;
+    reset.motors.dshot = [0; 4];
+    reset.kinematics.prev_linear_velocity = None;
+    reset.sim_state.vehicle = SimVehicleState::default();
+    reset.zed_store.reset_dynamic();
+    let rc_source = *reset.rc_source;
+    reset.interlock.begin(rc_source, &mut reset.rc_input);
 
-    if *rc_source == RcInputSource::Keyboard {
-        init_keyboard_rc(&mut rc_input);
-        info!("sim rc: reset to disarmed keyboard start");
+    #[cfg(feature = "sim")]
+    {
+        reset.copper.autonomy_link = SimAutonomyLink::default();
+        if let Err(err) = reset.copper.mcu.reset_sim_state() {
+            error!("failed to reset MCU task state: {}", err);
+        }
+        if let Err(err) = reset.copper.compute.reset_sim_state() {
+            error!("failed to reset compute task state: {}", err);
+        }
+    }
+
+    match rc_source {
+        RcInputSource::Keyboard => info!("sim reset: disarmed and cleared controller state"),
+        RcInputSource::Joystick => info!(
+            "sim reset: disarmed and cleared controller state; set ARM low and AUTO off before rearming"
+        ),
     }
 }
 
@@ -2526,7 +2728,11 @@ fn axis_or_unmapped(axis: Option<&String>) -> &str {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn connected_help_values(view_label: &str, joystick: &RcJoystick) -> String {
+fn connected_help_values(
+    view_label: &str,
+    joystick: &RcJoystick,
+    reset_interlock: &SimResetInterlock,
+) -> String {
     let axes: RcAxisBindings = joystick.axis_bindings();
     let frame = joystick.current_frame();
     let device_name = joystick.device_name();
@@ -2546,8 +2752,13 @@ fn connected_help_values(view_label: &str, joystick: &RcJoystick) -> String {
         axis_or_unmapped(axes.knob_sc.as_ref())
     );
 
+    let reset_line = if reset_interlock.waiting_for_joystick_safe {
+        "ARM LOW + AUTO OFF"
+    } else {
+        "R"
+    };
     format!(
-        "{view_label}\nConnected ({device_name})\n{arm_line}\n{mode_line}\n{auto_line}\n{}\n{} / {}\n{}\nR",
+        "{view_label}\nConnected ({device_name})\n{arm_line}\n{mode_line}\n{auto_line}\n{}\n{} / {}\n{}\n{reset_line}",
         axis_or_unmapped(axes.throttle.as_ref()),
         axis_or_unmapped(axes.roll.as_ref()),
         axis_or_unmapped(axes.pitch.as_ref()),
@@ -2558,6 +2769,7 @@ fn connected_help_values(view_label: &str, joystick: &RcJoystick) -> String {
 fn update_help_overlay(
     camera_view: Res<CameraView>,
     rc_source: Res<RcInputSource>,
+    reset_interlock: Res<SimResetInterlock>,
     _joystick_state: Res<SimJoystickState>,
     mut help_text_query: Query<&mut Text, With<SimHelpValuesText>>,
 ) {
@@ -2583,7 +2795,7 @@ fn update_help_overlay(
                             "{view_label}\nConnected (USB/BT)\nRC source initializing...\n-\n-\n-\n-\n-\nR"
                         )
                     },
-                    |joy| connected_help_values(view_label, joy),
+                    |joy| connected_help_values(view_label, joy, &reset_interlock),
                 )
             }
             #[cfg(target_arch = "wasm32")]
@@ -2958,6 +3170,7 @@ fn build_world_with_assets(
         .insert_resource(SimMotorCommands::default())
         .insert_resource(SimRcInput::default())
         .insert_resource(SimKinematics::default())
+        .insert_resource(SimResetInterlock::default())
         .insert_resource(RcInputSource::default())
         .insert_resource(SimJoystickState::default())
         .insert_resource(CameraView::default())
@@ -3211,6 +3424,52 @@ mod tests {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn joystick_reset_interlock_requires_safe_switch_positions() {
+        let mut rc_input = SimRcInput {
+            armed: true,
+            auto: true,
+            throttle: 0.8,
+            ..SimRcInput::default()
+        };
+        let mut interlock = SimResetInterlock::default();
+        interlock.begin(RcInputSource::Joystick, &mut rc_input);
+        assert!(!rc_input.armed);
+        assert!(!rc_input.auto);
+
+        let mut frame = RcFrame {
+            arm: Some(1.0),
+            knob_sc: Some(0.0),
+            throttle: 0.8,
+            ..RcFrame::default()
+        };
+        apply_joystick_frame(&frame, &mut rc_input);
+        interlock.apply_joystick_frame(&mut rc_input);
+        assert!(!rc_input.armed, "held ARM switch must not bypass reset");
+        assert!(!rc_input.auto, "held AUTO switch must not bypass reset");
+        assert_eq!(rc_input.throttle, 0.0);
+
+        frame.arm = Some(-1.0);
+        apply_joystick_frame(&frame, &mut rc_input);
+        interlock.apply_joystick_frame(&mut rc_input);
+        assert!(
+            interlock.waiting_for_joystick_safe,
+            "AUTO must also be switched off"
+        );
+
+        frame.knob_sc = Some(1.0);
+        apply_joystick_frame(&frame, &mut rc_input);
+        interlock.apply_joystick_frame(&mut rc_input);
+        assert!(!interlock.waiting_for_joystick_safe);
+
+        frame.arm = Some(1.0);
+        apply_joystick_frame(&frame, &mut rc_input);
+        interlock.apply_joystick_frame(&mut rc_input);
+        assert!(rc_input.armed, "arming should work after the safe cycle");
+        assert!(!rc_input.auto);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     fn build_test_copper_state() -> CopperState {
         let (clock, clock_mock) = RobotClock::mock();
         let mut mcu = mcu_copper::Runtime::without_logger(&clock);
@@ -3305,6 +3564,15 @@ mod tests {
             &mut osd_overlay,
         )
         .expect("copper sim iteration should keep running");
+
+        copper
+            .mcu
+            .reset_sim_state()
+            .expect("MCU task state should reset");
+        copper
+            .compute
+            .reset_sim_state()
+            .expect("compute task state should reset");
 
         copper.mcu.stop().expect("failed to stop tasks");
         copper
@@ -3434,12 +3702,187 @@ mod tests {
                 .payload()
                 .expect("active ViTFly command should cross the simulated bridge");
             assert!(command.forward.get::<meter_per_second>() >= 1.0);
+            assert_eq!(
+                zed_store.vitfly_prediction().1,
+                Some([
+                    command.forward.get::<meter_per_second>(),
+                    command.left.get::<meter_per_second>(),
+                    command.up.get::<meter_per_second>(),
+                ]),
+                "active preview should show the conditioned command sent to the controller"
+            );
         }
 
         compute.stop().expect("failed to stop compute tasks");
         compute
             .log_shutdown_completed()
             .expect("failed to log compute shutdown");
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn sim_reset_clears_vitfly_recurrent_state() {
+        let _guard = copper_runtime_test_lock().lock().unwrap();
+        let (clock, clock_mock) = RobotClock::mock();
+        let zed_store = sim_zed::SimZedFrameStore::default();
+        let pixel_count = (sim_zed::ZED_SIM_WIDTH * sim_zed::ZED_SIM_HEIGHT) as usize;
+        zed_store.set_depth(vec![6.0; pixel_count], vec![0.0; pixel_count]);
+
+        let mut compute = compute_copper::Runtime::new(&clock, zed_store.clone());
+        compute.start().expect("failed to start compute tasks");
+        let context = messages::AutonomyContext {
+            sequence: 1,
+            mission_generation: 1,
+            active: true,
+            pose: vitfly_pose(Quat::IDENTITY),
+            desired_speed: cu29::units::si::f32::Velocity::new::<meter_per_second>(4.0),
+        };
+        let mut autonomy_link = SimAutonomyLink::default();
+
+        clock_mock.set_value(1_000_000);
+        autonomy_link.context.tov = Tov::Time(clock.now());
+        autonomy_link.context.set_payload(context);
+        compute
+            .run_iteration(&clock, &mut autonomy_link)
+            .expect("first ViTFly inference should run");
+        let (_, first_prediction) = zed_store.vitfly_prediction();
+        let first_prediction = first_prediction.expect("first prediction should be published");
+
+        clock_mock.set_value(2_000_000);
+        compute
+            .run_iteration(&clock, &mut autonomy_link)
+            .expect("second ViTFly inference should run");
+
+        compute
+            .reset_sim_state()
+            .expect("ViTFly recurrent state should reset");
+        clock_mock.set_value(3_000_000);
+        autonomy_link.context.tov = Tov::Time(clock.now());
+        autonomy_link.context.set_payload(context);
+        compute
+            .run_iteration(&clock, &mut autonomy_link)
+            .expect("post-reset ViTFly inference should run");
+        let (_, reset_prediction) = zed_store.vitfly_prediction();
+        let reset_prediction = reset_prediction.expect("reset prediction should be published");
+
+        for (first, reset) in first_prediction.into_iter().zip(reset_prediction) {
+            assert!(
+                (first - reset).abs() < 1.0e-5,
+                "reset inference {reset} did not match initial inference {first}"
+            );
+        }
+
+        compute.stop().expect("failed to stop compute tasks");
+        compute
+            .log_shutdown_completed()
+            .expect("failed to log compute shutdown");
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn subsystem_logs_record_depth_and_complete_distributed_replay() {
+        let _guard = copper_runtime_test_lock().lock().unwrap();
+        let temp_dir = tempfile::tempdir().expect("failed to create temporary log directory");
+        let mcu_log_base = temp_dir.path().join("flight_controller_sim.copper");
+        let compute_log_base = temp_dir.path().join("flight_compute_sim.copper");
+        let zed_store = sim_zed::SimZedFrameStore::default();
+        let pixel_count = (sim_zed::ZED_SIM_WIDTH * sim_zed::ZED_SIM_HEIGHT) as usize;
+        zed_store.set_depth(vec![3.5; pixel_count], vec![0.0; pixel_count]);
+
+        let mut copper = build_sim_copper_state(
+            &mcu_log_base,
+            &compute_log_base,
+            Some(128 * 1024 * 1024),
+            zed_store,
+        );
+        let mut motors = SimMotorCommands::default();
+        let mut osd_overlay = SimOsdOverlay::default();
+        let rc = SimRcInput {
+            armed: true,
+            auto: true,
+            mode: messages::FlightMode::PositionHold,
+            ..SimRcInput::default()
+        };
+        for elapsed_ns in [1_000_000, 2_000_000] {
+            run_copper_iteration(
+                &mut copper,
+                elapsed_ns,
+                SimVehicleState::default(),
+                rc.clone(),
+                &mut motors,
+                &mut osd_overlay,
+            )
+            .expect("failed to run logged subsystem iteration");
+        }
+        copper.mcu.stop().expect("failed to stop MCU tasks");
+        copper
+            .mcu
+            .log_shutdown_completed()
+            .expect("failed to log MCU shutdown");
+        copper.compute.stop().expect("failed to stop compute tasks");
+        copper
+            .compute
+            .log_shutdown_completed()
+            .expect("failed to log compute shutdown");
+        drop(copper);
+
+        let discovered =
+            cu29::distributed_replay::DistributedReplayLog::discover(&compute_log_base)
+                .expect("compute log should be discoverable for distributed replay");
+        assert_eq!(discovered.instance_id(), 0);
+        assert_eq!(discovered.subsystem_id(), Some("compute"));
+
+        let UnifiedLogger::Read(logger) = UnifiedLoggerBuilder::new()
+            .file_base_name(&compute_log_base)
+            .build()
+            .expect("failed to reopen compute log")
+        else {
+            panic!("expected a readable compute log");
+        };
+        let mut reader = UnifiedLoggerIOReader::new(logger, UnifiedLogType::CopperList);
+        let (depth, prediction) =
+            cu29_export::copperlists_reader::<compute_copper::RecordedDataSet>(&mut reader)
+                .find_map(|copperlist| {
+                    Some((
+                        copperlist.msgs.0.1.payload()?.clone(),
+                        *copperlist.msgs.0.4.payload()?,
+                    ))
+                })
+                .expect("compute log should contain synchronized depth and prediction payloads");
+
+        assert_eq!(depth.format.width, sim_zed::ZED_SIM_WIDTH);
+        assert_eq!(depth.format.height, sim_zed::ZED_SIM_HEIGHT);
+        depth.buffer_handle.with_inner(|samples| {
+            assert_eq!(samples.len(), pixel_count);
+            assert!(samples.iter().all(|sample| *sample == 3.5));
+        });
+        assert!(prediction.iter().all(|component| {
+            component
+                .get::<cu29::units::si::velocity::meter_per_second>()
+                .is_finite()
+        }));
+
+        let multi_config_path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("multi_copper_vitfly_sim.ron");
+        let builder = cu29::distributed_replay::DistributedReplayPlan::builder(multi_config_path)
+            .expect("failed to load distributed replay config")
+            .discover_logs_under(temp_dir.path())
+            .expect("failed to discover subsystem logs");
+        let builder = mcu_copper::register_distributed_replay(builder)
+            .expect("failed to register MCU replay app");
+        let plan = compute_copper::register_distributed_replay(builder)
+            .expect("failed to register compute replay app")
+            .build()
+            .expect("the two subsystem logs should form a valid replay plan");
+        assert_eq!(plan.assignments.len(), 2);
+        assert!(plan.assignment(0, "mcu").is_some());
+        assert!(plan.assignment(0, "compute").is_some());
+
+        let mut replay = plan.start().expect("failed to start distributed replay");
+        replay
+            .run_all()
+            .expect("failed to replay both subsystem logs");
+        assert_eq!(replay.executed_nodes(), replay.total_nodes());
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/examples/cu_flight_controller/src/sim_zed.rs
+++ b/examples/cu_flight_controller/src/sim_zed.rs
@@ -12,9 +12,13 @@ use cu_zed::{
 use cu29::prelude::*;
 use std::sync::{Arc, Mutex};
 
+// Match the 640x480, 100-degree vertical-FOV Flightmare camera used to train
+// and evaluate the pretrained ViTFly policy. Half resolution preserves the
+// same 4:3 projection while avoiding pixels that are discarded by ViTFly's
+// fixed 90x60 input resize.
 pub(crate) const ZED_SIM_WIDTH: u32 = 320;
-pub(crate) const ZED_SIM_HEIGHT: u32 = 180;
-pub(crate) const ZED_SIM_VERTICAL_FOV_DEG: f32 = 70.0;
+pub(crate) const ZED_SIM_HEIGHT: u32 = 240;
+pub(crate) const ZED_SIM_VERTICAL_FOV_DEG: f32 = 100.0;
 pub(crate) const ZED_SIM_BASELINE_M: f32 = 0.12;
 pub(crate) const ZED_SIM_MAX_DEPTH_M: f32 = 20.0;
 pub(crate) const ZED_SIM_DEPTH_FPS: u64 = 30;
@@ -46,6 +50,19 @@ pub(crate) struct SimZedFrameStore {
 }
 
 impl SimZedFrameStore {
+    pub(crate) fn reset_dynamic(&self) {
+        let mut frame = self.lock();
+        frame.seq = frame.seq.wrapping_add(1);
+        frame.left = None;
+        frame.right = None;
+        frame.depth = None;
+        frame.confidence = None;
+        frame.sensors = None;
+        frame.published_depth = None;
+        frame.vitfly_prediction_seq = frame.vitfly_prediction_seq.wrapping_add(1);
+        frame.vitfly_prediction_mps = None;
+    }
+
     pub(crate) fn set_left_image(&self, pixels: Vec<u8>) {
         self.lock().left = Some(CuHandle::new_detached(pixels));
     }
@@ -279,6 +296,8 @@ mod tests {
         let calibration = calibration_bundle();
         assert_eq!(calibration.width, ZED_SIM_WIDTH);
         assert_eq!(calibration.height, ZED_SIM_HEIGHT);
+        assert_eq!(ZED_SIM_WIDTH * 3, ZED_SIM_HEIGHT * 4);
+        assert_eq!(calibration.left.v_fov, 100.0);
         assert_eq!(calibration.stereo_translation_m[0], ZED_SIM_BASELINE_M);
         assert!(calibration.left.fx > 0.0);
         assert!(calibration.left.fy > 0.0);
@@ -303,5 +322,25 @@ mod tests {
 
         // A compute tick without a new inference result does not touch the cache.
         assert_eq!(store.vitfly_prediction(), (published_seq, Some(prediction)));
+    }
+
+    #[cfg(feature = "sim")]
+    #[test]
+    fn reset_drops_stale_camera_and_prediction_state() {
+        let store = SimZedFrameStore::default();
+        store.set_left_image(vec![1; 4]);
+        store.set_right_image(vec![2; 4]);
+        store.set_depth(vec![3.0], vec![0.0]);
+        store.publish_vitfly_prediction([1.0, 2.0, 3.0]);
+
+        store.reset_dynamic();
+
+        let snapshot = store.snapshot();
+        assert!(snapshot.left.is_none());
+        assert!(snapshot.right.is_none());
+        assert!(snapshot.depth.is_none());
+        assert!(snapshot.confidence.is_none());
+        assert!(store.published_depth().is_none());
+        assert_eq!(store.vitfly_prediction().1, None);
     }
 }

--- a/examples/cu_flight_controller/src/tasks/autonomy.rs
+++ b/examples/cu_flight_controller/src/tasks/autonomy.rs
@@ -24,6 +24,12 @@ const CONTEXT_PERIOD: CuDuration = CuDuration(33_000_000);
 const COMMAND_TIMEOUT: CuDuration = CuDuration(250_000_000);
 const AUTO_MAX_SPEED_MPS: f32 = 4.0;
 const AUTO_HOVER_THROTTLE: f32 = 0.48;
+// ViTFly was evaluated with Flightmare's geometric controller, whose XY
+// velocity-error gain is 3 m/s^2 per m/s. With this app's 60-degree attitude
+// limit, the equivalent small-angle stick ratio is approximately
+// (3 / 9.81) / radians(60) = 0.29 per m/s.
+const AUTO_XY_VELOCITY_TO_TILT_RATIO_PER_MPS: f32 = 0.29;
+const AUTO_MAX_TILT_RATIO: f32 = 0.35;
 
 #[derive(Reflect, Default)]
 pub struct NavigationStateTask {
@@ -473,9 +479,15 @@ fn velocity_command_to_controls(
         wrap_signed_degrees(desired_heading_deg - navigation.heading.get::<degree>());
 
     ControlInputs {
-        roll: Ratio::new::<ratio>((-left_error * 0.08).clamp(-0.35, 0.35)),
+        roll: Ratio::new::<ratio>(
+            (-left_error * AUTO_XY_VELOCITY_TO_TILT_RATIO_PER_MPS)
+                .clamp(-AUTO_MAX_TILT_RATIO, AUTO_MAX_TILT_RATIO),
+        ),
         // Positive FC pitch is forward (the same convention produced by W through RcMapper).
-        pitch: Ratio::new::<ratio>((forward_error * 0.08).clamp(-0.35, 0.35)),
+        pitch: Ratio::new::<ratio>(
+            (forward_error * AUTO_XY_VELOCITY_TO_TILT_RATIO_PER_MPS)
+                .clamp(-AUTO_MAX_TILT_RATIO, AUTO_MAX_TILT_RATIO),
+        ),
         // FC yaw and compass heading have opposite signs.
         yaw: Ratio::new::<ratio>((-heading_error_deg * 0.005).clamp(-0.35, 0.35)),
         throttle: Ratio::new::<ratio>((AUTO_HOVER_THROTTLE + up_error * 0.06).clamp(0.25, 0.75)),
@@ -659,6 +671,40 @@ mod tests {
                 "heading {heading_deg} introduced lateral roll"
             );
         }
+    }
+
+    #[test]
+    fn auto_xy_velocity_gain_matches_flightmare_geometric_controller() {
+        let start = start();
+        let raw = ControlInputs {
+            armed: true,
+            auto: true,
+            ..ControlInputs::default()
+        };
+        let navigation = NavigationState {
+            valid: true,
+            position: start,
+            heading: cu29::units::si::f32::Angle::new::<degree>(0.0),
+            ..NavigationState::default()
+        };
+        let target = AutoMissionTarget {
+            active: true,
+            position: offset_position(start, 0.0, AUTO_DISTANCE_M),
+            ..AutoMissionTarget::default()
+        };
+        let command = AutonomyVelocityCommand {
+            forward: Velocity::new::<meter_per_second>(1.0),
+            left: Velocity::new::<meter_per_second>(1.0),
+            ..AutonomyVelocityCommand::default()
+        };
+
+        let controls = velocity_command_to_controls(&raw, &navigation, &target, &command);
+        assert!(
+            (controls.pitch.get::<ratio>() - AUTO_XY_VELOCITY_TO_TILT_RATIO_PER_MPS).abs() < 1.0e-6
+        );
+        assert!(
+            (controls.roll.get::<ratio>() + AUTO_XY_VELOCITY_TO_TILT_RATIO_PER_MPS).abs() < 1.0e-6
+        );
     }
 
     #[test]

--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ fmt-check: check-format-tools
 fmt: check-format-tools
 	@cargo +stable fmt --all
 	@git ls-files -z '*.toml' | xargs -0 -r env RUST_LOG=warn taplo format >/dev/null
-	@git ls-files -z '*.ron' ':!examples/modular_config_example/motors.ron' | xargs -0 -r -n 1 sh -c 'test ! -f "$1" || fmtron --input "$1"' _ >/dev/null
+	@git ls-files -z '*.ron' ':!examples/modular_config_example/motors.ron' ':!examples/cu_flight_controller/mcu_graph.ron' | xargs -0 -r -n 1 sh -c 'test ! -f "$1" || fmtron --input "$1"' _ >/dev/null
 	@find . -type f -name '*.ron.bak' -delete
 	@bash -lc 'set -euo pipefail; prek run --all-files {{PREK_FMT_FIX_HOOKS}} || prek run --all-files {{PREK_FMT_FIX_HOOKS}}'
 	@prek run --all-files {{PREK_FMT_CI_HOOKS}}

--- a/support/ci/check_ron_format.sh
+++ b/support/ci/check_ron_format.sh
@@ -15,7 +15,11 @@ while IFS= read -r -d '' f; do
     fi
 
     rm -f "$tmp" "$tmp.bak"
-done < <(git ls-files -z '*.ron' ':!examples/modular_config_example/motors.ron')
+done < <(
+    git ls-files -z '*.ron' \
+        ':!examples/modular_config_example/motors.ron' \
+        ':!examples/cu_flight_controller/mcu_graph.ron'
+)
 
 if ((${#changed[@]})); then
     printf 'RON formatting check failed:\n'


### PR DESCRIPTION
## Summary

- Add a compute-subsystem CopperList logreader and record depth/ViTFly outputs without copying raster storage.
- Write MCU and compute logs independently and cover the complete distributed replay path.
- Reset vehicle, controller, estimator, autonomy, camera, and ViTFly recurrent state together.
- Add a joystick re-arm interlock after reset and parameterize the shared attitude gain.
- Exclude the intentionally templated MCU graph from raw RON formatting in local and CI format paths.

## Stack

1. #1196 — resolved-config bundling prerequisite
2. #1194 — closed-loop VitFly autonomy
3. **This PR** — distributed logging and safe simulator reset

## Verification

- `just fmt`
- `just subsystems-check`
- `cargo test -p cu-flight-controller --no-default-features --features sim --bin quad-sim` (35 passed)