### PR TITLE
Add flight-controller compute replay debugger

### DIFF
--- a/examples/cu_flight_controller/Cargo.toml
+++ b/examples/cu_flight_controller/Cargo.toml
@@ -346,6 +346,11 @@ path = "src/resim.rs"
 required-features = ["sim-debug"]
 
 [[bin]]
+name = "quad-compute-resim"
+path = "src/compute_resim.rs"
+required-features = ["sim-debug"]
+
+[[bin]]
 name = "quad-bevymon"
 path = "src/bevymon.rs"
 required-features = ["bevymon"]

--- a/examples/cu_flight_controller/README.md
+++ b/examples/cu_flight_controller/README.md
@@ -135,6 +135,20 @@ just resim
 just resim-debug
 ```
 
+To inspect the compute-side log in Time Traveler—including the depth raster
+that was actually passed to ViTFly—run:
+
+```bash
+# Generate a flight_compute_sim.copper log, then exit the simulator.
+just sim
+
+# Serve that compute-side log to Time Traveler.
+just compute-resim
+```
+
+Then attach Time Traveler to
+`copper/examples/cu_flight_controller/compute/debug/v1`.
+
 The replay target uses the standardized replay contract:
 
 - `--debug-base` selects the remote debug namespace

--- a/examples/cu_flight_controller/compute_autonomy.ron
+++ b/examples/cu_flight_controller/compute_autonomy.ron
@@ -9,7 +9,7 @@
             id: "vitfly_depth_rate",
             type: "cu_ratelimit::CuRateLimit<cu_zed::ZedDepthMap<Vec<f32>>>",
             config: {"rate": 30.0},
-            logging: (enabled: false),
+            logging: (enabled: true),
         ),
         (
             id: "vitfly",

--- a/examples/cu_flight_controller/compute_config.ron
+++ b/examples/cu_flight_controller/compute_config.ron
@@ -34,7 +34,7 @@
             id: "zed",
             type: "cu_zed::Zed",
             run_in_sim: false,
-            logging: (enabled: false),
+            logging: (enabled: true),
         ),
     ],
     runtime: (rate_target_hz: 30),

--- a/examples/cu_flight_controller/justfile
+++ b/examples/cu_flight_controller/justfile
@@ -114,6 +114,26 @@ resim-debug debug_base="copper/examples/cu_flight_controller/debug/v1" log="logs
     --log-base "$log" \
     --replay-log-base "$replay_log"
 
+# Run the replay-backed debugger for the compute log, including the depth
+# images that were actually presented to ViTFly.
+compute-resim debug_base="copper/examples/cu_flight_controller/compute/debug/v1" log="logs/flight_compute_sim.copper" replay_log="logs/flight_compute_resim.copper":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  example_dir="{{justfile_directory()}}"
+  log="{{log}}"
+  replay_log="{{replay_log}}"
+  if [[ "$log" != /* ]]; then
+    log="${example_dir}/${log}"
+  fi
+  if [[ "$replay_log" != /* ]]; then
+    replay_log="${example_dir}/${replay_log}"
+  fi
+  cd "{{ROOT}}"
+  cargo --config examples/cu_flight_controller/.cargo/config.toml run -p cu-flight-controller --no-default-features --features sim-debug --bin quad-compute-resim -- \
+    --debug-base "{{debug_base}}" \
+    --log-base "$log" \
+    --replay-log-base "$replay_log"
+
 # Run the Bevy + Copper simulation loop with cu_bevymon embedded in the window.
 bevy:
   #!/usr/bin/env bash

--- a/examples/cu_flight_controller/src/compute_resim.rs
+++ b/examples/cu_flight_controller/src/compute_resim.rs
@@ -1,0 +1,100 @@
+extern crate alloc;
+
+mod autonomy_bridge;
+mod compute_tasks;
+mod messages;
+
+mod tasks {
+    pub use crate::compute_tasks::*;
+}
+
+use cu29::prelude::memmap::{MmapSectionStorage, MmapUnifiedLoggerWrite};
+use cu29::prelude::*;
+use cu29::remote_debug::SessionOpenParams;
+use cu29::replay::{
+    ReplayCli, ReplayDefaults, per_session_replay_log_base, remove_log_family, serve_remote_debug,
+};
+use std::error::Error;
+use std::path::Path;
+
+const DEFAULT_DEBUG_BASE: &str = "copper/examples/cu_flight_controller/compute/debug/v1";
+const DEFAULT_LOG_BASE: &str = "logs/flight_compute_sim.copper";
+const DEFAULT_REPLAY_LOG_BASE: &str = "logs/flight_compute_resim.copper";
+const REPLAY_LOG_SLAB_SIZE: Option<usize> = Some(128 * 1024 * 1024);
+
+#[copper_runtime(
+    config = "compute_config.ron",
+    sim_mode = true,
+    ignore_resources = true
+)]
+struct FlightComputeReSim {}
+
+type ReplayCopperList = CopperList<default::CuStampedDataSet>;
+type ReplayBuildCallback =
+    for<'a> fn(
+        &'a ReplayCopperList,
+        RobotClock,
+        RobotClockMock,
+    ) -> Box<dyn for<'z> FnMut(default::SimStep<'z>) -> SimOverride + 'a>;
+type ReplayTimeExtractor = fn(&ReplayCopperList) -> Option<CuTime>;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let cli = ReplayCli::parse(
+        ReplayDefaults::new(DEFAULT_LOG_BASE, DEFAULT_REPLAY_LOG_BASE)
+            .with_debug_base(DEFAULT_DEBUG_BASE),
+    );
+    let replay_template = cli.replay_log_base.clone();
+    serve_remote_debug::<
+        default::FlightComputeReSim,
+        default::CuStampedDataSet,
+        ReplayBuildCallback,
+        ReplayTimeExtractor,
+        MmapSectionStorage,
+        MmapUnifiedLoggerWrite,
+        _,
+    >(
+        cli.debug_base
+            .as_deref()
+            .expect("default debug base is always set"),
+        &cli.log_base,
+        move |params| app_factory(params, &replay_template),
+        build_callback,
+        extract_time,
+    )?;
+    Ok(())
+}
+
+fn app_factory(
+    params: &SessionOpenParams,
+    replay_template: &Path,
+) -> CuResult<(default::FlightComputeReSim, RobotClock, RobotClockMock)> {
+    let (clock, clock_mock) = RobotClock::mock();
+    let replay_log_base = per_session_replay_log_base(
+        replay_template,
+        [params.role.as_deref().unwrap_or("session")],
+    );
+    remove_log_family(&replay_log_base)?;
+
+    let mut default_callback = |_step: default::SimStep<'_>| SimOverride::ExecuteByRuntime;
+    let app = default::FlightComputeReSim::builder()
+        .with_clock(clock.clone())
+        .with_log_path(replay_log_base, REPLAY_LOG_SLAB_SIZE)?
+        .with_sim_callback(&mut default_callback)
+        .build()?;
+
+    Ok((app, clock, clock_mock))
+}
+
+fn build_callback<'a>(
+    copperlist: &'a ReplayCopperList,
+    _process_clock: RobotClock,
+    _clock_for_cb: RobotClockMock,
+) -> Box<dyn for<'z> FnMut(default::SimStep<'z>) -> SimOverride + 'a> {
+    Box::new(move |step: default::SimStep<'_>| {
+        default::recorded_debug_replay_step(step, copperlist)
+    })
+}
+
+fn extract_time(copperlist: &ReplayCopperList) -> Option<CuTime> {
+    cu29::simulation::recorded_copperlist_timestamp(copperlist)
+}


### PR DESCRIPTION
## Summary

- add the `quad-compute-resim` replay-backed remote-debug binary
- add a `just compute-resim` entry point with the standard replay CLI contract
- document the compute-side Time Traveler workflow
- enable only the compute messages needed to inspect the ZED/depth input presented to ViTFly

This intentionally excludes MCU-wide logging changes and CuDepthMap work.

## Verification

- `just fmt`
- `cargo --config examples/cu_flight_controller/.cargo/config.toml check -p cu-flight-controller --no-default-features --features sim-debug --bin quad-compute-resim`