### PR TITLE
Release v1.0.1

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -445,11 +445,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PUBLIC_API_VERSION: "0.51.0"
-      PUBLIC_API_TOOLCHAIN: nightly
+      PUBLIC_API_TOOLCHAIN: nightly-2026-06-25
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
-      - uses: dtolnay/rust-toolchain@nightly
+      - name: Install public API Rust toolchain
+        run: rustup toolchain install "${PUBLIC_API_TOOLCHAIN}" --profile minimal
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: api-check

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -2,9 +2,9 @@ name: "CI/CD"
 
 on:
   push:
-    branches: ["master"]
+    branches: ["master", "v1.0"]
   pull_request:
-    branches: ["master"]
+    branches: ["master", "v1.0"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ cu29-soa-derive = { path = "core/cu29_soa_derive", default-features = false, ver
 cu29-traits = { path = "core/cu29_traits", default-features = false, version = "1.0.1" }
 cu29-unifiedlog = { path = "core/cu29_unifiedlog", default-features = false, features = [
   "compact",
-], version = "1.0.0" }
+], version = "1.0.1" }
 cu29-units = { path = "core/cu29_units", version = "1.0.1" }
 cu29-value = { path = "core/cu29_value", default-features = false, version = "1.0.1" }
 cu-ffv1-codec = { path = "components/codecs/cu_ffv1_codec", version = "1.0.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ default-members = [
   "core/cu29_unifiedlog",
 ]
 
-resolver = "2"
+resolver = "3"
 
 [profile.release]
 debug = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ debug = 2
 soft_ratatui = { path = "vendor/soft_ratatui" }
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Guillaume Binet <gbin@gootz.net>"]
 edition = "2024"
 rust-version = "1.95"
@@ -162,56 +162,56 @@ no_individual_tags = true
 [workspace.dependencies]
 
 # Copper Core
-cu29 = { path = "core/cu29", version = "1.0.0" } # default std
-cu29-reflect-derive = { path = "core/cu29_reflect_derive", version = "1.0.0" }
-cu29-clock = { path = "core/cu29_clock", default-features = false, version = "1.0.0" }
-cu29-derive = { path = "core/cu29_derive", default-features = false, version = "1.0.0" }
-cu29-export = { path = "core/cu29_export", version = "1.0.0" } # std only
-cu29-helpers = { path = "core/cu29_helpers", version = "1.0.0" } # compatibility stub
-cu29-intern-strs = { path = "core/cu29_intern_strs", version = "1.0.0" } # std only
-cu29-log = { path = "core/cu29_log", default-features = false, version = "1.0.0" }
-cu29-log-derive = { path = "core/cu29_log_derive", default-features = false, version = "1.0.0" }
-cu29-log-runtime = { path = "core/cu29_log_runtime", default-features = false, version = "1.0.0" }
-cu29-runtime = { path = "core/cu29_runtime", default-features = false, version = "1.0.0" }
-cu29-soa-derive = { path = "core/cu29_soa_derive", default-features = false, version = "1.0.0" }
-cu29-traits = { path = "core/cu29_traits", default-features = false, version = "1.0.0" }
+cu29 = { path = "core/cu29", version = "1.0.1" } # default std
+cu29-reflect-derive = { path = "core/cu29_reflect_derive", version = "1.0.1" }
+cu29-clock = { path = "core/cu29_clock", default-features = false, version = "1.0.1" }
+cu29-derive = { path = "core/cu29_derive", default-features = false, version = "1.0.1" }
+cu29-export = { path = "core/cu29_export", version = "1.0.1" } # std only
+cu29-helpers = { path = "core/cu29_helpers", version = "1.0.1" } # compatibility stub
+cu29-intern-strs = { path = "core/cu29_intern_strs", version = "1.0.1" } # std only
+cu29-log = { path = "core/cu29_log", default-features = false, version = "1.0.1" }
+cu29-log-derive = { path = "core/cu29_log_derive", default-features = false, version = "1.0.1" }
+cu29-log-runtime = { path = "core/cu29_log_runtime", default-features = false, version = "1.0.1" }
+cu29-runtime = { path = "core/cu29_runtime", default-features = false, version = "1.0.1" }
+cu29-soa-derive = { path = "core/cu29_soa_derive", default-features = false, version = "1.0.1" }
+cu29-traits = { path = "core/cu29_traits", default-features = false, version = "1.0.1" }
 cu29-unifiedlog = { path = "core/cu29_unifiedlog", default-features = false, features = [
   "compact",
 ], version = "1.0.0" }
-cu29-units = { path = "core/cu29_units", version = "1.0.0" }
-cu29-value = { path = "core/cu29_value", default-features = false, version = "1.0.0" }
-cu-ffv1-codec = { path = "components/codecs/cu_ffv1_codec", version = "1.0.0" }
-cu-linux-resources = { path = "components/res/cu_linux_resources", version = "1.0.0" }
-cu-png-codec = { path = "components/codecs/cu_png_codec", version = "1.0.0" }
+cu29-units = { path = "core/cu29_units", version = "1.0.1" }
+cu29-value = { path = "core/cu29_value", default-features = false, version = "1.0.1" }
+cu-ffv1-codec = { path = "components/codecs/cu_ffv1_codec", version = "1.0.1" }
+cu-linux-resources = { path = "components/res/cu_linux_resources", version = "1.0.1" }
+cu-png-codec = { path = "components/codecs/cu_png_codec", version = "1.0.1" }
 
 # Copper components
-cu-ads7883-new = { path = "components/sources/cu_ads7883", version = "1.0.0" }
-cu-ahrs = { path = "components/tasks/cu_ahrs", version = "1.0.0" }
-cu-bdshot = { path = "components/bridges/cu_bdshot", version = "1.0.0" }
-cu-bevymon = { path = "components/monitors/cu_bevymon", version = "1.0.0" }
-cu-bmi088 = { path = "components/sources/cu_bmi088", version = "1.0.0" }
-cu-consolemon = { path = "components/monitors/cu_consolemon", version = "1.0.0" }
-cu-crsf = { path = "components/bridges/cu_crsf", version = "1.0.0" }
-cu-dps310 = { path = "components/sources/cu_dps310", version = "1.0.0" }
-cu-feetech = { path = "components/bridges/cu_feetech", version = "1.0.0" }
-cu-gnss-ublox = { path = "components/sources/cu_gnss_ublox", version = "1.0.0" }
-cu-gstreamer = { path = "components/sources/cu_gstreamer", version = "1.0.0" }
-cu-ist8310 = { path = "components/sources/cu_ist8310", version = "1.0.0" }
-cu-logmon = { path = "components/monitors/cu_logmon", version = "1.0.0" }
-cu-micoairh743 = { path = "components/res/cu_micoairh743", version = "1.0.0" }
-cu-msp-bridge = { path = "components/bridges/cu_msp_bridge", version = "1.0.0" }
-cu-msp-lib = { path = "components/libs/cu_msp_lib", version = "1.0.0" }
-cu-rp-encoder = { path = "components/sources/cu_rp_encoder", version = "1.0.0" }
-cu-rp-sn754410-new = { path = "components/sinks/cu_rp_sn754410", version = "1.0.0" }
-cu-sdlogger = { path = "components/libs/cu_sdlogger", version = "1.0.0" }
-cu-zenoh-bridge = { path = "components/bridges/cu_zenoh_bridge", version = "1.0.0" }
+cu-ads7883-new = { path = "components/sources/cu_ads7883", version = "1.0.1" }
+cu-ahrs = { path = "components/tasks/cu_ahrs", version = "1.0.1" }
+cu-bdshot = { path = "components/bridges/cu_bdshot", version = "1.0.1" }
+cu-bevymon = { path = "components/monitors/cu_bevymon", version = "1.0.1" }
+cu-bmi088 = { path = "components/sources/cu_bmi088", version = "1.0.1" }
+cu-consolemon = { path = "components/monitors/cu_consolemon", version = "1.0.1" }
+cu-crsf = { path = "components/bridges/cu_crsf", version = "1.0.1" }
+cu-dps310 = { path = "components/sources/cu_dps310", version = "1.0.1" }
+cu-feetech = { path = "components/bridges/cu_feetech", version = "1.0.1" }
+cu-gnss-ublox = { path = "components/sources/cu_gnss_ublox", version = "1.0.1" }
+cu-gstreamer = { path = "components/sources/cu_gstreamer", version = "1.0.1" }
+cu-ist8310 = { path = "components/sources/cu_ist8310", version = "1.0.1" }
+cu-logmon = { path = "components/monitors/cu_logmon", version = "1.0.1" }
+cu-micoairh743 = { path = "components/res/cu_micoairh743", version = "1.0.1" }
+cu-msp-bridge = { path = "components/bridges/cu_msp_bridge", version = "1.0.1" }
+cu-msp-lib = { path = "components/libs/cu_msp_lib", version = "1.0.1" }
+cu-rp-encoder = { path = "components/sources/cu_rp_encoder", version = "1.0.1" }
+cu-rp-sn754410-new = { path = "components/sinks/cu_rp_sn754410", version = "1.0.1" }
+cu-sdlogger = { path = "components/libs/cu_sdlogger", version = "1.0.1" }
+cu-zenoh-bridge = { path = "components/bridges/cu_zenoh_bridge", version = "1.0.1" }
 
 # Payload definitions
