### PR TITLE
CuAnytimeTask trait for supporting anytime algorithm

### DIFF
--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -961,30 +961,23 @@ pub fn cu29_runtime::simulation::CuSimBridge<Tx, Rx>::thaw<D: cu_bincode::de::De
 pub fn cu29_runtime::cutask::encode_metadata_only<T, M, E>(msg: &cu29_runtime::cutask::CuStampedData<T, M>, encoder: &mut E) -> core::result::Result<(), cu_bincode::error::EncodeError> where T: cu29_runtime::cutask::CuMsgPayload, M: cu29_traits::Metadata, E: cu_bincode::enc::Encoder
 pub type cu29_runtime::cutask::CuMsg<T> = cu29_runtime::cutask::CuStampedData<T, cu29_runtime::cutask::CuMsgMetadata>
 pub mod cu29_runtime::cutask_anytime
-pub enum cu29_runtime::cutask_anytime::AnytimeStatus
+pub enum cu29_runtime::cutask_anytime::AnytimeStatus<Q>
 pub cu29_runtime::cutask_anytime::AnytimeStatus::Aborted
-pub cu29_runtime::cutask_anytime::AnytimeStatus::Aborted::error: core::option::Option<cu29_traits::CuError>
-pub cu29_runtime::cutask_anytime::AnytimeStatus::Converged
-pub cu29_runtime::cutask_anytime::AnytimeStatus::Converged::quality: core::option::Option<cu29_runtime::cutask_anytime::Quality>
-pub cu29_runtime::cutask_anytime::AnytimeStatus::Improved
-pub cu29_runtime::cutask_anytime::AnytimeStatus::Improved::quality: core::option::Option<cu29_runtime::cutask_anytime::Quality>
-pub struct cu29_runtime::cutask_anytime::AnytimeStep
-pub cu29_runtime::cutask_anytime::AnytimeStep::best_quality: core::option::Option<cu29_runtime::cutask_anytime::Quality>
-pub cu29_runtime::cutask_anytime::AnytimeStep::elapsed: cu29_clock::CuDuration
-pub cu29_runtime::cutask_anytime::AnytimeStep::iteration: u32
-pub cu29_runtime::cutask_anytime::AnytimeStep::remaining: core::option::Option<cu29_clock::CuDuration>
+pub cu29_runtime::cutask_anytime::AnytimeStatus::Converged(Q)
+pub cu29_runtime::cutask_anytime::AnytimeStatus::Improved(Q)
 pub trait cu29_runtime::cutask_anytime::CuAnytimeTask: cu29_runtime::cutask::Freezable + cu29_runtime::reflect::Reflect
 pub type cu29_runtime::cutask_anytime::CuAnytimeTask::Input<'m>: cu29_runtime::cutask::CuMsgPack
 pub type cu29_runtime::cutask_anytime::CuAnytimeTask::Output<'m>: cu29_runtime::cutask::CuMsgPayload
+pub type cu29_runtime::cutask_anytime::CuAnytimeTask::Quality: core::marker::Copy + core::cmp::PartialOrd
 pub type cu29_runtime::cutask_anytime::CuAnytimeTask::Resources<'r>
