### PR TITLE
Initialize CopperLists safely and clear generated slots on reuse

### DIFF
--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -510,7 +510,8 @@ pub fn cu29_runtime::copperlist::CuListsManager<P, N>::fmt(&self, f: &mut core::
 impl<P: cu29_traits::CopperListTuple + cu29_runtime::copperlist::CuListZeroedInit, const N: usize> core::default::Default for cu29_runtime::copperlist::CuListsManager<P, N>
 pub fn cu29_runtime::copperlist::CuListsManager<P, N>::default() -> Self
 pub trait cu29_runtime::copperlist::CuListZeroedInit: cu29_traits::CopperListTuple
-pub fn cu29_runtime::copperlist::CuListZeroedInit::init_zeroed(&mut self)
+pub unsafe fn cu29_runtime::copperlist::CuListZeroedInit::init_uninit(ptr: *mut Self)
+pub fn cu29_runtime::copperlist::CuListZeroedInit::reset_for_runtime_use(&mut self)
 pub type cu29_runtime::copperlist::AscIter<'a, T> = core::iter::adapters::chain::Chain<core::slice::iter::Iter<'a, T>, core::slice::iter::Iter<'a, T>>
 pub type cu29_runtime::copperlist::AscIterMut<'a, T> = core::iter::adapters::chain::Chain<core::slice::iter::IterMut<'a, T>, core::slice::iter::IterMut<'a, T>>
 pub type cu29_runtime::copperlist::Iter<'a, T> = core::iter::adapters::chain::Chain<core::iter::adapters::rev::Rev<core::slice::iter::Iter<'a, T>>, core::iter::adapters::rev::Rev<core::slice::iter::Iter<'a, T>>>

--- a/core/cu29/src/safety_runtime_cases.rs
+++ b/core/cu29/src/safety_runtime_cases.rs
@@ -25,9 +25,7 @@ impl MatchingTasks for IntMsgs {
     }
 }
 
-impl CuListZeroedInit for IntMsgs {
-    fn init_zeroed(&mut self) {}
-}
+impl CuListZeroedInit for IntMsgs {}
 
 #[derive(Debug)]
 struct RecordingSyncWriter {

--- a/core/cu29/tests/config/copperlist_reuse_valid.ron
+++ b/core/cu29/tests/config/copperlist_reuse_valid.ron
@@ -1,0 +1,17 @@
+(
+    tasks: [
+        (
+            id: "src",
+            type: "ReuseSource",
+            kind: source,
+            run_in_sim: true,
+        ),
+    ],
+    cnx: [
+        (
+            src: "src",
+            dst: "__nc__",
+            msg: "u32",
+        ),
+    ],
+)

--- a/core/cu29/tests/copperlist_reuse.rs
+++ b/core/cu29/tests/copperlist_reuse.rs
@@ -1,0 +1,44 @@
+use cu29::prelude::*;
+
+#[derive(Reflect)]
+struct ReuseSource;
+
+impl Freezable for ReuseSource {}
+
+impl CuSrcTask for ReuseSource {
+    type Resources<'r> = ();
+    type Output<'m> = output_msg!(u32);
+
+    fn new(_config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self> {
+        Ok(Self)
+    }
+
+    fn process(&mut self, _ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
+        output.set_payload(42);
+        Ok(())
+    }
+}
+
+#[copper_runtime(
+    config = "tests/config/copperlist_reuse_valid.ron",
+    sim_mode = true,
+    ignore_resources = true
+)]
+struct ReuseApp {}
+
+#[test]
+fn generated_copperlist_clears_payload_on_slot_reuse() {
+    let mut manager = CuListsManager::<default::CuStampedDataSet, 1>::new();
+
+    manager
+        .create()
+        .expect("fresh slot")
+        .msgs
+        .0
+        .0
+        .set_payload(99);
+    let _ = manager.pop().expect("pop populated slot");
+
+    let reused = manager.create().expect("reuse slot");
+    assert!(reused.msgs.0.0.payload().is_none());
+}

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -824,32 +824,9 @@ fn gen_culist_support(
             ::core::ptr::addr_of_mut!((*ptr).0.#slot_index)
                 .write(::core::default::Default::default());
         });