-cu-sensor-payloads = { path = "components/payloads/cu_sensor_payloads", version = "1.0.0" }
-cu-gnss-payloads = { path = "components/payloads/cu_gnss_payloads", version = "1.0.0" }
-cu-spatial-payloads = { path = "components/payloads/cu_spatial_payloads", version = "1.0.0" }
-cu-ros2-payloads = { path = "components/payloads/cu_ros2_payloads", version = "1.0.0" }
-cu-pid = { path = "components/tasks/cu_pid", version = "1.0.0" }
+cu-sensor-payloads = { path = "components/payloads/cu_sensor_payloads", version = "1.0.1" }
+cu-gnss-payloads = { path = "components/payloads/cu_gnss_payloads", version = "1.0.1" }
+cu-spatial-payloads = { path = "components/payloads/cu_spatial_payloads", version = "1.0.1" }
+cu-ros2-payloads = { path = "components/payloads/cu_ros2_payloads", version = "1.0.1" }
+cu-pid = { path = "components/tasks/cu_pid", version = "1.0.1" }
 
 # External serialization
 bincode = { package = "cu-bincode", version = "2.0", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ If you use Copper-rs in your research, please cite it as:
   year         = {2026},
   howpublished = {GitHub repository},
   url          = {https://github.com/copper-project/copper-rs},
-  note         = {Version v1.0.0 or latest}
+  note         = {Version v1.0.1 or latest}
 }
 ```
 

--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -875,6 +875,18 @@ pub fn cu29_runtime::cutask::CuSrcTask::register_debug_state_types(registry: &mu
 pub fn cu29_runtime::cutask::CuSrcTask::start(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
 pub fn cu29_runtime::cutask::CuSrcTask::stop(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
 pub fn cu29_runtime::cutask::CuSrcTask::with_debug_state<R>(&self, f: impl core::ops::function::FnOnce(&dyn cu29_runtime::reflect::Reflect) -> R) -> R where Self: core::marker::Sized
+impl<O: cu29_runtime::cutask::CuMsgPayload + 'static> cu29_runtime::cutask::CuSrcTask for cu29_runtime::simulation::CuSimSrcTaskPack<O>
+pub type cu29_runtime::simulation::CuSimSrcTaskPack<O>::Output<'m> = O
+pub type cu29_runtime::simulation::CuSimSrcTaskPack<O>::Resources<'r> = ()
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::debug_state_type_path() -> &'static str where Self: cu29_runtime::reflect::TypePath + core::marker::Sized
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::new(_config: core::option::Option<&cu29_runtime::config::ComponentConfig>, _resources: Self::Resources) -> cu29_traits::CuResult<Self> where Self: core::marker::Sized
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::postprocess(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::preprocess(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::process(&mut self, _ctx: &cu29_runtime::context::CuContext, _new_msg: &mut Self::Output) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::register_debug_state_types(registry: &mut cu29_runtime::reflect::TypeRegistry) where Self: cu29_runtime::reflect::GetTypeRegistration + core::marker::Sized
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::start(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::stop(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::with_debug_state<R>(&self, f: impl core::ops::function::FnOnce(&dyn cu29_runtime::reflect::Reflect) -> R) -> R where Self: core::marker::Sized
 impl<T, O> cu29_runtime::cutask::CuSrcTask for cu29_runtime::cuasynctask::CuAsyncSrcTask<T, O> where T: for<'m> cu29_runtime::cutask::CuSrcTask<Output<'m> = cu29_runtime::cutask::CuMsg<O>> + core::marker::Send + 'static, O: cu29_runtime::cutask::CuMsgPayload + core::marker::Send + 'static
 pub type cu29_runtime::cuasynctask::CuAsyncSrcTask<T, O>::Output<'m> = <T as cu29_runtime::cutask::CuSrcTask>::Output
 pub type cu29_runtime::cuasynctask::CuAsyncSrcTask<T, O>::Resources<'r> = cu29_runtime::cuasynctask::CuAsyncSrcTaskResources<'r, T>
@@ -931,6 +943,9 @@ pub fn cu29_runtime::cutask::Freezable::thaw<D: cu_bincode::de::Decoder>(&mut se
 impl<I> cu29_runtime::cutask::Freezable for cu29_runtime::simulation::CuSimSinkTask<I>
 pub fn cu29_runtime::simulation::CuSimSinkTask<I>::freeze<E: cu_bincode::enc::Encoder>(&self, encoder: &mut E) -> core::result::Result<(), cu_bincode::error::EncodeError>
 pub fn cu29_runtime::simulation::CuSimSinkTask<I>::thaw<D: cu_bincode::de::Decoder>(&mut self, _decoder: &mut D) -> core::result::Result<(), cu_bincode::error::DecodeError>
+impl<O> cu29_runtime::cutask::Freezable for cu29_runtime::simulation::CuSimSrcTaskPack<O>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::freeze<E: cu_bincode::enc::Encoder>(&self, encoder: &mut E) -> core::result::Result<(), cu_bincode::error::EncodeError>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::thaw<D: cu_bincode::de::Decoder>(&mut self, decoder: &mut D) -> core::result::Result<(), cu_bincode::error::DecodeError>
 impl<T, O> cu29_runtime::cutask::Freezable for cu29_runtime::cuasynctask::CuAsyncSrcTask<T, O> where T: for<'m> cu29_runtime::cutask::CuSrcTask<Output<'m> = cu29_runtime::cutask::CuMsg<O>> + core::marker::Send + 'static, O: cu29_runtime::cutask::CuMsgPayload + core::marker::Send + 'static
 pub fn cu29_runtime::cuasynctask::CuAsyncSrcTask<T, O>::freeze<E: cu_bincode::enc::Encoder>(&self, encoder: &mut E) -> core::result::Result<(), cu_bincode::error::EncodeError>
 pub fn cu29_runtime::cuasynctask::CuAsyncSrcTask<T, O>::thaw<D: cu_bincode::de::Decoder>(&mut self, decoder: &mut D) -> core::result::Result<(), cu_bincode::error::DecodeError>
@@ -1786,6 +1801,12 @@ pub fn cu29_runtime::simulation::CuSimSinkTask<I>::module_path() -> core::option
 pub fn cu29_runtime::simulation::CuSimSinkTask<I>::short_type_path() -> &'static str
 pub fn cu29_runtime::simulation::CuSimSinkTask<I>::type_ident() -> core::option::Option<&'static str>
 pub fn cu29_runtime::simulation::CuSimSinkTask<I>::type_path() -> &'static str
+impl<O: 'static> cu29_runtime::reflect::TypePath for cu29_runtime::simulation::CuSimSrcTaskPack<O>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::crate_name() -> core::option::Option<&'static str>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::module_path() -> core::option::Option<&'static str>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::short_type_path() -> &'static str
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::type_ident() -> core::option::Option<&'static str>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::type_path() -> &'static str
 impl<T, M> cu29_runtime::reflect::TypePath for cu29_runtime::cutask::CuStampedData<T, M> where T: cu29_runtime::cutask::CuMsgPayload, M: cu29_traits::Metadata
 pub fn cu29_runtime::cutask::CuStampedData<T, M>::crate_name() -> core::option::Option<&'static str>
 pub fn cu29_runtime::cutask::CuStampedData<T, M>::module_path() -> core::option::Option<&'static str>
@@ -2000,6 +2021,30 @@ pub fn cu29_runtime::simulation::CuSimSrcTask<T>::with_debug_state<R>(&self, f: 
 impl<T> cu29_runtime::cutask::Freezable for cu29_runtime::simulation::CuSimSrcTask<T>
 pub fn cu29_runtime::simulation::CuSimSrcTask<T>::freeze<E: cu_bincode::enc::Encoder>(&self, encoder: &mut E) -> core::result::Result<(), cu_bincode::error::EncodeError>
 pub fn cu29_runtime::simulation::CuSimSrcTask<T>::thaw<D: cu_bincode::de::Decoder>(&mut self, decoder: &mut D) -> core::result::Result<(), cu_bincode::error::DecodeError>
+pub struct cu29_runtime::simulation::CuSimSrcTaskPack<O>
+impl<O> cu29_runtime::simulation::CuSimSrcTaskPack<O>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::sim_tick(&mut self)
+impl<O: 'static> cu29_runtime::reflect::TypePath for cu29_runtime::simulation::CuSimSrcTaskPack<O>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::crate_name() -> core::option::Option<&'static str>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::module_path() -> core::option::Option<&'static str>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::short_type_path() -> &'static str
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::type_ident() -> core::option::Option<&'static str>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::type_path() -> &'static str
+impl<O: cu29_runtime::cutask::CuMsgPayload + 'static> cu29_runtime::cutask::CuSrcTask for cu29_runtime::simulation::CuSimSrcTaskPack<O>
+pub type cu29_runtime::simulation::CuSimSrcTaskPack<O>::Output<'m> = O
+pub type cu29_runtime::simulation::CuSimSrcTaskPack<O>::Resources<'r> = ()
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::debug_state_type_path() -> &'static str where Self: cu29_runtime::reflect::TypePath + core::marker::Sized
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::new(_config: core::option::Option<&cu29_runtime::config::ComponentConfig>, _resources: Self::Resources) -> cu29_traits::CuResult<Self> where Self: core::marker::Sized
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::postprocess(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::preprocess(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::process(&mut self, _ctx: &cu29_runtime::context::CuContext, _new_msg: &mut Self::Output) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::register_debug_state_types(registry: &mut cu29_runtime::reflect::TypeRegistry) where Self: cu29_runtime::reflect::GetTypeRegistration + core::marker::Sized
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::start(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::stop(&mut self, _ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::with_debug_state<R>(&self, f: impl core::ops::function::FnOnce(&dyn cu29_runtime::reflect::Reflect) -> R) -> R where Self: core::marker::Sized
+impl<O> cu29_runtime::cutask::Freezable for cu29_runtime::simulation::CuSimSrcTaskPack<O>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::freeze<E: cu_bincode::enc::Encoder>(&self, encoder: &mut E) -> core::result::Result<(), cu_bincode::error::EncodeError>
+pub fn cu29_runtime::simulation::CuSimSrcTaskPack<O>::thaw<D: cu_bincode::de::Decoder>(&mut self, decoder: &mut D) -> core::result::Result<(), cu_bincode::error::DecodeError>
 pub trait cu29_runtime::simulation::CuSimSinkInput
 pub type cu29_runtime::simulation::CuSimSinkInput::With<'m> where Self: 'm: cu29_runtime::cutask::CuMsgPack
 impl<T1: cu29_runtime::cutask::CuMsgPayload, T2: cu29_runtime::cutask::CuMsgPayload, T3: cu29_runtime::cutask::CuMsgPayload, T4: cu29_runtime::cutask::CuMsgPayload, T5: cu29_runtime::cutask::CuMsgPayload, T6: cu29_runtime::cutask::CuMsgPayload, T7: cu29_runtime::cutask::CuMsgPayload, T8: cu29_runtime::cutask::CuMsgPayload, T9: cu29_runtime::cutask::CuMsgPayload, T10: cu29_runtime::cutask::CuMsgPayload, T11: cu29_runtime::cutask::CuMsgPayload, T12: cu29_runtime::cutask::CuMsgPayload> cu29_runtime::simulation::CuSimSinkInput for (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)

--- a/api/v1/cu29-unifiedlog.txt
+++ b/api/v1/cu29-unifiedlog.txt
@@ -21,7 +21,7 @@ pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerWrite::flush_section(&mut self,
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerWrite::status(&self) -> cu29_unifiedlog::UnifiedLogStatus
 pub struct cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder
 impl cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder
-pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::build(self) -> core::io::error::Result<cu29_unifiedlog::memmap::MmapUnifiedLogger>
+pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::build(self) -> std::io::error::Result<cu29_unifiedlog::memmap::MmapUnifiedLogger>
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::create(self, create: bool) -> Self
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::file_base_name(self, file_path: &std::path::Path) -> Self
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::new() -> Self
@@ -31,7 +31,7 @@ impl core::default::Default for cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilde
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::default() -> Self
 pub struct cu29_unifiedlog::memmap::MmapUnifiedLoggerRead
 impl cu29_unifiedlog::memmap::MmapUnifiedLoggerRead
-pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::new(base_file_path: &std::path::Path) -> core::io::error::Result<Self>
+pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::new(base_file_path: &std::path::Path) -> std::io::error::Result<Self>
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::position(&self) -> cu29_unifiedlog::memmap::LogPosition
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::raw_main_header(&self) -> &cu29_unifiedlog::MainHeader
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::scan_section_bytes(&mut self, datalogtype: cu29_traits::UnifiedLogType) -> cu29_traits::CuResult<u64>
@@ -52,7 +52,7 @@ pub struct cu29_unifiedlog::memmap::UnifiedLoggerIOReader
 impl cu29_unifiedlog::memmap::UnifiedLoggerIOReader
 pub fn cu29_unifiedlog::memmap::UnifiedLoggerIOReader::new(logger: cu29_unifiedlog::memmap::MmapUnifiedLoggerRead, log_type: cu29_traits::UnifiedLogType) -> Self
 impl std::io::Read for cu29_unifiedlog::memmap::UnifiedLoggerIOReader
-pub fn cu29_unifiedlog::memmap::UnifiedLoggerIOReader::read(&mut self, buf: &mut [u8]) -> core::io::error::Result<usize>
+pub fn cu29_unifiedlog::memmap::UnifiedLoggerIOReader::read(&mut self, buf: &mut [u8]) -> std::io::error::Result<usize>
 pub mod cu29_unifiedlog::noop
 pub struct cu29_unifiedlog::noop::NoopLogger
 impl cu29_unifiedlog::noop::NoopLogger
@@ -156,7 +156,7 @@ pub cu29_unifiedlog::UnifiedLogStatus::total_allocated_space: usize
 pub cu29_unifiedlog::UnifiedLogStatus::total_used_space: usize
 pub struct cu29_unifiedlog::UnifiedLoggerBuilder
 impl cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder
-pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::build(self) -> core::io::error::Result<cu29_unifiedlog::memmap::MmapUnifiedLogger>
+pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::build(self) -> std::io::error::Result<cu29_unifiedlog::memmap::MmapUnifiedLogger>
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::create(self, create: bool) -> Self
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::file_base_name(self, file_path: &std::path::Path) -> Self
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerBuilder::new() -> Self
@@ -168,10 +168,10 @@ pub struct cu29_unifiedlog::UnifiedLoggerIOReader
 impl cu29_unifiedlog::memmap::UnifiedLoggerIOReader
 pub fn cu29_unifiedlog::memmap::UnifiedLoggerIOReader::new(logger: cu29_unifiedlog::memmap::MmapUnifiedLoggerRead, log_type: cu29_traits::UnifiedLogType) -> Self
 impl std::io::Read for cu29_unifiedlog::memmap::UnifiedLoggerIOReader
-pub fn cu29_unifiedlog::memmap::UnifiedLoggerIOReader::read(&mut self, buf: &mut [u8]) -> core::io::error::Result<usize>
+pub fn cu29_unifiedlog::memmap::UnifiedLoggerIOReader::read(&mut self, buf: &mut [u8]) -> std::io::error::Result<usize>
 pub struct cu29_unifiedlog::UnifiedLoggerRead
 impl cu29_unifiedlog::memmap::MmapUnifiedLoggerRead
-pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::new(base_file_path: &std::path::Path) -> core::io::error::Result<Self>
+pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::new(base_file_path: &std::path::Path) -> std::io::error::Result<Self>
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::position(&self) -> cu29_unifiedlog::memmap::LogPosition
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::raw_main_header(&self) -> &cu29_unifiedlog::MainHeader
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::scan_section_bytes(&mut self, datalogtype: cu29_traits::UnifiedLogType) -> cu29_traits::CuResult<u64>

--- a/benchmarks/dora_caterpillar/Cargo.toml
+++ b/benchmarks/dora_caterpillar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-caterpillat"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 [workspace]

--- a/benchmarks/horus_caterpillar/Cargo.toml
+++ b/benchmarks/horus_caterpillar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horus-caterpillar"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 [workspace]

--- a/components/bridges/cu_bdshot/Cargo.toml
+++ b/components/bridges/cu_bdshot/Cargo.toml
@@ -19,7 +19,7 @@ environments = ["embedded"]
 embedded_targets = ["thumbv8m.main-none-eabihf"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false }
 rp235x-hal = { workspace = true, features = [
   "critical-section-impl",
 ], optional = true }

--- a/components/bridges/cu_crsf/Cargo.toml
+++ b/components/bridges/cu_crsf/Cargo.toml
@@ -18,7 +18,7 @@ domains = ["control/radio", "protocol/crsf"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false }
 crsf = "2.0.1"
 embedded-io = { version = "0.7.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }

--- a/components/bridges/cu_iceoryx2_bridge/Cargo.toml
+++ b/components/bridges/cu_iceoryx2_bridge/Cargo.toml
@@ -18,7 +18,7 @@ domains = ["middleware/iceoryx2"]
 environments = ["host"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false }
 iceoryx2 = { version = "0.9.0", default-features = false }
 bincode = { workspace = true }
 

--- a/components/bridges/cu_msp_bridge/Cargo.toml
+++ b/components/bridges/cu_msp_bridge/Cargo.toml
@@ -18,8 +18,8 @@ domains = ["control/flight", "protocol/msp"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
-cu-msp-lib = { path = "../../libs/cu_msp_lib", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false }
+cu-msp-lib = { path = "../../libs/cu_msp_lib", version = "1.0.1", default-features = false, features = [
   "bincode",
 ] }
 embedded-io = { version = "0.7.1", default-features = false }

--- a/components/bridges/cu_ros2_bridge/Cargo.toml
+++ b/components/bridges/cu_ros2_bridge/Cargo.toml
@@ -33,3 +33,6 @@ cdr = { version = "0.2.4" }
 
 [features]
 humble = ["cu-ros2-payloads/humble"]
+
+[dev-dependencies]
+bincode = { workspace = true }

--- a/components/bridges/cu_ros2_bridge/README.md
+++ b/components/bridges/cu_ros2_bridge/README.md
@@ -58,6 +58,14 @@ cu_ros2_bridge::register_ros2_payload::<MyPayload>();
 Copper -> ROS 2 samples are serialized as OMG CDR little-endian (`CdrLe`). Inbound samples use
 `cdr::deserialize`, which reads the CDR encapsulation header and accepts either endianness.
 
+### ROS 2 Humble image compatibility
+
+Enable the `humble` feature when bridging `cu_sensor_payloads::CuImage<Vec<u8>>` to ROS 2 Humble.
+The image adapter uses Humble's legacy `yuv422_yuy2` and `yuv422` encoding names for YUYV and
+UYVY buffers. Humble's `cv_bridge` cannot consume NV12, NV21, I420, or YV12 images, so the bridge
+rejects those formats instead of publishing an image that tools such as `rqt_image_view` cannot
+decode. Convert those images to a supported packed format before sending them through the bridge.
+
 ## ROS 2 interop test
 
 The `ros2_interop` test auto-detects a sourced ROS 2 environment. If `ros2`, `std_msgs`, or

--- a/components/bridges/cu_ros2_bridge/src/lib.rs
+++ b/components/bridges/cu_ros2_bridge/src/lib.rs
@@ -88,6 +88,9 @@ where
             type_name::<Payload>()
         ))
     })?;
+    payload
+        .validate_ros_message()
+        .map_err(|e| CuError::from(format!("Ros2Bridge: Payload is not ROS-compatible: {e}")))?;
     let ros_payload = payload.to_ros_message();
     cdr::serialize::<_, _, CdrLe>(&ros_payload, Infinite)
         .map_err(|e| CuError::new_with_cause("Ros2Bridge: Failed to serialize payload", e))
@@ -708,6 +711,43 @@ fn cu_error_map(msg: &str) -> impl FnOnce(ZenohError) -> CuError + '_ {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cu29::bincode::{Decode, Encode};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Clone, Debug, Default, Encode, Decode, Serialize, Deserialize, Reflect)]
+    struct RejectingPayload;
+
+    impl RosBridgeAdapter for RejectingPayload {
+        type RosMessage = i32;
+
+        fn validate_ros_message(&self) -> Result<(), String> {
+            Err("test payload rejected".to_string())
+        }
+
+        fn namespace() -> &'static str {
+            "test_msgs"
+        }
+
+        fn type_hash() -> &'static str {
+            "test_hash"
+        }
+
+        fn to_ros_message(&self) -> Self::RosMessage {
+            0
+        }
+
+        fn from_ros_message(_msg: Self::RosMessage) -> Result<Self, String> {
+            Ok(Self)
+        }
+    }
+
+    #[test]
+    fn payload_validation_failure_stops_encoding() {
+        let error = encode_payload_with::<RejectingPayload>(&RejectingPayload)
+            .expect_err("validation failure should stop ROS encoding");
+
+        assert!(error.to_string().contains("test payload rejected"));
+    }
 
     #[test]
     fn scalar_payload_cdr_roundtrip_uses_little_endian_encapsulation() {

--- a/components/libs/cu_sdlogger/Cargo.toml
+++ b/components/libs/cu_sdlogger/Cargo.toml
@@ -18,7 +18,7 @@ domains = ["storage/logging"]
 environments = ["embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false }
 # HALs we target (e.g. stm32h7xx-hal 0.16) still vendor embedded-sdmmc 0.5, so keep it aligned to avoid dual versions.
 embedded-sdmmc = { version = "0.5", default-features = false, optional = true }
 # Some HALs (e.g. rp235x-hal) sit on embedded-hal 1.0 and need embedded-sdmmc 0.9.

--- a/components/libs/cu_transform/Cargo.toml
+++ b/components/libs/cu_transform/Cargo.toml
@@ -22,7 +22,7 @@ cu29 = { workspace = true }
 bincode = { workspace = true }
 serde = { workspace = true }
 
-cu-spatial-payloads = { path = "../../payloads/cu_spatial_payloads", version = "1.0.0", features = [
+cu-spatial-payloads = { path = "../../payloads/cu_spatial_payloads", version = "1.0.1", features = [
   "glam",
 ] }
 

--- a/components/libs/cu_tuimon/Cargo.toml
+++ b/components/libs/cu_tuimon/Cargo.toml
@@ -31,7 +31,7 @@ sysinfo_pane = [
 [dependencies]
 ansi-to-tui = { version = "8.0.0", default-features = false }
 compact_str = { workspace = true }
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false, features = [
   "std",
 ] }
 cu29-log = { workspace = true, optional = true }

--- a/components/libs/cu_tuimon/src/tui_nodes/graph.rs
+++ b/components/libs/cu_tuimon/src/tui_nodes/graph.rs
@@ -161,7 +161,7 @@ impl<'a> NodeGraph<'a> {
         // Repeat the for loop until in runs all the way through without any
         // intersections. Surely there's a more efficient way to do this.
         'outer: loop {
-            for (_, ea_them) in self.placements.iter() {
+            for ea_them in self.placements.values() {
                 if rect_me.intersects(*ea_them) {
                     rect_me.y = rect_me.y.max(ea_them.bottom());
                     continue 'outer;

--- a/components/monitors/cu_bevymon/Cargo.toml
+++ b/components/monitors/cu_bevymon/Cargo.toml
@@ -36,10 +36,10 @@ bevy = { workspace = true, features = [
   "keyboard",
   "mouse",
 ] }
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false, features = [
   "std",
 ] }
-cu-tuimon = { path = "../../libs/cu_tuimon", version = "1.0.0", default-features = false, features = [
+cu-tuimon = { path = "../../libs/cu_tuimon", version = "1.0.1", default-features = false, features = [
   "log_pane",
 ] }
 ratatui = { version = "0.30.0", default-features = false }

--- a/components/monitors/cu_consolemon/Cargo.toml
+++ b/components/monitors/cu_consolemon/Cargo.toml
@@ -25,7 +25,7 @@ sysinfo = ["cu-tuimon/sysinfo_pane"]
 
 [dependencies]
 cu29 = { workspace = true }
-cu-tuimon = { path = "../../libs/cu_tuimon", version = "1.0.0", default-features = false }
+cu-tuimon = { path = "../../libs/cu_tuimon", version = "1.0.1", default-features = false }
 compact_str = { workspace = true }
 ratatui = "0.30"
 ansi-to-tui = { version = "8.0.0", default-features = false }

--- a/components/monitors/cu_logmon/Cargo.toml
+++ b/components/monitors/cu_logmon/Cargo.toml
@@ -25,14 +25,14 @@ ignored = ["serde"]
 path = "src/lib.rs"
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
-cu29-log-runtime = { path = "../../../core/cu29_log_runtime", version = "1.0.0", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false }
+cu29-log-runtime = { path = "../../../core/cu29_log_runtime", version = "1.0.1", default-features = false }
 defmt = { workspace = true, optional = true }
 spin = { workspace = true }
 
 [dev-dependencies]
 log = { workspace = true }
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false, features = [
   "log-level-info",
 ] }
 serde = { workspace = true }

--- a/components/monitors/cu_memmon/Cargo.toml
+++ b/components/monitors/cu_memmon/Cargo.toml
@@ -25,12 +25,12 @@ ignored = ["serde"]
 path = "src/lib.rs"
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false }
 spin = { workspace = true }
 
 [dev-dependencies]
 serde = { workspace = true }
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false, features = [
   "log-level-info",
 ] }
 

--- a/components/monitors/cu_memmon/README.md
+++ b/components/monitors/cu_memmon/README.md
@@ -31,7 +31,7 @@ is installed but no scopes have fired (the derive-side feature is off).
 Coverage in this release: task `start` / `stop` / `preprocess` / `process` /
 `postprocess`; bridge `start` / `stop` / `preprocess` / `process` (rx and tx) /
 `postprocess`; and the parallel-rt counterparts of both. So all monitored
-lifecycle steps from cu29 1.0.0 are observed.
+lifecycle steps from cu29 1.0.1 are observed.
 
 ## Usage
 

--- a/components/monitors/cu_safetymon/Cargo.toml
+++ b/components/monitors/cu_safetymon/Cargo.toml
@@ -31,10 +31,10 @@ required-features = ["safety-ids"]
 path = "src/lib.rs"
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false }
 
 [dev-dependencies]
-cu-logmon = { path = "../cu_logmon", version = "1.0.0", default-features = false, features = [
+cu-logmon = { path = "../cu_logmon", version = "1.0.1", default-features = false, features = [
   "std",
 ] }
 

--- a/components/payloads/cu_gnss_payloads/Cargo.toml
+++ b/components/payloads/cu_gnss_payloads/Cargo.toml
@@ -20,10 +20,10 @@ environments = ["host", "embedded"]
 
 [dependencies]
 bincode = { workspace = true }
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false, features = [
   "units",
 ] }
-cu-spatial-payloads = { path = "../cu_spatial_payloads", version = "1.0.0", default-features = false }
+cu-spatial-payloads = { path = "../cu_spatial_payloads", version = "1.0.1", default-features = false }
 serde = { workspace = true }
 
 [features]

--- a/components/payloads/cu_ros2_payloads/src/lib.rs
+++ b/components/payloads/cu_ros2_payloads/src/lib.rs
@@ -20,6 +20,14 @@ macro_rules! ros_type_name {
 pub trait RosMsgAdapter<'a>: Sized {
     type Output: Serialize + for<'b> From<&'b Self>;
 
+    /// Validates that this payload can be represented by the selected ROS compatibility profile.
+    ///
+    /// Most adapters are always representable. Payloads with distro-specific restrictions can
+    /// override this hook so bridges fail before conversion and serialization.
+    fn validate_ros_message(&self) -> Result<(), String> {
+        Ok(())
+    }
+
     /// The namespace of the ROS message, such as "std_msgs" or "sensor_msgs".
     fn namespace() -> &'a str;
 
@@ -42,6 +50,11 @@ pub trait RosMsgAdapter<'a>: Sized {
 pub trait RosBridgeAdapter: Sized + 'static {
     type RosMessage: Serialize + DeserializeOwned + 'static;
 
+    /// Validates that this payload can be represented by the selected ROS compatibility profile.
+    fn validate_ros_message(&self) -> Result<(), String> {
+        Ok(())
+    }
+
     fn namespace() -> &'static str;
 
     fn type_name() -> &'static str {
@@ -62,6 +75,10 @@ where
     <T as TryFrom<<T as RosMsgAdapter<'static>>::Output>>::Error: Display,
 {
     type RosMessage = <T as RosMsgAdapter<'static>>::Output;
+
+    fn validate_ros_message(&self) -> Result<(), String> {
+        <T as RosMsgAdapter<'static>>::validate_ros_message(self)
+    }
 
     fn namespace() -> &'static str {
         <T as RosMsgAdapter<'static>>::namespace()

--- a/components/payloads/cu_ros2_payloads/src/sensor_msgs.rs
+++ b/components/payloads/cu_ros2_payloads/src/sensor_msgs.rs
@@ -134,6 +134,18 @@ impl<const N: usize> RosMsgAdapter<'static> for PointCloudSoaHandle<N> {
 impl RosMsgAdapter<'static> for CuImage<Vec<u8>> {
     type Output = Image;
 
+    #[cfg(feature = "humble")]
+    fn validate_ros_message(&self) -> Result<(), String> {
+        match &self.format.pixel_format {
+            b"GRAY" | b"Y800" | b"RGB3" | b"RGB " | b"BGR3" | b"BGR " | b"RGBA" | b"BGRA"
+            | b"YUYV" | b"UYVY" => Ok(()),
+            pixel_format => Err(format!(
+                "CuImage pixel format '{}' is not supported by ROS 2 Humble cv_bridge",
+                String::from_utf8_lossy(pixel_format)
+            )),
+        }
+    }
+
     fn namespace() -> &'static str {
         "sensor_msgs"
     }
@@ -572,16 +584,22 @@ fn read_u32(data: &[u8], offset: usize) -> Result<u32, String> {
 
 fn pixel_format_to_encoding(pixel_format: [u8; 4]) -> String {
     match &pixel_format {
-        b"GRAY" => "mono8".to_string(),
-        b"RGB3" => "rgb8".to_string(),
-        b"BGR3" => "bgr8".to_string(),
+        b"GRAY" | b"Y800" => "mono8".to_string(),
+        b"RGB3" | b"RGB " => "rgb8".to_string(),
+        b"BGR3" | b"BGR " => "bgr8".to_string(),
         b"RGBA" => "rgba8".to_string(),
         b"BGRA" => "bgra8".to_string(),
         b"NV12" => "nv12".to_string(),
         b"NV21" => "nv21".to_string(),
         b"I420" => "i420".to_string(),
         b"YV12" => "yv12".to_string(),
+        #[cfg(feature = "humble")]
+        b"YUYV" => "yuv422_yuy2".to_string(),
+        #[cfg(not(feature = "humble"))]
         b"YUYV" => "yuyv".to_string(),
+        #[cfg(feature = "humble")]
+        b"UYVY" => "yuv422".to_string(),
+        #[cfg(not(feature = "humble"))]
         b"UYVY" => "uyvy".to_string(),
         _ => {
             let end = pixel_format
@@ -604,8 +622,8 @@ fn encoding_to_pixel_format(encoding: &str) -> [u8; 4] {
         "nv21" | "NV21" => *b"NV21",
         "i420" | "I420" => *b"I420",
         "yv12" | "YV12" => *b"YV12",
-        "yuyv" | "YUYV" => *b"YUYV",
-        "uyvy" | "UYVY" => *b"UYVY",
+        "yuyv" | "YUYV" | "yuv422_yuy2" | "YUV422_YUY2" => *b"YUYV",
+        "uyvy" | "UYVY" | "yuv422" | "YUV422" => *b"UYVY",
         _ => {
             let mut out = [0u8; 4];
             let bytes = encoding.as_bytes();
@@ -732,6 +750,88 @@ mod tests {
         assert_eq!(recovered.format.required_bytes(), 12);
         let recovered_bytes = recovered.buffer_handle.with_inner(|inner| inner.to_vec());
         assert_eq!(recovered_bytes, bytes);
+    }
+
+    #[test]
+    fn image_packed_aliases_use_standard_ros_encodings() {
+        let cases = [
+            (*b"GRAY", "mono8"),
+            (*b"Y800", "mono8"),
+            (*b"RGB3", "rgb8"),
+            (*b"RGB ", "rgb8"),
+            (*b"BGR3", "bgr8"),
+            (*b"BGR ", "bgr8"),
+            (*b"RGBA", "rgba8"),
+            (*b"BGRA", "bgra8"),
+        ];
+
+        for (pixel_format, expected) in cases {
+            assert_eq!(pixel_format_to_encoding(pixel_format), expected);
+        }
+    }
+
+    #[test]
+    fn image_yuv422_encoding_matches_ros_profile() {
+        #[cfg(feature = "humble")]
+        let expected = [(b"YUYV", "yuv422_yuy2"), (b"UYVY", "yuv422")];
+        #[cfg(not(feature = "humble"))]
+        let expected = [(b"YUYV", "yuyv"), (b"UYVY", "uyvy")];
+
+        for (pixel_format, encoding) in expected {
+            assert_eq!(pixel_format_to_encoding(*pixel_format), encoding);
+        }
+    }
+
+    #[test]
+    fn image_yuv422_input_accepts_modern_and_legacy_encodings() {
+        for encoding in ["yuyv", "YUYV", "yuv422_yuy2", "YUV422_YUY2"] {
+            assert_eq!(encoding_to_pixel_format(encoding), *b"YUYV");
+        }
+        for encoding in ["uyvy", "UYVY", "yuv422", "YUV422"] {
+            assert_eq!(encoding_to_pixel_format(encoding), *b"UYVY");
+        }
+    }
+
+    #[cfg(feature = "humble")]
+    #[test]
+    fn image_validation_rejects_formats_unsupported_by_humble_cv_bridge() {
+        for pixel_format in [b"NV12", b"NV21", b"I420", b"YV12", b"MJPG"] {
+            let image = CuImage::new(
+                CuImageBufferFormat {
+                    width: 4,
+                    height: 2,
+                    stride: 4,
+                    pixel_format: *pixel_format,
+                },
+                CuHandle::new_detached(vec![0; 64]),
+            );
+
+            let error = <CuImage<Vec<u8>> as RosBridgeAdapter>::validate_ros_message(&image)
+                .expect_err("unsupported Humble image format should be rejected");
+            assert!(error.contains(String::from_utf8_lossy(pixel_format).as_ref()));
+        }
+    }
+
+    #[cfg(feature = "humble")]
+    #[test]
+    fn image_validation_accepts_humble_cv_bridge_formats() {
+        for pixel_format in [
+            b"GRAY", b"Y800", b"RGB3", b"RGB ", b"BGR3", b"BGR ", b"RGBA", b"BGRA", b"YUYV",
+            b"UYVY",
+        ] {
+            let image = CuImage::new(
+                CuImageBufferFormat {
+                    width: 4,
+                    height: 2,
+                    stride: 16,
+                    pixel_format: *pixel_format,
+                },
+                CuHandle::new_detached(vec![0; 64]),
+            );
+
+            <CuImage<Vec<u8>> as RosBridgeAdapter>::validate_ros_message(&image)
+                .expect("supported Humble image format should pass validation");
+        }
     }
 
     #[test]

--- a/components/payloads/cu_sensor_payloads/Cargo.toml
+++ b/components/payloads/cu_sensor_payloads/Cargo.toml
@@ -21,8 +21,8 @@ environments = ["host", "embedded"]
 [dependencies]
 bincode = { workspace = true }
 cu29-soa-derive = { workspace = true }
-cu29-clock = { path = "../../../core/cu29_clock", version = "1.0.0", default-features = false }
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29-clock = { path = "../../../core/cu29_clock", version = "1.0.1", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false, features = [
   "units",
 ] }
 rerun = { workspace = true, optional = true }

--- a/components/payloads/cu_spatial_payloads/Cargo.toml
+++ b/components/payloads/cu_spatial_payloads/Cargo.toml
@@ -19,7 +19,7 @@ environments = ["host", "embedded"]
 
 [dependencies]
 bincode = { workspace = true }
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false, features = [
   "units",
 ] }
 serde = { workspace = true }

--- a/components/res/cu_linux_resources/Cargo.toml
+++ b/components/res/cu_linux_resources/Cargo.toml
@@ -19,7 +19,7 @@ environments = ["host"]
 host_os = ["linux"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false, features = [
   "std",
 ] }
 embedded-hal = { version = "1.0.0", default-features = false }

--- a/components/res/cu_micoairh743/Cargo.toml
+++ b/components/res/cu_micoairh743/Cargo.toml
@@ -24,13 +24,13 @@ defmt = ["dep:defmt", "cu-bdshot/defmt", "stm32h7xx-hal/defmt"]
 textlogs = ["cu29/textlogs", "cu-bdshot/textlogs", "cu-sdlogger/textlogs"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
-cu-dps310 = { path = "../../sources/cu_dps310", version = "1.0.0", default-features = false }
-cu-ist8310 = { path = "../../sources/cu_ist8310", version = "1.0.0", default-features = false }
-cu-bdshot = { path = "../../bridges/cu_bdshot", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false }
+cu-dps310 = { path = "../../sources/cu_dps310", version = "1.0.1", default-features = false }
+cu-ist8310 = { path = "../../sources/cu_ist8310", version = "1.0.1", default-features = false }
+cu-bdshot = { path = "../../bridges/cu_bdshot", version = "1.0.1", default-features = false, features = [
   "stm32h7",
 ] }
-cu-sdlogger = { path = "../../libs/cu_sdlogger", version = "1.0.0" }
+cu-sdlogger = { path = "../../libs/cu_sdlogger", version = "1.0.1" }
 cortex-m = { workspace = true, features = ["critical-section-single-core"] }
 defmt = { workspace = true, optional = true }
 embedded-hal = { version = "0.2.7", default-features = false }

--- a/components/sinks/cu_rp_sn754410/Cargo.toml
+++ b/components/sinks/cu_rp_sn754410/Cargo.toml
@@ -19,7 +19,7 @@ environments = ["host"]
 host_os = ["linux"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false, features = [
   "std",
   "textlogs",
   "units",

--- a/components/sources/cu_ads7883/Cargo.toml
+++ b/components/sources/cu_ads7883/Cargo.toml
@@ -19,7 +19,7 @@ environments = ["host"]
 host_os = ["linux"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false, features = [
   "std",
   "textlogs",
   "units",

--- a/components/sources/cu_bmi088/Cargo.toml
+++ b/components/sources/cu_bmi088/Cargo.toml
@@ -18,8 +18,8 @@ domains = ["sensor/imu"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.0", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.1", default-features = false }
 serde = { workspace = true }
 embedded-hal = { version = "0.2.7", default-features = false }
 

--- a/components/sources/cu_dps310/Cargo.toml
+++ b/components/sources/cu_dps310/Cargo.toml
@@ -18,8 +18,8 @@ domains = ["sensor/barometer"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.0", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.1", default-features = false }
 serde = { workspace = true }
 
 [features]

--- a/components/sources/cu_gnss_ublox/Cargo.toml
+++ b/components/sources/cu_gnss_ublox/Cargo.toml
@@ -19,9 +19,9 @@ domains = ["sensor/gnss"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false }
 cu-linux-resources = { workspace = true, optional = true }
-cu-gnss-payloads = { path = "../../payloads/cu_gnss_payloads", version = "1.0.0", default-features = false }
+cu-gnss-payloads = { path = "../../payloads/cu_gnss_payloads", version = "1.0.1", default-features = false }
 embedded-io = "0.7.1"
 
 [features]

--- a/components/sources/cu_hesai/Cargo.toml
+++ b/components/sources/cu_hesai/Cargo.toml
@@ -29,7 +29,7 @@ serde = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-cu-udp-inject = { path = "../../testing/cu_udp_inject", version = "1.0.0" }
+cu-udp-inject = { path = "../../testing/cu_udp_inject", version = "1.0.1" }
 serde = { workspace = true }
 
 [features]

--- a/components/sources/cu_ist8310/Cargo.toml
+++ b/components/sources/cu_ist8310/Cargo.toml
@@ -18,8 +18,8 @@ domains = ["sensor/magnetometer"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.0", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.1", default-features = false }
 
 [features]
 default = []

--- a/components/sources/cu_livox/Cargo.toml
+++ b/components/sources/cu_livox/Cargo.toml
@@ -28,7 +28,7 @@ serde = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-cu-udp-inject = { path = "../../testing/cu_udp_inject", version = "1.0.0" }
+cu-udp-inject = { path = "../../testing/cu_udp_inject", version = "1.0.1" }
 serde = { workspace = true }
 
 [features]

--- a/components/sources/cu_mpu9250/Cargo.toml
+++ b/components/sources/cu_mpu9250/Cargo.toml
@@ -18,10 +18,10 @@ domains = ["sensor/imu"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false, features = [
   "units",
 ] }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.0", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.1", default-features = false }
 mpu9250 = { version = "0.25.0", default-features = false }
 serde = { workspace = true }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0.0", default-features = false }

--- a/components/sources/cu_rp_encoder/Cargo.toml
+++ b/components/sources/cu_rp_encoder/Cargo.toml
@@ -19,7 +19,7 @@ environments = ["host"]
 host_os = ["linux"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false, features = [
   "std",
   "textlogs",
   "units",

--- a/components/sources/cu_ryuw122/Cargo.toml
+++ b/components/sources/cu_ryuw122/Cargo.toml
@@ -19,9 +19,9 @@ domains = ["sensor/uwb", "sensor/ranging"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false }
 cu-linux-resources = { workspace = true, optional = true }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.0", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.1", default-features = false }
 embedded-io = "0.7.1"
 
 [features]

--- a/components/sources/cu_sen0682/Cargo.toml
+++ b/components/sources/cu_sen0682/Cargo.toml
@@ -18,8 +18,8 @@ domains = ["sensor/lidar"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.0", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.1", default-features = false }
 cu-linux-resources = { workspace = true, optional = true }
 embedded-io = "0.7.1"
 

--- a/components/sources/cu_vlp16/Cargo.toml
+++ b/components/sources/cu_vlp16/Cargo.toml
@@ -24,4 +24,4 @@ velodyne-lidar = { version = "0.3.0", features = ["pcap", "parallel"] }
 # remove `nmea` for `velodyne-lidar` since it has conflicts for `dep:serde_with` with `dep:zenoh-config`
 
 [dev-dependencies]
-cu-udp-inject = { path = "../../testing/cu_udp_inject", version = "1.0.0" }
+cu-udp-inject = { path = "../../testing/cu_udp_inject", version = "1.0.1" }

--- a/components/tasks/cu_ahrs/Cargo.toml
+++ b/components/tasks/cu_ahrs/Cargo.toml
@@ -40,10 +40,10 @@ textlogs = [
 ]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false, features = [
   "units",
 ] }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.0", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.1", default-features = false }
 bincode = { workspace = true }
 serde = { workspace = true }
 uf-ahrs = { version = "=0.2.1", default-features = false }
@@ -66,7 +66,7 @@ rp235x-hal = { workspace = true, features = [
   "defmt",
 ], optional = true }
 spin = { workspace = true, optional = true }
-cu-mpu9250 = { path = "../../sources/cu_mpu9250", version = "1.0.0", default-features = false, optional = true }
+cu-mpu9250 = { path = "../../sources/cu_mpu9250", version = "1.0.1", default-features = false, optional = true }
 
 [[example]]
 name = "rp2350_copper"

--- a/components/tasks/cu_apriltag/Cargo.toml
+++ b/components/tasks/cu_apriltag/Cargo.toml
@@ -21,8 +21,8 @@ environments = ["host"]
 bincode = { workspace = true }
 cu29 = { workspace = true }
 serde = { workspace = true }
-cu-spatial-payloads = { path = "../../payloads/cu_spatial_payloads", version = "1.0.0" }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.0" }
+cu-spatial-payloads = { path = "../../payloads/cu_spatial_payloads", version = "1.0.1" }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.1" }
 
 [target.'cfg(unix)'.dependencies]
 apriltag = { version = "0.4.0" }

--- a/components/tasks/cu_dynthreshold/Cargo.toml
+++ b/components/tasks/cu_dynthreshold/Cargo.toml
@@ -21,8 +21,8 @@ environments = ["host"]
 [dependencies]
 gstreamer = { workspace = true, default-features = false, optional = true }
 cu29 = { workspace = true }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.0" }
-cu-gstreamer = { path = "../../sources/cu_gstreamer", version = "1.0.0", optional = true }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.1" }
+cu-gstreamer = { path = "../../sources/cu_gstreamer", version = "1.0.1", optional = true }
 
 [features]
 # The 'gst' feature includes dependencies for GStreamer support.

--- a/components/tasks/cu_peer_range_accumulator/Cargo.toml
+++ b/components/tasks/cu_peer_range_accumulator/Cargo.toml
@@ -18,8 +18,8 @@ domains = ["algorithm/ranging"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.0", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.1", default-features = false }
 serde = { workspace = true }
 
 [features]

--- a/components/tasks/cu_peer_triangulation/Cargo.toml
+++ b/components/tasks/cu_peer_triangulation/Cargo.toml
@@ -19,10 +19,10 @@ environments = ["host", "embedded"]
 
 [dependencies]
 bincode = { workspace = true }
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false, features = [
   "units",
 ] }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.0", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.0.1", default-features = false }
 libm = { version = "0.2", default-features = false }
 serde = { workspace = true }
 

--- a/components/tasks/cu_pid/Cargo.toml
+++ b/components/tasks/cu_pid/Cargo.toml
@@ -24,6 +24,6 @@ textlogs = ["cu29/textlogs"]
 reflect = ["cu29/reflect"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.0.0", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.0.1", default-features = false }
 bincode = { workspace = true }
 serde = { workspace = true }

--- a/components/tasks/cu_pid/src/lib.rs
+++ b/components/tasks/cu_pid/src/lib.rs
@@ -283,7 +283,7 @@ where
                 }
                 output.metadata.set_status(format!(
                     "{:>5.2} {:>5.2} {:>5.2} {:>5.2}",
-                    &state.output, &state.p, &state.i, &state.d
+                    state.output, state.p, state.i, state.d
                 ));
                 output.set_payload(state);
             }

--- a/components/tasks/cu_ratelimit/src/lib.rs
+++ b/components/tasks/cu_ratelimit/src/lib.rs
@@ -5,6 +5,11 @@ use bincode::{Decode, Encode};
 use cu29::prelude::*;
 use std::marker::PhantomData;
 
+fn phase_at_or_before(tov: CuTime, interval: CuDuration) -> CuTime {
+    let interval_ns = interval.as_nanos();
+    CuTime::from(tov.as_nanos() / interval_ns * interval_ns)
+}
+
 #[derive(Reflect)]
 #[reflect(no_field_bounds, from_reflect = false, type_path = false)]
 pub struct CuRateLimit<T>
@@ -71,7 +76,13 @@ where
                 .ok_or("Missing required 'rate' config for CuRateLimiter")?,
             None => return Err("Missing required 'rate' config for CuRateLimiter".into()),
         };
+        if !hz.is_finite() || hz <= 0.0 {
+            return Err("CuRateLimiter 'rate' must be finite and greater than zero".into());
+        }
         let interval_ns = (1e9 / hz) as u64;
+        if interval_ns == 0 {
+            return Err("CuRateLimiter 'rate' cannot exceed 1 GHz".into());
+        }
         Ok(Self {
             _marker: PhantomData,
             interval: CuDuration::from(interval_ns),
@@ -89,14 +100,31 @@ where
             Tov::Time(ts) => ts,
             _ => return Err("Expected single timestamp TOV".into()),
         };
+        output.tov = input.tov;
 
         let allow = match self.last_tov {
-            None => true,
-            Some(last) => (tov - last) >= self.interval,
+            None => {
+                self.last_tov = Some(phase_at_or_before(tov, self.interval));
+                true
+            }
+            Some(last) if tov < last => {
+                // Re-anchor after replay/simulation time is reset.
+                self.last_tov = Some(phase_at_or_before(tov, self.interval));
+                true
+            }
+            Some(last) => {
+                let elapsed = tov - last;
+                if elapsed < self.interval {
+                    false
+                } else {
+                    let elapsed_intervals = elapsed.as_nanos() / self.interval.as_nanos();
+                    self.last_tov = Some(last + elapsed_intervals * self.interval);
+                    true
+                }
+            }
         };
 
         if allow {
-            self.last_tov = Some(tov);
             if let Some(payload) = input.payload() {
                 output.set_payload(payload.clone());
             } else {
@@ -141,6 +169,7 @@ mod tests {
         input.tov = Tov::Time(CuTime::from(100_000_000)); // 100ms
         limiter.process(&ctx, &input, &mut output).unwrap();
         assert_eq!(output.payload(), Some(&42));
+        assert_eq!(output.tov, input.tov);
     }
 
     #[test]
@@ -161,5 +190,71 @@ mod tests {
         input.tov = Tov::Time(CuTime::from(100_000_000));
         limiter.process(&ctx, &input, &mut output).unwrap();
         assert_eq!(output.payload(), None);
+    }
+
+    #[test]
+    fn test_phase_preserving_64_hz_to_30_hz() {
+        let ctx = CuContext::new_with_clock();
+        let mut limiter = create_test_ratelimiter(30.0);
+        let mut input = CuMsg::<i32>::new(Some(42));
+        let mut output = CuMsg::<i32>::new(None);
+        let mut emitted = 0;
+
+        // 64 source samples span [0, 984.375 ms], which contains exactly 30
+        // points of the 30 Hz output phase including the initial sample.
+        for source_tick in 0..64 {
+            input.tov = Tov::Time(CuTime::from(source_tick * 15_625_000));
+            limiter.process(&ctx, &input, &mut output).unwrap();
+            emitted += usize::from(output.payload().is_some());
+        }
+
+        assert_eq!(emitted, 30);
+    }
+
+    #[test]
+    fn test_first_sample_uses_absolute_rate_phase() {
+        let ctx = CuContext::new_with_clock();
+        let mut limiter = create_test_ratelimiter(30.0);
+        let mut input = CuMsg::<i32>::new(Some(42));
+        let mut output = CuMsg::<i32>::new(None);
+
+        // A camera that becomes ready off-phase must join the same 30 Hz
+        // schedule as other graph inputs instead of creating its own phase.
+        input.tov = Tov::Time(CuTime::from(78_125_000));
+        limiter.process(&ctx, &input, &mut output).unwrap();
+        assert!(output.payload().is_some());
+
+        input.tov = Tov::Time(CuTime::from(93_750_000));
+        limiter.process(&ctx, &input, &mut output).unwrap();
+        assert!(output.payload().is_none());
+
+        input.tov = Tov::Time(CuTime::from(109_375_000));
+        limiter.process(&ctx, &input, &mut output).unwrap();
+        assert!(output.payload().is_some());
+    }
+
+    #[test]
+    fn test_time_rewind_reanchors_limiter() {
+        let ctx = CuContext::new_with_clock();
+        let mut limiter = create_test_ratelimiter(30.0);
+        let mut input = CuMsg::<i32>::new(Some(42));
+        let mut output = CuMsg::<i32>::new(None);
+
+        input.tov = Tov::Time(CuTime::from(1_000_000_000));
+        limiter.process(&ctx, &input, &mut output).unwrap();
+        assert!(output.payload().is_some());
+
+        input.tov = Tov::Time(CuTime::from(1_000_000));
+        limiter.process(&ctx, &input, &mut output).unwrap();
+        assert!(output.payload().is_some());
+    }
+
+    #[test]
+    fn test_invalid_rates_are_rejected() {
+        for rate in [0.0, -1.0, f64::NAN, f64::INFINITY, 1_000_000_001.0] {
+            let mut cfg = ComponentConfig::new();
+            cfg.set("rate", rate);
+            assert!(CuRateLimit::<i32>::new(Some(&cfg), ()).is_err());
+        }
     }
 }

--- a/core/cu29/Cargo.toml
+++ b/core/cu29/Cargo.toml
@@ -31,7 +31,7 @@ cu29-log-runtime = { workspace = true }
 cu29-reflect-derive = { workspace = true }
 cu29-runtime = { workspace = true }
 cu29-traits = { workspace = true }
-cu29-units = { path = "../cu29_units", version = "1.0.0", default-features = false, optional = true }
+cu29-units = { path = "../cu29_units", version = "1.0.1", default-features = false, optional = true }
 cu29-unifiedlog = { workspace = true }
 cu29-value = { workspace = true }
 defmt = { workspace = true, optional = true }

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -1,7 +1,6 @@
 use proc_macro::TokenStream;
 use quote::{ToTokens, format_ident, quote};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::fs::read_to_string;
 use std::path::Path;
 use std::process::Command;
 use syn::Fields::{Named, Unnamed};
@@ -17,7 +16,7 @@ use crate::utils::{config_id_to_bridge_const, config_id_to_enum, config_id_to_st
 use cu29_runtime::config::CuConfig;
 use cu29_runtime::config::{
     BridgeChannelConfigRepresentation, ConfigGraphs, CuGraph, Flavor, HandleContent, Node, NodeId,
-    RT_POOL, ResourceBundleConfig, read_configuration,
+    RT_POOL, ResourceBundleConfig, read_configuration, read_configuration_with_resolved_ron,
 };
 use cu29_runtime::curuntime::{
     CuExecutionLoop, CuExecutionStep, CuExecutionUnit, CuTaskType, compute_runtime_plan,
@@ -5745,30 +5744,29 @@ fn resolve_runtime_config_with_root(
                 args.config_path
             ))
         })?;
-        let bundled_local_config_content = read_to_string(&subsystem.config_path).map_err(|e| {
-            CuError::from(format!(
-                "Failed to read bundled local configuration for subsystem '{subsystem_id}' from '{}'.",
-                subsystem.config_path
-            ))
-            .add_cause(e.to_string().as_str())
-        })?;
+        // Bundle the include-expanded source representation. Serializing the lowered
+        // mission graphs would lose the source task order because missions use hash maps.
+        let (local_config, bundled_local_config_content) =
+            read_configuration_with_resolved_ron(&subsystem.config_path).map_err(|e| {
+                CuError::from(format!(
+                    "Failed to prepare bundled local configuration for subsystem '{subsystem_id}' from '{}'.",
+                    subsystem.config_path
+                ))
+                .add_cause(e.to_string().as_str())
+            })?;
 
         Ok(ResolvedRuntimeConfig {
-            local_config: subsystem.config.clone(),
+            local_config,
             bundled_local_config_content,
             subsystem_id: Some(subsystem_id.to_string()),
             subsystem_code: subsystem.subsystem_code,
         })
     } else {
+        let (local_config, bundled_local_config_content) =
+            read_configuration_with_resolved_ron(filename.as_str())?;
         Ok(ResolvedRuntimeConfig {
-            local_config: read_configuration(filename.as_str())?,
-            bundled_local_config_content: read_to_string(&filename).map_err(|e| {
-                CuError::from(format!(
-                    "Could not read the configuration file '{}'.",
-                    args.config_path
-                ))
-                .add_cause(e.to_string().as_str())
-            })?,
+            local_config,
+            bundled_local_config_content,
             subsystem_id: None,
             subsystem_code: 0,
         })
@@ -9714,6 +9712,7 @@ mod tests {
 
         let root = unique_test_dir("multi_runtime_resolve");
         let alpha_config = root.join("alpha.ron");
+        let beta_base_config = root.join("beta_base.ron");
         let beta_config = root.join("beta.ron");
         let network_config = root.join("multi.ron");
 
@@ -9732,11 +9731,23 @@ mod tests {
 "#,
         );
         write_file(
-            &beta_config,
+            &beta_base_config,
             r#"
 (
     tasks: [
         (id: "src", type: "BetaSource", run_in_sim: true),
+    ],
+)
+"#,
+        );
+        write_file(
+            &beta_config,
+            r#"
+(
+    includes: [
+        (path: "beta_base.ron", params: {}),
+    ],
+    tasks: [
         (id: "sink", type: "BetaSink", run_in_sim: true),
     ],
     cnx: [
@@ -9776,6 +9787,149 @@ mod tests {
             .expect("resolved local config graph");
         assert!(graph.get_node_id_by_name("src").is_some());
         assert!(resolved.bundled_local_config_content.contains("BetaSource"));
+        assert!(
+            !resolved
+                .bundled_local_config_content
+                .contains("beta_base.ron")
+        );
+
+        let bundled = CuConfig::deserialize_ron(&resolved.bundled_local_config_content)
+            .expect("bundled subsystem config must not need include path resolution");
+        let bundled_graph = bundled.get_graph(None).expect("bundled graph");
+        assert!(bundled_graph.get_node_id_by_name("src").is_some());
+        assert!(bundled_graph.get_node_id_by_name("sink").is_some());
+        assert_eq!(bundled_graph.edge_count(), 1);
+    }
+
+    #[test]
+    fn resolve_runtime_config_bundles_resolved_single_config() {
+        use super::*;
+
+        let root = unique_test_dir("single_runtime_resolve");
+        let base_config = root.join("base.ron");
+        let app_config = root.join("app.ron");
+
+        write_file(
+            &base_config,
+            r#"
+(
+    tasks: [
+        (id: "src", type: "IncludedSource", run_in_sim: true),
+    ],
+)
+"#,
+        );
+        write_file(
+            &app_config,
+            r#"
+(
+    includes: [
+        (path: "base.ron", params: {}),
+    ],
+    tasks: [
+        (id: "sink", type: "LocalSink", run_in_sim: true),
+    ],
+    cnx: [
+        (src: "src", dst: "sink", msg: "u32"),
+    ],
+)
+"#,
+        );
+
+        let args = CopperRuntimeArgs {
+            config_path: "app.ron".to_string(),
+            subsystem_id: None,
+            sim_mode: false,
+            ignore_resources: false,
+        };
+
+        let resolved =
+            resolve_runtime_config_with_root(&args, &root).expect("resolve single runtime config");
+
+        assert!(
+            resolved
+                .bundled_local_config_content
+                .contains("IncludedSource")
+        );
+        assert!(!resolved.bundled_local_config_content.contains("base.ron"));
+        let bundled = CuConfig::deserialize_ron(&resolved.bundled_local_config_content)
+            .expect("bundled config must not need include path resolution");
+        let graph = bundled.get_graph(None).expect("bundled graph");
+        assert!(graph.get_node_id_by_name("src").is_some());
+        assert!(graph.get_node_id_by_name("sink").is_some());
+        assert_eq!(graph.edge_count(), 1);
+    }
+
+    #[test]
+    fn resolve_runtime_config_preserves_mission_task_order_in_bundle() {
+        use super::*;
+
+        let root = unique_test_dir("mission_runtime_resolve_order");
+        let base_config = root.join("base.ron");
+        let app_config = root.join("app.ron");
+
+        write_file(
+            &base_config,
+            r#"
+(
+    tasks: [
+        (id: "c", type: "TaskC", missions: ["one", "two"]),
+    ],
+)
+"#,
+        );
+        write_file(
+            &app_config,
+            r#"
+(
+    includes: [
+        (path: "base.ron", params: {}),
+    ],
+    missions: [
+        (id: "one"),
+        (id: "two"),
+    ],
+    tasks: [
+        (id: "a", type: "TaskA", missions: ["two"]),
+        (id: "b", type: "TaskB", missions: ["one"]),
+    ],
+)
+"#,
+        );
+
+        let args = CopperRuntimeArgs {
+            config_path: "app.ron".to_string(),
+            subsystem_id: None,
+            sim_mode: false,
+            ignore_resources: false,
+        };
+        let resolved = resolve_runtime_config_with_root(&args, &root)
+            .expect("resolve mission config with includes");
+        let bundled = CuConfig::deserialize_ron(&resolved.bundled_local_config_content)
+            .expect("bundled mission config");
+
+        let task_order = |config: &CuConfig, mission: &str| {
+            config
+                .get_graph(Some(mission))
+                .expect("mission graph")
+                .get_all_nodes()
+                .into_iter()
+                .filter(|(_, node)| node.get_flavor() == Flavor::Task)
+                .map(|(_, node)| node.get_id())
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(task_order(&resolved.local_config, "one"), vec!["b", "c"]);
+        assert_eq!(task_order(&resolved.local_config, "two"), vec!["a", "c"]);
+        assert_eq!(
+            task_order(&bundled, "one"),
+            task_order(&resolved.local_config, "one")
+        );
+        assert_eq!(
+            task_order(&bundled, "two"),
+            task_order(&resolved.local_config, "two")
+        );
+        assert!(!resolved.bundled_local_config_content.contains("base.ron"));
     }
 
     #[test]

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -5413,6 +5413,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 use cu29::simulation::SimOverride;
                 use cu29::simulation::CuTaskCallbackState;
                 use cu29::simulation::CuSimSrcTask;
+                use cu29::simulation::CuSimSrcTaskPack;
                 use cu29::simulation::CuSimSinkTask;
                 use cu29::simulation::CuSimBridge;
                 use cu29::prelude::app::CuSimApplication;
@@ -9350,12 +9351,23 @@ fn runtime_task_type_for_index(
     match task_specs.cutypes[index] {
         CuTaskType::Source => {
             if sim_mode && !run_in_sim {
-                let msg_type = graph.get_node_output_msg_type(task_id.as_str()).unwrap_or_else(|| {
-                    panic!(
-                        "CuSrcTask {task_id} should have an outgoing connection with a valid output msg type"
-                    )
-                });
-                let sim_task_name = format!("CuSimSrcTask<{msg_type}>");
+                let msg_types = graph
+                    .get_node_output_msg_types(task_id.as_str())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "CuSrcTask {task_id} should have an outgoing connection with a valid output msg type"
+                        )
+                    });
+                let sim_task_name = if msg_types.len() == 1 {
+                    format!("CuSimSrcTask<{}>", msg_types[0])
+                } else {
+                    let messages = msg_types
+                        .iter()
+                        .map(|msg_type| format!("cu29::prelude::CuMsg<{msg_type}>"))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!("CuSimSrcTaskPack<({messages})>")
+                };
                 parse_str(sim_task_name.as_str()).unwrap_or_else(|_| {
                     panic!("Could not build the placeholder for simulation: {sim_task_name}")
                 })

--- a/core/cu29_derive/tests/config/multi_output_source_subset_valid.ron
+++ b/core/cu29_derive/tests/config/multi_output_source_subset_valid.ron
@@ -3,7 +3,7 @@
         (
             id: "src",
             type: "MultiSource",
-            run_in_sim: true,
+            run_in_sim: false,
         ),
         (
             id: "sink",

--- a/core/cu29_export/src/lib.rs
+++ b/core/cu29_export/src/lib.rs
@@ -608,12 +608,10 @@ pub fn textlog_dump(src: impl Read, index: &Path) -> CuResult<()> {
     })?;
 
     for result in structlog_reader(src) {
-        match result {
-            Ok(entry) => match rebuild_logline(&all_strings, &entry) {
-                Ok(line) => println!("{line}"),
-                Err(e) => println!("Failed to rebuild log line: {e:?}"),
-            },
-            Err(e) => return Err(e),
+        let entry = result?;
+        match rebuild_logline(&all_strings, &entry) {
+            Ok(line) => println!("{line}"),
+            Err(e) => println!("Failed to rebuild log line: {e:?}"),
         }
     }
 

--- a/core/cu29_log/README.md
+++ b/core/cu29_log/README.md
@@ -22,15 +22,15 @@ To set the minimum log level for your application, add one of the following feat
 
 ```toml
 [dependencies]
-cu29-log = { version = "1.0.0" }
-cu29-log-derive = { version = "1.0.0", features = ["log-level-info"]  }
+cu29-log = { version = "1.0.1" }
+cu29-log-derive = { version = "1.0.1", features = ["log-level-info"]  }
 ```
 
 or
 
 ```toml
 [dependencies]
-cu29 = { version = "1.0.0", features = ["log-level-info"]}
+cu29 = { version = "1.0.1", features = ["log-level-info"]}
 ```
 
 Available feature flags:

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -4084,7 +4084,7 @@ fn read_configuration_content(config_filename: &str) -> CuResult<String> {
     read_to_string(config_filename).map_err(|e| {
         CuError::from(format!(
             "Failed to read configuration file: {:?}",
-            &config_filename
+            config_filename
         ))
         .add_cause(e.to_string().as_str())
     })
@@ -4178,7 +4178,7 @@ pub fn read_multi_configuration(config_filename: &str) -> CuResult<MultiCopperCo
     let config_content = read_to_string(config_filename).map_err(|e| {
         CuError::from(format!(
             "Failed to read multi-Copper configuration file: {:?}",
-            &config_filename
+            config_filename
         ))
         .add_cause(e.to_string().as_str())
     })?;

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -4075,14 +4075,19 @@ fn validate_multi_config_representation(
 /// Read a copper configuration from a file.
 #[cfg(feature = "std")]
 pub fn read_configuration(config_filename: &str) -> CuResult<CuConfig> {
-    let config_content = read_to_string(config_filename).map_err(|e| {
+    let config_content = read_configuration_content(config_filename)?;
+    read_configuration_str(config_content, Some(config_filename))
+}
+
+#[cfg(feature = "std")]
+fn read_configuration_content(config_filename: &str) -> CuResult<String> {
+    read_to_string(config_filename).map_err(|e| {
         CuError::from(format!(
             "Failed to read configuration file: {:?}",
             &config_filename
         ))
         .add_cause(e.to_string().as_str())
-    })?;
-    read_configuration_str(config_content, Some(config_filename))
+    })
 }
 
 /// Read a copper configuration from a String.
@@ -4119,12 +4124,12 @@ fn config_representation_to_config(representation: CuConfigRepresentation) -> Cu
 }
 
 #[allow(unused_variables)]
-pub fn read_configuration_str(
-    config_content: String,
+fn resolve_configuration_representation(
+    config_content: &str,
     file_path: Option<&str>,
-) -> CuResult<CuConfig> {
+) -> CuResult<CuConfigRepresentation> {
     // Parse the configuration string
-    let representation = parse_config_string(&config_content)?;
+    let representation = parse_config_string(config_content)?;
 
     // Process includes and generate a merged configuration if a file path is provided
     // includes are only available with std.
@@ -4134,6 +4139,33 @@ pub fn read_configuration_str(
     } else {
         representation
     };
+
+    Ok(representation)
+}
+
+/// Read a Copper configuration and return the include-expanded RON used by proc-macro bundling.
+///
+/// The RON is serialized from the ordered source representation before it is lowered into
+/// mission graph hash maps. This keeps task ordering aligned with generated runtime code.
+#[cfg(feature = "std")]
+#[doc(hidden)]
+#[allow(dead_code)]
+pub fn read_configuration_with_resolved_ron(config_filename: &str) -> CuResult<(CuConfig, String)> {
+    let config_content = read_configuration_content(config_filename)?;
+    let representation =
+        resolve_configuration_representation(&config_content, Some(config_filename))?;
+    let resolved_ron = CuConfig::get_options()
+        .to_string_pretty(&representation, ron::ser::PrettyConfig::default())
+        .map_err(|e| CuError::from(format!("Error serializing configuration: {e}")))?;
+    let config = config_representation_to_config(representation)?;
+    Ok((config, resolved_ron))
+}
+
+pub fn read_configuration_str(
+    config_content: String,
+    file_path: Option<&str>,
+) -> CuResult<CuConfig> {
+    let representation = resolve_configuration_representation(&config_content, file_path)?;
 
     // Convert the representation to a CuConfig and validate
     config_representation_to_config(representation)

--- a/core/cu29_runtime/src/simulation.rs
+++ b/core/cu29_runtime/src/simulation.rs
@@ -93,6 +93,7 @@
 //!
 //! - **`CuSimSrcTask<T>`**: A placeholder for a source task that simulates a sensor or data acquisition hardware.
 //!   This task provides the ability to simulate incoming data without requiring actual hardware initialization.
+//! - **`CuSimSrcTaskPack<O>`**: The corresponding placeholder for multi-output sources.
 //!
 //! - **`CuSimSinkTask<T>`**: A placeholder for a sink task that simulates sending data to hardware. It serves as a
 //!   mock for hardware actuators or output devices during simulations.
@@ -273,6 +274,74 @@ impl<T> CuSimSrcTask<T> {
     /// simulator is responsible for providing deterministic outputs and state
     /// snapshots are carried by the real task (when run_in_sim = true).
     /// Keeping this as a no-op avoids baking any fake behavior into keyframes.
+    pub fn sim_tick(&mut self) {}
+}
+
+/// Simulation placeholder preserving the complete output tuple of a multi-output source.
+#[derive(Reflect)]
+#[reflect(no_field_bounds, from_reflect = false, type_path = false)]
+pub struct CuSimSrcTaskPack<O> {
+    #[reflect(ignore)]
+    output: PhantomData<fn() -> O>,
+    state: bool,
+}
+
+impl<O: 'static> TypePath for CuSimSrcTaskPack<O> {
+    fn type_path() -> &'static str {
+        "cu29_runtime::simulation::CuSimSrcTaskPack"
+    }
+
+    fn short_type_path() -> &'static str {
+        "CuSimSrcTaskPack"
+    }
+
+    fn type_ident() -> Option<&'static str> {
+        Some("CuSimSrcTaskPack")
+    }
+
+    fn crate_name() -> Option<&'static str> {
+        Some("cu29_runtime")
+    }
+
+    fn module_path() -> Option<&'static str> {
+        Some("simulation")
+    }
+}
+
+impl<O> Freezable for CuSimSrcTaskPack<O> {
+    fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        Encode::encode(&self.state, encoder)
+    }
+
+    fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
+        self.state = Decode::decode(decoder)?;
+        Ok(())
+    }
+}
+
+impl<O: CuMsgPayload + 'static> CuSrcTask for CuSimSrcTaskPack<O> {
+    type Resources<'r> = ();
+    type Output<'m> = O;
+
+    fn new(_config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self {
+            output: PhantomData,
+            state: true,
+        })
+    }
+
+    fn process(&mut self, _ctx: &CuContext, _new_msg: &mut Self::Output<'_>) -> CuResult<()> {
+        unimplemented!(
+            "A placeholder for sim was called for a multi-output source, you need answer SimOverride to ExecutedBySim for the Process step."
+        )
+    }
+}
+
+impl<O> CuSimSrcTaskPack<O> {
+    /// Placeholder hook for simulation-driven multi-output sources.
     pub fn sim_tick(&mut self) {}
 }
 

--- a/examples/cu_bevymon_demo/Cargo.toml
+++ b/examples/cu_bevymon_demo/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 
 [dependencies]
 bevy_ecs = { version = "0.19.0", default-features = false }
-cu29 = { path = "../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../core/cu29", version = "1.0.1", default-features = false, features = [
   "std",
   "textlogs",
 ] }
@@ -34,7 +34,7 @@ bevy = { workspace = true, default-features = false, features = [
   "bevy_ui",
   "bevy_ui_render",
 ] }
-cu-bevymon = { path = "../../components/monitors/cu_bevymon", version = "1.0.0" }
+cu-bevymon = { path = "../../components/monitors/cu_bevymon", version = "1.0.1" }
 image = { workspace = true, default-features = false, features = ["png"] }
 winit = { version = "=0.30.13", default-features = false }
 
@@ -48,7 +48,7 @@ bevy = { workspace = true, default-features = false, features = [
   "bevy_ui",
   "bevy_ui_render",
 ] }
-cu-bevymon = { path = "../../components/monitors/cu_bevymon", version = "1.0.0", default-features = false }
+cu-bevymon = { path = "../../components/monitors/cu_bevymon", version = "1.0.1", default-features = false }
 
 [[bin]]
 name = "cu-bevymon-demo"

--- a/examples/cu_bridge_test/Cargo.toml
+++ b/examples/cu_bridge_test/Cargo.toml
@@ -25,7 +25,7 @@ cu29-unifiedlog = { workspace = true }
 bincode = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }
-cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.0.0" }
+cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.0.1" }
 
 [[bin]]
 name = "resim"

--- a/examples/cu_caterpillar/Cargo.toml
+++ b/examples/cu_caterpillar/Cargo.toml
@@ -39,8 +39,8 @@ cu29-export = { workspace = true, features = ["python", "mcap"] }
 serde = { workspace = true }
 cu29-unifiedlog = { workspace = true }
 
-cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.0.0" } # needed
-cu-rp-gpio = { path = "../../components/sinks/cu_rp_gpio", version = "1.0.0" }
+cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.0.1" } # needed
+cu-rp-gpio = { path = "../../components/sinks/cu_rp_gpio", version = "1.0.1" }
 
 
 [features]

--- a/examples/cu_config_variation/Cargo.toml
+++ b/examples/cu_config_variation/Cargo.toml
@@ -14,8 +14,8 @@ repository.workspace = true
 publish = false
 [dependencies]
 cu29 = { workspace = true }
-cu-caterpillar = { path = "../cu_caterpillar", version = "1.0.0" }
-cu-rp-gpio = { path = "../../components/sinks/cu_rp_gpio", version = "1.0.0" }
+cu-caterpillar = { path = "../cu_caterpillar", version = "1.0.1" }
+cu-rp-gpio = { path = "../../components/sinks/cu_rp_gpio", version = "1.0.1" }
 serde = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/examples/cu_distributed_resim_demo/Cargo.toml
+++ b/examples/cu_distributed_resim_demo/Cargo.toml
@@ -18,7 +18,7 @@ default-run = "distributed-scout"
 cu29 = { workspace = true }
 cu29-export = { workspace = true }
 cu29-unifiedlog = { workspace = true }
-cu-zenoh-bridge = { path = "../../components/bridges/cu_zenoh_bridge", version = "1.0.0" }
+cu-zenoh-bridge = { path = "../../components/bridges/cu_zenoh_bridge", version = "1.0.1" }
 serde = { workspace = true }
 bincode = { workspace = true }
 

--- a/examples/cu_elrs_bdshot_demo/Cargo.toml
+++ b/examples/cu_elrs_bdshot_demo/Cargo.toml
@@ -23,19 +23,19 @@ embedded_targets = ["thumbv8m.main-none-eabihf"]
 buddy_system_allocator = { workspace = true, default-features = false, features = [
   "use_spin",
 ] }
-cu29 = { path = "../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../core/cu29", version = "1.0.1", default-features = false, features = [
   "defmt",
   "log-level-debug",
   "textlogs",
 ] }
-cu-bdshot = { path = "../../components/bridges/cu_bdshot", version = "1.0.0", default-features = false, features = [
+cu-bdshot = { path = "../../components/bridges/cu_bdshot", version = "1.0.1", default-features = false, features = [
   "rp2350",
 ] }
-cu-crsf = { path = "../../components/bridges/cu_crsf", version = "1.0.0", default-features = false, features = [
+cu-crsf = { path = "../../components/bridges/cu_crsf", version = "1.0.1", default-features = false, features = [
   "defmt",
   "alloc",
 ] }
-cu-sdlogger = { path = "../../components/libs/cu_sdlogger", version = "1.0.0", default-features = false, features = [
+cu-sdlogger = { path = "../../components/libs/cu_sdlogger", version = "1.0.1", default-features = false, features = [
   "eh1",
 ] }
 cortex-m-rt = { workspace = true }

--- a/examples/cu_flight_controller/Cargo.toml
+++ b/examples/cu_flight_controller/Cargo.toml
@@ -31,31 +31,31 @@ bevy_ecs = { version = "0.19.0", default-features = false }
 ## Flight controller components
 
 ### Hardware
-cu-bdshot = { path = "../../components/bridges/cu_bdshot", version = "1.0.0", default-features = false, optional = true }
-cu-crsf = { path = "../../components/bridges/cu_crsf", version = "1.0.0", default-features = false, features = [
+cu-bdshot = { path = "../../components/bridges/cu_bdshot", version = "1.0.1", default-features = false, optional = true }
+cu-crsf = { path = "../../components/bridges/cu_crsf", version = "1.0.1", default-features = false, features = [
   "alloc",
 ], optional = true }
-cu-msp-bridge = { path = "../../components/bridges/cu_msp_bridge", version = "1.0.0", default-features = false, features = [
+cu-msp-bridge = { path = "../../components/bridges/cu_msp_bridge", version = "1.0.1", default-features = false, features = [
   "alloc",
 ], optional = true }
-cu-msp-lib = { path = "../../components/libs/cu_msp_lib", version = "1.0.0", default-features = false, features = [
+cu-msp-lib = { path = "../../components/libs/cu_msp_lib", version = "1.0.1", default-features = false, features = [
   "bincode",
 ] }
 cu-sdlogger = { workspace = true, optional = true }
 cu-micoairh743 = { workspace = true, optional = true }
-cu-logmon = { path = "../../components/monitors/cu_logmon", version = "1.0.0", default-features = false, features = [
+cu-logmon = { path = "../../components/monitors/cu_logmon", version = "1.0.1", default-features = false, features = [
   "color_log",
 ], optional = true }
-cu-ahrs = { path = "../../components/tasks/cu_ahrs", version = "1.0.0", default-features = false, optional = true }
-cu-bmi088 = { path = "../../components/sources/cu_bmi088", version = "1.0.0", default-features = false, optional = true }
-cu-dps310 = { path = "../../components/sources/cu_dps310", version = "1.0.0", default-features = false, optional = true }
-cu-ist8310 = { path = "../../components/sources/cu_ist8310", version = "1.0.0", default-features = false, optional = true }
-cu-gnss-payloads = { path = "../../components/payloads/cu_gnss_payloads", version = "1.0.0", default-features = false, optional = true }
-cu-gnss-ublox = { path = "../../components/sources/cu_gnss_ublox", version = "1.0.0", default-features = false, optional = true }
+cu-ahrs = { path = "../../components/tasks/cu_ahrs", version = "1.0.1", default-features = false, optional = true }
+cu-bmi088 = { path = "../../components/sources/cu_bmi088", version = "1.0.1", default-features = false, optional = true }
+cu-dps310 = { path = "../../components/sources/cu_dps310", version = "1.0.1", default-features = false, optional = true }
+cu-ist8310 = { path = "../../components/sources/cu_ist8310", version = "1.0.1", default-features = false, optional = true }
+cu-gnss-payloads = { path = "../../components/payloads/cu_gnss_payloads", version = "1.0.1", default-features = false, optional = true }
+cu-gnss-ublox = { path = "../../components/sources/cu_gnss_ublox", version = "1.0.1", default-features = false, optional = true }
 
 ### Algos
-cu-pid = { path = "../../components/tasks/cu_pid", version = "1.0.0", default-features = false }
-cu-sensor-payloads = { path = "../../components/payloads/cu_sensor_payloads", version = "1.0.0", default-features = false }
+cu-pid = { path = "../../components/tasks/cu_pid", version = "1.0.1", default-features = false }
+cu-sensor-payloads = { path = "../../components/payloads/cu_sensor_payloads", version = "1.0.1", default-features = false }
 bincode = { workspace = true }
 serde = { workspace = true }
 spin = { workspace = true }
@@ -81,7 +81,7 @@ avian3d = { workspace = true, default-features = false, features = [
   "parry-f32",
 ], optional = true }
 
-cu29 = { path = "../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../core/cu29", version = "1.0.1", default-features = false, features = [
   "log-level-debug",
   "units",
 ], optional = true }
@@ -107,7 +107,7 @@ cortex-m = { workspace = true, features = [
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cu-consolemon = { workspace = true, optional = true }
 cu-bevymon = { workspace = true, optional = true }
-cu-memmon = { path = "../../components/monitors/cu_memmon", version = "1.0.0", default-features = false, features = [
+cu-memmon = { path = "../../components/monitors/cu_memmon", version = "1.0.1", default-features = false, features = [
   "std",
   "memory_monitoring",
 ], optional = true }
@@ -144,7 +144,7 @@ evdev = { version = "0.13.2", optional = true }
 winit = { version = "=0.30.13", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-cu-bevymon = { path = "../../components/monitors/cu_bevymon", version = "1.0.0", default-features = false, optional = true }
+cu-bevymon = { path = "../../components/monitors/cu_bevymon", version = "1.0.1", default-features = false, optional = true }
 bevy = { workspace = true, default-features = false, features = [
   "default_font",
   "bevy_render",

--- a/examples/cu_flight_controller/README.md
+++ b/examples/cu_flight_controller/README.md
@@ -188,8 +188,10 @@ Notes:
 
 - **Simulation path**: no receiver is used directly; input is read from the host joystick interface.
 - **Auto-detected TX joystick profiles**:
-  - ExpressLRS-style USB joystick names (`expresslrs`, `radiomaster`)
+  - ExpressLRS-style joystick names (`expresslrs`, `elrs`, `radiomaster`)
   - OpenTX / EdgeTX USB joystick names (`opentx`, `edgetx`)
+- **ExpressLRS BLE mapping**: CH1-CH8 are joystick axes and CH9-CH16 are buttons. The sim uses
+  CH5 (`ABS_Z`) for arm and CH6 (`ABS_RZ`) for flight mode.
 - **Firmware path (real hardware)**: RC input is CRSF on UART, so use a CRSF-compatible RX link
   (for example ExpressLRS/Crossfire-class receivers and compatible transmitters).
 

--- a/examples/cu_flight_controller/src/sim.rs
+++ b/examples/cu_flight_controller/src/sim.rs
@@ -1330,11 +1330,14 @@ fn apply_joystick_frame(frame: &RcFrame, rc_input: &mut SimRcInput) {
     rc_input.yaw = (-frame.yaw).clamp(-1.0, 1.0);
     rc_input.throttle = frame.throttle.clamp(0.0, 1.0);
 
+    let armed_from_axis = frame.arm.map(|arm| arm > 0.5);
     let armed_from_switch = arm_from_switches(frame);
-    let arm_uses_sa_axis = armed_from_switch.is_none();
-    rc_input.armed = armed_from_switch.unwrap_or(frame.knob_sa > 0.5);
+    let arm_uses_aux_axis = armed_from_axis.is_some() || armed_from_switch.is_none();
+    rc_input.armed = armed_from_axis
+        .or(armed_from_switch)
+        .unwrap_or(frame.knob_sa > 0.5);
 
-    let mode_axis = if arm_uses_sa_axis {
+    let mode_axis = if arm_uses_aux_axis {
         frame.knob_sb
     } else {
         frame.knob_sa
@@ -1802,13 +1805,15 @@ fn connected_help_values(view_label: &str, joystick: &RcJoystick) -> String {
     let arm_switch = find_arm_switch(&frame);
     let device_name = joystick.device_name();
 
-    let arm_line = if let Some(sw) = arm_switch {
+    let arm_line = if frame.arm.is_some() {
+        format!("arm {} > 0.5", axis_or_unmapped(axes.arm.as_ref()))
+    } else if let Some(sw) = arm_switch {
         format!("switch {}", sw.name)
     } else {
         format!("knob_sa {} > 0.5", axis_or_unmapped(axes.knob_sa.as_ref()))
     };
 
-    let mode_line = if arm_switch.is_some() {
+    let mode_line = if frame.arm.is_none() && arm_switch.is_some() {
         format!(
             "knob_sa {} (3-pos)",
             axis_or_unmapped(axes.knob_sa.as_ref())
@@ -2372,6 +2377,28 @@ mod tests {
             err.abs() < 1.0e-3,
             "heading mismatch: actual={actual} expected={expected} err={err}"
         );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn elrs_arm_axis_takes_precedence_over_hid_buttons() {
+        let mut rc_input = SimRcInput::default();
+        let mut frame = RcFrame {
+            arm: Some(1.0),
+            switches: vec![rc_joystick::SwitchState {
+                name: "ch9".to_string(),
+                on: false,
+            }],
+            ..RcFrame::default()
+        };
+
+        apply_joystick_frame(&frame, &mut rc_input);
+        assert!(rc_input.armed);
+
+        frame.arm = Some(-1.0);
+        frame.switches[0].on = true;
+        apply_joystick_frame(&frame, &mut rc_input);
+        assert!(!rc_input.armed);
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/examples/cu_flight_controller/src/sim/rc_joystick.rs
+++ b/examples/cu_flight_controller/src/sim/rc_joystick.rs
@@ -6,13 +6,14 @@ use std::path::PathBuf;
 
 use evdev::{AbsoluteAxisCode, AttributeSetRef, Device, EventSummary, EventType, KeyCode};
 
-/// Snapshot of all RC inputs normalized to [-1.0, 1.0].
-#[derive(Debug, Clone)]
+/// Snapshot of the normalized RC inputs exposed by a joystick device.
+#[derive(Debug, Clone, Default)]
 pub struct RcFrame {
     pub roll: f32,
     pub pitch: f32,
     pub yaw: f32,
     pub throttle: f32,
+    pub arm: Option<f32>,
     pub knob_sa: f32,
     pub knob_sb: f32,
     pub knob_sc: f32,
@@ -39,6 +40,7 @@ pub struct RcAxisBindings {
     pub pitch: Option<String>,
     pub yaw: Option<String>,
     pub throttle: Option<String>,
+    pub arm: Option<String>,
     pub knob_sa: Option<String>,
     pub knob_sb: Option<String>,
     pub knob_sc: Option<String>,
@@ -50,6 +52,7 @@ enum RcAxis {
     Pitch,
     Yaw,
     Throttle,
+    Arm,
     KnobSa,
     KnobSb,
     KnobSc,
@@ -100,6 +103,7 @@ impl RcJoystick {
             pitch: 0.0,
             yaw: 0.0,
             throttle: 0.0,
+            arm: None,
             knob_sa: 0.0,
             knob_sb: 0.0,
             knob_sc: 0.0,
@@ -182,6 +186,7 @@ impl RcJoystick {
                 RcAxis::Pitch => bindings.pitch = Some(label),
                 RcAxis::Yaw => bindings.yaw = Some(label),
                 RcAxis::Throttle => bindings.throttle = Some(label),
+                RcAxis::Arm => bindings.arm = Some(label),
                 RcAxis::KnobSa => bindings.knob_sa = Some(label),
                 RcAxis::KnobSb => bindings.knob_sb = Some(label),
                 RcAxis::KnobSc => bindings.knob_sc = Some(label),
@@ -216,6 +221,11 @@ impl RcJoystick {
             RcAxis::Throttle => {
                 let changed = !float_eq(self.state.throttle, value);
                 self.state.throttle = value;
+                changed
+            }
+            RcAxis::Arm => {
+                let changed = self.state.arm.is_none_or(|arm| !float_eq(arm, value));
+                self.state.arm = Some(value);
                 changed
             }
             RcAxis::KnobSa => {
@@ -266,6 +276,7 @@ fn prime_axes(device: &Device, axis_map: &HashMap<u16, (RcAxis, AxisScale)>, sta
                 RcAxis::Pitch => state.pitch = value,
                 RcAxis::Yaw => state.yaw = value,
                 RcAxis::Throttle => state.throttle = value,
+                RcAxis::Arm => state.arm = Some(value),
                 RcAxis::KnobSa => state.knob_sa = value,
                 RcAxis::KnobSb => state.knob_sb = value,
                 RcAxis::KnobSc => state.knob_sc = value,
@@ -298,23 +309,30 @@ fn is_radio_profile_name(name: &str) -> bool {
 }
 
 fn is_elrs_profile_name(name: &str) -> bool {
-    name.contains("expresslrs") || name.contains("radiomaster")
+    name.contains("expresslrs") || name.contains("elrs") || name.contains("radiomaster")
 }
 
 fn is_opentx_profile_name(name: &str) -> bool {
     name.contains("opentx") || name.contains("edgetx")
 }
 
-// ExpressLRS joystick switch codes mapped to radio labels directly.
-// Update these names if your Lua script exports different labels.
-const ELRS_SWITCH_CODES: &[(KeyCode, &str)] =
-    &[(KeyCode::new(0x120), "se"), (KeyCode::new(0x121), "sf")];
+// ExpressLRS maps channels 9-16 to the eight HID joystick buttons.
+const ELRS_SWITCH_CODES: &[(KeyCode, &str)] = &[
+    (KeyCode::new(0x120), "ch9"),
+    (KeyCode::new(0x121), "ch10"),
+    (KeyCode::new(0x122), "ch11"),
+    (KeyCode::new(0x123), "ch12"),
+    (KeyCode::new(0x124), "ch13"),
+    (KeyCode::new(0x125), "ch14"),
+    (KeyCode::new(0x126), "ch15"),
+    (KeyCode::new(0x127), "ch16"),
+];
 
 fn build_switches(device: &Device) -> Vec<SwitchState> {
     let name = joystick_device_name(device);
     let supported = device.supported_keys();
 
-    if is_radio_profile_name(&name) {
+    if is_elrs_profile_name(&name) {
         return ELRS_SWITCH_CODES
             .iter()
             .filter(|(code, _)| supported.is_some_and(|s| s.contains(*code)))
@@ -341,7 +359,7 @@ fn build_switches(device: &Device) -> Vec<SwitchState> {
 fn build_switch_map(device: &Device, switches: &[SwitchState]) -> HashMap<u16, usize> {
     let mut map = HashMap::new();
     let device_name = joystick_device_name(device);
-    if is_radio_profile_name(&device_name) {
+    if is_elrs_profile_name(&device_name) {
         for (code, name) in ELRS_SWITCH_CODES.iter() {
             if let Some(idx) = switches.iter().position(|s| s.name == *name) {
                 map.insert(code.0, idx);
@@ -460,7 +478,7 @@ fn build_axis_map(device: &Device) -> HashMap<u16, (RcAxis, AxisScale)> {
             axes,
             &mut map,
             AbsoluteAxisCode::ABS_Z,
-            RcAxis::KnobSa,
+            RcAxis::Arm,
             AxisScale::NegOneToOne,
         );
         insert_if_present(

--- a/examples/cu_flight_controller/src/sim/rc_tester.rs
+++ b/examples/cu_flight_controller/src/sim/rc_tester.rs
@@ -27,22 +27,24 @@ fn main() -> io::Result<()> {
     let bindings = joystick.axis_bindings();
     println!("Using RC joystick: {}", joystick.device_name());
     println!(
-        "Axis bindings: roll={:?} pitch={:?} yaw={:?} throttle={:?} sa={:?} sb={:?} sc={:?}",
+        "Axis bindings: roll={:?} pitch={:?} yaw={:?} throttle={:?} arm={:?} sa={:?} sb={:?} sc={:?}",
         bindings.roll,
         bindings.pitch,
         bindings.yaw,
         bindings.throttle,
+        bindings.arm,
         bindings.knob_sa,
         bindings.knob_sb,
         bindings.knob_sc
     );
     let frame = joystick.current_frame();
     println!(
-        "Initial frame: roll {:+.2} pitch {:+.2} yaw {:+.2} throttle {:+.2} sa {:+.2} sb {:+.2} sc {:+.2}",
+        "Initial frame: roll {:+.2} pitch {:+.2} yaw {:+.2} throttle {:+.2} arm {:?} sa {:+.2} sb {:+.2} sc {:+.2}",
         frame.roll,
         frame.pitch,
         frame.yaw,
         frame.throttle,
+        frame.arm,
         frame.knob_sa,
         frame.knob_sb,
         frame.knob_sc
@@ -65,11 +67,12 @@ fn main() -> io::Result<()> {
                     .collect::<Vec<_>>()
                     .join(" ");
                 println!(
-                    "roll {:+.2} pitch {:+.2} yaw {:+.2} throttle {:+.2} sa {:+.2} sb {:+.2} sc {:+.2} | {} | {}",
+                    "roll {:+.2} pitch {:+.2} yaw {:+.2} throttle {:+.2} arm {:?} sa {:+.2} sb {:+.2} sc {:+.2} | {} | {}",
                     frame.roll,
                     frame.pitch,
                     frame.yaw,
                     frame.throttle,
+                    frame.arm,
                     frame.knob_sa,
                     frame.knob_sb,
                     frame.knob_sc,

--- a/examples/cu_iceoryx2_bridge_demo/Cargo.toml
+++ b/examples/cu_iceoryx2_bridge_demo/Cargo.toml
@@ -17,7 +17,7 @@ default-run = "iceoryx2-ping"
 
 [dependencies]
 cu29 = { workspace = true }
-cu-iceoryx2-bridge = { path = "../../components/bridges/cu_iceoryx2_bridge", version = "1.0.0" }
+cu-iceoryx2-bridge = { path = "../../components/bridges/cu_iceoryx2_bridge", version = "1.0.1" }
 serde = { workspace = true }
 bincode = { workspace = true }
 tempfile = { workspace = true }

--- a/examples/cu_image_aligner/Cargo.toml
+++ b/examples/cu_image_aligner/Cargo.toml
@@ -18,8 +18,8 @@ publish = false
 cu29 = { workspace = true }
 cu29-clock = { workspace = true }
 tempfile = { workspace = true }
-cu-aligner = { path = "../../components/tasks/cu_aligner", version = "1.0.0" }
-cu-sensor-payloads = { path = "../../components/payloads/cu_sensor_payloads", version = "1.0.0" }
+cu-aligner = { path = "../../components/tasks/cu_aligner", version = "1.0.1" }
+cu-sensor-payloads = { path = "../../components/payloads/cu_sensor_payloads", version = "1.0.1" }
 paste = { workspace = true }
 serde = { workspace = true }
 

--- a/examples/cu_image_codec_demo/Cargo.toml
+++ b/examples/cu_image_codec_demo/Cargo.toml
@@ -35,7 +35,7 @@ logreader = ["ffv1", "dep:cu29-export"]
 
 [dependencies]
 cu-ffv1-codec = { workspace = true, optional = true, features = ["ffmpeg"] }
-cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.0.0", optional = true }
+cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.0.1", optional = true }
 cu-png-codec = { workspace = true, optional = true }
 cu-sensor-payloads = { workspace = true }
 cu29 = { workspace = true }

--- a/examples/cu_min_baremetal/Cargo.toml
+++ b/examples/cu_min_baremetal/Cargo.toml
@@ -32,7 +32,7 @@ required-features = ["std"]
 [dependencies]
 
 bincode = { workspace = true }
-cu29 = { path = "../../core/cu29", default-features = false, version = "1.0.0", features = [
+cu29 = { path = "../../core/cu29", default-features = false, version = "1.0.1", features = [
   "textlogs",
 ] } # default-features = false -> enables no-std for all cu29 dependencies
 serde = { workspace = true }

--- a/examples/cu_monitoring/Cargo.toml
+++ b/examples/cu_monitoring/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 [dependencies]
 cu29 = { workspace = true }
 serde = { workspace = true }
-cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.0.0" }
+cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.0.1" }
 
 [package.metadata.cargo-shear]
 ignored = ["serde"]

--- a/examples/cu_msp_bridge_loopback/Cargo.toml
+++ b/examples/cu_msp_bridge_loopback/Cargo.toml
@@ -19,9 +19,9 @@ path = "src/main.rs"
 [dependencies]
 cu29 = { workspace = true }
 cu-linux-resources = { workspace = true }
-cu-msp-bridge = { path = "../../components/bridges/cu_msp_bridge", version = "1.0.0" }
-cu-msp-lib = { path = "../../components/libs/cu_msp_lib", version = "1.0.0" }
-cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.0.0" }
+cu-msp-bridge = { path = "../../components/bridges/cu_msp_bridge", version = "1.0.1" }
+cu-msp-lib = { path = "../../components/libs/cu_msp_lib", version = "1.0.1" }
+cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.0.1" }
 nix = { workspace = true, default-features = false, features = ["term", "fs"] }
 serde = { workspace = true }
 ctrlc = { workspace = true }

--- a/examples/cu_parallel_mandelbrot/Cargo.toml
+++ b/examples/cu_parallel_mandelbrot/Cargo.toml
@@ -18,7 +18,7 @@ publish = false
 bincode = { workspace = true }
 cu29 = { workspace = true }
 cu29-export = { workspace = true, features = ["mcap"] }
-cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.0.0" }
+cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.0.1" }
 cu-sensor-payloads = { workspace = true }
 libc = { workspace = true }
 minifb = "0.28.0"

--- a/examples/cu_peer_triangulation/Cargo.toml
+++ b/examples/cu_peer_triangulation/Cargo.toml
@@ -19,6 +19,6 @@ path = "src/main.rs"
 
 [dependencies]
 cu29 = { workspace = true }
-cu-peer-range-accumulator = { path = "../../components/tasks/cu_peer_range_accumulator", version = "1.0.0" }
-cu-peer-triangulation = { path = "../../components/tasks/cu_peer_triangulation", version = "1.0.0" }
+cu-peer-range-accumulator = { path = "../../components/tasks/cu_peer_range_accumulator", version = "1.0.1" }
+cu-peer-triangulation = { path = "../../components/tasks/cu_peer_triangulation", version = "1.0.1" }
 cu-sensor-payloads = { workspace = true }

--- a/examples/cu_pointclouds/Cargo.toml
+++ b/examples/cu_pointclouds/Cargo.toml
@@ -15,8 +15,8 @@ publish = false
 [dependencies]
 cu29 = { workspace = true }
 tempfile = { workspace = true }
-cu-hesai = { path = "../../components/sources/cu_hesai", version = "1.0.0" }
-cu-udp-inject = { path = "../../components/testing/cu_udp_inject", version = "1.0.0" }
+cu-hesai = { path = "../../components/sources/cu_hesai", version = "1.0.1" }
+cu-udp-inject = { path = "../../components/testing/cu_udp_inject", version = "1.0.1" }
 rerun = { workspace = true }
 serde = { workspace = true }
 

--- a/examples/cu_python_task_demo/Cargo.toml
+++ b/examples/cu_python_task_demo/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 cu29 = { workspace = true, features = ["reflect"] }
-cu-python-task = { path = "../../components/tasks/cu_python_task", version = "1.0.0" }
+cu-python-task = { path = "../../components/tasks/cu_python_task", version = "1.0.1" }
 serde = { workspace = true }
 bincode = { workspace = true }
 tempfile = { workspace = true }

--- a/examples/cu_resources_test/Cargo.toml
+++ b/examples/cu_resources_test/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 clap = { workspace = true }
 cu29 = { workspace = true, features = ["log-level-debug"] }
 cu29-unifiedlog = { workspace = true }
-cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.0.0" }
+cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.0.1" }
 serde = { workspace = true }
 bincode = { workspace = true }
 parking_lot = "0.12"

--- a/examples/cu_ros2_bridge_demo/Cargo.toml
+++ b/examples/cu_ros2_bridge_demo/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 
 [dependencies]
 cu29 = { workspace = true }
-cu-ros2-bridge = { path = "../../components/bridges/cu_ros2_bridge", version = "1.0.0" }
+cu-ros2-bridge = { path = "../../components/bridges/cu_ros2_bridge", version = "1.0.1" }
 tempfile = { workspace = true }
 serde = { workspace = true }
 

--- a/examples/cu_rp2350_skeleton/Cargo.toml
+++ b/examples/cu_rp2350_skeleton/Cargo.toml
@@ -20,14 +20,14 @@ default-run = "main"
 
 publish = false
 [dependencies]
-cu29 = { path = "../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../core/cu29", version = "1.0.1", default-features = false, features = [
   "log-level-debug",
   "textlogs",
 ] } # pick it up directly to build it no-std
 cu-sdlogger = { path = "../../components/libs/cu_sdlogger", default-features = false, features = [
   "eh1",
 ], optional = true, version = "1.0.0" }
-cu29-export = { path = "../../core/cu29_export", version = "1.0.0", optional = true, default-features = false }
+cu29-export = { path = "../../core/cu29_export", version = "1.0.1", optional = true, default-features = false }
 bincode = { version = "2.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 

--- a/examples/cu_rp2350_skeleton/Cargo.toml
+++ b/examples/cu_rp2350_skeleton/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cu-rp2350-skeleton"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 rust-version = "1.95"
 description = "A minimal example of using Copper on a RP2350 microcontroller"
@@ -26,7 +26,7 @@ cu29 = { path = "../../core/cu29", version = "1.0.1", default-features = false, 
 ] } # pick it up directly to build it no-std
 cu-sdlogger = { path = "../../components/libs/cu_sdlogger", default-features = false, features = [
   "eh1",
-], optional = true, version = "1.0.0" }
+], optional = true, version = "1.0.1" }
 cu29-export = { path = "../../core/cu29_export", version = "1.0.1", optional = true, default-features = false }
 bincode = { version = "2.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/examples/cu_rp_balancebot/Cargo.toml
+++ b/examples/cu_rp_balancebot/Cargo.toml
@@ -49,7 +49,7 @@ avian3d = { workspace = true, default-features = false, features = [
 cu29 = { workspace = true }
 cu-consolemon = { workspace = true }
 cu-bevymon = { workspace = true, optional = true }
-cu-memmon = { path = "../../components/monitors/cu_memmon", version = "1.0.0", default-features = false, features = [
+cu-memmon = { path = "../../components/monitors/cu_memmon", version = "1.0.1", default-features = false, features = [
   "std",
   "memory_monitoring",
 ], optional = true }
@@ -88,12 +88,12 @@ winit = { version = "=0.30.13", default-features = false, optional = true }
 bevy_anti_alias = { version = "0.19.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-cu29 = { path = "../../core/cu29", version = "1.0.0", default-features = false, features = [
+cu29 = { path = "../../core/cu29", version = "1.0.1", default-features = false, features = [
   "std",
   "textlogs",
   "units",
 ] }
-cu-bevymon = { path = "../../components/monitors/cu_bevymon", version = "1.0.0", default-features = false, optional = true }
+cu-bevymon = { path = "../../components/monitors/cu_bevymon", version = "1.0.1", default-features = false, optional = true }
 bevy_anti_alias = { version = "0.19.0", optional = true }
 bevy = { workspace = true, default-features = false, features = [
   "default_font",

--- a/examples/cu_ryuw122_probe/Cargo.toml
+++ b/examples/cu_ryuw122_probe/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 clap = { workspace = true }
 ctrlc = { workspace = true }
 cu-linux-resources = { workspace = true }
-cu-ryuw122 = { path = "../../components/sources/cu_ryuw122", version = "1.0.0" }
+cu-ryuw122 = { path = "../../components/sources/cu_ryuw122", version = "1.0.1" }
 cu-sensor-payloads = { workspace = true }
 cu29 = { workspace = true }
 serialport = { workspace = true }

--- a/examples/cu_zenoh/Cargo.toml
+++ b/examples/cu_zenoh/Cargo.toml
@@ -14,7 +14,7 @@ description = "Copper example to use zenoh as a middleware."
 publish = false
 [dependencies]
 cu29 = { workspace = true }
-cu-zenoh-sink = { path = "../../components/sinks/cu_zenoh_sink", version = "1.0.0" }
+cu-zenoh-sink = { path = "../../components/sinks/cu_zenoh_sink", version = "1.0.1" }
 tempfile = { workspace = true }
 serde = { workspace = true }
 

--- a/examples/cu_zenoh_bridge_demo/Cargo.toml
+++ b/examples/cu_zenoh_bridge_demo/Cargo.toml
@@ -18,7 +18,7 @@ default-run = "zenoh-ping"
 [dependencies]
 cu29 = { workspace = true }
 cu29-export = { workspace = true }
-cu-zenoh-bridge = { path = "../../components/bridges/cu_zenoh_bridge", version = "1.0.0" }
+cu-zenoh-bridge = { path = "../../components/bridges/cu_zenoh_bridge", version = "1.0.1" }
 serde = { workspace = true }
 bincode = { workspace = true }
 

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ BASE_FEATURES := "mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,de
 WINDOWS_BASE_FEATURES := "mock,cu-sensor-payloads/image,kornia,python,gst,faer,nalgebra,glam,debug_pane,bincode"
 MSRV := "1.95.0"
 PUBLIC_API_VERSION := "0.51.0"
-PUBLIC_API_TOOLCHAIN := "nightly"
+PUBLIC_API_TOOLCHAIN := "nightly-2026-06-25"
 export ROOT := justfile_directory()
 WORKSPACE_EXCLUDES := shell('python3 $1/support/ci/workspace_excludes.py excludes --toolchain stable', ROOT)
 PREK_FMT_FIX_HOOKS := "trailing-whitespace mixed-line-ending"
@@ -87,11 +87,11 @@ check-public-api:
 
 # Check the V1 public API snapshot baseline.
 api-check: check-public-api
-	@support/ci/check_public_api.sh
+	@PUBLIC_API_TOOLCHAIN={{PUBLIC_API_TOOLCHAIN}} support/ci/check_public_api.sh
 
 # Refresh the V1 public API snapshot baseline after an intentional API change.
 api-update: check-public-api
-	@UPDATE_PUBLIC_API=1 support/ci/check_public_api.sh
+	@UPDATE_PUBLIC_API=1 PUBLIC_API_TOOLCHAIN={{PUBLIC_API_TOOLCHAIN}} support/ci/check_public_api.sh
 
 # Std clippy checks aligned with reusable unit-test workflow defaults.
 clippy-std:

--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ fmt-check: check-format-tools
 fmt: check-format-tools
 	@cargo +stable fmt --all
 	@git ls-files -z '*.toml' | xargs -0 -r env RUST_LOG=warn taplo format >/dev/null
-	@git ls-files -z '*.ron' ':!examples/modular_config_example/motors.ron' | xargs -0 -r -n 1 fmtron --input>/dev/null
+	@git ls-files -z '*.ron' ':!examples/modular_config_example/motors.ron' | xargs -0 -r -n 1 sh -c 'test ! -f "$1" || fmtron --input "$1"' _ >/dev/null
 	@find . -type f -name '*.ron.bak' -delete
 	@bash -lc 'set -euo pipefail; prek run --all-files {{PREK_FMT_FIX_HOOKS}} || prek run --all-files {{PREK_FMT_FIX_HOOKS}}'
 	@prek run --all-files {{PREK_FMT_CI_HOOKS}}

--- a/support/cargo_cubuild/Cargo.toml
+++ b/support/cargo_cubuild/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-cubuild"
 description = "A cargo tool to help with copper macro expansion errors."
 publish = false
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 rust-version = "1.95"
 license = "Apache-2.0"

--- a/support/cargo_cunew/templates/cu_full/cargo-generate.toml
+++ b/support/cargo_cunew/templates/cu_full/cargo-generate.toml
@@ -3,7 +3,7 @@ pre = ["init.rhai"]
 
 [template]
 description = "A template for a Copper-based Rust project and workspace"
-version = "1.0.0"
+version = "1.0.1"
 
 [placeholders]
 copper_source = { prompt = "Select which Copper do you want to use: crates.io == latest stable from crates.io, git == master on the public git repo, local == your own local clone.", choices = [
@@ -12,7 +12,7 @@ copper_source = { prompt = "Select which Copper do you want to use: crates.io ==
   "local",
 ], default = "crates.io", type = "string" }
 copper_root_path = { prompt = "Enter the path to the Copper root directory (from the workspace root):", default = "../..", type = "string" }
-copper_version = { prompt = "Enter the cu29 version to use for crates.io dependencies:", default = "1.0.0", type = "string" }
-copper_export_version = { prompt = "Enter the cu29-export version to use for crates.io dependencies:", default = "1.0.0", type = "string" }
+copper_version = { prompt = "Enter the cu29 version to use for crates.io dependencies:", default = "1.0.1", type = "string" }
+copper_export_version = { prompt = "Enter the cu29-export version to use for crates.io dependencies:", default = "1.0.1", type = "string" }
 copper_git_url = { prompt = "Enter the Copper git URL to use for git dependencies:", default = "https://github.com/copper-project/copper-rs.git", type = "string" }
 copper_git_ref_snippet = { prompt = "Optional extra git dependency fields such as , branch = \"master\":", default = "", type = "string" }

--- a/support/cargo_cunew/templates/cu_project/cargo-generate.toml
+++ b/support/cargo_cunew/templates/cu_project/cargo-generate.toml
@@ -3,7 +3,7 @@ pre = ["init.rhai"]
 
 [template]
 description = "A template for a Copper-based Rust project"
-version = "1.0.0"
+version = "1.0.1"
 
 [placeholders]
 copper_source = { prompt = "Select which Copper do you want to use: crates.io == latest stable from crates.io, git == master on the public git repo, local == your own local clone.", choices = [
@@ -12,7 +12,7 @@ copper_source = { prompt = "Select which Copper do you want to use: crates.io ==
   "local",
 ], default = "crates.io", type = "string" }
 copper_root_path = { prompt = "Enter the path to the Copper root directory:", default = "../..", type = "string" }
-copper_version = { prompt = "Enter the cu29 version to use for crates.io dependencies:", default = "1.0.0", type = "string" }
-copper_export_version = { prompt = "Enter the cu29-export version to use for crates.io dependencies:", default = "1.0.0", type = "string" }
+copper_version = { prompt = "Enter the cu29 version to use for crates.io dependencies:", default = "1.0.1", type = "string" }
+copper_export_version = { prompt = "Enter the cu29-export version to use for crates.io dependencies:", default = "1.0.1", type = "string" }
 copper_git_url = { prompt = "Enter the Copper git URL to use for git dependencies:", default = "https://github.com/copper-project/copper-rs.git", type = "string" }
 copper_git_ref_snippet = { prompt = "Optional extra git dependency fields such as , branch = \"master\":", default = "", type = "string" }

--- a/support/ci/check_public_api.sh
+++ b/support/ci/check_public_api.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT="${ROOT:-$(git rev-parse --show-toplevel)}"
 BASELINE_DIR="${ROOT}/api/v1"
 UPDATE="${UPDATE_PUBLIC_API:-0}"
-PUBLIC_API_TOOLCHAIN="${PUBLIC_API_TOOLCHAIN:-nightly}"
+PUBLIC_API_TOOLCHAIN="${PUBLIC_API_TOOLCHAIN:-nightly-2026-06-25}"
 CARGO_PUBLIC_API=(cargo "+${PUBLIC_API_TOOLCHAIN}" public-api)
 
 CRATES=(

--- a/support/ci/check_ron_format.sh
+++ b/support/ci/check_ron_format.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 changed=()
 
 while IFS= read -r -d '' f; do
+    [[ -f "$f" ]] || continue
+
     tmp=$(mktemp)
     cp "$f" "$tmp"
     fmtron --input "$tmp" >/dev/null

--- a/support/cu_catalog/Cargo.toml
+++ b/support/cu_catalog/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cu-catalog"
 description = "Generate the Copper component catalog from RON source entries."
 publish = false
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 rust-version = "1.95"
 license = "Apache-2.0"


### PR DESCRIPTION
## Fixes

- #1187 multi-output simulation sources
- #1192 ExpressLRS BLE channel mapping
- #1193 RON formatting after tracked-file deletion
- #1196 resolved configuration bundling order
- #1198 Rust-version-aware dependency resolution
- #1201 rate limiter phase drift
- #1218 ROS 2 Humble image compatibility

Also bumps workspace and template versions to 1.0.1 and keeps release checks compatible with current toolchains.

## Verification

- just pr-check
- just nostd-ci
- just msrv-check
- just api-check
- focused tests for all seven backports
- cargo test -p cargo-cunew