### PR TITLE
fix: Use Rust-version-aware dependency resolution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ default-members = [
   "core/cu29_unifiedlog",
 ]
 
-resolver = "2"
+resolver = "3"
 
 [profile.release]
 debug = 2


### PR DESCRIPTION
## Summary

Keep Copper Rust 1.95 compatible when resolving a fresh dependency graph.

## Related issues

- None

## Changes

- Switch the workspace dependency resolver from version 2 to version 3.
- Make Cargo prefer dependency releases compatible with the workspace rust-version.
- Resolve kstring 2.0.2 under the MSRV instead of kstring 2.0.3, which requires Rust 1.96.

## Reminder

- [x] I ran just from the repo root
- [x] I have updated docs or examples where needed (no documentation changes required)

## Additional context

- just msrv-check passes after a fresh lockfile resolution.
- The full just pipeline passes.