-        let pack = output_packs
-            .get(*idx)
-            .unwrap_or_else(|| panic!("Missing output pack for index {idx}"));
-        if pack.is_multi() {
-            for port_idx in 0..pack.msg_types.len() {
-                let port_index = syn::Index::from(port_idx);
-                runtime_reset_tokens.push(quote! {
-                    self.0.#slot_index.#port_index.metadata.status_txt =
-                        CuCompactString::default();
-                    self.0.#slot_index.#port_index.metadata.process_time.start =
-                        cu29::clock::OptionCuTime::none();
-                    self.0.#slot_index.#port_index.metadata.process_time.end =
-                        cu29::clock::OptionCuTime::none();
-                    self.0.#slot_index.#port_index.metadata.origin = None;
-                });
-            }
-        } else {
-            runtime_reset_tokens.push(quote! {
-                self.0.#slot_index.metadata.status_txt = CuCompactString::default();
-                self.0.#slot_index.metadata.process_time.start =
-                    cu29::clock::OptionCuTime::none();
-                self.0.#slot_index.metadata.process_time.end =
-                    cu29::clock::OptionCuTime::none();
-                self.0.#slot_index.metadata.origin = None;
-            });
-        }
+        runtime_reset_tokens.push(quote! {
+            self.0.#slot_index = ::core::default::Default::default();
+        });
     }
     let collect_metadata_function = quote! {
         pub fn collect_metadata<'a>(culist: &'a CuList) -> [&'a CuMsgMetadata; #culist_size] {

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -817,16 +817,22 @@ fn gen_culist_support(
         })
         .collect();
     let mut zeroed_init_tokens: Vec<proc_macro2::TokenStream> = Vec::new();