-pub fn cu29_runtime::cutask_anytime::CuAnytimeTask::base<'i, 'o>(&mut self, ctx: &cu29_runtime::context::CuContext, input: &Self::Input, output: &mut Self::Output) -> cu29_traits::CuResult<cu29_runtime::cutask_anytime::AnytimeStatus>
+pub fn cu29_runtime::cutask_anytime::CuAnytimeTask::base<'i, 'o>(&mut self, ctx: &cu29_runtime::context::CuContext, input: &Self::Input, output: &mut Self::Output) -> cu29_traits::CuResult<cu29_runtime::cutask_anytime::AnytimeStatus<Self::Quality>>
 pub fn cu29_runtime::cutask_anytime::CuAnytimeTask::new(_config: core::option::Option<&cu29_runtime::config::ComponentConfig>, _resources: Self::Resources) -> cu29_traits::CuResult<Self> where Self: core::marker::Sized
 pub fn cu29_runtime::cutask_anytime::CuAnytimeTask::postprocess(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
 pub fn cu29_runtime::cutask_anytime::CuAnytimeTask::preprocess(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
-pub fn cu29_runtime::cutask_anytime::CuAnytimeTask::refine<'o>(&mut self, ctx: &cu29_runtime::context::CuContext, step: &cu29_runtime::cutask_anytime::AnytimeStep, output: &mut Self::Output) -> cu29_traits::CuResult<cu29_runtime::cutask_anytime::AnytimeStatus>
+pub fn cu29_runtime::cutask_anytime::CuAnytimeTask::refine<'o>(&mut self, ctx: &cu29_runtime::context::CuContext, output: &mut Self::Output) -> cu29_traits::CuResult<cu29_runtime::cutask_anytime::AnytimeStatus<Self::Quality>>
 pub fn cu29_runtime::cutask_anytime::CuAnytimeTask::start(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
 pub fn cu29_runtime::cutask_anytime::CuAnytimeTask::stop(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
-pub type cu29_runtime::cutask_anytime::Quality = f32
+pub type cu29_runtime::cutask_anytime::Quality = cu29_units::si::f32::Ratio
 pub mod cu29_runtime::debug
 pub struct cu29_runtime::debug::CuDebugSession<App, P, CB, TF, S, L> where P: cu29_traits::CopperListTuple, S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static
 impl<App, P, CB, TF, S, L> cu29_runtime::debug::CuDebugSession<App, P, CB, TF, S, L> where App: cu29_runtime::app::CuSimApplication<S, L> + cu29_runtime::reflect::ReflectTaskIntrospection, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, S: cu29_unifiedlog::SectionStorage, P: cu29_traits::CopperListTuple, CB: for<'a> core::ops::function::Fn(&'a cu29_runtime::copperlist::CopperList<P>, cu29_clock::RobotClock, cu29_clock::RobotClockMock) -> alloc::boxed::Box<(dyn for<'z> core::ops::function::FnMut(<App as cu29_runtime::app::CuSimApplication>::Step) -> cu29_runtime::simulation::SimOverride + 'a)>, TF: core::ops::function::Fn(&cu29_runtime::copperlist::CopperList<P>) -> core::option::Option<cu29_clock::CuTime> + core::clone::Clone

--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -960,6 +960,31 @@ pub fn cu29_runtime::simulation::CuSimBridge<Tx, Rx>::freeze<E: cu_bincode::enc:
 pub fn cu29_runtime::simulation::CuSimBridge<Tx, Rx>::thaw<D: cu_bincode::de::Decoder>(&mut self, _decoder: &mut D) -> core::result::Result<(), cu_bincode::error::DecodeError>
 pub fn cu29_runtime::cutask::encode_metadata_only<T, M, E>(msg: &cu29_runtime::cutask::CuStampedData<T, M>, encoder: &mut E) -> core::result::Result<(), cu_bincode::error::EncodeError> where T: cu29_runtime::cutask::CuMsgPayload, M: cu29_traits::Metadata, E: cu_bincode::enc::Encoder
 pub type cu29_runtime::cutask::CuMsg<T> = cu29_runtime::cutask::CuStampedData<T, cu29_runtime::cutask::CuMsgMetadata>
+pub mod cu29_runtime::cutask_anytime
+pub enum cu29_runtime::cutask_anytime::AnytimeStatus
+pub cu29_runtime::cutask_anytime::AnytimeStatus::Aborted
+pub cu29_runtime::cutask_anytime::AnytimeStatus::Aborted::error: core::option::Option<cu29_traits::CuError>
+pub cu29_runtime::cutask_anytime::AnytimeStatus::Converged
+pub cu29_runtime::cutask_anytime::AnytimeStatus::Converged::quality: core::option::Option<cu29_runtime::cutask_anytime::Quality>
+pub cu29_runtime::cutask_anytime::AnytimeStatus::Improved
+pub cu29_runtime::cutask_anytime::AnytimeStatus::Improved::quality: core::option::Option<cu29_runtime::cutask_anytime::Quality>
+pub struct cu29_runtime::cutask_anytime::AnytimeStep
+pub cu29_runtime::cutask_anytime::AnytimeStep::best_quality: core::option::Option<cu29_runtime::cutask_anytime::Quality>
+pub cu29_runtime::cutask_anytime::AnytimeStep::elapsed: cu29_clock::CuDuration
+pub cu29_runtime::cutask_anytime::AnytimeStep::iteration: u32
+pub cu29_runtime::cutask_anytime::AnytimeStep::remaining: core::option::Option<cu29_clock::CuDuration>
+pub trait cu29_runtime::cutask_anytime::CuAnytimeTask: cu29_runtime::cutask::Freezable + cu29_runtime::reflect::Reflect
+pub type cu29_runtime::cutask_anytime::CuAnytimeTask::Input<'m>: cu29_runtime::cutask::CuMsgPack
+pub type cu29_runtime::cutask_anytime::CuAnytimeTask::Output<'m>: cu29_runtime::cutask::CuMsgPayload
+pub type cu29_runtime::cutask_anytime::CuAnytimeTask::Resources<'r>
+pub fn cu29_runtime::cutask_anytime::CuAnytimeTask::base<'i, 'o>(&mut self, ctx: &cu29_runtime::context::CuContext, input: &Self::Input, output: &mut Self::Output) -> cu29_traits::CuResult<cu29_runtime::cutask_anytime::AnytimeStatus>
+pub fn cu29_runtime::cutask_anytime::CuAnytimeTask::new(_config: core::option::Option<&cu29_runtime::config::ComponentConfig>, _resources: Self::Resources) -> cu29_traits::CuResult<Self> where Self: core::marker::Sized
+pub fn cu29_runtime::cutask_anytime::CuAnytimeTask::postprocess(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::cutask_anytime::CuAnytimeTask::preprocess(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::cutask_anytime::CuAnytimeTask::refine<'o>(&mut self, ctx: &cu29_runtime::context::CuContext, step: &cu29_runtime::cutask_anytime::AnytimeStep, output: &mut Self::Output) -> cu29_traits::CuResult<cu29_runtime::cutask_anytime::AnytimeStatus>
+pub fn cu29_runtime::cutask_anytime::CuAnytimeTask::start(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::cutask_anytime::CuAnytimeTask::stop(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub type cu29_runtime::cutask_anytime::Quality = f32
 pub mod cu29_runtime::debug
 pub struct cu29_runtime::debug::CuDebugSession<App, P, CB, TF, S, L> where P: cu29_traits::CopperListTuple, S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static
 impl<App, P, CB, TF, S, L> cu29_runtime::debug::CuDebugSession<App, P, CB, TF, S, L> where App: cu29_runtime::app::CuSimApplication<S, L> + cu29_runtime::reflect::ReflectTaskIntrospection, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, S: cu29_unifiedlog::SectionStorage, P: cu29_traits::CopperListTuple, CB: for<'a> core::ops::function::Fn(&'a cu29_runtime::copperlist::CopperList<P>, cu29_clock::RobotClock, cu29_clock::RobotClockMock) -> alloc::boxed::Box<(dyn for<'z> core::ops::function::FnMut(<App as cu29_runtime::app::CuSimApplication>::Step) -> cu29_runtime::simulation::SimOverride + 'a)>, TF: core::ops::function::Fn(&cu29_runtime::copperlist::CopperList<P>) -> core::option::Option<cu29_clock::CuTime> + core::clone::Clone

--- a/api/v1/cu29.txt
+++ b/api/v1/cu29.txt
@@ -12,6 +12,7 @@ pub use cu29::cuasynctask
 pub use cu29::cubridge
 pub use cu29::curuntime
 pub use cu29::cutask
+pub use cu29::cutask_anytime
 pub use cu29::debug
 pub use cu29::distributed_replay
 pub use cu29::input_msg

--- a/core/cu29/src/lib.rs
+++ b/core/cu29/src/lib.rs
@@ -78,6 +78,7 @@ pub use cu29_runtime::cuasynctask;
 pub use cu29_runtime::cubridge;
 pub use cu29_runtime::curuntime;
 pub use cu29_runtime::cutask;
+pub use cu29_runtime::cutask_anytime;
 #[cfg(feature = "std")]
 pub use cu29_runtime::debug;
 #[cfg(feature = "std")]

--- a/core/cu29_runtime/Cargo.toml
+++ b/core/cu29_runtime/Cargo.toml
@@ -23,9 +23,9 @@ cu29-clock = { workspace = true }
 cu29-intern-strs = { workspace = true, optional = true }
 cu29-log = { workspace = true }
 cu29-log-derive = { workspace = true }
-cu29-log-runtime = { workspace = true }                  # needed
+cu29-log-runtime = { workspace = true }                                              # needed
 cu29-traits = { workspace = true }
-cu29-units = { workspace = true, optional = true }
+cu29-units = { path = "../cu29_units", version = "1.0.0", default-features = false }
 cu29-unifiedlog = { workspace = true }
 cu29-value = { workspace = true }
 
@@ -114,7 +114,6 @@ remote-debug = [
   "std",
   "reflect",
   "dep:cu29-intern-strs",
-  "dep:cu29-units",
   "dep:serde_json",
   "dep:zenoh",
   "dep:minicbor-serde",
@@ -134,6 +133,7 @@ std = [
   "portable-atomic/require-cas",
   "cu29-clock/std",
   "cu29-log/std",
+  "cu29-units/std",
   "cu29-log-runtime/std",
   "cu29-traits/std",
   "cu29-unifiedlog/std",

--- a/core/cu29_runtime/src/cutask_anytime.rs
+++ b/core/cu29_runtime/src/cutask_anytime.rs
@@ -12,11 +12,13 @@ use crate::context::CuContext;
 use crate::cutask::{CuMsgPack, CuMsgPayload, Freezable};
 use crate::reflect::Reflect;
 use cu29_traits::CuResult;
+use cu29_units::si::f32::Ratio;
 
-/// Normalized quality of a published result: a unit ratio in `0.0..=1.0`, higher is
-/// better and `1.0` means no further improvement is meaningful. Sharing one scale
-/// across tasks keeps a configured quality target portable.
-pub type Quality = f32;
+/// Normalized quality of a published result: a dimensionless [`Ratio`] in
+/// `0.0..=1.0`, higher is better and `1.0` means no further improvement is
+/// meaningful. Sharing one scale across tasks keeps a configured quality target
+/// portable.
+pub type Quality = Ratio;
 
 /// Returned by [`CuAnytimeTask::base`] and [`CuAnytimeTask::refine`]; drives the
 /// runtime's refinement scheduling.
@@ -40,11 +42,6 @@ pub enum AnytimeStatus<Q> {
     /// for this job. Refinement stops; the output is published as-is, so a task that
     /// can no longer vouch even for its base result must clear the payload before
     /// returning this. The next copperlist starts a fresh job.
-    ///
-    /// This is a controlled per-job outcome, not a failure, so it carries no error:
-    /// return it when retrying with fresh input could plausibly succeed (logging any
-    /// diagnostics from the task), and return `Err` from `base`/`refine` when the
-    /// task itself is broken.
     Aborted,
 }
 
@@ -142,6 +139,7 @@ mod tests {
     use crate::cutask::CuMsg;
     use crate::input_msg;
     use crate::output_msg;
+    use cu29_units::si::ratio::ratio;
 
     /// Sums its input one increment per quantum: base publishes 0, each refine
     /// commits one more increment until the captured input is fully consumed.
@@ -175,7 +173,7 @@ mod tests {
             self.target = *input.payload().ok_or("no input")?;
             self.acc = 0;
             output.set_payload(self.acc);
-            Ok(AnytimeStatus::Improved(0.0))
+            Ok(AnytimeStatus::Improved(Quality::new::<ratio>(0.0)))
         }
 
         fn refine<'o>(
@@ -184,13 +182,13 @@ mod tests {
             output: &mut Self::Output<'o>,
         ) -> CuResult<AnytimeStatus<Quality>> {
             if self.acc == self.target {
-                return Ok(AnytimeStatus::Converged(1.0));
+                return Ok(AnytimeStatus::Converged(Quality::new::<ratio>(1.0)));
             }
             self.acc += 1;
             output.set_payload(self.acc);
-            Ok(AnytimeStatus::Improved(
-                self.acc as Quality / self.target as Quality,
-            ))
+            Ok(AnytimeStatus::Improved(Quality::new::<ratio>(
+                self.acc as f32 / self.target as f32,
+            )))
         }
     }
 
@@ -207,7 +205,7 @@ mod tests {
         assert!(matches!(status, AnytimeStatus::Improved(_)));
         assert_eq!(output.payload(), Some(&0));
 
-        let mut best_quality = 0.0;
+        let mut best_quality = Quality::new::<ratio>(0.0);
         for _ in 0..8 {
             match task.refine(&ctx, &mut output).unwrap() {
                 AnytimeStatus::Improved(quality) => best_quality = quality,
@@ -219,7 +217,7 @@ mod tests {
             }
         }
         assert_eq!(output.payload(), Some(&3));
-        assert_eq!(best_quality, 1.0);
+        assert_eq!(best_quality.get::<ratio>(), 1.0);
         task.postprocess(&ctx).unwrap();
         task.stop(&ctx).unwrap();
     }

--- a/core/cu29_runtime/src/cutask_anytime.rs
+++ b/core/cu29_runtime/src/cutask_anytime.rs
@@ -4,58 +4,48 @@
 //! plus optional bounded improvements ([`CuAnytimeTask::refine`]). The task *reports*
 //! what each quantum achieved through [`AnytimeStatus`]; the runtime *decides* whether
 //! to schedule another quantum from that status stream and its configured time budget
-//! and quality target. The task never sees the policy, only the [`AnytimeStep`] hints,
-//! so implementations stay reusable under any policy.
+//! and quality target. The task never sees the policy, so implementations stay
+//! reusable under any policy.
 
 use crate::config::ComponentConfig;
 use crate::context::CuContext;
 use crate::cutask::{CuMsgPack, CuMsgPayload, Freezable};
 use crate::reflect::Reflect;
-use cu29_clock::CuDuration;
-use cu29_traits::{CuError, CuResult};
+use cu29_traits::CuResult;
 
-/// User-defined quality metric; higher is better. The scale is task-defined but must
-/// be consistent with the quality target configured for the task.
+/// Normalized quality of a published result: a unit ratio in `0.0..=1.0`, higher is
+/// better and `1.0` means no further improvement is meaningful. Sharing one scale
+/// across tasks keeps a configured quality target portable.
 pub type Quality = f32;
 
 /// Returned by [`CuAnytimeTask::base`] and [`CuAnytimeTask::refine`]; drives the
 /// runtime's refinement scheduling.
+///
+/// `Q` is [`CuAnytimeTask::Quality`]: [`Quality`] for tasks that can score their
+/// result, `()` for tasks that cannot.
 ///
 /// After any `Ok` return, the output must be valid and hold the best result produced
 /// so far for the current job: a quantum that regresses or plateaus keeps its
 /// candidate in task-local state and leaves the output untouched. The runtime never
 /// buffers or rolls back the output, so it can publish it at any stop point, and the
 /// published quality is monotone even when the algorithm internally is not.
-#[derive(Debug, Clone)]
-pub enum AnytimeStatus {
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AnytimeStatus<Q> {
     /// The output holds the best result so far; further refinement may help.
-    Improved { quality: Option<Quality> },
+    Improved(Q),
     /// Proactive yield: no further improvement is possible for this job. The output
     /// holds the final result.
-    Converged { quality: Option<Quality> },
+    Converged(Q),
     /// Proactive give-up: the algorithm diverged or reached an unrecoverable state
     /// for this job. Refinement stops; the output is published as-is, so a task that
     /// can no longer vouch even for its base result must clear the payload before
     /// returning this. The next copperlist starts a fresh job.
     ///
-    /// Return this when retrying with fresh input could plausibly succeed; return
-    /// `Err` from `base`/`refine` when the task itself is broken.
-    Aborted { error: Option<CuError> },
-}
-
-/// Runtime knowledge passed to [`CuAnytimeTask::refine`] — scheduling hints, not
-/// commands.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct AnytimeStep {
-    /// 0 for the first `refine()` after `base()`.
-    pub iteration: u32,
-    /// Time since `base()` started for this job.
-    pub elapsed: CuDuration,
-    /// Time left in the budget; `None` if no time budget is configured. A task can
-    /// use this to size its next quantum (e.g. skip a strategy that cannot fit).
-    pub remaining: Option<CuDuration>,
-    /// Best quality reported so far for this job, including by `base()`.
-    pub best_quality: Option<Quality>,
+    /// This is a controlled per-job outcome, not a failure, so it carries no error:
+    /// return it when retrying with fresh input could plausibly succeed (logging any
+    /// diagnostics from the task), and return `Err` from `base`/`refine` when the
+    /// task itself is broken.
+    Aborted,
 }
 
 /// A task producing a valid result from the bare-minimum compute, then improving it
@@ -69,6 +59,11 @@ pub trait CuAnytimeTask: Freezable + Reflect {
     type Output<'m>: CuMsgPayload;
     /// Resources required by the task.
     type Resources<'r>;
+    /// Measure reported through [`AnytimeStatus`]: [`Quality`] for tasks that can
+    /// score their result, `()` for tasks that cannot. A quality target can only be
+    /// configured for tasks whose `Quality` is comparable to it, so a target on a
+    /// `()` task is rejected at compile time.
+    type Quality: Copy + PartialOrd;
 
     /// Here you need to initialize everything your task will need for the duration
     /// of its lifetime. The config allows you to access the configuration of the task.
@@ -105,7 +100,7 @@ pub trait CuAnytimeTask: Freezable + Reflect {
         ctx: &CuContext,
         input: &Self::Input<'i>,
         output: &mut Self::Output<'o>,
-    ) -> CuResult<AnytimeStatus>;
+    ) -> CuResult<AnytimeStatus<Self::Quality>>;
 
     /// Performs exactly one bounded refinement quantum.
     ///
@@ -113,15 +108,18 @@ pub trait CuAnytimeTask: Freezable + Reflect {
     /// far for this job; see [`AnytimeStatus`] for the commit-only-improvements
     /// contract.
     ///
+    /// Anything a quantum could want to know about its own job the task already has:
+    /// it can count its quanta, read the clock through `ctx`, and remembers the last
+    /// quality it reported.
+    ///
     /// This method must not contain an unbounded refinement loop: the runtime can
     /// only observe time and quality *between* calls, so one call must be one
     /// bounded quantum.
     fn refine<'o>(
         &mut self,
         ctx: &CuContext,
-        step: &AnytimeStep,
         output: &mut Self::Output<'o>,
-    ) -> CuResult<AnytimeStatus>;
+    ) -> CuResult<AnytimeStatus<Self::Quality>>;
 
     /// This is a method called by the runtime after the job's refinement window has
     /// closed. It is best effort a chance for the task to update some state out of
@@ -159,6 +157,7 @@ mod tests {
         type Input<'m> = input_msg!(u32);
         type Output<'m> = output_msg!(u32);
         type Resources<'r> = ();
+        type Quality = Quality;
 
         fn new(
             _config: Option<&ComponentConfig>,
@@ -172,27 +171,26 @@ mod tests {
             _ctx: &CuContext,
             input: &Self::Input<'i>,
             output: &mut Self::Output<'o>,
-        ) -> CuResult<AnytimeStatus> {
+        ) -> CuResult<AnytimeStatus<Quality>> {
             self.target = *input.payload().ok_or("no input")?;
             self.acc = 0;
             output.set_payload(self.acc);
-            Ok(AnytimeStatus::Improved { quality: Some(0.0) })
+            Ok(AnytimeStatus::Improved(0.0))
         }
 
         fn refine<'o>(
             &mut self,
             _ctx: &CuContext,
-            _step: &AnytimeStep,
             output: &mut Self::Output<'o>,
-        ) -> CuResult<AnytimeStatus> {
+        ) -> CuResult<AnytimeStatus<Quality>> {
             if self.acc == self.target {
-                return Ok(AnytimeStatus::Converged { quality: Some(1.0) });
+                return Ok(AnytimeStatus::Converged(1.0));
             }
             self.acc += 1;
             output.set_payload(self.acc);
-            Ok(AnytimeStatus::Improved {
-                quality: Some(self.acc as Quality / self.target as Quality),
-            })
+            Ok(AnytimeStatus::Improved(
+                self.acc as Quality / self.target as Quality,
+            ))
         }
     }
 
@@ -206,25 +204,22 @@ mod tests {
         task.start(&ctx).unwrap();
         task.preprocess(&ctx).unwrap();
         let status = task.base(&ctx, &input, &mut output).unwrap();
-        assert!(matches!(status, AnytimeStatus::Improved { .. }));
+        assert!(matches!(status, AnytimeStatus::Improved(_)));
         assert_eq!(output.payload(), Some(&0));
 
-        let mut best_quality = Some(0.0);
-        for iteration in 0..8 {
-            let step = AnytimeStep {
-                iteration,
-                elapsed: CuDuration(0),
-                remaining: None,
-                best_quality,
-            };
-            match task.refine(&ctx, &step, &mut output).unwrap() {
-                AnytimeStatus::Improved { quality } => best_quality = quality,
-                AnytimeStatus::Converged { .. } => break,
+        let mut best_quality = 0.0;
+        for _ in 0..8 {
+            match task.refine(&ctx, &mut output).unwrap() {
+                AnytimeStatus::Improved(quality) => best_quality = quality,
+                AnytimeStatus::Converged(quality) => {
+                    best_quality = quality;
+                    break;
+                }
                 status => panic!("unexpected status: {status:?}"),
             }
         }
         assert_eq!(output.payload(), Some(&3));
-        assert_eq!(best_quality, Some(1.0));
+        assert_eq!(best_quality, 1.0);
         task.postprocess(&ctx).unwrap();
         task.stop(&ctx).unwrap();
     }

--- a/core/cu29_runtime/src/cutask_anytime.rs
+++ b/core/cu29_runtime/src/cutask_anytime.rs
@@ -1,0 +1,231 @@
+//! Trait and types to implement an anytime Copper task.
+//!
+//! An anytime task splits its work into a mandatory minimum ([`CuAnytimeTask::base`])
+//! plus optional bounded improvements ([`CuAnytimeTask::refine`]). The task *reports*
+//! what each quantum achieved through [`AnytimeStatus`]; the runtime *decides* whether
+//! to schedule another quantum from that status stream and its configured time budget
+//! and quality target. The task never sees the policy, only the [`AnytimeStep`] hints,
+//! so implementations stay reusable under any policy.
+
+use crate::config::ComponentConfig;
+use crate::context::CuContext;
+use crate::cutask::{CuMsgPack, CuMsgPayload, Freezable};
+use crate::reflect::Reflect;
+use cu29_clock::CuDuration;
+use cu29_traits::{CuError, CuResult};
+
+/// User-defined quality metric; higher is better. The scale is task-defined but must
+/// be consistent with the quality target configured for the task.
+pub type Quality = f32;
+
+/// Returned by [`CuAnytimeTask::base`] and [`CuAnytimeTask::refine`]; drives the
+/// runtime's refinement scheduling.
+///
+/// After any `Ok` return, the output must be valid and hold the best result produced
+/// so far for the current job: a quantum that regresses or plateaus keeps its
+/// candidate in task-local state and leaves the output untouched. The runtime never
+/// buffers or rolls back the output, so it can publish it at any stop point, and the
+/// published quality is monotone even when the algorithm internally is not.
+#[derive(Debug, Clone)]
+pub enum AnytimeStatus {
+    /// The output holds the best result so far; further refinement may help.
+    Improved { quality: Option<Quality> },
+    /// Proactive yield: no further improvement is possible for this job. The output
+    /// holds the final result.
+    Converged { quality: Option<Quality> },
+    /// Proactive give-up: the algorithm diverged or reached an unrecoverable state
+    /// for this job. Refinement stops; the output is published as-is, so a task that
+    /// can no longer vouch even for its base result must clear the payload before
+    /// returning this. The next copperlist starts a fresh job.
+    ///
+    /// Return this when retrying with fresh input could plausibly succeed; return
+    /// `Err` from `base`/`refine` when the task itself is broken.
+    Aborted { error: Option<CuError> },
+}
+
+/// Runtime knowledge passed to [`CuAnytimeTask::refine`] — scheduling hints, not
+/// commands.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AnytimeStep {
+    /// 0 for the first `refine()` after `base()`.
+    pub iteration: u32,
+    /// Time since `base()` started for this job.
+    pub elapsed: CuDuration,
+    /// Time left in the budget; `None` if no time budget is configured. A task can
+    /// use this to size its next quantum (e.g. skip a strategy that cannot fit).
+    pub remaining: Option<CuDuration>,
+    /// Best quality reported so far for this job, including by `base()`.
+    pub best_quality: Option<Quality>,
+}
+
+/// A task producing a valid result from the bare-minimum compute, then improving it
+/// in bounded quanta for as long as the runtime allows.
+///
+/// Per job: `preprocess` → `base` → N × `refine` → `postprocess`, where N is chosen
+/// by the runtime (possibly 0: a time budget may suppress every refinement, but
+/// never the base computation).
+pub trait CuAnytimeTask: Freezable + Reflect {
+    type Input<'m>: CuMsgPack;
+    type Output<'m>: CuMsgPayload;
+    /// Resources required by the task.
+    type Resources<'r>;
+
+    /// Here you need to initialize everything your task will need for the duration
+    /// of its lifetime. The config allows you to access the configuration of the task.
+    fn new(_config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self>
+    where
+        Self: Sized;
+
+    /// Start is called between the creation of the task and the first call to
+    /// pre/base.
+    fn start(&mut self, _ctx: &CuContext) -> CuResult<()> {
+        Ok(())
+    }
+
+    /// This is a method called by the runtime before "base". This is a kind of best
+    /// effort, as soon as possible call to give a chance for the task to do some work
+    /// before to prepare to make "base" as short as possible.
+    fn preprocess(&mut self, _ctx: &CuContext) -> CuResult<()> {
+        Ok(())
+    }
+
+    /// Starts a new job and writes its minimum valid result into `output`.
+    ///
+    /// On `Ok`: `output` is valid and safe to publish, refinement state from the
+    /// preceding job has been reset, and later `refine()` calls improve this job.
+    /// The task must capture into its own per-job state everything refinement will
+    /// need from `input`: `refine()` does not receive the input (in background
+    /// placements refinement outlives the copperlist that carried it), and the task
+    /// knows the cheapest representation to retain.
+    ///
+    /// On `Err`: the job produced no valid output and the error propagates like a
+    /// `CuTask::process` failure.
+    fn base<'i, 'o>(
+        &mut self,
+        ctx: &CuContext,
+        input: &Self::Input<'i>,
+        output: &mut Self::Output<'o>,
+    ) -> CuResult<AnytimeStatus>;
+
+    /// Performs exactly one bounded refinement quantum.
+    ///
+    /// On `Ok` (any status), `output` is valid and holds the best result produced so
+    /// far for this job; see [`AnytimeStatus`] for the commit-only-improvements
+    /// contract.
+    ///
+    /// This method must not contain an unbounded refinement loop: the runtime can
+    /// only observe time and quality *between* calls, so one call must be one
+    /// bounded quantum.
+    fn refine<'o>(
+        &mut self,
+        ctx: &CuContext,
+        step: &AnytimeStep,
+        output: &mut Self::Output<'o>,
+    ) -> CuResult<AnytimeStatus>;
+
+    /// This is a method called by the runtime after the job's refinement window has
+    /// closed. It is best effort a chance for the task to update some state out of
+    /// the critical path, for example to release scratch memory or maintain
+    /// statistics that are not time-critical for the robot.
+    fn postprocess(&mut self, _ctx: &CuContext) -> CuResult<()> {
+        Ok(())
+    }
+
+    /// Called to stop the task. It signals that `base`/`refine` won't be called
+    /// until start is called again.
+    fn stop(&mut self, _ctx: &CuContext) -> CuResult<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cutask::CuMsg;
+    use crate::input_msg;
+    use crate::output_msg;
+
+    /// Sums its input one increment per quantum: base publishes 0, each refine
+    /// commits one more increment until the captured input is fully consumed.
+    #[derive(Reflect)]
+    struct IncrementalSum {
+        target: u32,
+        acc: u32,
+    }
+
+    impl Freezable for IncrementalSum {}
+
+    impl CuAnytimeTask for IncrementalSum {
+        type Input<'m> = input_msg!(u32);
+        type Output<'m> = output_msg!(u32);
+        type Resources<'r> = ();
+
+        fn new(
+            _config: Option<&ComponentConfig>,
+            _resources: Self::Resources<'_>,
+        ) -> CuResult<Self> {
+            Ok(Self { target: 0, acc: 0 })
+        }
+
+        fn base<'i, 'o>(
+            &mut self,
+            _ctx: &CuContext,
+            input: &Self::Input<'i>,
+            output: &mut Self::Output<'o>,
+        ) -> CuResult<AnytimeStatus> {
+            self.target = *input.payload().ok_or("no input")?;
+            self.acc = 0;
+            output.set_payload(self.acc);
+            Ok(AnytimeStatus::Improved { quality: Some(0.0) })
+        }
+
+        fn refine<'o>(
+            &mut self,
+            _ctx: &CuContext,
+            _step: &AnytimeStep,
+            output: &mut Self::Output<'o>,
+        ) -> CuResult<AnytimeStatus> {
+            if self.acc == self.target {
+                return Ok(AnytimeStatus::Converged { quality: Some(1.0) });
+            }
+            self.acc += 1;
+            output.set_payload(self.acc);
+            Ok(AnytimeStatus::Improved {
+                quality: Some(self.acc as Quality / self.target as Quality),
+            })
+        }
+    }
+
+    #[test]
+    fn base_then_refine_until_converged() {
+        let ctx = CuContext::new_with_clock();
+        let mut task = IncrementalSum::new(None, ()).unwrap();
+        let input = CuMsg::new(Some(3u32));
+        let mut output = CuMsg::new(None);
+
+        task.start(&ctx).unwrap();
+        task.preprocess(&ctx).unwrap();
+        let status = task.base(&ctx, &input, &mut output).unwrap();
+        assert!(matches!(status, AnytimeStatus::Improved { .. }));
+        assert_eq!(output.payload(), Some(&0));
+
+        let mut best_quality = Some(0.0);
+        for iteration in 0..8 {
+            let step = AnytimeStep {
+                iteration,
+                elapsed: CuDuration(0),
+                remaining: None,
+                best_quality,
+            };
+            match task.refine(&ctx, &step, &mut output).unwrap() {
+                AnytimeStatus::Improved { quality } => best_quality = quality,
+                AnytimeStatus::Converged { .. } => break,
+                status => panic!("unexpected status: {status:?}"),
+            }
+        }
+        assert_eq!(output.payload(), Some(&3));
+        assert_eq!(best_quality, Some(1.0));
+        task.postprocess(&ctx).unwrap();
+        task.stop(&ctx).unwrap();
+    }
+}

--- a/core/cu29_runtime/src/lib.rs
+++ b/core/cu29_runtime/src/lib.rs
@@ -21,6 +21,7 @@ pub mod cuasynctask; // no no-std version yet
 pub mod cubridge;
 pub mod curuntime;
 pub mod cutask;
+pub mod cutask_anytime;
 #[cfg(feature = "std")]
 pub mod debug;
 #[cfg(feature = "std")]


### PR DESCRIPTION
Adds the task-facing contract for anytime tasks: a mandatory `base()` producing a minimum valid result, then bounded `refine()` quanta the runtime schedules until its policy (time budget / quality target) says stop.

- `CuAnytimeTask`: `new`/`start`/`preprocess`/`base`/`refine`/`postprocess`/`stop`. `refine()` takes no input: `base()` captures what refinement needs into per-job state.
- `AnytimeStatus` (`Improved`/`Converged`/`Aborted`): task reports, runtime decides. Output must always hold the best result so far, so the runtime can publish at any stop point without buffering or rollback.
- `AnytimeStep`: per-quantum scheduling hints (iteration, elapsed, remaining budget, best quality).

Trait-only PR: the foreground/background runner, policy wiring, and codegen integration come separately. Includes a unit test implementing the trait end-to-end and updated `api/v1` snapshots.