### PR TITLE
Fix ROS 2 Jazzy image compatibility

### DIFF
--- a/components/bridges/cu_ros2_bridge/Cargo.toml
+++ b/components/bridges/cu_ros2_bridge/Cargo.toml
@@ -33,6 +33,7 @@ cdr = { version = "0.2.4" }
 
 [features]
 humble = ["cu-ros2-payloads/humble"]
+jazzy = ["cu-ros2-payloads/jazzy"]
 
 [dev-dependencies]
 bincode = { workspace = true }

--- a/components/bridges/cu_ros2_bridge/README.md
+++ b/components/bridges/cu_ros2_bridge/README.md
@@ -58,13 +58,15 @@ cu_ros2_bridge::register_ros2_payload::<MyPayload>();
 Copper -> ROS 2 samples are serialized as OMG CDR little-endian (`CdrLe`). Inbound samples use
 `cdr::deserialize`, which reads the CDR encapsulation header and accepts either endianness.
 
-### ROS 2 Humble image compatibility
+### ROS 2 Humble and Jazzy image compatibility
 
-Enable the `humble` feature when bridging `cu_sensor_payloads::CuImage<Vec<u8>>` to ROS 2 Humble.
-The image adapter uses Humble's legacy `yuv422_yuy2` and `yuv422` encoding names for YUYV and
-UYVY buffers. Humble's `cv_bridge` cannot consume NV12, NV21, I420, or YV12 images, so the bridge
-rejects those formats instead of publishing an image that tools such as `rqt_image_view` cannot
-decode. Convert those images to a supported packed format before sending them through the bridge.
+Enable the `humble` or `jazzy` feature when bridging
+`cu_sensor_payloads::CuImage<Vec<u8>>` to the corresponding ROS 2 distribution. These features
+are mutually exclusive. The image adapter uses the legacy `yuv422_yuy2` and `yuv422` encoding
+names for YUYV and UYVY buffers. The `cv_bridge` versions released for Humble and Jazzy cannot
+consume NV12, NV21, I420, or YV12 images, so the bridge rejects those formats instead of
+publishing an image that tools such as `rqt_image_view` cannot decode. Convert those images to a
+supported packed format before sending them through the bridge.
 
 ## ROS 2 interop test
 

--- a/components/payloads/cu_ros2_payloads/Cargo.toml
+++ b/components/payloads/cu_ros2_payloads/Cargo.toml
@@ -25,7 +25,8 @@ cu-sensor-payloads = { workspace = true }
 cu29 = { workspace = true }
 
 [features]
-humble = [] # Activate for ROS2 Humble, disable for later versions
+humble = [] # Activate for ROS 2 Humble compatibility
+jazzy = []  # Activate for ROS 2 Jazzy compatibility
 
 [dev-dependencies]
 cdr = { version = "0.2.4" }

--- a/components/payloads/cu_ros2_payloads/README.md
+++ b/components/payloads/cu_ros2_payloads/README.md
@@ -22,6 +22,13 @@ Types that are supported are:
 - `sensor_msgs/Imu` <-> `ImuPayload` (accel/gyro mapped; temperature defaults to `0°C` when decoding from ROS)
 - `sensor_msgs/MagneticField` <-> `MagnetometerPayload`
 
+## ROS 2 compatibility features
+
+Enable the mutually exclusive `humble` or `jazzy` feature when targeting that ROS 2 distribution.
+Both profiles use the legacy image encoding names supported by their released `cv_bridge`
+versions and reject image layouts those versions cannot consume. Only the `humble` profile
+disables ROS type hashes.
+
 ## Adding new payloads (feel free to contribute!)
 
 To add a new payload, we pregenerated all the RIHS01 in the [RIHS payloads](all_rihs.md) file from Jazzy.

--- a/components/payloads/cu_ros2_payloads/src/lib.rs
+++ b/components/payloads/cu_ros2_payloads/src/lib.rs
@@ -2,6 +2,9 @@ pub mod builtin;
 pub mod sensor_msgs;
 pub mod std_msgs;
 
+#[cfg(all(feature = "humble", feature = "jazzy"))]
+compile_error!("features `humble` and `jazzy` are mutually exclusive");
+
 use core::fmt::Display;
 use serde::Serialize;
 use serde::de::DeserializeOwned;

--- a/components/payloads/cu_ros2_payloads/src/sensor_msgs.rs
+++ b/components/payloads/cu_ros2_payloads/src/sensor_msgs.rs
@@ -19,6 +19,11 @@ const DATATYPE_FLOAT32: u8 = 7;
 const UT_TO_TESLA: f64 = 1e-6;
 const TESLA_TO_UT: f64 = 1e6;
 