+    let mut runtime_reset_tokens: Vec<proc_macro2::TokenStream> = Vec::new();
     for idx in culist_indices_in_plan_order {
         let slot_index = syn::Index::from(*idx);
+        zeroed_init_tokens.push(quote! {
+            ::core::ptr::addr_of_mut!((*ptr).0.#slot_index)
+                .write(::core::default::Default::default());
+        });
         let pack = output_packs
             .get(*idx)
             .unwrap_or_else(|| panic!("Missing output pack for index {idx}"));
         if pack.is_multi() {
             for port_idx in 0..pack.msg_types.len() {
                 let port_index = syn::Index::from(port_idx);
-                zeroed_init_tokens.push(quote! {
-                    self.0.#slot_index.#port_index.metadata.status_txt = CuCompactString::default();
+                runtime_reset_tokens.push(quote! {
+                    self.0.#slot_index.#port_index.metadata.status_txt =
+                        CuCompactString::default();
                     self.0.#slot_index.#port_index.metadata.process_time.start =
                         cu29::clock::OptionCuTime::none();
                     self.0.#slot_index.#port_index.metadata.process_time.end =
@@ -835,10 +841,12 @@ fn gen_culist_support(
                 });
             }
         } else {
-            zeroed_init_tokens.push(quote! {
+            runtime_reset_tokens.push(quote! {
                 self.0.#slot_index.metadata.status_txt = CuCompactString::default();
-                self.0.#slot_index.metadata.process_time.start = cu29::clock::OptionCuTime::none();
-                self.0.#slot_index.metadata.process_time.end = cu29::clock::OptionCuTime::none();
+                self.0.#slot_index.metadata.process_time.start =
+                    cu29::clock::OptionCuTime::none();
+                self.0.#slot_index.metadata.process_time.end =
+                    cu29::clock::OptionCuTime::none();
                 self.0.#slot_index.metadata.origin = None;
             });
         }
@@ -1157,9 +1165,20 @@ fn gen_culist_support(
         #erasedmsg_trait_impl
 
         impl CuListZeroedInit for CuStampedDataSet {
-            fn init_zeroed(&mut self) {
+            unsafe fn init_uninit(ptr: *mut Self) {
+                // Initialize directly in the surrounding CopperList's uninitialized
+                // heap storage. This avoids both large stack temporaries and references
+                // to invalid `Option<Payload>` bit patterns.
+                unsafe {
+                    ::core::ptr::addr_of_mut!((*ptr).1)
+                        .write(::core::default::Default::default());
+                    #(#zeroed_init_tokens)*
+                }
+            }
+
+            fn reset_for_runtime_use(&mut self) {
                 self.1.clear();
-                #(#zeroed_init_tokens)*
+                #(#runtime_reset_tokens)*
             }
         }
     }

--- a/core/cu29_runtime/src/copperlist.rs
+++ b/core/cu29_runtime/src/copperlist.rs
@@ -84,9 +84,8 @@ impl<P: CopperListTuple> CopperList<P> {
         self.state
     }
 
-    /// Restores the lifecycle state expected at allocation time and reruns
-    /// payload-container fixups before the list is reused. This does not imply
-    /// a full `P::default()` payload reset.
+    /// Restores the lifecycle state expected at allocation time and asks the
+    /// generated message tuple to clear every payload slot before reuse.
     #[doc(hidden)]
     pub fn reset_for_runtime_use(&mut self, id: u64)
     where
@@ -149,8 +148,7 @@ pub trait CuListZeroedInit: CopperListTuple {
         }
     }
 
-    /// Restores runtime invariants on a fully initialized copper list before it
-    /// is reused.
+    /// Clears a fully initialized copper list before it is reused.
     ///
     /// Unlike [`init_uninit`](Self::init_uninit), this method may safely drop
     /// values left in the previous iteration.
@@ -341,6 +339,7 @@ mod tests {
     use super::*;
     use cu29_traits::{ErasedCuStampedData, ErasedCuStampedDataSet, MatchingTasks};
     use serde::{Deserialize, Serialize, Serializer};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[derive(Debug, Encode, Decode, PartialEq, Clone, Copy, Serialize, Deserialize, Default)]
     struct CuStampedDataSet(i32);
@@ -358,6 +357,83 @@ mod tests {
     }
 
     impl CuListZeroedInit for CuStampedDataSet {}
+
+    static DROPPED_REUSED_PAYLOADS: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(Debug, Encode, Decode, Serialize)]
+    struct DropTrackedPayload;
+
+    impl Drop for DropTrackedPayload {
+        fn drop(&mut self) {
+            DROPPED_REUSED_PAYLOADS.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[derive(Debug, Encode, Decode, Serialize, Default)]
+    struct ResettingDataSet(Option<DropTrackedPayload>);
+
+    impl ErasedCuStampedDataSet for ResettingDataSet {
+        fn cumsgs(&self) -> Vec<&dyn ErasedCuStampedData> {
+            Vec::new()
+        }
+    }
+
+    impl MatchingTasks for ResettingDataSet {
+        fn get_all_task_ids() -> &'static [&'static str] {
+            &[]
+        }
+    }
+
+    impl CuListZeroedInit for ResettingDataSet {
+        fn reset_for_runtime_use(&mut self) {
+            *self = Self::default();
+        }
+    }
+
+    #[test]
+    fn reused_slot_reset_drops_stale_payload() {
+        DROPPED_REUSED_PAYLOADS.store(0, Ordering::SeqCst);
+        let mut q = CuListsManager::<ResettingDataSet, 1>::new();
+
+        q.create().unwrap().msgs.0 = Some(DropTrackedPayload);
+        let _ = q.pop().unwrap();
+        let reused = q.create().unwrap();
+
+        assert!(reused.msgs.0.is_none());
+        assert_eq!(DROPPED_REUSED_PAYLOADS.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    #[ignore = "manual microbenchmark; run in release mode with --ignored --nocapture"]
+    fn benchmark_reused_slot_reset_cost() {
+        const ITERATIONS: u32 = 5_000_000;
+
+        let mut preserved = CuListsManager::<CuStampedDataSet, 1>::new();
+        let started = std::time::Instant::now();
+        for _ in 0..ITERATIONS {
+            let cl = preserved.create().unwrap();
+            std::hint::black_box(&mut cl.msgs);
+            let _ = preserved.pop().unwrap();
+        }
+        let preserved_elapsed = started.elapsed();
+
+        let mut reset = CuListsManager::<ResettingDataSet, 1>::new();
+        let started = std::time::Instant::now();
+        for _ in 0..ITERATIONS {
+            let cl = reset.create().unwrap();
+            std::hint::black_box(&mut cl.msgs);
+            let _ = reset.pop().unwrap();
+        }
+        let reset_elapsed = started.elapsed();
+
+        eprintln!(
+            "reuse preserve={:.2} ns/op reset={:.2} ns/op delta={:.2} ns/op",
+            preserved_elapsed.as_nanos() as f64 / f64::from(ITERATIONS),
+            reset_elapsed.as_nanos() as f64 / f64::from(ITERATIONS),
+            reset_elapsed.saturating_sub(preserved_elapsed).as_nanos() as f64
+                / f64::from(ITERATIONS),
+        );
+    }
 
     #[test]
     fn empty_queue() {

--- a/core/cu29_runtime/src/copperlist.rs
+++ b/core/cu29_runtime/src/copperlist.rs
@@ -3,10 +3,8 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-use alloc::alloc::{alloc_zeroed, handle_alloc_error};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use core::alloc::Layout;
 
 use bincode::{Decode, Encode};
 use core::fmt;
@@ -87,8 +85,8 @@ impl<P: CopperListTuple> CopperList<P> {
     }
 
     /// Restores the lifecycle state expected at allocation time and reruns
-    /// zero-memory fixups for payload containers that cannot remain valid after
-    /// raw zeroing. This does not imply a full `P::default()` payload reset.
+    /// payload-container fixups before the list is reused. This does not imply
+    /// a full `P::default()` payload reset.
     #[doc(hidden)]
     pub fn reset_for_runtime_use(&mut self, id: u64)
     where
@@ -96,7 +94,7 @@ impl<P: CopperListTuple> CopperList<P> {
     {
         self.id = id;
         self.state = CopperListState::Initialized;
-        self.msgs.init_zeroed();
+        self.msgs.reset_for_runtime_use();
     }
 }
 
@@ -132,12 +130,31 @@ pub type IterMut<'a, T> = Chain<Rev<SliceIterMut<'a, T>>, Rev<SliceIterMut<'a, T
 pub type AscIter<'a, T> = Chain<SliceIter<'a, T>, SliceIter<'a, T>>;
 pub type AscIterMut<'a, T> = Chain<SliceIterMut<'a, T>, SliceIterMut<'a, T>>;
 
-/// Initializes fields that cannot be zeroed after allocating a zeroed
-/// [`CopperList`].
+/// Initializes a Copper-list message tuple directly in uninitialized heap storage.
 pub trait CuListZeroedInit: CopperListTuple {
-    /// Fixes up a zero-initialized copper list so that all internal fields are
-    /// in a valid state.
-    fn init_zeroed(&mut self);
+    /// Initializes `ptr` without first creating a reference to its uninitialized value.
+    ///
+    /// Generated Copper message tuples override this to initialize each field in place,
+    /// avoiding a potentially very large temporary on the stack.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be non-null, aligned, and valid for writes of one `Self`. It must point
+    /// to uninitialized storage, and the implementation must leave a fully initialized
+    /// `Self` behind.
+    unsafe fn init_uninit(ptr: *mut Self) {
+        // SAFETY: upheld by the caller and the method contract above.
+        unsafe {
+            ptr.write(Self::default());
+        }
+    }
+
+    /// Restores runtime invariants on a fully initialized copper list before it
+    /// is reused.
+    ///
+    /// Unlike [`init_uninit`](Self::init_uninit), this method may safely drop
+    /// values left in the previous iteration.
+    fn reset_for_runtime_use(&mut self) {}
 }
 
 impl<P: CopperListTuple + CuListZeroedInit, const N: usize> Default for CuListsManager<P, N> {
@@ -151,27 +168,26 @@ impl<P: CopperListTuple, const N: usize> CuListsManager<P, N> {
     where
         P: CuListZeroedInit,
     {
-        // SAFETY: We allocate zeroed memory and immediately initialize required fields.
-        let data = unsafe {
-            let layout = Layout::new::<[CopperList<P>; N]>();
-            let ptr = alloc_zeroed(layout) as *mut [CopperList<P>; N];
-            if ptr.is_null() {
-                handle_alloc_error(layout);
+        let mut data = Box::<[CopperList<P>; N]>::new_uninit();
+        let first = data.as_mut_ptr().cast::<CopperList<P>>();
+        for index in 0..N {
+            // SAFETY: each pointer addresses one distinct element of the allocated array.
+            // Every CopperList field is initialized before the array is assumed initialized.
+            unsafe {
+                let cl = first.add(index);
+                core::ptr::addr_of_mut!((*cl).id).write(0);
+                core::ptr::addr_of_mut!((*cl).state).write(CopperListState::Free);
+                P::init_uninit(core::ptr::addr_of_mut!((*cl).msgs));
             }
-            Box::from_raw(ptr)
-        };
-        let mut manager = CuListsManager {
+        }
+        // SAFETY: the loop above initialized every element and every field.
+        let data = unsafe { data.assume_init() };
+        CuListsManager {
             data,
             length: 0,
             insertion_index: 0,
             current_cl_id: 0,
-        };
-
-        for cl in manager.data.iter_mut() {
-            cl.msgs.init_zeroed();
         }
-
-        manager
     }
 
     /// Returns the current number of elements in the queue.
@@ -341,9 +357,7 @@ mod tests {
         }
     }
 
-    impl CuListZeroedInit for CuStampedDataSet {
-        fn init_zeroed(&mut self) {}
-    }
+    impl CuListZeroedInit for CuStampedDataSet {}
 
     #[test]
     fn empty_queue() {
@@ -717,7 +731,13 @@ mod tests {
     }
 
     impl CuListZeroedInit for TestStruct {
-        fn init_zeroed(&mut self) {}
+        unsafe fn init_uninit(ptr: *mut Self) {
+            // SAFETY: the caller provides writable storage and every bit pattern is valid
+            // for this byte-array-only test type.
+            unsafe {
+                ptr.write_bytes(0, 1);
+            }
+        }
     }
 
     #[test]

--- a/core/cu29_runtime/src/curuntime.rs
+++ b/core/cu29_runtime/src/curuntime.rs
@@ -47,8 +47,6 @@ use cu29_log_runtime::log_debug_mode;
 #[allow(unused_imports)]
 use cu29_value::to_value;
 
-#[cfg(all(feature = "std", any(feature = "async-cl-io", feature = "parallel-rt")))]
-use alloc::alloc::{alloc_zeroed, handle_alloc_error};
 use alloc::boxed::Box;
 use alloc::collections::{BTreeSet, VecDeque};
 use alloc::format;
@@ -58,8 +56,6 @@ use bincode::enc::EncoderImpl;
 use bincode::enc::write::{SizeWriter, SliceWriter};
 use bincode::error::EncodeError;
 use bincode::{Decode, Encode};
-#[cfg(all(feature = "std", any(feature = "async-cl-io", feature = "parallel-rt")))]
-use core::alloc::Layout;
 use core::fmt::Result as FmtResult;
 use core::fmt::{Debug, Formatter};
 use core::marker::PhantomData;
@@ -610,17 +606,15 @@ fn allocate_zeroed_copperlist<P>() -> Box<CopperList<P>>
 where
     P: CopperListTuple + CuListZeroedInit,
 {
-    // SAFETY: We allocate zeroed memory and immediately initialize required fields.
-    let mut culist = unsafe {
-        let layout = Layout::new::<CopperList<P>>();
-        let ptr = alloc_zeroed(layout) as *mut CopperList<P>;
-        if ptr.is_null() {
-            handle_alloc_error(layout);
-        }
-        Box::from_raw(ptr)
-    };
-    culist.msgs.init_zeroed();
-    culist
+    let mut culist = Box::<CopperList<P>>::new_uninit();
+    let ptr = culist.as_mut_ptr();
+    // SAFETY: every CopperList field is initialized before the box is assumed initialized.
+    unsafe {
+        core::ptr::addr_of_mut!((*ptr).id).write(0);
+        core::ptr::addr_of_mut!((*ptr).state).write(CopperListState::Free);
+        P::init_uninit(core::ptr::addr_of_mut!((*ptr).msgs));
+        culist.assume_init()
+    }
 }
 
 #[cfg(all(feature = "std", feature = "parallel-rt"))]
@@ -2059,9 +2053,7 @@ mod tests {
         }
     }
 
-    impl CuListZeroedInit for Msgs {
-        fn init_zeroed(&mut self) {}
-    }
+    impl CuListZeroedInit for Msgs {}
 
     #[derive(Debug, Encode, Decode, Serialize, Deserialize, Default)]
     struct IntMsgs(i32);
@@ -2078,9 +2070,7 @@ mod tests {
         }
     }
 
-    impl CuListZeroedInit for IntMsgs {
-        fn init_zeroed(&mut self) {}
-    }
+    impl CuListZeroedInit for IntMsgs {}
 
     #[cfg(feature = "std")]
     fn tasks_instanciator(


### PR DESCRIPTION
## Why this is a draft

The first commit is an independent safety fix. The second commit deliberately isolates the policy question of whether every generated CopperList slot should be reset to `Default` on reuse. Please review those separately; the reset commit can be dropped without losing the initialization fix.

## Commits

1. initialize CopperLists field-by-field in uninitialized heap storage, avoiding invalid zeroed values and large stack temporaries while preserving existing reuse behavior
2. reset each generated message slot to `Default` on reuse, dropping stale payloads

## Evidence

- generated-runtime test proves a reused slot has no stale payload
- drop-tracking test proves reset releases the prior payload
- manual release microbenchmark is committed as an ignored test
- local synthetic result: preserve 0.28 ns/op, reset 0.37 ns/op, delta 0.09 ns/op

The benchmark uses a minimal one-slot payload and is only a lower-bound microbenchmark. Real graphs with large inline payloads need representative measurements before merging the second commit.

## Verification

- `just pr-check`
- 692 std tests and 375 no_std test-profile tests passed
- embedded/no_std clippy passed
- `just api-check`