### PR TITLE
Fix: cu-rate-limiter phase drift

### DIFF
--- a/components/tasks/cu_ratelimit/src/lib.rs
+++ b/components/tasks/cu_ratelimit/src/lib.rs
@@ -5,6 +5,11 @@ use bincode::{Decode, Encode};
 use cu29::prelude::*;
 use std::marker::PhantomData;
 
+fn phase_at_or_before(tov: CuTime, interval: CuDuration) -> CuTime {
+    let interval_ns = interval.as_nanos();
+    CuTime::from(tov.as_nanos() / interval_ns * interval_ns)
+}
+
 #[derive(Reflect)]
 #[reflect(no_field_bounds, from_reflect = false, type_path = false)]
 pub struct CuRateLimit<T>
@@ -71,7 +76,13 @@ where
                 .ok_or("Missing required 'rate' config for CuRateLimiter")?,
             None => return Err("Missing required 'rate' config for CuRateLimiter".into()),
         };
+        if !hz.is_finite() || hz <= 0.0 {
+            return Err("CuRateLimiter 'rate' must be finite and greater than zero".into());
+        }
         let interval_ns = (1e9 / hz) as u64;
+        if interval_ns == 0 {
+            return Err("CuRateLimiter 'rate' cannot exceed 1 GHz".into());
+        }
         Ok(Self {
             _marker: PhantomData,
             interval: CuDuration::from(interval_ns),
@@ -89,14 +100,31 @@ where
             Tov::Time(ts) => ts,
             _ => return Err("Expected single timestamp TOV".into()),
         };
+        output.tov = input.tov;
 
         let allow = match self.last_tov {
-            None => true,
-            Some(last) => (tov - last) >= self.interval,
+            None => {
+                self.last_tov = Some(phase_at_or_before(tov, self.interval));
+                true
+            }
+            Some(last) if tov < last => {
+                // Re-anchor after replay/simulation time is reset.
+                self.last_tov = Some(phase_at_or_before(tov, self.interval));
+                true
+            }
+            Some(last) => {
+                let elapsed = tov - last;
+                if elapsed < self.interval {
+                    false
+                } else {
+                    let elapsed_intervals = elapsed.as_nanos() / self.interval.as_nanos();
+                    self.last_tov = Some(last + elapsed_intervals * self.interval);
+                    true
+                }
+            }
         };
 
         if allow {
-            self.last_tov = Some(tov);
             if let Some(payload) = input.payload() {
                 output.set_payload(payload.clone());
             } else {
@@ -141,6 +169,7 @@ mod tests {
         input.tov = Tov::Time(CuTime::from(100_000_000)); // 100ms
         limiter.process(&ctx, &input, &mut output).unwrap();
         assert_eq!(output.payload(), Some(&42));
+        assert_eq!(output.tov, input.tov);
     }
 
     #[test]
@@ -161,5 +190,71 @@ mod tests {
         input.tov = Tov::Time(CuTime::from(100_000_000));
         limiter.process(&ctx, &input, &mut output).unwrap();
         assert_eq!(output.payload(), None);
+    }
+
+    #[test]
+    fn test_phase_preserving_64_hz_to_30_hz() {
+        let ctx = CuContext::new_with_clock();
+        let mut limiter = create_test_ratelimiter(30.0);
+        let mut input = CuMsg::<i32>::new(Some(42));
+        let mut output = CuMsg::<i32>::new(None);
+        let mut emitted = 0;
+
+        // 64 source samples span [0, 984.375 ms], which contains exactly 30
+        // points of the 30 Hz output phase including the initial sample.
+        for source_tick in 0..64 {
+            input.tov = Tov::Time(CuTime::from(source_tick * 15_625_000));
+            limiter.process(&ctx, &input, &mut output).unwrap();
+            emitted += usize::from(output.payload().is_some());
+        }
+
+        assert_eq!(emitted, 30);
+    }
+
+    #[test]
+    fn test_first_sample_uses_absolute_rate_phase() {
+        let ctx = CuContext::new_with_clock();
+        let mut limiter = create_test_ratelimiter(30.0);
+        let mut input = CuMsg::<i32>::new(Some(42));
+        let mut output = CuMsg::<i32>::new(None);
+
+        // A camera that becomes ready off-phase must join the same 30 Hz
+        // schedule as other graph inputs instead of creating its own phase.
+        input.tov = Tov::Time(CuTime::from(78_125_000));
+        limiter.process(&ctx, &input, &mut output).unwrap();
+        assert!(output.payload().is_some());
+
+        input.tov = Tov::Time(CuTime::from(93_750_000));
+        limiter.process(&ctx, &input, &mut output).unwrap();
+        assert!(output.payload().is_none());
+
+        input.tov = Tov::Time(CuTime::from(109_375_000));
+        limiter.process(&ctx, &input, &mut output).unwrap();
+        assert!(output.payload().is_some());
+    }
+
+    #[test]
+    fn test_time_rewind_reanchors_limiter() {
+        let ctx = CuContext::new_with_clock();
+        let mut limiter = create_test_ratelimiter(30.0);
+        let mut input = CuMsg::<i32>::new(Some(42));
+        let mut output = CuMsg::<i32>::new(None);
+
+        input.tov = Tov::Time(CuTime::from(1_000_000_000));
+        limiter.process(&ctx, &input, &mut output).unwrap();
+        assert!(output.payload().is_some());
+
+        input.tov = Tov::Time(CuTime::from(1_000_000));
+        limiter.process(&ctx, &input, &mut output).unwrap();
+        assert!(output.payload().is_some());
+    }
+
+    #[test]
+    fn test_invalid_rates_are_rejected() {
+        for rate in [0.0, -1.0, f64::NAN, f64::INFINITY, 1_000_000_001.0] {
+            let mut cfg = ComponentConfig::new();
+            cfg.set("rate", rate);
+            assert!(CuRateLimit::<i32>::new(Some(&cfg), ()).is_err());
+        }
     }
 }


### PR DESCRIPTION
Fix CuRateLimit phase drift when the source cadence is not an integer multiple of the requested output rate.\n\nAlso propagates input timestamps, validates invalid rates, and re-anchors cleanly when replay or simulation time rewinds.\n\nVerification: cargo test -p cu-ratelimit