+#[cfg(feature = "humble")]
+const ROS2_IMAGE_COMPAT_DISTRO: &str = "Humble";
+#[cfg(all(not(feature = "humble"), feature = "jazzy"))]
+const ROS2_IMAGE_COMPAT_DISTRO: &str = "Jazzy";
+
 // sensor_msgs/PointField
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct PointField {
@@ -134,14 +139,15 @@ impl<const N: usize> RosMsgAdapter<'static> for PointCloudSoaHandle<N> {
 impl RosMsgAdapter<'static> for CuImage<Vec<u8>> {
     type Output = Image;
 
-    #[cfg(feature = "humble")]
+    #[cfg(any(feature = "humble", feature = "jazzy"))]
     fn validate_ros_message(&self) -> Result<(), String> {
         match &self.format.pixel_format {
             b"GRAY" | b"Y800" | b"RGB3" | b"RGB " | b"BGR3" | b"BGR " | b"RGBA" | b"BGRA"
             | b"YUYV" | b"UYVY" => Ok(()),
             pixel_format => Err(format!(
-                "CuImage pixel format '{}' is not supported by ROS 2 Humble cv_bridge",
-                String::from_utf8_lossy(pixel_format)
+                "CuImage pixel format '{}' is not supported by ROS 2 {} cv_bridge",
+                String::from_utf8_lossy(pixel_format),
+                ROS2_IMAGE_COMPAT_DISTRO
             )),
         }
     }
@@ -593,13 +599,13 @@ fn pixel_format_to_encoding(pixel_format: [u8; 4]) -> String {
         b"NV21" => "nv21".to_string(),
         b"I420" => "i420".to_string(),
         b"YV12" => "yv12".to_string(),
-        #[cfg(feature = "humble")]
+        #[cfg(any(feature = "humble", feature = "jazzy"))]
         b"YUYV" => "yuv422_yuy2".to_string(),
-        #[cfg(not(feature = "humble"))]
+        #[cfg(not(any(feature = "humble", feature = "jazzy")))]
         b"YUYV" => "yuyv".to_string(),
-        #[cfg(feature = "humble")]
+        #[cfg(any(feature = "humble", feature = "jazzy"))]
         b"UYVY" => "yuv422".to_string(),
-        #[cfg(not(feature = "humble"))]
+        #[cfg(not(any(feature = "humble", feature = "jazzy")))]
         b"UYVY" => "uyvy".to_string(),
         _ => {
             let end = pixel_format
@@ -772,9 +778,9 @@ mod tests {
 
     #[test]
     fn image_yuv422_encoding_matches_ros_profile() {
-        #[cfg(feature = "humble")]
+        #[cfg(any(feature = "humble", feature = "jazzy"))]
         let expected = [(b"YUYV", "yuv422_yuy2"), (b"UYVY", "yuv422")];
-        #[cfg(not(feature = "humble"))]
+        #[cfg(not(any(feature = "humble", feature = "jazzy")))]
         let expected = [(b"YUYV", "yuyv"), (b"UYVY", "uyvy")];
 
         for (pixel_format, encoding) in expected {
@@ -792,9 +798,22 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "humble")]
     #[test]
-    fn image_validation_rejects_formats_unsupported_by_humble_cv_bridge() {
+    fn image_type_hash_matches_ros_profile() {
+        #[cfg(feature = "humble")]
+        let expected = "TypeHashNotSupported";
+        #[cfg(not(feature = "humble"))]
+        let expected = "RIHS01_d31d41a9a4c4bc8eae9be757b0beed306564f7526c88ea6a4588fb9582527d47";
+
+        assert_eq!(
+            <CuImage<Vec<u8>> as RosBridgeAdapter>::type_hash(),
+            expected
+        );
+    }
+
+    #[cfg(any(feature = "humble", feature = "jazzy"))]
+    #[test]
+    fn image_validation_rejects_formats_unsupported_by_legacy_cv_bridge() {
         for pixel_format in [b"NV12", b"NV21", b"I420", b"YV12", b"MJPG"] {
             let image = CuImage::new(
                 CuImageBufferFormat {
@@ -807,14 +826,14 @@ mod tests {
             );
 
             let error = <CuImage<Vec<u8>> as RosBridgeAdapter>::validate_ros_message(&image)
-                .expect_err("unsupported Humble image format should be rejected");
+                .expect_err("unsupported image format should be rejected");
             assert!(error.contains(String::from_utf8_lossy(pixel_format).as_ref()));
         }
     }
 
-    #[cfg(feature = "humble")]
+    #[cfg(any(feature = "humble", feature = "jazzy"))]
     #[test]
-    fn image_validation_accepts_humble_cv_bridge_formats() {
+    fn image_validation_accepts_legacy_cv_bridge_formats() {
         for pixel_format in [
             b"GRAY", b"Y800", b"RGB3", b"RGB ", b"BGR3", b"BGR ", b"RGBA", b"BGRA", b"YUYV",
             b"UYVY",
@@ -830,7 +849,7 @@ mod tests {
             );
 
             <CuImage<Vec<u8>> as RosBridgeAdapter>::validate_ros_message(&image)
-                .expect("supported Humble image format should pass validation");
+                .expect("supported image format should pass validation");
         }
     }
 

--- a/examples/cu_ros2_bridge_demo/Cargo.toml
+++ b/examples/cu_ros2_bridge_demo/Cargo.toml
@@ -21,7 +21,7 @@ serde = { workspace = true }
 
 [features]
 humble = ["cu-ros2-bridge/humble"]
-
+jazzy = ["cu-ros2-bridge/jazzy"]
 
 [package.metadata.cargo-shear]
 ignored = ["serde"]


### PR DESCRIPTION
## Summary

Add an explicit ROS 2 Jazzy compatibility profile for image payloads. Jazzy `cv_bridge` still requires the legacy YUV422 encoding names and cannot consume the planar formats already rejected for Humble.

## Related issues

- Follow-up to #1218

## Changes

- add a `jazzy` feature to the ROS 2 payload, bridge, and demo crates
- use `yuv422_yuy2` and `yuv422` for YUYV and UYVY under Humble and Jazzy
- reject NV12, NV21, I420, and YV12 for both released `cv_bridge` profiles
- keep RIHS type hashes enabled for Jazzy and disabled only for Humble
- reject simultaneous `humble` and `jazzy` activation at compile time
- document the distro profiles and add profile-specific regression coverage

## Reminder

- [x] I ran `just` from the repo root
- [x] I have updated docs or examples where needed

## Additional context

Focused verification also covered default, Humble, and Jazzy payload tests, the Jazzy bridge and demo builds, and the expected compile failure for `--features humble,jazzy`.