### PR TITLE
config: compose graphs from Cargo features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ members = [
   "examples/cu_distributed_resim_demo",
   "examples/cu_elrs_bdshot_demo",
   "examples/cu_feetech_demo",
+  "examples/cu_feature_gated_camera",
   "examples/cu_flight_controller",
   "examples/cu_config_gen",
   "examples/cu_config_variation",

--- a/api/v1/cu29-build.txt
+++ b/api/v1/cu29-build.txt
@@ -1,2 +1,3 @@
 pub mod cu29_build
+pub const cu29_build::COPPER_CFG_FEATURES_ENV: &str
 pub fn cu29_build::setup()

--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -61,6 +61,11 @@ pub fn cu29_runtime::config::ConfigGraphs::get_all_missions_graphs(&self) -> has
 pub fn cu29_runtime::config::ConfigGraphs::get_default_mission_graph(&self) -> cu29_traits::CuResult<&cu29_runtime::config::CuGraph>
 pub fn cu29_runtime::config::ConfigGraphs::get_graph(&self, mission_id: core::option::Option<&str>) -> cu29_traits::CuResult<&cu29_runtime::config::CuGraph>
 pub fn cu29_runtime::config::ConfigGraphs::get_graph_mut(&mut self, mission_id: core::option::Option<&str>) -> cu29_traits::CuResult<&mut cu29_runtime::config::CuGraph>
+pub enum cu29_runtime::config::ConfigPredicate
+pub cu29_runtime::config::ConfigPredicate::All(alloc::vec::Vec<cu29_runtime::config::ConfigPredicate>)
+pub cu29_runtime::config::ConfigPredicate::Any(alloc::vec::Vec<cu29_runtime::config::ConfigPredicate>)
+pub cu29_runtime::config::ConfigPredicate::Feature(alloc::string::String)
+pub cu29_runtime::config::ConfigPredicate::Not(alloc::boxed::Box<cu29_runtime::config::ConfigPredicate>)
 pub enum cu29_runtime::config::CuDirection
 pub cu29_runtime::config::CuDirection::Incoming
 pub cu29_runtime::config::CuDirection::Outgoing
@@ -195,6 +200,7 @@ pub struct cu29_runtime::config::IncludesConfig
 pub cu29_runtime::config::IncludesConfig::missions: core::option::Option<alloc::vec::Vec<alloc::string::String>>
 pub cu29_runtime::config::IncludesConfig::params: hashbrown::map::HashMap<alloc::string::String, cu29_runtime::config::Value>
 pub cu29_runtime::config::IncludesConfig::path: alloc::string::String
+pub cu29_runtime::config::IncludesConfig::when: core::option::Option<cu29_runtime::config::ConfigPredicate>
 pub struct cu29_runtime::config::InstanceConfigSetOperation
 pub cu29_runtime::config::InstanceConfigSetOperation::path: alloc::string::String
 pub cu29_runtime::config::InstanceConfigSetOperation::value: cu29_runtime::config::ComponentConfig
@@ -397,8 +403,12 @@ pub const cu29_runtime::config::RT_POOL: &str
 pub fn cu29_runtime::config::infer_task_kind_for_id(graph: &cu29_runtime::config::CuGraph, node_id: cu29_runtime::config::NodeId) -> core::option::Option<cu29_runtime::config::TaskKind>
 pub fn cu29_runtime::config::read_configuration(config_filename: &str) -> cu29_traits::CuResult<cu29_runtime::config::CuConfig>
 pub fn cu29_runtime::config::read_configuration_str(config_content: alloc::string::String, file_path: core::option::Option<&str>) -> cu29_traits::CuResult<cu29_runtime::config::CuConfig>
+pub fn cu29_runtime::config::read_configuration_str_with_features(config_content: alloc::string::String, file_path: core::option::Option<&str>, active_features: &[&str]) -> cu29_traits::CuResult<cu29_runtime::config::CuConfig>
+pub fn cu29_runtime::config::read_configuration_with_features(config_filename: &str, active_features: &[&str]) -> cu29_traits::CuResult<cu29_runtime::config::CuConfig>
 pub fn cu29_runtime::config::read_multi_configuration(config_filename: &str) -> cu29_traits::CuResult<cu29_runtime::config::MultiCopperConfig>
 pub fn cu29_runtime::config::read_multi_configuration_str(config_content: alloc::string::String, file_path: core::option::Option<&str>) -> cu29_traits::CuResult<cu29_runtime::config::MultiCopperConfig>
+pub fn cu29_runtime::config::read_multi_configuration_str_with_features(config_content: alloc::string::String, file_path: core::option::Option<&str>, active_features: &[&str]) -> cu29_traits::CuResult<cu29_runtime::config::MultiCopperConfig>
+pub fn cu29_runtime::config::read_multi_configuration_with_features(config_filename: &str, active_features: &[&str]) -> cu29_traits::CuResult<cu29_runtime::config::MultiCopperConfig>
 pub fn cu29_runtime::config::resolve_task_kind_for_id(graph: &cu29_runtime::config::CuGraph, node_id: cu29_runtime::config::NodeId) -> cu29_traits::CuResult<cu29_runtime::config::TaskKind>
 pub type cu29_runtime::config::NodeId = u32
 pub mod cu29_runtime::context

--- a/core/cu29_build/README.md
+++ b/core/cu29_build/README.md
@@ -2,4 +2,5 @@
 
 Shared build-script setup for Copper crates and applications.
 
-Call `cu29_build::setup()` once from `build.rs`.
+Call `cu29_build::setup()` once from `build.rs`. It configures Copper's logging
+macros and forwards the crate's active Cargo features to Copper code generation.

--- a/core/cu29_build/src/lib.rs
+++ b/core/cu29_build/src/lib.rs
@@ -1,9 +1,37 @@
 #![doc = include_str!("../README.md")]
 
+/// Environment variable used to pass the consuming crate's Cargo features to
+/// Copper's procedural macros and generated runtime.
+pub const COPPER_CFG_FEATURES_ENV: &str = "COPPER_CFG_FEATURES";
+
 /// Emit the standard Cargo build-script configuration required by Copper.
 pub fn setup() {
     println!(
         "cargo::rustc-env=LOG_INDEX_DIR={}",
         std::env::var("OUT_DIR").expect("Cargo must provide OUT_DIR")
     );
+
+    let mut features: Vec<_> = std::env::var("CARGO_CFG_FEATURE")
+        .unwrap_or_default()
+        .split(',')
+        .filter(|feature| !feature.is_empty())
+        .map(str::to_owned)
+        .collect();
+    features.sort_unstable();
+    features.dedup();
+
+    println!(
+        "cargo::rustc-env={COPPER_CFG_FEATURES_ENV}={}",
+        features.join(",")
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::COPPER_CFG_FEATURES_ENV;
+
+    #[test]
+    fn feature_environment_name_is_stable() {
+        assert_eq!(COPPER_CFG_FEATURES_ENV, "COPPER_CFG_FEATURES");
+    }
 }

--- a/core/cu29_derive/Cargo.toml
+++ b/core/cu29_derive/Cargo.toml
@@ -16,6 +16,7 @@ repository.workspace = true
 proc-macro = true
 
 [dependencies]
+cu29-build = { workspace = true }
 cu29-runtime = { workspace = true, features = ["std"] }
 cu29-traits = { workspace = true }
 convert_case = "0.11"

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -13,10 +13,12 @@ use syn::{
 };
 
 use crate::utils::{config_id_to_bridge_const, config_id_to_enum, config_id_to_struct_member};
+use cu29_build::COPPER_CFG_FEATURES_ENV;
 use cu29_runtime::config::CuConfig;
 use cu29_runtime::config::{
     BridgeChannelConfigRepresentation, ConfigGraphs, CuGraph, Flavor, HandleContent, Node, NodeId,
-    RT_POOL, ResourceBundleConfig, read_configuration, read_configuration_with_resolved_ron,
+    RT_POOL, ResourceBundleConfig, read_configuration_with_features,
+    read_configuration_with_resolved_ron_and_features,
 };
 use cu29_runtime::curuntime::{
     CuExecutionLoop, CuExecutionStep, CuExecutionUnit, CuTaskType, compute_runtime_plan,
@@ -187,6 +189,7 @@ impl CopperRuntimeArgs {
 struct ResolvedRuntimeConfig {
     local_config: CuConfig,
     bundled_local_config_content: String,
+    active_features: Vec<String>,
     subsystem_id: Option<String>,
     subsystem_code: u16,
 }
@@ -1545,6 +1548,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
     };
     let subsystem_code = resolved_runtime_config.subsystem_code;
     let subsystem_id = resolved_runtime_config.subsystem_id.clone();
+    let config_features = resolved_runtime_config.active_features.clone();
     let copper_config_content = resolved_runtime_config.bundled_local_config_content.clone();
     let copper_config = resolved_runtime_config.local_config;
     let copperlist_count = copper_config
@@ -3845,8 +3849,12 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
             quote! {}
         };
 
-        let config_load_stmt =
-            build_config_load_stmt(std, application_name, subsystem_id.as_deref());
+        let config_load_stmt = build_config_load_stmt(
+            std,
+            application_name,
+            subsystem_id.as_deref(),
+            &config_features,
+        );
 
         let copperlist_count_check = quote! {
             let configured_copperlist_count = config
@@ -5722,6 +5730,16 @@ fn resolve_runtime_config_with_root(
     args: &CopperRuntimeArgs,
     caller_root: &Path,
 ) -> CuResult<ResolvedRuntimeConfig> {
+    let active_features = active_config_features();
+    let active_feature_refs: Vec<_> = active_features.iter().map(String::as_str).collect();
+    resolve_runtime_config_with_root_and_features(args, caller_root, &active_feature_refs)
+}
+
+fn resolve_runtime_config_with_root_and_features(
+    args: &CopperRuntimeArgs,
+    caller_root: &Path,
+    active_features: &[&str],
+) -> CuResult<ResolvedRuntimeConfig> {
     let filename = config_full_path_from_root(caller_root, &args.config_path);
     if !Path::new(&filename).exists() {
         return Err(CuError::from(format!(
@@ -5731,13 +5749,16 @@ fn resolve_runtime_config_with_root(
     }
 
     if let Some(subsystem_id) = args.subsystem_id.as_deref() {
-        let multi_config = cu29_runtime::config::read_multi_configuration(filename.as_str())
-            .map_err(|e| {
-                CuError::from(format!(
-                    "When `subsystem = \"{subsystem_id}\"` is provided, `config = \"{}\"` must point to a valid multi-Copper configuration: {e}",
-                    args.config_path
-                ))
-            })?;
+        let multi_config = cu29_runtime::config::read_multi_configuration_with_features(
+            filename.as_str(),
+            active_features,
+        )
+        .map_err(|e| {
+            CuError::from(format!(
+                "When `subsystem = \"{subsystem_id}\"` is provided, `config = \"{}\"` must point to a valid multi-Copper configuration: {e}",
+                args.config_path
+            ))
+        })?;
         let subsystem = multi_config.subsystem(subsystem_id).ok_or_else(|| {
             CuError::from(format!(
                 "Subsystem '{subsystem_id}' was not found in multi-Copper configuration '{}'.",
@@ -5747,7 +5768,11 @@ fn resolve_runtime_config_with_root(
         // Bundle the include-expanded source representation. Serializing the lowered
         // mission graphs would lose the source task order because missions use hash maps.
         let (local_config, bundled_local_config_content) =
-            read_configuration_with_resolved_ron(&subsystem.config_path).map_err(|e| {
+            read_configuration_with_resolved_ron_and_features(
+                &subsystem.config_path,
+                active_features,
+            )
+            .map_err(|e| {
                 CuError::from(format!(
                     "Failed to prepare bundled local configuration for subsystem '{subsystem_id}' from '{}'.",
                     subsystem.config_path
@@ -5758,29 +5783,52 @@ fn resolve_runtime_config_with_root(
         Ok(ResolvedRuntimeConfig {
             local_config,
             bundled_local_config_content,
+            active_features: active_features
+                .iter()
+                .map(|feature| (*feature).to_string())
+                .collect(),
             subsystem_id: Some(subsystem_id.to_string()),
             subsystem_code: subsystem.subsystem_code,
         })
     } else {
         let (local_config, bundled_local_config_content) =
-            read_configuration_with_resolved_ron(filename.as_str())?;
+            read_configuration_with_resolved_ron_and_features(filename.as_str(), active_features)?;
         Ok(ResolvedRuntimeConfig {
             local_config,
             bundled_local_config_content,
+            active_features: active_features
+                .iter()
+                .map(|feature| (*feature).to_string())
+                .collect(),
             subsystem_id: None,
             subsystem_code: 0,
         })
     }
 }
 
+fn active_config_features() -> Vec<String> {
+    let mut features: Vec<_> = std::env::var(COPPER_CFG_FEATURES_ENV)
+        .unwrap_or_default()
+        .split(',')
+        .filter(|feature| !feature.is_empty())
+        .map(str::to_owned)
+        .collect();
+    features.sort_unstable();
+    features.dedup();
+    features
+}
+
 fn build_config_load_stmt(
     std_enabled: bool,
     application_name: &Ident,
     subsystem_id: Option<&str>,
+    active_features: &[String],
 ) -> proc_macro2::TokenStream {
+    let active_features = active_features.iter();
     if std_enabled {
         if let Some(subsystem_id) = subsystem_id {
             quote! {
+                const COPPER_CFG_FEATURES: &[&str] = &[#(#active_features),*];
                 let (config, config_source) = if let Some(overridden_config) = config_override {
                     debug!("CuConfig: Overridden programmatically.");
                     (overridden_config, RuntimeLifecycleConfigSource::ProgrammaticOverride)
@@ -5793,7 +5841,10 @@ fn build_config_load_stmt(
                         config_filename,
                         subsystem_id
                     );
-                    let multi_config = cu29::config::read_multi_configuration(config_filename)?;
+                    let multi_config = cu29::config::read_multi_configuration_with_features(
+                        config_filename,
+                        COPPER_CFG_FEATURES,
+                    )?;
                     (
                         multi_config.resolve_subsystem_config_for_instance(subsystem_id, instance_id)?,
                         RuntimeLifecycleConfigSource::ExternalFile,
@@ -5819,6 +5870,7 @@ fn build_config_load_stmt(
             }
         } else {
             quote! {
+                const COPPER_CFG_FEATURES: &[&str] = &[#(#active_features),*];
                 let _ = instance_id;
                 let (config, config_source) = if let Some(overridden_config) = config_override {
                     debug!("CuConfig: Overridden programmatically.");
@@ -5826,7 +5878,10 @@ fn build_config_load_stmt(
                 } else if ::std::path::Path::new(config_filename).exists() {
                     debug!("CuConfig: Reading configuration from file: {}", config_filename);
                     (
-                        cu29::config::read_configuration(config_filename)?,
+                        cu29::config::read_configuration_with_features(
+                            config_filename,
+                            COPPER_CFG_FEATURES,
+                        )?,
                         RuntimeLifecycleConfigSource::ExternalFile,
                     )
                 } else {
@@ -5866,7 +5921,9 @@ fn config_full_path_from_root(caller_root: &Path, config_file: &str) -> String {
 
 fn read_config(config_file: &str) -> CuResult<CuConfig> {
     let filename = config_full_path(config_file);
-    read_configuration(filename.as_str())
+    let active_features = active_config_features();
+    let active_feature_refs: Vec<_> = active_features.iter().map(String::as_str).collect();
+    read_configuration_with_features(filename.as_str(), &active_feature_refs)
 }
 
 fn inferred_single_output_payload_type(task_type: &Type, task_kind: CuTaskType) -> Type {
@@ -9858,6 +9915,151 @@ mod tests {
         assert!(graph.get_node_id_by_name("src").is_some());
         assert!(graph.get_node_id_by_name("sink").is_some());
         assert_eq!(graph.edge_count(), 1);
+    }
+
+    #[test]
+    fn resolve_runtime_config_uses_forwarded_features_for_codegen_and_reload() {
+        use super::*;
+
+        let root = unique_test_dir("feature_runtime_resolve");
+        let camera_config = root.join("camera.ron");
+        let app_config = root.join("app.ron");
+
+        write_file(
+            &camera_config,
+            r#"
+(
+    tasks: [
+        (id: "camera", type: "target_camera::Camera"),
+        (id: "sink", type: "tasks::CameraSink"),
+    ],
+    cnx: [
+        (src: "camera", dst: "sink", msg: "target_camera::Frame"),
+    ],
+)
+"#,
+        );
+        write_file(
+            &app_config,
+            r#"
+(
+    tasks: [],
+    cnx: [],
+    includes: [
+        (path: "camera.ron", when: Feature("camera")),
+    ],
+)
+"#,
+        );
+
+        let args = CopperRuntimeArgs {
+            config_path: "app.ron".to_string(),
+            subsystem_id: None,
+            sim_mode: false,
+            ignore_resources: false,
+        };
+
+        let without_camera =
+            resolve_runtime_config_with_root_and_features(&args, &root, &[]).unwrap();
+        assert!(without_camera.active_features.is_empty());
+        assert!(
+            !without_camera
+                .bundled_local_config_content
+                .contains("target_camera")
+        );
+
+        let with_camera =
+            resolve_runtime_config_with_root_and_features(&args, &root, &["camera"]).unwrap();
+        assert_eq!(with_camera.active_features, ["camera"]);
+        assert!(
+            with_camera
+                .bundled_local_config_content
+                .contains("target_camera::Camera")
+        );
+        assert!(
+            with_camera
+                .bundled_local_config_content
+                .contains("target_camera::Frame")
+        );
+        assert!(!with_camera.bundled_local_config_content.contains("Feature"));
+    }
+
+    #[test]
+    fn resolve_multi_runtime_config_uses_forwarded_features() {
+        use super::*;
+
+        let root = unique_test_dir("feature_multi_runtime_resolve");
+        write_file(
+            &root.join("camera.ron"),
+            r#"
+(
+    tasks: [
+        (id: "camera", type: "target_camera::Camera"),
+        (id: "sink", type: "tasks::CameraSink"),
+    ],
+    cnx: [
+        (src: "camera", dst: "sink", msg: "target_camera::Frame"),
+    ],
+)
+"#,
+        );
+        write_file(
+            &root.join("robot.ron"),
+            r#"
+(
+    tasks: [],
+    cnx: [],
+    includes: [
+        (path: "camera.ron", when: Feature("camera")),
+    ],
+)
+"#,
+        );
+        write_file(
+            &root.join("multi.ron"),
+            r#"
+(
+    subsystems: [
+        (id: "robot", config: "robot.ron"),
+    ],
+    interconnects: [],
+)
+"#,
+        );
+
+        let args = CopperRuntimeArgs {
+            config_path: "multi.ron".to_string(),
+            subsystem_id: Some("robot".to_string()),
+            sim_mode: false,
+            ignore_resources: false,
+        };
+
+        let without_camera =
+            resolve_runtime_config_with_root_and_features(&args, &root, &[]).unwrap();
+        assert_eq!(
+            without_camera
+                .local_config
+                .get_graph(None)
+                .unwrap()
+                .node_count(),
+            0
+        );
+
+        let with_camera =
+            resolve_runtime_config_with_root_and_features(&args, &root, &["camera"]).unwrap();
+        assert_eq!(
+            with_camera
+                .local_config
+                .get_graph(None)
+                .unwrap()
+                .node_count(),
+            2
+        );
+        assert!(
+            with_camera
+                .bundled_local_config_content
+                .contains("target_camera::Frame")
+        );
     }
 
     #[test]

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -2024,12 +2024,41 @@ pub struct MissionsConfig {
     pub id: String,
 }
 
+/// A compile-time predicate controlling whether a configuration fragment is included.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum ConfigPredicate {
+    Feature(String),
+    Not(Box<ConfigPredicate>),
+    All(Vec<ConfigPredicate>),
+    Any(Vec<ConfigPredicate>),
+}
+
+#[cfg(feature = "std")]
+impl ConfigPredicate {
+    fn evaluate(&self, active_features: &[&str]) -> bool {
+        match self {
+            Self::Feature(feature) => active_features.contains(&feature.as_str()),
+            Self::Not(predicate) => !predicate.evaluate(active_features),
+            Self::All(predicates) => predicates
+                .iter()
+                .all(|predicate| predicate.evaluate(active_features)),
+            Self::Any(predicates) => predicates
+                .iter()
+                .any(|predicate| predicate.evaluate(active_features)),
+        }
+    }
+}
+
 /// Includes are used to include other configuration files.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IncludesConfig {
     pub path: String,
+    #[serde(default)]
     pub params: HashMap<String, Value>,
+    #[serde(default)]
     pub missions: Option<Vec<String>>,
+    #[serde(default)]
+    pub when: Option<ConfigPredicate>,
 }
 
 /// One subsystem participating in a multi-Copper deployment.
@@ -3349,6 +3378,7 @@ fn process_includes(
     file_path: &str,
     base_representation: CuConfigRepresentation,
     processed_files: &mut Vec<String>,
+    active_features: &[&str],
 ) -> CuResult<CuConfigRepresentation> {
     // Note: Circular dependency detection removed
     processed_files.push(file_path.to_string());
@@ -3357,6 +3387,14 @@ fn process_includes(
 
     if let Some(includes) = result.includes.take() {
         for include in includes {
+            if include
+                .when
+                .as_ref()
+                .is_some_and(|predicate| !predicate.evaluate(active_features))
+            {
+                continue;
+            }
+
             let include_path = if include.path.starts_with('/') {
                 include.path.clone()
             } else {
@@ -3392,8 +3430,12 @@ fn process_includes(
                 }
             };
 
-            included_representation =
-                process_includes(&include_path, included_representation, processed_files)?;
+            included_representation = process_includes(
+                &include_path,
+                included_representation,
+                processed_files,
+                active_features,
+            )?;
 
             if let Some(included_tasks) = included_representation.tasks {
                 if result.tasks.is_none() {
@@ -3878,6 +3920,7 @@ fn build_multi_bridge_channel_contracts(
 fn validate_multi_config_representation(
     representation: MultiCopperConfigRepresentation,
     file_path: Option<&str>,
+    active_features: &[&str],
 ) -> CuResult<MultiCopperConfig> {
     if representation
         .instance_overrides_root
@@ -3938,12 +3981,13 @@ fn validate_multi_config_representation(
 
     for subsystem in representation.subsystems {
         let resolved_config_path = resolve_relative_config_path(file_path, &subsystem.config);
-        let config = read_configuration(&resolved_config_path).map_err(|e| {
-            CuError::from(format!(
-                "Failed to read subsystem '{}' from '{}': {e}",
-                subsystem.id, resolved_config_path
-            ))
-        })?;
+        let config = read_configuration_with_features(&resolved_config_path, active_features)
+            .map_err(|e| {
+                CuError::from(format!(
+                    "Failed to read subsystem '{}' from '{}': {e}",
+                    subsystem.id, resolved_config_path
+                ))
+            })?;
         let contracts = build_multi_bridge_channel_contracts(&config).map_err(|e| {
             CuError::from(format!(
                 "Invalid subsystem '{}' for multi-Copper validation: {e}",
@@ -4075,8 +4119,17 @@ fn validate_multi_config_representation(
 /// Read a copper configuration from a file.
 #[cfg(feature = "std")]
 pub fn read_configuration(config_filename: &str) -> CuResult<CuConfig> {
+    read_configuration_with_features(config_filename, &[])
+}
+
+/// Read a Copper configuration using the supplied compile-time Cargo features.
+#[cfg(feature = "std")]
+pub fn read_configuration_with_features(
+    config_filename: &str,
+    active_features: &[&str],
+) -> CuResult<CuConfig> {
     let config_content = read_configuration_content(config_filename)?;
-    read_configuration_str(config_content, Some(config_filename))
+    read_configuration_str_with_features(config_content, Some(config_filename), active_features)
 }
 
 #[cfg(feature = "std")]
@@ -4127,6 +4180,7 @@ fn config_representation_to_config(representation: CuConfigRepresentation) -> Cu
 fn resolve_configuration_representation(
     config_content: &str,
     file_path: Option<&str>,
+    active_features: &[&str],
 ) -> CuResult<CuConfigRepresentation> {
     // Parse the configuration string
     let representation = parse_config_string(config_content)?;
@@ -4135,7 +4189,7 @@ fn resolve_configuration_representation(
     // includes are only available with std.
     #[cfg(feature = "std")]
     let representation = if let Some(path) = file_path {
-        process_includes(path, representation, &mut Vec::new())?
+        process_includes(path, representation, &mut Vec::new(), active_features)?
     } else {
         representation
     };
@@ -4151,9 +4205,22 @@ fn resolve_configuration_representation(
 #[doc(hidden)]
 #[allow(dead_code)]
 pub fn read_configuration_with_resolved_ron(config_filename: &str) -> CuResult<(CuConfig, String)> {
+    read_configuration_with_resolved_ron_and_features(config_filename, &[])
+}
+
+/// Read and expand a Copper configuration using the supplied compile-time Cargo features.
+#[cfg(feature = "std")]
+#[doc(hidden)]
+pub fn read_configuration_with_resolved_ron_and_features(
+    config_filename: &str,
+    active_features: &[&str],
+) -> CuResult<(CuConfig, String)> {
     let config_content = read_configuration_content(config_filename)?;
-    let representation =
-        resolve_configuration_representation(&config_content, Some(config_filename))?;
+    let representation = resolve_configuration_representation(
+        &config_content,
+        Some(config_filename),
+        active_features,
+    )?;
     let resolved_ron = CuConfig::get_options()
         .to_string_pretty(&representation, ron::ser::PrettyConfig::default())
         .map_err(|e| CuError::from(format!("Error serializing configuration: {e}")))?;
@@ -4161,11 +4228,22 @@ pub fn read_configuration_with_resolved_ron(config_filename: &str) -> CuResult<(
     Ok((config, resolved_ron))
 }
 
+#[allow(dead_code)]
 pub fn read_configuration_str(
     config_content: String,
     file_path: Option<&str>,
 ) -> CuResult<CuConfig> {
-    let representation = resolve_configuration_representation(&config_content, file_path)?;
+    read_configuration_str_with_features(config_content, file_path, &[])
+}
+
+/// Read a Copper configuration string using the supplied compile-time Cargo features.
+pub fn read_configuration_str_with_features(
+    config_content: String,
+    file_path: Option<&str>,
+    active_features: &[&str],
+) -> CuResult<CuConfig> {
+    let representation =
+        resolve_configuration_representation(&config_content, file_path, active_features)?;
 
     // Convert the representation to a CuConfig and validate
     config_representation_to_config(representation)
@@ -4175,6 +4253,16 @@ pub fn read_configuration_str(
 #[cfg(feature = "std")]
 #[allow(dead_code)]
 pub fn read_multi_configuration(config_filename: &str) -> CuResult<MultiCopperConfig> {
+    read_multi_configuration_with_features(config_filename, &[])
+}
+
+/// Read a multi-Copper configuration using the supplied compile-time Cargo features.
+#[cfg(feature = "std")]
+#[allow(dead_code)]
+pub fn read_multi_configuration_with_features(
+    config_filename: &str,
+    active_features: &[&str],
+) -> CuResult<MultiCopperConfig> {
     let config_content = read_to_string(config_filename).map_err(|e| {
         CuError::from(format!(
             "Failed to read multi-Copper configuration file: {:?}",
@@ -4182,7 +4270,11 @@ pub fn read_multi_configuration(config_filename: &str) -> CuResult<MultiCopperCo
         ))
         .add_cause(e.to_string().as_str())
     })?;
-    read_multi_configuration_str(config_content, Some(config_filename))
+    read_multi_configuration_str_with_features(
+        config_content,
+        Some(config_filename),
+        active_features,
+    )
 }
 
 /// Read a strict multi-Copper umbrella configuration from a string.
@@ -4192,8 +4284,19 @@ pub fn read_multi_configuration_str(
     config_content: String,
     file_path: Option<&str>,
 ) -> CuResult<MultiCopperConfig> {
+    read_multi_configuration_str_with_features(config_content, file_path, &[])
+}
+
+/// Read a multi-Copper configuration string using the supplied compile-time Cargo features.
+#[cfg(feature = "std")]
+#[allow(dead_code)]
+pub fn read_multi_configuration_str_with_features(
+    config_content: String,
+    file_path: Option<&str>,
+    active_features: &[&str],
+) -> CuResult<MultiCopperConfig> {
     let representation = parse_multi_config_string(&config_content)?;
-    validate_multi_config_representation(representation, file_path)
+    validate_multi_config_representation(representation, file_path, active_features)
 }
 
 // tests

--- a/core/cu29_runtime/tests/includes.rs
+++ b/core/cu29_runtime/tests/includes.rs
@@ -1,6 +1,10 @@
 #[cfg(all(test, feature = "std"))]
 mod tests {
-    use cu29_runtime::config::{NodeId, read_configuration};
+    use cu29_runtime::config::{
+        NodeId, read_configuration, read_configuration_with_features,
+        read_configuration_with_resolved_ron_and_features,
+    };
+    use std::collections::BTreeSet;
     use std::fs::{create_dir_all, write};
     use tempfile::tempdir;
 
@@ -57,6 +61,159 @@ mod tests {
             .collect();
         assert!(task_ids.contains(&"main_task".to_string()));
         assert!(task_ids.contains(&"included_task".to_string()));
+    }
+
+    #[test]
+    fn test_feature_predicate_combinations() {
+        let temp_dir = tempdir().unwrap();
+        let config_dir = temp_dir.path().join("config");
+        create_dir_all(&config_dir).unwrap();
+
+        for (name, task_id) in [
+            ("feature", "feature_task"),
+            ("not", "not_task"),
+            ("all", "all_task"),
+            ("any", "any_task"),
+        ] {
+            write(
+                config_dir.join(format!("{name}.ron")),
+                format!(
+                    r#"(
+                        tasks: [(id: "{task_id}", type: "tasks::Marker")],
+                        cnx: [],
+                    )"#
+                ),
+            )
+            .unwrap();
+        }
+
+        let main_path = config_dir.join("main.ron");
+        write(
+            &main_path,
+            r#"(
+                tasks: [],
+                cnx: [],
+                includes: [
+                    (path: "feature.ron", when: Feature("camera")),
+                    (path: "not.ron", when: Not(Feature("camera"))),
+                    (
+                        path: "all.ron",
+                        when: All([Feature("camera"), Feature("recording")]),
+                    ),
+                    (
+                        path: "any.ron",
+                        when: Any([Feature("camera"), Feature("recording")]),
+                    ),
+                ],
+            )"#,
+        )
+        .unwrap();
+
+        let cases: &[(&[&str], &[&str])] = &[
+            (&[], &["not_task"]),
+            (&["camera"], &["any_task", "feature_task"]),
+            (
+                &["camera", "recording"],
+                &["all_task", "any_task", "feature_task"],
+            ),
+            (&["recording"], &["any_task", "not_task"]),
+        ];
+
+        for (features, expected_tasks) in cases {
+            let config =
+                read_configuration_with_features(main_path.to_str().unwrap(), features).unwrap();
+            let actual: BTreeSet<_> = config
+                .get_graph(None)
+                .unwrap()
+                .get_all_nodes()
+                .into_iter()
+                .map(|(_, node)| node.get_id())
+                .collect();
+            let expected: BTreeSet<_> = expected_tasks
+                .iter()
+                .map(|task| (*task).to_string())
+                .collect();
+            assert_eq!(actual, expected, "features={features:?}");
+        }
+    }
+
+    #[test]
+    fn test_disabled_feature_include_is_not_read() {
+        let temp_dir = tempdir().unwrap();
+        let main_path = temp_dir.path().join("main.ron");
+        write(
+            &main_path,
+            r#"(
+                tasks: [],
+                cnx: [],
+                includes: [
+                    (path: "target-only.ron", when: Feature("target-camera")),
+                ],
+            )"#,
+        )
+        .unwrap();
+
+        read_configuration_with_features(main_path.to_str().unwrap(), &[])
+            .expect("a disabled include must not touch its file");
+
+        let error =
+            read_configuration_with_features(main_path.to_str().unwrap(), &["target-camera"])
+                .expect_err("an enabled include must be read");
+        assert!(error.to_string().contains("target-only.ron"));
+    }
+
+    #[test]
+    fn test_resolved_ron_contains_only_the_selected_graph() {
+        let temp_dir = tempdir().unwrap();
+        let camera_path = temp_dir.path().join("camera.ron");
+        write(
+            &camera_path,
+            r#"(
+                tasks: [
+                    (id: "camera", type: "target_camera::Camera"),
+                    (id: "sink", type: "tasks::FrameSink"),
+                ],
+                cnx: [
+                    (src: "camera", dst: "sink", msg: "target_camera::Frame"),
+                ],
+            )"#,
+        )
+        .unwrap();
+
+        let main_path = temp_dir.path().join("main.ron");
+        write(
+            &main_path,
+            r#"(
+                tasks: [],
+                cnx: [],
+                includes: [
+                    (path: "camera.ron", when: Feature("target-camera")),
+                ],
+            )"#,
+        )
+        .unwrap();
+
+        let (without_camera, resolved_without_camera) =
+            read_configuration_with_resolved_ron_and_features(main_path.to_str().unwrap(), &[])
+                .unwrap();
+        assert_eq!(without_camera.get_graph(None).unwrap().node_count(), 0);
+        assert!(!resolved_without_camera.contains("target_camera"));
+        assert!(!resolved_without_camera.contains("camera.ron"));
+        assert!(!resolved_without_camera.contains("Feature"));
+
+        let (with_camera, resolved_with_camera) =
+            read_configuration_with_resolved_ron_and_features(
+                main_path.to_str().unwrap(),
+                &["target-camera"],
+            )
+            .unwrap();
+        let graph = with_camera.get_graph(None).unwrap();
+        assert_eq!(graph.node_count(), 2);
+        assert_eq!(graph.edge_count(), 1);
+        assert!(resolved_with_camera.contains("target_camera::Camera"));
+        assert!(resolved_with_camera.contains("target_camera::Frame"));
+        assert!(!resolved_with_camera.contains("camera.ron"));
+        assert!(!resolved_with_camera.contains("Feature"));
     }
 
     #[test]

--- a/examples/cu_feature_gated_camera/Cargo.toml
+++ b/examples/cu_feature_gated_camera/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "cu-feature-gated-camera"
+description = "Feature-gated Copper graph with a Jetson-only camera dependency."
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+publish = false
+
+[[bin]]
+name = "cu-feature-gated-camera"
+path = "src/main.rs"
+test = false
+bench = false
+
+[package.metadata.copper]
+environments = ["host"]
+ci_exclude_workspace = true
+
+[features]
+default = []
+jetson-mipi = ["dep:cu-gstreamer"]
+
+[dependencies]
+cu29 = { workspace = true }
+
+[target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies]
+cu-gstreamer = { workspace = true, features = ["gst"], optional = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_feature_gated_camera/README.md
+++ b/examples/cu_feature_gated_camera/README.md
@@ -1,0 +1,9 @@
+# Feature-gated camera graph
+
+The `jetson-mipi` Cargo feature enables the target-only `cu-gstreamer`
+dependency and the complete camera graph fragment together.
+
+```console
+just matrix
+just jetson
+```

--- a/examples/cu_feature_gated_camera/build.rs
+++ b/examples/cu_feature_gated_camera/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    cu29_build::setup();
+
+    println!("cargo::rerun-if-changed=copperconfig.ron");
+    println!("cargo::rerun-if-changed=graph/base.ron");
+    println!("cargo::rerun-if-changed=graph/jetson_mipi.ron");
+    println!("cargo::rerun-if-changed=tests/forwarding");
+}

--- a/examples/cu_feature_gated_camera/copperconfig.ron
+++ b/examples/cu_feature_gated_camera/copperconfig.ron
@@ -1,0 +1,17 @@
+(
+    includes: [
+        (
+            path: "graph/base.ron",
+            params: {},
+        ),
+        (
+            path: "graph/jetson_mipi.ron",
+            params: {},
+            when: Feature("jetson-mipi"),
+        ),
+    ],
+    logging: (
+        enable_task_logging: false,
+        slab_size_mib: 16,
+    ),
+)

--- a/examples/cu_feature_gated_camera/graph/base.ron
+++ b/examples/cu_feature_gated_camera/graph/base.ron
@@ -1,0 +1,19 @@
+(
+    tasks: [
+        (
+            id: "heartbeat",
+            type: "tasks::HeartbeatSource",
+        ),
+        (
+            id: "heartbeat_sink",
+            type: "tasks::HeartbeatSink",
+        ),
+    ],
+    cnx: [
+        (
+            src: "heartbeat",
+            dst: "heartbeat_sink",
+            msg: "u64",
+        ),
+    ],
+)

--- a/examples/cu_feature_gated_camera/graph/jetson_mipi.ron
+++ b/examples/cu_feature_gated_camera/graph/jetson_mipi.ron
@@ -1,0 +1,23 @@
+(
+    tasks: [
+        (
+            id: "mipi_camera",
+            type: "cu_gstreamer::CuDefaultGStreamer",
+            config: {
+                "pipeline": "nvarguscamerasrc ! video/x-raw(memory:NVMM),width=1920,height=1080,framerate=30/1 ! appsink name=copper",
+                "caps": "video/x-raw(memory:NVMM),format=NV12,width=1920,height=1080",
+            },
+        ),
+        (
+            id: "camera_sink",
+            type: "tasks::JetsonFrameSink",
+        ),
+    ],
+    cnx: [
+        (
+            src: "mipi_camera",
+            dst: "camera_sink",
+            msg: "cu_gstreamer::CuGstBuffer",
+        ),
+    ],
+)

--- a/examples/cu_feature_gated_camera/justfile
+++ b/examples/cu_feature_gated_camera/justfile
@@ -1,0 +1,54 @@
+ROOT := shell('cd "$1/../.." && pwd', justfile_directory())
+
+default: host
+
+# Compile the host graph and prove the Jetson dependency is absent.
+host:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cd "{{ROOT}}"
+  cargo check -p cu-feature-gated-camera --no-default-features
+  if cargo tree -p cu-feature-gated-camera --no-default-features --target x86_64-unknown-linux-gnu | rg -q 'cu-gstreamer v'; then
+    echo "cu-gstreamer unexpectedly present in the host dependency graph" >&2
+    exit 1
+  fi
+
+# Enabling Jetson hardware on the wrong target must fail with a focused error.
+wrong-target:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cd "{{ROOT}}"
+  if cargo tree -p cu-feature-gated-camera --no-default-features --features jetson-mipi --target x86_64-unknown-linux-gnu | rg -q 'cu-gstreamer v'; then
+    echo "cu-gstreamer unexpectedly present on the wrong target" >&2
+    exit 1
+  fi
+  output="$(mktemp)"
+  trap 'rm -f "$output"' EXIT
+  if cargo check -p cu-feature-gated-camera --no-default-features --features jetson-mipi >"$output" 2>&1; then
+    echo "jetson-mipi unexpectedly compiled on the host target" >&2
+    exit 1
+  fi
+  rg -q 'feature `jetson-mipi` requires a Linux/aarch64 Jetson target' "$output"
+
+# Prove the optional hardware crate enters Cargo's graph on the Jetson target.
+jetson-deps target="aarch64-unknown-linux-gnu":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cd "{{ROOT}}"
+  cargo tree -p cu-feature-gated-camera --no-default-features --features jetson-mipi --target "{{target}}" | rg -q 'cu-gstreamer v'
+
+# Compile the complete hardware graph on a configured Jetson toolchain.
+jetson target="aarch64-unknown-linux-gnu":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cd "{{ROOT}}"
+  cargo check -p cu-feature-gated-camera --no-default-features --features jetson-mipi --target "{{target}}"
+
+# Run every host-verifiable feature/target combination.
+matrix: host wrong-target jetson-deps
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cd "{{ROOT}}"
+  cargo test -p cu-feature-gated-camera --no-default-features --test config_matrix
+  cargo test -p cu-feature-gated-camera --no-default-features --lib
+  cargo test -p cu-feature-gated-camera --no-default-features --features jetson-mipi --lib

--- a/examples/cu_feature_gated_camera/src/lib.rs
+++ b/examples/cu_feature_gated_camera/src/lib.rs
@@ -1,0 +1,67 @@
+#[cfg(test)]
+mod tests {
+    mod tasks {
+        use cu29::prelude::*;
+
+        #[derive(Reflect)]
+        pub struct Source;
+
+        impl Freezable for Source {}
+
+        impl CuSrcTask for Source {
+            type Resources<'r> = ();
+            type Output<'m> = output_msg!(u64);
+
+            fn new(
+                _config: Option<&ComponentConfig>,
+                _resources: Self::Resources<'_>,
+            ) -> CuResult<Self> {
+                Ok(Self)
+            }
+
+            fn process(&mut self, _ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
+                output.set_payload(1);
+                Ok(())
+            }
+        }
+
+        #[derive(Reflect)]
+        pub struct Sink;
+
+        impl Freezable for Sink {}
+
+        impl CuSinkTask for Sink {
+            type Resources<'r> = ();
+            type Input<'m> = input_msg!(u64);
+
+            fn new(
+                _config: Option<&ComponentConfig>,
+                _resources: Self::Resources<'_>,
+            ) -> CuResult<Self> {
+                Ok(Self)
+            }
+
+            fn process(&mut self, _ctx: &CuContext, _input: &Self::Input<'_>) -> CuResult<()> {
+                Ok(())
+            }
+        }
+    }
+
+    use cu29::prelude::*;
+
+    #[copper_runtime(config = "tests/forwarding/main.ron")]
+    struct FeatureForwardingApp {}
+
+    #[test]
+    fn cargo_feature_reaches_the_runtime_macro() {
+        let resolved = FeatureForwardingApp::original_config();
+
+        assert!(resolved.contains("base_source"));
+        if cfg!(feature = "jetson-mipi") {
+            assert!(resolved.contains("feature_source"));
+        } else {
+            assert!(!resolved.contains("feature_source"));
+        }
+        assert!(!resolved.contains("Feature"));
+    }
+}

--- a/examples/cu_feature_gated_camera/src/main.rs
+++ b/examples/cu_feature_gated_camera/src/main.rs
@@ -1,0 +1,54 @@
+#[cfg(any(
+    not(feature = "jetson-mipi"),
+    all(target_os = "linux", target_arch = "aarch64")
+))]
+mod tasks;
+
+#[cfg(all(
+    feature = "jetson-mipi",
+    not(all(target_os = "linux", target_arch = "aarch64"))
+))]
+compile_error!("feature `jetson-mipi` requires a Linux/aarch64 Jetson target");
+
+#[cfg(any(
+    not(feature = "jetson-mipi"),
+    all(target_os = "linux", target_arch = "aarch64")
+))]
+mod app {
+    use crate::tasks;
+    use cu29::prelude::*;
+    use std::path::PathBuf;
+
+    #[copper_runtime(config = "copperconfig.ron")]
+    struct CameraApp {}
+
+    pub fn run() -> CuResult<()> {
+        let log_path =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("logs/feature_gated_camera.copper");
+        if let Some(parent) = log_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|error| CuError::new_with_cause("creating log directory", error))?;
+        }
+
+        let mut app = CameraApp::builder()
+            .with_log_path(&log_path, Some(16 * 1024 * 1024))?
+            .build()?;
+        app.start_all_tasks()?;
+        app.run_one_iteration()?;
+        app.stop_all_tasks()
+    }
+}
+
+#[cfg(any(
+    not(feature = "jetson-mipi"),
+    all(target_os = "linux", target_arch = "aarch64")
+))]
+fn main() {
+    app::run().expect("feature-gated camera example failed");
+}
+
+#[cfg(all(
+    feature = "jetson-mipi",
+    not(all(target_os = "linux", target_arch = "aarch64"))
+))]
+fn main() {}

--- a/examples/cu_feature_gated_camera/src/tasks/base.rs
+++ b/examples/cu_feature_gated_camera/src/tasks/base.rs
@@ -1,0 +1,38 @@
+use cu29::prelude::*;
+
+#[derive(Reflect)]
+pub struct HeartbeatSource;
+
+impl Freezable for HeartbeatSource {}
+
+impl CuSrcTask for HeartbeatSource {
+    type Resources<'r> = ();
+    type Output<'m> = output_msg!(u64);
+
+    fn new(_config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self> {
+        Ok(Self)
+    }
+
+    fn process(&mut self, _ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
+        output.set_payload(1);
+        Ok(())
+    }
+}
+
+#[derive(Reflect)]
+pub struct HeartbeatSink;
+
+impl Freezable for HeartbeatSink {}
+
+impl CuSinkTask for HeartbeatSink {
+    type Resources<'r> = ();
+    type Input<'m> = input_msg!(u64);
+
+    fn new(_config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self> {
+        Ok(Self)
+    }
+
+    fn process(&mut self, _ctx: &CuContext, _input: &Self::Input<'_>) -> CuResult<()> {
+        Ok(())
+    }
+}

--- a/examples/cu_feature_gated_camera/src/tasks/jetson.rs
+++ b/examples/cu_feature_gated_camera/src/tasks/jetson.rs
@@ -1,0 +1,24 @@
+use cu_gstreamer::CuGstBuffer;
+use cu29::prelude::*;
+
+#[derive(Reflect)]
+pub struct JetsonFrameSink;
+
+impl Freezable for JetsonFrameSink {}
+
+impl CuSinkTask for JetsonFrameSink {
+    type Resources<'r> = ();
+    type Input<'m> = input_msg!(CuGstBuffer);
+
+    fn new(_config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self> {
+        Ok(Self)
+    }
+
+    fn process(&mut self, _ctx: &CuContext, input: &Self::Input<'_>) -> CuResult<()> {
+        if let Some(frame) = input.payload() {
+            let bytes = frame.map_readable()?;
+            let _frame_size = bytes.len();
+        }
+        Ok(())
+    }
+}

--- a/examples/cu_feature_gated_camera/src/tasks/mod.rs
+++ b/examples/cu_feature_gated_camera/src/tasks/mod.rs
@@ -1,0 +1,9 @@
+mod base;
+
+pub use base::*;
+
+#[cfg(all(feature = "jetson-mipi", target_os = "linux", target_arch = "aarch64"))]
+mod jetson;
+
+#[cfg(all(feature = "jetson-mipi", target_os = "linux", target_arch = "aarch64"))]
+pub use jetson::*;

--- a/examples/cu_feature_gated_camera/tests/config_matrix.rs
+++ b/examples/cu_feature_gated_camera/tests/config_matrix.rs
@@ -1,0 +1,38 @@
+use cu29::config::read_configuration_with_resolved_ron_and_features;
+use std::path::PathBuf;
+
+fn config_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("copperconfig.ron")
+}
+
+#[test]
+fn feature_off_excludes_camera_tasks_connection_and_message() {
+    let (config, resolved) =
+        read_configuration_with_resolved_ron_and_features(config_path().to_str().unwrap(), &[])
+            .unwrap();
+    let graph = config.get_graph(None).unwrap();
+
+    assert_eq!(graph.node_count(), 2);
+    assert_eq!(graph.edge_count(), 1);
+    assert!(!resolved.contains("cu_gstreamer"));
+    assert!(!resolved.contains("JetsonFrameSink"));
+    assert!(!resolved.contains("jetson_mipi.ron"));
+}
+
+#[test]
+fn feature_on_includes_camera_tasks_connection_and_message() {
+    let (config, resolved) = read_configuration_with_resolved_ron_and_features(
+        config_path().to_str().unwrap(),
+        &["jetson-mipi"],
+    )
+    .unwrap();
+    let graph = config.get_graph(None).unwrap();
+
+    assert_eq!(graph.node_count(), 4);
+    assert_eq!(graph.edge_count(), 2);
+    assert!(resolved.contains("cu_gstreamer::CuDefaultGStreamer"));
+    assert!(resolved.contains("cu_gstreamer::CuGstBuffer"));
+    assert!(resolved.contains("tasks::JetsonFrameSink"));
+    assert!(!resolved.contains("jetson_mipi.ron"));
+    assert!(!resolved.contains("Feature"));
+}

--- a/examples/cu_feature_gated_camera/tests/forwarding/base.ron
+++ b/examples/cu_feature_gated_camera/tests/forwarding/base.ron
@@ -1,0 +1,19 @@
+(
+    tasks: [
+        (
+            id: "base_source",
+            type: "tasks::Source",
+        ),
+        (
+            id: "base_sink",
+            type: "tasks::Sink",
+        ),
+    ],
+    cnx: [
+        (
+            src: "base_source",
+            dst: "base_sink",
+            msg: "u64",
+        ),
+    ],
+)

--- a/examples/cu_feature_gated_camera/tests/forwarding/feature.ron
+++ b/examples/cu_feature_gated_camera/tests/forwarding/feature.ron
@@ -1,0 +1,19 @@
+(
+    tasks: [
+        (
+            id: "feature_source",
+            type: "tasks::Source",
+        ),
+        (
+            id: "feature_sink",
+            type: "tasks::Sink",
+        ),
+    ],
+    cnx: [
+        (
+            src: "feature_source",
+            dst: "feature_sink",
+            msg: "u64",
+        ),
+    ],
+)

--- a/examples/cu_feature_gated_camera/tests/forwarding/main.ron
+++ b/examples/cu_feature_gated_camera/tests/forwarding/main.ron
@@ -1,0 +1,9 @@
+(
+    includes: [
+        (path: "base.ron"),
+        (
+            path: "feature.ron",
+            when: Feature("jetson-mipi"),
+        ),
+    ],
+)


### PR DESCRIPTION
## Summary
- add `when: Feature(...)`, `Not(...)`, `All(...)`, and `Any(...)` predicates to RON includes
- forward Cargo features through the unconditional `cu29_build::setup()` call into compile-time generation and runtime config reloads
- cover single configs, multi-Copper configs, missions, and resolved RON bundling
- add a complete Jetson MIPI camera example whose dependency, tasks, connection, and message type disappear together when disabled

Stacked on #1202.

## Verification
- `just lint`
- `just -f examples/cu_feature_gated_camera/justfile matrix`
- `cargo test -p cu29-runtime --test includes`
- `cargo test -p cu29-derive`
- `cargo test -p cu29-build`