### PR TITLE
chore(deps): update syn to 3.0 with Pat::Guard migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,7 +286,7 @@ clap = { version = "4.5", default-features = false, features = [
 # External proc macros
 proc-macro2 = { version = "1.0", default-features = false }
 quote = { version = "1.0", default-features = false } # proc macros
-syn = { version = "2.0", default-features = false, features = [
+syn = { version = "3.0", default-features = false, features = [
   "full",
   "derive",
   "parsing",

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -382,8 +382,8 @@ fn collect_safety_checks_from_expr(
         Expr::Match(expr) => {
             collect_safety_checks_from_expr(&expr.expr, checks)?;
             for arm in &expr.arms {
-                if let Some((_, guard)) = &arm.guard {
-                    collect_safety_checks_from_expr(guard, checks)?;
+                if let syn::Pat::Guard(pat_guard) = &arm.pat {
+                    collect_safety_checks_from_expr(&pat_guard.guard, checks)?;
                 }
                 collect_safety_checks_from_expr(&arm.body, checks)?;
             }


### PR DESCRIPTION
Supersedes #1210, which fails CI because syn 3.0 removed the `guard` field from `syn::Arm` — match arm guards are now represented as `Pat::Guard` on the arm pattern (per the guard-patterns RFC).

This includes dependabot's `syn = "3.0"` bump plus the one-line migration in `cu29_derive`'s safety-check collector to read the guard expression from `Pat::Guard` instead of `Arm::guard`.

Verified locally: `cargo check`/`cargo test -p cu29-derive` (15 tests) and `cargo clippy -D warnings` on all five syn-dependent derive crates pass; this was the only syn 3.0 break in the workspace.