### PR TITLE
build: centralize Copper build-script setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
   "core/cu29",
+  "core/cu29_build",
   "core/cu29_base_derive",
   "core/cu29_reflect_derive",
   "core/cu29_clock",
@@ -124,6 +125,7 @@ members = [
 # put only the core crates here that are not platform specific
 default-members = [
   "core/cu29",
+  "core/cu29_build",
   "core/cu29_clock",
   "core/cu29_derive",
   "core/cu29_export",
@@ -199,6 +201,7 @@ no_individual_tags = true
 
 # Copper Core
 cu29 = { path = "core/cu29", version = "1.0.0" } # default std
+cu29-build = { path = "core/cu29_build", version = "1.0.0" }
 cu29-reflect-derive = { path = "core/cu29_reflect_derive", version = "1.0.0" }
 cu29-clock = { path = "core/cu29_clock", default-features = false, version = "1.0.0" }
 cu29-derive = { path = "core/cu29_derive", default-features = false, version = "1.0.0" }

--- a/api/v1/cu29-build.txt
+++ b/api/v1/cu29-build.txt
@@ -1,0 +1,2 @@
+pub mod cu29_build
+pub fn cu29_build::setup()

--- a/benchmarks/cu_async_cl_io_bench/Cargo.toml
+++ b/benchmarks/cu_async_cl_io_bench/Cargo.toml
@@ -34,3 +34,6 @@ async-cl-io = ["cu29/async-cl-io"]
 
 [package.metadata.cargo-shear]
 ignored = ["bincode", "serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/benchmarks/cu_async_cl_io_bench/build.rs
+++ b/benchmarks/cu_async_cl_io_bench/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").expect("OUT_DIR not set")
-    );
+    cu29_build::setup();
 }

--- a/benchmarks/cu_dorabench/Cargo.toml
+++ b/benchmarks/cu_dorabench/Cargo.toml
@@ -33,3 +33,6 @@ cu29 = { workspace = true }
 cu29-export = { workspace = true, features = ["python", "mcap"] }
 serde = { workspace = true }
 cu-consolemon = { workspace = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/benchmarks/cu_dorabench/build.rs
+++ b/benchmarks/cu_dorabench/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/benchmarks/cu_zenoh_bridge_bench/Cargo.toml
+++ b/benchmarks/cu_zenoh_bridge_bench/Cargo.toml
@@ -32,3 +32,6 @@ path = "src/bin/tx.rs"
 [[bin]]
 name = "zenoh-bench-rx"
 path = "src/bin/rx.rs"
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/benchmarks/cu_zenoh_bridge_bench/build.rs
+++ b/benchmarks/cu_zenoh_bridge_bench/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/bridges/cu_bdshot/Cargo.toml
+++ b/components/bridges/cu_bdshot/Cargo.toml
@@ -39,3 +39,6 @@ defmt = ["stm32h7xx-hal/defmt"]
 stm32h7 = ["dep:stm32h7xx-hal", "defmt"]
 messages-only = []
 textlogs = ["cu29/textlogs"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/bridges/cu_bdshot/build.rs
+++ b/components/bridges/cu_bdshot/build.rs
@@ -1,9 +1,6 @@
 fn main() {
     // Struct logging for Copper
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 
     println!("cargo:rerun-if-changed=src/dshot.pio");
 }

--- a/components/bridges/cu_crsf/Cargo.toml
+++ b/components/bridges/cu_crsf/Cargo.toml
@@ -31,3 +31,6 @@ std = ["cu29/std", "embedded-io/std", "dep:cu-linux-resources"]
 defmt = ["cu29/defmt"]
 alloc = []
 textlogs = ["cu29/textlogs"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/bridges/cu_crsf/build.rs
+++ b/components/bridges/cu_crsf/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/bridges/cu_feetech/Cargo.toml
+++ b/components/bridges/cu_feetech/Cargo.toml
@@ -29,3 +29,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 cu-linux-resources = { workspace = true }
 heapless = { workspace = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/bridges/cu_feetech/build.rs
+++ b/components/bridges/cu_feetech/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/bridges/cu_msp_bridge/Cargo.toml
+++ b/components/bridges/cu_msp_bridge/Cargo.toml
@@ -40,3 +40,6 @@ defmt = ["embedded-io/defmt", "cu29/defmt"]
 alloc = ["embedded-io/alloc"]
 textlogs = ["cu29/textlogs"]
 log-level-info = ["cu29/log-level-info"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/bridges/cu_msp_bridge/build.rs
+++ b/components/bridges/cu_msp_bridge/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/bridges/cu_ros2_bridge/Cargo.toml
+++ b/components/bridges/cu_ros2_bridge/Cargo.toml
@@ -33,3 +33,6 @@ cdr = { version = "0.2.4" }
 
 [features]
 humble = ["cu-ros2-payloads/humble"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/bridges/cu_ros2_bridge/build.rs
+++ b/components/bridges/cu_ros2_bridge/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/monitors/cu_logmon/Cargo.toml
+++ b/components/monitors/cu_logmon/Cargo.toml
@@ -44,3 +44,6 @@ defmt = ["dep:defmt", "cu29/defmt"]
 color_log = []
 textlogs = ["cu29/textlogs"]
 log-level-info = ["cu29/log-level-info"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/monitors/cu_logmon/build.rs
+++ b/components/monitors/cu_logmon/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/monitors/cu_memmon/Cargo.toml
+++ b/components/monitors/cu_memmon/Cargo.toml
@@ -41,3 +41,6 @@ std = ["cu29/std"]
 # the derive macro. Without this, the monitor compiles and runs but reports
 # zeros — and warns once at startup or on the first summary tick.
 memory_monitoring = ["cu29/memory_monitoring"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/monitors/cu_memmon/build.rs
+++ b/components/monitors/cu_memmon/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/monitors/cu_safetymon/Cargo.toml
+++ b/components/monitors/cu_safetymon/Cargo.toml
@@ -42,3 +42,6 @@ cu-logmon = { path = "../cu_logmon", version = "1.0.0", default-features = false
 default = ["std"]
 std = ["cu29/std"]
 safety-ids = ["std", "cu29/safety-ids"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/monitors/cu_safetymon/build.rs
+++ b/components/monitors/cu_safetymon/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").expect("OUT_DIR is always set by cargo"),
-    );
+    cu29_build::setup();
 }

--- a/components/res/cu_linux_resources/Cargo.toml
+++ b/components/res/cu_linux_resources/Cargo.toml
@@ -36,3 +36,6 @@ rppal = { workspace = true, default-features = false, features = ["hal"] }
 default = []
 defmt = ["embedded-io/defmt", "embedded-hal/defmt-03", "cu29/defmt"]
 alloc = ["embedded-io/alloc"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/res/cu_linux_resources/build.rs
+++ b/components/res/cu_linux_resources/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/sinks/cu_rp_gpio/Cargo.toml
+++ b/components/sinks/cu_rp_gpio/Cargo.toml
@@ -27,6 +27,7 @@ serde = { workspace = true }
 cu-linux-resources = { workspace = true }
 
 [build-dependencies]
+cu29-build = { workspace = true }
 cfg_aliases = { workspace = true }
 
 [features]

--- a/components/sinks/cu_rp_gpio/build.rs
+++ b/components/sinks/cu_rp_gpio/build.rs
@@ -1,9 +1,6 @@
 use cfg_aliases::cfg_aliases;
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
     cfg_aliases! {
         hardware: { all(target_os = "linux", not(feature = "mock")) },
         mock: { any(not(target_os = "linux"), feature = "mock") },

--- a/components/sinks/cu_rp_sn754410/Cargo.toml
+++ b/components/sinks/cu_rp_sn754410/Cargo.toml
@@ -34,6 +34,7 @@ tempfile = { workspace = true }
 rppal = { workspace = true, default-features = false, features = ["hal"] }
 
 [build-dependencies]
+cu29-build = { workspace = true }
 cfg_aliases = { workspace = true }
 
 [features]

--- a/components/sinks/cu_rp_sn754410/build.rs
+++ b/components/sinks/cu_rp_sn754410/build.rs
@@ -1,9 +1,6 @@
 use cfg_aliases::cfg_aliases;
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
     cfg_aliases! {
         hardware: { all(target_os = "linux", not(feature = "mock")) },
         mock: { any(not(target_os = "linux"), feature = "mock") },

--- a/components/sinks/cu_zenoh_sink/Cargo.toml
+++ b/components/sinks/cu_zenoh_sink/Cargo.toml
@@ -22,3 +22,6 @@ zenoh = { workspace = true, default-features = false, features = [
   "transport_tcp",
 ] }
 cu29 = { workspace = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/sinks/cu_zenoh_sink/build.rs
+++ b/components/sinks/cu_zenoh_sink/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/sources/cu_ads7883/Cargo.toml
+++ b/components/sources/cu_ads7883/Cargo.toml
@@ -34,6 +34,7 @@ spidev = "0.7.0"
 tempfile = { workspace = true }
 
 [build-dependencies]
+cu29-build = { workspace = true }
 cfg_aliases = { workspace = true }
 
 [features]

--- a/components/sources/cu_ads7883/build.rs
+++ b/components/sources/cu_ads7883/build.rs
@@ -1,9 +1,6 @@
 use cfg_aliases::cfg_aliases;
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 
     cfg_aliases! {
         hardware: { all(target_os = "linux", not(feature = "mock")) },

--- a/components/sources/cu_bmi088/Cargo.toml
+++ b/components/sources/cu_bmi088/Cargo.toml
@@ -31,3 +31,6 @@ textlogs = ["cu29/textlogs", "cu-sensor-payloads/textlogs"]
 
 [package.metadata.cargo-shear]
 ignored = ["serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/sources/cu_bmi088/build.rs
+++ b/components/sources/cu_bmi088/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/sources/cu_dps310/Cargo.toml
+++ b/components/sources/cu_dps310/Cargo.toml
@@ -30,3 +30,6 @@ textlogs = ["cu29/textlogs", "cu-sensor-payloads/textlogs"]
 
 [package.metadata.cargo-shear]
 ignored = ["serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/sources/cu_dps310/build.rs
+++ b/components/sources/cu_dps310/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/sources/cu_gstreamer/Cargo.toml
+++ b/components/sources/cu_gstreamer/Cargo.toml
@@ -31,6 +31,7 @@ tempfile = { workspace = true }
 rerun = { workspace = true }
 
 [build-dependencies]
+cu29-build = { workspace = true }
 cfg_aliases = { workspace = true }
 
 [features]

--- a/components/sources/cu_gstreamer/build.rs
+++ b/components/sources/cu_gstreamer/build.rs
@@ -6,10 +6,7 @@ fn main() {
             "cargo:warning=GStreamer feature (gst) is not enabled. Skipping cu_gstreamer build."
         );
     }
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
     cfg_aliases! {
         hardware: { all(target_os = "linux", not(feature = "mock")) },
         mock: { any(not(target_os = "linux"), feature = "mock") },

--- a/components/sources/cu_hesai/Cargo.toml
+++ b/components/sources/cu_hesai/Cargo.toml
@@ -34,3 +34,6 @@ serde = { workspace = true }
 
 [features]
 hardware = []
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/sources/cu_hesai/build.rs
+++ b/components/sources/cu_hesai/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/sources/cu_ist8310/Cargo.toml
+++ b/components/sources/cu_ist8310/Cargo.toml
@@ -26,3 +26,6 @@ default = []
 std = ["cu29/std", "cu-sensor-payloads/std"]
 defmt = ["cu29/defmt"]
 textlogs = ["cu29/textlogs", "cu-sensor-payloads/textlogs"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/sources/cu_ist8310/build.rs
+++ b/components/sources/cu_ist8310/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/sources/cu_livox/Cargo.toml
+++ b/components/sources/cu_livox/Cargo.toml
@@ -33,3 +33,6 @@ serde = { workspace = true }
 
 [features]
 hardware = []
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/sources/cu_livox/build.rs
+++ b/components/sources/cu_livox/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/sources/cu_rp_encoder/Cargo.toml
+++ b/components/sources/cu_rp_encoder/Cargo.toml
@@ -33,6 +33,7 @@ rppal = { workspace = true, default-features = false, features = ["hal"] }
 cu-linux-resources = { workspace = true }
 
 [build-dependencies]
+cu29-build = { workspace = true }
 cfg_aliases = { workspace = true }
 
 [features]

--- a/components/sources/cu_rp_encoder/build.rs
+++ b/components/sources/cu_rp_encoder/build.rs
@@ -1,9 +1,6 @@
 use cfg_aliases::cfg_aliases;
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
     cfg_aliases! {
         hardware: { all(target_os = "linux", not(feature = "mock")) },
         mock: { any(not(target_os = "linux"), feature = "mock") },

--- a/components/sources/cu_sen0682/Cargo.toml
+++ b/components/sources/cu_sen0682/Cargo.toml
@@ -36,3 +36,6 @@ std = ["cu29/std", "cu-sensor-payloads/std", "dep:cu-linux-resources"]
 defmt = ["cu29/defmt"]
 textlogs = ["cu29/textlogs", "cu-sensor-payloads/textlogs"]
 reflect = ["cu29/reflect"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/sources/cu_sen0682/build.rs
+++ b/components/sources/cu_sen0682/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/sources/cu_v4l/Cargo.toml
+++ b/components/sources/cu_v4l/Cargo.toml
@@ -30,3 +30,6 @@ v4l = "0.14.0"
 [dev-dependencies]
 rerun = { workspace = true }
 simplelog = { workspace = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/sources/cu_v4l/build.rs
+++ b/components/sources/cu_v4l/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/sources/cu_vlp16/Cargo.toml
+++ b/components/sources/cu_vlp16/Cargo.toml
@@ -25,3 +25,6 @@ velodyne-lidar = { version = "0.3.0", features = ["pcap", "parallel"] }
 
 [dev-dependencies]
 cu-udp-inject = { path = "../../testing/cu_udp_inject", version = "1.0.0" }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/sources/cu_vlp16/build.rs
+++ b/components/sources/cu_vlp16/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/sources/cu_wt901/Cargo.toml
+++ b/components/sources/cu_wt901/Cargo.toml
@@ -35,6 +35,7 @@ embedded-hal = "1"
 cu-linux-resources = { workspace = true }
 
 [build-dependencies]
+cu29-build = { workspace = true }
 cfg_aliases = { workspace = true }
 
 [features]

--- a/components/sources/cu_wt901/build.rs
+++ b/components/sources/cu_wt901/build.rs
@@ -1,9 +1,6 @@
 use cfg_aliases::cfg_aliases;
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
     cfg_aliases! {
         hardware: { all(target_os = "linux", not(feature = "mock")) },
         mock: { any(not(target_os = "linux"), feature = "mock") },

--- a/components/tasks/cu_ahrs/Cargo.toml
+++ b/components/tasks/cu_ahrs/Cargo.toml
@@ -74,3 +74,6 @@ path = "examples/rp2350_copper.rs"
 required-features = ["rp2350-demo"]
 
 [dev-dependencies]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/tasks/cu_ahrs/build.rs
+++ b/components/tasks/cu_ahrs/build.rs
@@ -19,6 +19,6 @@ fn main() {
     }
     println!("cargo:rerun-if-changed=build.rs");
 
-    // Needed by cu29 logging macros (LOG_INDEX_DIR env var)
-    println!("cargo:rustc-env=LOG_INDEX_DIR={}", out.display());
+    // Configure Copper's build-time support.
+    cu29_build::setup();
 }

--- a/components/tasks/cu_dynthreshold/Cargo.toml
+++ b/components/tasks/cu_dynthreshold/Cargo.toml
@@ -28,3 +28,6 @@ cu-gstreamer = { path = "../../sources/cu_gstreamer", version = "1.0.0", optiona
 # The 'gst' feature includes dependencies for GStreamer support.
 # 'cu-gstreamer/gst' is included to propagate the 'gst' flag to the cu-gstreamer crate.
 gst = ["dep:gstreamer", "dep:cu-gstreamer", "cu-gstreamer/gst"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/tasks/cu_dynthreshold/build.rs
+++ b/components/tasks/cu_dynthreshold/build.rs
@@ -5,8 +5,5 @@ fn main() {
             "cargo:warning=GStreamer feature (gst) is not enabled. Skipping cu_dynthreshold build."
         );
     }
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/tasks/cu_pid/Cargo.toml
+++ b/components/tasks/cu_pid/Cargo.toml
@@ -27,3 +27,6 @@ reflect = ["cu29/reflect"]
 cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
 bincode = { workspace = true }
 serde = { workspace = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/tasks/cu_pid/build.rs
+++ b/components/tasks/cu_pid/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/tasks/cu_python_task/Cargo.toml
+++ b/components/tasks/cu_python_task/Cargo.toml
@@ -32,3 +32,6 @@ tempfile = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["bincode"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/tasks/cu_python_task/build.rs
+++ b/components/tasks/cu_python_task/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/components/tasks/cu_ratelimit/Cargo.toml
+++ b/components/tasks/cu_ratelimit/Cargo.toml
@@ -20,3 +20,6 @@ environments = ["host"]
 [dependencies]
 cu29 = { workspace = true }
 bincode = { workspace = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/tasks/cu_ratelimit/build.rs
+++ b/components/tasks/cu_ratelimit/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/core/cu29/Cargo.toml
+++ b/core/cu29/Cargo.toml
@@ -106,3 +106,6 @@ std = [
 ]
 rtsan = ["dep:rtsan-standalone", "cu29-derive/rtsan"]
 safety-ids = ["std", "dep:inventory", "dep:serde_json"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/core/cu29/build.rs
+++ b/core/cu29/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/core/cu29_build/Cargo.toml
+++ b/core/cu29_build/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cu29-build"
+description = "Build-script support for Copper crates and applications."
+documentation = "https://docs.rs/cu29-build"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true

--- a/core/cu29_build/README.md
+++ b/core/cu29_build/README.md
@@ -1,0 +1,5 @@
+# cu29-build
+
+Shared build-script setup for Copper crates and applications.
+
+Call `cu29_build::setup()` once from `build.rs`.

--- a/core/cu29_build/src/lib.rs
+++ b/core/cu29_build/src/lib.rs
@@ -1,0 +1,9 @@
+#![doc = include_str!("../README.md")]
+
+/// Emit the standard Cargo build-script configuration required by Copper.
+pub fn setup() {
+    println!(
+        "cargo::rustc-env=LOG_INDEX_DIR={}",
+        std::env::var("OUT_DIR").expect("Cargo must provide OUT_DIR")
+    );
+}

--- a/core/cu29_log_derive/Cargo.toml
+++ b/core/cu29_log_derive/Cargo.toml
@@ -47,3 +47,6 @@ cu29-log-runtime = { workspace = true, features = ["std"] }
 cu29-clock = { workspace = true, features = ["std"] }
 cu29-traits = { workspace = true, features = ["std"] }
 cu29-value = { workspace = true, features = ["std"] }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/core/cu29_log_derive/build.rs
+++ b/core/cu29_log_derive/build.rs
@@ -19,8 +19,5 @@ fn main() {
     if cfg!(target_os = "windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/core/cu29_log_runtime/Cargo.toml
+++ b/core/cu29_log_runtime/Cargo.toml
@@ -34,3 +34,6 @@ std = [
   "bincode/std",
   "dep:strfmt",
 ]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/core/cu29_log_runtime/build.rs
+++ b/core/cu29_log_runtime/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/core/cu29_runtime/Cargo.toml
+++ b/core/cu29_runtime/Cargo.toml
@@ -142,3 +142,6 @@ std = [
 ]
 memory_monitoring = []
 bridge-sim-callbacks = []
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/core/cu29_runtime/build.rs
+++ b/core/cu29_runtime/build.rs
@@ -1,9 +1,6 @@
 use std::path::Path;
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 
     println!("cargo:rustc-check-cfg=cfg(has_nvidia_gpu)");
     if Path::new("/proc/driver/nvidia/gpus").exists() {

--- a/examples/cu_background_task/Cargo.toml
+++ b/examples/cu_background_task/Cargo.toml
@@ -18,3 +18,6 @@ serde = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_background_task/build.rs
+++ b/examples/cu_background_task/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_baremetal_safety/Cargo.toml
+++ b/examples/cu_baremetal_safety/Cargo.toml
@@ -30,3 +30,6 @@ tempfile = { workspace = true }
 [features]
 default = []
 safety-ids = ["cu29/safety-ids"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_baremetal_safety/build.rs
+++ b/examples/cu_baremetal_safety/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_bevymon_demo/Cargo.toml
+++ b/examples/cu_bevymon_demo/Cargo.toml
@@ -53,3 +53,6 @@ cu-bevymon = { path = "../../components/monitors/cu_bevymon", version = "1.0.0",
 [[bin]]
 name = "cu-bevymon-demo"
 path = "src/main.rs"
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_bevymon_demo/build.rs
+++ b/examples/cu_bevymon_demo/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_bridge_test/Cargo.toml
+++ b/examples/cu_bridge_test/Cargo.toml
@@ -37,3 +37,6 @@ default = []
 macro_debug = ["cu29/macro_debug"]
 reflect = ["cu29/reflect"]
 sim-debug = ["reflect", "cu29/remote-debug"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_bridge_test/build.rs
+++ b/examples/cu_bridge_test/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_caterpillar/Cargo.toml
+++ b/examples/cu_caterpillar/Cargo.toml
@@ -53,3 +53,6 @@ safety-ids = ["determinism_ci", "cu29/safety-ids"]
 
 [package.metadata.cargo-shear]
 ignored = ["serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_caterpillar/build.rs
+++ b/examples/cu_caterpillar/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_config_variation/Cargo.toml
+++ b/examples/cu_config_variation/Cargo.toml
@@ -20,3 +20,6 @@ serde = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["cu-caterpillar", "cu-rp-gpio", "serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_config_variation/build.rs
+++ b/examples/cu_config_variation/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_debug_session/Cargo.toml
+++ b/examples/cu_debug_session/Cargo.toml
@@ -20,3 +20,6 @@ bincode = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["bincode"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_debug_session/build.rs
+++ b/examples/cu_debug_session/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").expect("OUT_DIR not set")
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_distributed_resim_demo/Cargo.toml
+++ b/examples/cu_distributed_resim_demo/Cargo.toml
@@ -37,3 +37,6 @@ path = "src/bin/control.rs"
 [[bin]]
 name = "distributed-resim"
 path = "src/bin/resim.rs"
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_distributed_resim_demo/build.rs
+++ b/examples/cu_distributed_resim_demo/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_elrs_bdshot_demo/Cargo.toml
+++ b/examples/cu_elrs_bdshot_demo/Cargo.toml
@@ -58,3 +58,6 @@ default = []
 
 [package.metadata.cargo-shear]
 ignored = ["serde", "bincode"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_elrs_bdshot_demo/build.rs
+++ b/examples/cu_elrs_bdshot_demo/build.rs
@@ -4,10 +4,7 @@ use std::path::PathBuf;
 
 fn main() {
     // Struct logging for Copper
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
     //
     // Put the linker script somewhere the linker can find it
     let out = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());

--- a/examples/cu_feetech_demo/Cargo.toml
+++ b/examples/cu_feetech_demo/Cargo.toml
@@ -28,3 +28,6 @@ serde = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["bincode", "serde", "cu-linux-resources"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_feetech_demo/build.rs
+++ b/examples/cu_feetech_demo/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").expect("OUT_DIR not set")
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_flight_controller/Cargo.toml
+++ b/examples/cu_flight_controller/Cargo.toml
@@ -353,3 +353,6 @@ required-features = ["bevymon"]
 [dev-dependencies]
 cu29-export = { workspace = true }
 tempfile = { workspace = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_flight_controller/build.rs
+++ b/examples/cu_flight_controller/build.rs
@@ -20,8 +20,5 @@ fn main() {
         println!("cargo:rerun-if-changed={config}");
     }
 
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_gnss_ublox_demo/Cargo.toml
+++ b/examples/cu_gnss_ublox_demo/Cargo.toml
@@ -27,3 +27,6 @@ ignored = ["serde", "cu-linux-resources"]
 [features]
 default = []
 logexport = ["dep:cu29-export", "cu-gnss-ublox/reflect"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_gnss_ublox_demo/build.rs
+++ b/examples/cu_gnss_ublox_demo/build.rs
@@ -1,8 +1,5 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=copperconfig.ron");
 }

--- a/examples/cu_human_pose/Cargo.toml
+++ b/examples/cu_human_pose/Cargo.toml
@@ -43,3 +43,6 @@ hf-hub = { version = "1.0.0", features = ["blocking"] }
 
 [package.metadata.cargo-shear]
 ignored = ["cu-logmon"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_human_pose/build.rs
+++ b/examples/cu_human_pose/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_iceoryx2_bridge_demo/Cargo.toml
+++ b/examples/cu_iceoryx2_bridge_demo/Cargo.toml
@@ -29,3 +29,6 @@ path = "src/bin/ping.rs"
 [[bin]]
 name = "iceoryx2-pong"
 path = "src/bin/pong.rs"
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_iceoryx2_bridge_demo/build.rs
+++ b/examples/cu_iceoryx2_bridge_demo/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_image_aligner/Cargo.toml
+++ b/examples/cu_image_aligner/Cargo.toml
@@ -25,3 +25,6 @@ serde = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["cu29-clock", "paste", "serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_image_aligner/build.rs
+++ b/examples/cu_image_aligner/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_image_codec_demo/Cargo.toml
+++ b/examples/cu_image_codec_demo/Cargo.toml
@@ -41,3 +41,6 @@ cu-sensor-payloads = { workspace = true }
 cu29 = { workspace = true }
 cu29-export = { workspace = true, optional = true }
 serde = { workspace = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_image_codec_demo/build.rs
+++ b/examples/cu_image_codec_demo/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_instance_overrides_demo/Cargo.toml
+++ b/examples/cu_instance_overrides_demo/Cargo.toml
@@ -16,3 +16,6 @@ publish = false
 [dependencies]
 cu29 = { workspace = true }
 serde = { workspace = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_instance_overrides_demo/build.rs
+++ b/examples/cu_instance_overrides_demo/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_logging_size/Cargo.toml
+++ b/examples/cu_logging_size/Cargo.toml
@@ -19,3 +19,6 @@ serde = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_logging_size/build.rs
+++ b/examples/cu_logging_size/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_min_baremetal/Cargo.toml
+++ b/examples/cu_min_baremetal/Cargo.toml
@@ -49,3 +49,6 @@ cu29-export = { workspace = true, features = [
 [features]
 default = ["std"]                                     # Compile with --no-default-features to target no_std
 std = ["dep:cu29-export", "bincode/std", "serde/std"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_min_baremetal/build.rs
+++ b/examples/cu_min_baremetal/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_missions/Cargo.toml
+++ b/examples/cu_missions/Cargo.toml
@@ -20,3 +20,6 @@ serde = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_missions/build.rs
+++ b/examples/cu_missions/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_monitoring/Cargo.toml
+++ b/examples/cu_monitoring/Cargo.toml
@@ -19,3 +19,6 @@ cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1
 
 [package.metadata.cargo-shear]
 ignored = ["serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_monitoring/build.rs
+++ b/examples/cu_monitoring/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_msp_bridge_loopback/Cargo.toml
+++ b/examples/cu_msp_bridge_loopback/Cargo.toml
@@ -28,3 +28,6 @@ ctrlc = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["serde", "cu-linux-resources"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_msp_bridge_loopback/build.rs
+++ b/examples/cu_msp_bridge_loopback/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").expect("OUT_DIR not set")
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_multi_output/Cargo.toml
+++ b/examples/cu_multi_output/Cargo.toml
@@ -20,3 +20,6 @@ serde = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_multi_output/build.rs
+++ b/examples/cu_multi_output/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_multisources/Cargo.toml
+++ b/examples/cu_multisources/Cargo.toml
@@ -19,3 +19,6 @@ tempfile = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_multisources/build.rs
+++ b/examples/cu_multisources/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_multisources_structs/Cargo.toml
+++ b/examples/cu_multisources_structs/Cargo.toml
@@ -31,3 +31,6 @@ cu29 = { workspace = true }
 bincode = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 cu29-export = { workspace = true, optional = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_multisources_structs/build.rs
+++ b/examples/cu_multisources_structs/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_nologging_task/Cargo.toml
+++ b/examples/cu_nologging_task/Cargo.toml
@@ -29,3 +29,6 @@ path = "src/logreader.rs"
 
 [package.metadata.cargo-shear]
 ignored = ["serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_nologging_task/build.rs
+++ b/examples/cu_nologging_task/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_parallel_mandelbrot/Cargo.toml
+++ b/examples/cu_parallel_mandelbrot/Cargo.toml
@@ -46,3 +46,6 @@ path = "src/logreader.rs"
 
 [package.metadata.cargo-shear]
 ignored = ["bincode", "serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_parallel_mandelbrot/build.rs
+++ b/examples/cu_parallel_mandelbrot/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_peer_triangulation/Cargo.toml
+++ b/examples/cu_peer_triangulation/Cargo.toml
@@ -22,3 +22,6 @@ cu29 = { workspace = true }
 cu-peer-range-accumulator = { path = "../../components/tasks/cu_peer_range_accumulator", version = "1.0.0" }
 cu-peer-triangulation = { path = "../../components/tasks/cu_peer_triangulation", version = "1.0.0" }
 cu-sensor-payloads = { workspace = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_peer_triangulation/build.rs
+++ b/examples/cu_peer_triangulation/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_pointclouds/Cargo.toml
+++ b/examples/cu_pointclouds/Cargo.toml
@@ -22,3 +22,6 @@ serde = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_pointclouds/build.rs
+++ b/examples/cu_pointclouds/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_python_task_demo/Cargo.toml
+++ b/examples/cu_python_task_demo/Cargo.toml
@@ -26,3 +26,6 @@ tempfile = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["bincode", "serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_python_task_demo/build.rs
+++ b/examples/cu_python_task_demo/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_rate_target/Cargo.toml
+++ b/examples/cu_rate_target/Cargo.toml
@@ -37,3 +37,6 @@ required-features = ["high-precision-limiter"]
 
 [package.metadata.cargo-shear]
 ignored = ["serde", "cu29-export"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_rate_target/build.rs
+++ b/examples/cu_rate_target/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_reflect_demo/Cargo.toml
+++ b/examples/cu_reflect_demo/Cargo.toml
@@ -21,3 +21,6 @@ bincode = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["bincode"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_reflect_demo/build.rs
+++ b/examples/cu_reflect_demo/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_remote_debug_session/Cargo.toml
+++ b/examples/cu_remote_debug_session/Cargo.toml
@@ -21,3 +21,6 @@ serde_json = { version = "1.0", default-features = false }
 
 [package.metadata.cargo-shear]
 ignored = ["bincode"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_remote_debug_session/build.rs
+++ b/examples/cu_remote_debug_session/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").expect("OUT_DIR not set")
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_resources_test/Cargo.toml
+++ b/examples/cu_resources_test/Cargo.toml
@@ -30,3 +30,6 @@ parking_lot = "0.12"
 [features]
 default = []
 macro_debug = ["cu29/macro_debug"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_resources_test/build.rs
+++ b/examples/cu_resources_test/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_ros2_bridge_demo/Cargo.toml
+++ b/examples/cu_ros2_bridge_demo/Cargo.toml
@@ -25,3 +25,6 @@ humble = ["cu-ros2-bridge/humble"]
 
 [package.metadata.cargo-shear]
 ignored = ["serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_ros2_bridge_demo/build.rs
+++ b/examples/cu_ros2_bridge_demo/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_rp2350_skeleton/Cargo.toml
+++ b/examples/cu_rp2350_skeleton/Cargo.toml
@@ -101,3 +101,6 @@ firmware = [
   "dep:cu-sdlogger",
 ]
 host = ["dep:cu29-export", "cu29/std", "bincode/std", "serde/std"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_rp2350_skeleton/Cargo.toml
+++ b/examples/cu_rp2350_skeleton/Cargo.toml
@@ -103,4 +103,4 @@ firmware = [
 host = ["dep:cu29-export", "cu29/std", "bincode/std", "serde/std"]
 
 [build-dependencies]
-cu29-build = { workspace = true }
+cu29-build = { path = "../../core/cu29_build", version = "1.0.0" }

--- a/examples/cu_rp2350_skeleton/build.rs
+++ b/examples/cu_rp2350_skeleton/build.rs
@@ -24,8 +24,5 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     // Struct logging for Copper
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_rp_balancebot/Cargo.toml
+++ b/examples/cu_rp_balancebot/Cargo.toml
@@ -161,3 +161,6 @@ required-features = ["sim"]
 name = "balancebot-resim"
 path = "src/resim.rs"
 required-features = ["sim-debug"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_rp_balancebot/build.rs
+++ b/examples/cu_rp_balancebot/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_run_in_sim/Cargo.toml
+++ b/examples/cu_run_in_sim/Cargo.toml
@@ -19,3 +19,6 @@ bincode = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["bincode"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_run_in_sim/build.rs
+++ b/examples/cu_run_in_sim/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_runtime_matrix/Cargo.toml
+++ b/examples/cu_runtime_matrix/Cargo.toml
@@ -34,3 +34,6 @@ rt-scheduling = ["cu29/rt-scheduling"]
 
 [package.metadata.cargo-shear]
 ignored = ["bincode", "serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_runtime_matrix/build.rs
+++ b/examples/cu_runtime_matrix/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_ryuw122_probe/Cargo.toml
+++ b/examples/cu_ryuw122_probe/Cargo.toml
@@ -26,3 +26,6 @@ cu-ryuw122 = { path = "../../components/sources/cu_ryuw122", version = "1.0.0" }
 cu-sensor-payloads = { workspace = true }
 cu29 = { workspace = true }
 serialport = { workspace = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_ryuw122_probe/build.rs
+++ b/examples/cu_ryuw122_probe/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_standalone_structlog/Cargo.toml
+++ b/examples/cu_standalone_structlog/Cargo.toml
@@ -25,3 +25,6 @@ cu29 = { workspace = true }       # needed
 cu29-clock = { workspace = true }
 log = { workspace = true }
 simplelog = { workspace = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_standalone_structlog/build.rs
+++ b/examples/cu_standalone_structlog/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_zenoh/Cargo.toml
+++ b/examples/cu_zenoh/Cargo.toml
@@ -20,3 +20,6 @@ serde = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["serde"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_zenoh/build.rs
+++ b/examples/cu_zenoh/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/examples/cu_zenoh_bridge_demo/Cargo.toml
+++ b/examples/cu_zenoh_bridge_demo/Cargo.toml
@@ -41,3 +41,6 @@ path = "src/bin/inspect_ping_provenance.rs"
 [[bin]]
 name = "inspect-pong-provenance"
 path = "src/bin/inspect_pong_provenance.rs"
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_zenoh_bridge_demo/build.rs
+++ b/examples/cu_zenoh_bridge_demo/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/support/cargo_cunew/templates/cu_full/Cargo.toml.template
+++ b/support/cargo_cunew/templates/cu_full/Cargo.toml.template
@@ -7,6 +7,7 @@ resolver = "2"
 
 [workspace.dependencies]
 cu29 = { {%if copper_source == "crates.io" %} version = "{{copper_version}}" {%elsif copper_source == "git" %} git = "{{copper_git_url}}"{{copper_git_ref_snippet}} {%elsif copper_source == "local" %} path = "{{copper_root_path}}/core/cu29" {%endif %} }
+cu29-build = { {%if copper_source == "crates.io" %} version = "{{copper_version}}" {%elsif copper_source == "git" %} git = "{{copper_git_url}}"{{copper_git_ref_snippet}} {%elsif copper_source == "local" %} path = "{{copper_root_path}}/core/cu29_build" {%endif %} }
 cu29-export = { {%if copper_source == "crates.io" %} version = "{{copper_export_version}}" {%elsif copper_source == "git" %} git = "{{copper_git_url}}"{{copper_git_ref_snippet}} {%elsif copper_source == "local" %} path = "{{copper_root_path}}/core/cu29_export" {%endif %} }
 bincode = { package = "cu-bincode", version = "2.0", default-features = false, features = ["derive", "alloc"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/support/cargo_cunew/templates/cu_full/apps/cu_example_app/Cargo.toml.template
+++ b/support/cargo_cunew/templates/cu_full/apps/cu_example_app/Cargo.toml.template
@@ -34,3 +34,6 @@ cu29-export = { workspace = true, optional = true }
 bincode = { workspace = true }
 serde = { workspace = true }
 # cu-memmon = { workspace = true, optional = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/support/cargo_cunew/templates/cu_full/apps/cu_example_app/build.rs
+++ b/support/cargo_cunew/templates/cu_full/apps/cu_example_app/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/support/cargo_cunew/templates/cu_project/Cargo.toml.template
+++ b/support/cargo_cunew/templates/cu_project/Cargo.toml.template
@@ -39,3 +39,6 @@ bincode = { package = "cu-bincode", version = "2.0", default-features = false, f
 serde = { version = "1.0", features = ["derive"] }
 cu29-export = { {%if copper_source == "crates.io" %} version = "{{copper_export_version}}" {%elsif copper_source == "git" %} git = "{{copper_git_url}}"{{copper_git_ref_snippet}} {%elsif copper_source == "local" %} path = "{{copper_root_path}}/core/cu29_export" {%endif %}, optional = true }
 # cu-memmon = { {%if copper_source == "crates.io" %} version = "{{copper_version}}" {%elsif copper_source == "git" %} git = "{{copper_git_url}}"{{copper_git_ref_snippet}} {%elsif copper_source == "local" %} path = "{{copper_root_path}}/components/monitors/cu_memmon" {%endif %}, default-features = false, features = ["std", "memory_monitoring"], optional = true }
+
+[build-dependencies]
+cu29-build = { {%if copper_source == "crates.io" %} version = "{{copper_version}}" {%elsif copper_source == "git" %} git = "{{copper_git_url}}"{{copper_git_ref_snippet}} {%elsif copper_source == "local" %} path = "{{copper_root_path}}/core/cu29_build" {%endif %} }

--- a/support/cargo_cunew/templates/cu_project/build.rs
+++ b/support/cargo_cunew/templates/cu_project/build.rs
@@ -1,6 +1,3 @@
 fn main() {
-    println!(
-        "cargo:rustc-env=LOG_INDEX_DIR={}",
-        std::env::var("OUT_DIR").unwrap()
-    );
+    cu29_build::setup();
 }

--- a/support/ci/check_public_api.sh
+++ b/support/ci/check_public_api.sh
@@ -9,6 +9,7 @@ CARGO_PUBLIC_API=(cargo "+${PUBLIC_API_TOOLCHAIN}" public-api)
 
 CRATES=(
   cu29
+  cu29-build
   cu29-runtime
   cu29-traits
   cu29-derive


### PR DESCRIPTION
## Summary
- add `cu29_build::setup()` as the single Copper build-script entry point
- replace repeated `LOG_INDEX_DIR` setup across all Copper build scripts
- update both `cargo cunew` templates

This PR intentionally preserves only the existing behavior; feature forwarding follows in the next stacked PR.

## Verification
- `just lint`
- `cargo test -p cu29-build`
- generated and built both `project` and `workspace` templates