### PR TITLE
cu-spatial-payloads: unit-typed points, BBox, Transform3D point ops

### DIFF
--- a/components/payloads/cu_spatial_payloads/Cargo.toml
+++ b/components/payloads/cu_spatial_payloads/Cargo.toml
@@ -22,6 +22,7 @@ bincode = { workspace = true }
 cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
   "units",
 ] }
+libm = { version = "0.2", default-features = false }
 serde = { workspace = true }
 rerun = { workspace = true, optional = true }
 

--- a/components/payloads/cu_spatial_payloads/Cargo.toml
+++ b/components/payloads/cu_spatial_payloads/Cargo.toml
@@ -22,6 +22,7 @@ bincode = { workspace = true }
 cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
   "units",
 ] }
+cu29-soa-derive = { workspace = true }
 libm = { version = "0.2", default-features = false }
 serde = { workspace = true }
 rerun = { workspace = true, optional = true }

--- a/components/payloads/cu_spatial_payloads/src/geometry.rs
+++ b/components/payloads/cu_spatial_payloads/src/geometry.rs
@@ -4,18 +4,23 @@
 use bincode::{Decode, Encode};
 use core::fmt::Debug;
 use cu29::prelude::*;
+use cu29::units::si::area::square_meter;
+use cu29::units::si::f32::Area as Area32;
 use cu29::units::si::f32::Length as Length32;
+use cu29::units::si::f64::Area as Area64;
 use cu29::units::si::f64::Length as Length64;
 use cu29::units::si::length::meter;
+use cu29_soa_derive::Soa;
 use serde::{Deserialize, Serialize};
 
 /// A 2D point with unit-typed coordinates.
 ///
-/// This is a scalar type; for large batches consider an SoA layout so bulk
-/// operations vectorize (see `cu29_soa_derive`).
+/// This is a scalar type; for large batches use [`Point2Soa`] so bulk
+/// operations vectorize.
 #[derive(
-    Default, Debug, Clone, Copy, PartialEq, Encode, Decode, Serialize, Deserialize, Reflect,
+    Default, Debug, Clone, Copy, PartialEq, Encode, Decode, Serialize, Deserialize, Reflect, Soa,
 )]
+#[reflect(from_reflect = false)]
 pub struct Point2<L: Copy + Debug + 'static> {
     pub x: L,
     pub y: L,
@@ -23,11 +28,12 @@ pub struct Point2<L: Copy + Debug + 'static> {
 
 /// A 3D point with unit-typed coordinates.
 ///
-/// This is a scalar type; for large batches consider an SoA layout so bulk
-/// operations vectorize (see `cu29_soa_derive`).
+/// This is a scalar type; for large batches use [`Point3Soa`] so bulk
+/// operations vectorize.
 #[derive(
-    Default, Debug, Clone, Copy, PartialEq, Encode, Decode, Serialize, Deserialize, Reflect,
+    Default, Debug, Clone, Copy, PartialEq, Encode, Decode, Serialize, Deserialize, Reflect, Soa,
 )]
+#[reflect(from_reflect = false)]
 pub struct Point3<L: Copy + Debug + 'static> {
     pub x: L,
     pub y: L,
@@ -43,6 +49,13 @@ pub type Point3d = Point3<Length64>;
 pub type Point2u = Point2<u32>;
 /// A 2D point in signed pixel coordinates, for image-space offsets.
 pub type Point2i = Point2<i32>;
+
+pub type Point2fSoa<const N: usize> = Point2Soa<Length32, N>;
+pub type Point2dSoa<const N: usize> = Point2Soa<Length64, N>;
+pub type Point3fSoa<const N: usize> = Point3Soa<Length32, N>;
+pub type Point3dSoa<const N: usize> = Point3Soa<Length64, N>;
+pub type Point2uSoa<const N: usize> = Point2Soa<u32, N>;
+pub type Point2iSoa<const N: usize> = Point2Soa<i32, N>;
 
 impl<L: Copy + Debug + 'static> Point2<L> {
     pub const fn new(x: L, y: L) -> Self {
@@ -67,7 +80,7 @@ impl<L: Copy + Debug + 'static> Point3<L> {
 }
 
 macro_rules! impl_point_metrics {
-    ($len:ty, $scalar:ty, $sqrt:path) => {
+    ($len:ty, $area:ty, $scalar:ty, $sqrt:path) => {
         impl Point2<$len> {
             pub fn from_meters(x: $scalar, y: $scalar) -> Self {
                 Self::new(<$len>::new::<meter>(x), <$len>::new::<meter>(y))
@@ -79,8 +92,8 @@ macro_rules! impl_point_metrics {
                 <$len>::new::<meter>($sqrt(dx * dx + dy * dy))
             }
 
-            /// The point at `ratio` of the way toward `other`: 0 is `self`,
-            /// 1 is `other`.
+            /// The point at `ratio` of the way toward `other`. Ratio 0
+            /// returns `self` exactly; ratio 1 returns `other` up to rounding.
             pub fn lerp(self, other: Self, ratio: $scalar) -> Self {
                 Self::new(
                     self.x + (other.x - self.x) * ratio,
@@ -108,8 +121,8 @@ macro_rules! impl_point_metrics {
                 <$len>::new::<meter>($sqrt(dx * dx + dy * dy + dz * dz))
             }
 
-            /// The point at `ratio` of the way toward `other`: 0 is `self`,
-            /// 1 is `other`.
+            /// The point at `ratio` of the way toward `other`. Ratio 0
+            /// returns `self` exactly; ratio 1 returns `other` up to rounding.
             pub fn lerp(self, other: Self, ratio: $scalar) -> Self {
                 Self::new(
                     self.x + (other.x - self.x) * ratio,
@@ -118,11 +131,96 @@ macro_rules! impl_point_metrics {
                 )
             }
         }
+
+        impl<const N: usize> Point2Soa<$len, N> {
+            /// Squared distance from every point to `target`, written to
+            /// `out[..len]`. Sqrt-free, so the loop vectorizes; enough for
+            /// nearest-neighbor style comparisons. Accurate to 1 ulp.
+            ///
+            /// # Panics
+            /// If `out` is shorter than `self.len()`.
+            pub fn distances_squared(&self, target: Point2<$len>, out: &mut [$area]) {
+                let n = self.len();
+                let (xs, ys, out) = (&self.x[..n], &self.y[..n], &mut out[..n]);
+                let (tx, ty) = (target.x.raw(), target.y.raw());
+                for i in 0..n {
+                    let (dx, dy) = (xs[i].raw() - tx, ys[i].raw() - ty);
+                    out[i] = <$area>::new::<square_meter>(dx * dx + dy * dy);
+                }
+            }
+
+            /// Distance from every point to `target`, written to `out[..len]`.
+            ///
+            /// # Panics
+            /// If `out` is shorter than `self.len()`.
+            pub fn distances(&self, target: Point2<$len>, out: &mut [$len]) {
+                let n = self.len();
+                let (xs, ys, out) = (&self.x[..n], &self.y[..n], &mut out[..n]);
+                let (tx, ty) = (target.x.raw(), target.y.raw());
+                for i in 0..n {
+                    let (dx, dy) = (xs[i].raw() - tx, ys[i].raw() - ty);
+                    out[i] = <$len>::new::<meter>($sqrt(dx * dx + dy * dy));
+                }
+            }
+
+            /// Every point moved `ratio` of the way toward `target`, in place.
+            pub fn lerp_toward(&mut self, target: Point2<$len>, ratio: $scalar) {
+                let n = self.len();
+                for i in 0..n {
+                    self.x[i] = self.x[i] + (target.x - self.x[i]) * ratio;
+                    self.y[i] = self.y[i] + (target.y - self.y[i]) * ratio;
+                }
+            }
+        }
+
+        impl<const N: usize> Point3Soa<$len, N> {
+            /// Squared distance from every point to `target`, written to
+            /// `out[..len]`. Sqrt-free, so the loop vectorizes; enough for
+            /// nearest-neighbor style comparisons. Accurate to 1 ulp.
+            ///
+            /// # Panics
+            /// If `out` is shorter than `self.len()`.
+            pub fn distances_squared(&self, target: Point3<$len>, out: &mut [$area]) {
+                let n = self.len();
+                let (xs, ys, zs) = (&self.x[..n], &self.y[..n], &self.z[..n]);
+                let out = &mut out[..n];
+                let (tx, ty, tz) = (target.x.raw(), target.y.raw(), target.z.raw());
+                for i in 0..n {
+                    let (dx, dy, dz) = (xs[i].raw() - tx, ys[i].raw() - ty, zs[i].raw() - tz);
+                    out[i] = <$area>::new::<square_meter>(dx * dx + dy * dy + dz * dz);
+                }
+            }
+
+            /// Distance from every point to `target`, written to `out[..len]`.
+            ///
+            /// # Panics
+            /// If `out` is shorter than `self.len()`.
+            pub fn distances(&self, target: Point3<$len>, out: &mut [$len]) {
+                let n = self.len();
+                let (xs, ys, zs) = (&self.x[..n], &self.y[..n], &self.z[..n]);
+                let out = &mut out[..n];
+                let (tx, ty, tz) = (target.x.raw(), target.y.raw(), target.z.raw());
+                for i in 0..n {
+                    let (dx, dy, dz) = (xs[i].raw() - tx, ys[i].raw() - ty, zs[i].raw() - tz);
+                    out[i] = <$len>::new::<meter>($sqrt(dx * dx + dy * dy + dz * dz));
+                }
+            }
+
+            /// Every point moved `ratio` of the way toward `target`, in place.
+            pub fn lerp_toward(&mut self, target: Point3<$len>, ratio: $scalar) {
+                let n = self.len();
+                for i in 0..n {
+                    self.x[i] = self.x[i] + (target.x - self.x[i]) * ratio;
+                    self.y[i] = self.y[i] + (target.y - self.y[i]) * ratio;
+                    self.z[i] = self.z[i] + (target.z - self.z[i]) * ratio;
+                }
+            }
+        }
     };
 }
 
-impl_point_metrics!(Length32, f32, libm::sqrtf);
-impl_point_metrics!(Length64, f64, libm::sqrt);
+impl_point_metrics!(Length32, Area32, f32, libm::sqrtf);
+impl_point_metrics!(Length64, Area64, f64, libm::sqrt);
 
 /// An axis-aligned bounding box; the point type carries the dimension.
 ///
@@ -157,6 +255,21 @@ impl<L: Copy + Debug + PartialOrd + 'static> BBox<Point2<L>> {
     pub fn contains(&self, p: Point2<L>) -> bool {
         self.min.x <= p.x && p.x <= self.max.x && self.min.y <= p.y && p.y <= self.max.y
     }
+
+    /// `contains` for every point in the set, written to `out[..len]`.
+    ///
+    /// # Panics
+    /// If `out` is shorter than `points.len()`.
+    pub fn contains_points<const N: usize>(&self, points: &Point2Soa<L, N>, out: &mut [bool]) {
+        let n = points.len();
+        let (xs, ys, out) = (&points.x[..n], &points.y[..n], &mut out[..n]);
+        for i in 0..n {
+            out[i] = (self.min.x <= xs[i])
+                & (xs[i] <= self.max.x)
+                & (self.min.y <= ys[i])
+                & (ys[i] <= self.max.y);
+        }
+    }
 }
 
 impl<L: Copy + Debug + PartialOrd + 'static> BBox<Point3<L>> {
@@ -169,6 +282,24 @@ impl<L: Copy + Debug + PartialOrd + 'static> BBox<Point3<L>> {
             && self.min.z <= p.z
             && p.z <= self.max.z
     }
+
+    /// `contains` for every point in the set, written to `out[..len]`.
+    ///
+    /// # Panics
+    /// If `out` is shorter than `points.len()`.
+    pub fn contains_points<const N: usize>(&self, points: &Point3Soa<L, N>, out: &mut [bool]) {
+        let n = points.len();
+        let (xs, ys, zs) = (&points.x[..n], &points.y[..n], &points.z[..n]);
+        let out = &mut out[..n];
+        for i in 0..n {
+            out[i] = (self.min.x <= xs[i])
+                & (xs[i] <= self.max.x)
+                & (self.min.y <= ys[i])
+                & (ys[i] <= self.max.y)
+                & (self.min.z <= zs[i])
+                & (zs[i] <= self.max.z);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -180,8 +311,9 @@ mod tests {
         let a = Point2f::from_meters(1.0, 2.0);
         let b = Point2f::from_meters(4.0, 6.0);
         assert_eq!(a.distance(b).raw(), 5.0);
+        // Ratio 0 is exact; ratio 1 is only exact up to rounding.
         assert_eq!(a.lerp(b, 0.0), a);
-        assert_eq!(a.lerp(b, 1.0), b);
+        assert!((a.lerp(b, 1.0).distance(b)).raw() <= 1e-6);
         assert_eq!(a.lerp(b, 0.5), Point2f::from_meters(2.5, 4.0));
 
         let a = Point3d::from_meters(1.0, 2.0, 3.0);
@@ -223,5 +355,130 @@ mod tests {
         assert!(b.contains(Point2u::new(60, 120)));
         assert!(!b.contains(Point2u::new(9, 120)));
         assert!(!b.contains(Point2u::new(60, 221)));
+    }
+
+    #[test]
+    fn soa_distances_match_scalar() {
+        let mut set = Point2fSoa::<8>::default();
+        let target = Point2f::from_meters(1.0, -2.0);
+        let points = [(0.0, 0.0), (3.0, 2.0), (-1.5, 4.0)];
+        for (x, y) in points {
+            set.push(Point2f::from_meters(x, y));
+        }
+
+        let mut d = [Length32::default(); 3];
+        let mut d2 = [Area32::default(); 3];
+        set.distances(target, &mut d);
+        set.distances_squared(target, &mut d2);
+        for i in 0..set.len() {
+            let scalar = set.get(i).distance(target);
+            assert!((d[i] - scalar).raw().abs() < 1e-6);
+            assert!((d2[i].raw() - scalar.raw() * scalar.raw()).abs() < 1e-5);
+        }
+
+        let mut set3 = Point3dSoa::<4>::default();
+        set3.push(Point3d::from_meters(1.0, 2.0, 3.0));
+        set3.push(Point3d::from_meters(-2.0, 0.5, 1.0));
+        let target3 = Point3d::from_meters(0.0, 1.0, -1.0);
+        let mut d3 = [Length64::default(); 2];
+        set3.distances(target3, &mut d3);
+        for (i, d) in d3.iter().enumerate() {
+            assert!((*d - set3.get(i).distance(target3)).raw().abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn soa_lerp_toward_matches_scalar() {
+        let mut set = Point2fSoa::<4>::default();
+        set.push(Point2f::from_meters(0.0, 0.0));
+        set.push(Point2f::from_meters(4.0, -2.0));
+        let target = Point2f::from_meters(2.0, 2.0);
+
+        let expected: [Point2f; 2] = [set.get(0).lerp(target, 0.25), set.get(1).lerp(target, 0.25)];
+        set.lerp_toward(target, 0.25);
+        assert_eq!(set.get(0), expected[0]);
+        assert_eq!(set.get(1), expected[1]);
+    }
+
+    #[test]
+    fn bbox_contains_points_bulk() {
+        let b = BBox2f::new(
+            Point2f::from_meters(0.0, 0.0),
+            Point2f::from_meters(2.0, 2.0),
+        );
+        let mut set = Point2fSoa::<4>::default();
+        set.push(Point2f::from_meters(1.0, 1.0));
+        set.push(Point2f::from_meters(0.0, 2.0));
+        set.push(Point2f::from_meters(-0.1, 1.0));
+        let mut out = [false; 3];
+        b.contains_points(&set, &mut out);
+        assert_eq!(out, [true, true, false]);
+
+        let pix = BBox2u::new(Point2u::new(10, 20), Point2u::new(110, 220));
+        let mut pixels = Point2uSoa::<4>::default();
+        pixels.push(Point2u::new(60, 120));
+        pixels.push(Point2u::new(9, 120));
+        let mut out = [false; 2];
+        pix.contains_points(&pixels, &mut out);
+        assert_eq!(out, [true, false]);
+    }
+
+    #[test]
+    fn bbox3_contains_points_bulk_matches_scalar() {
+        let b = BBox3f::new(
+            Point3f::from_meters(0.0, 0.0, 0.0),
+            Point3f::from_meters(1.0, 1.0, 1.0),
+        );
+        let points = [
+            Point3f::from_meters(0.5, 0.5, 1.0),  // on the z boundary
+            Point3f::from_meters(0.5, 0.5, 1.1),  // outside in z
+            Point3f::from_meters(0.0, 0.0, 0.0),  // corner
+            Point3f::from_meters(-0.1, 0.5, 0.5), // outside in x
+        ];
+        let mut set = Point3fSoa::<8>::default();
+        for p in points {
+            set.push(p);
+        }
+
+        // `out` is longer than the set; the tail stays untouched.
+        let mut out = [true; 6];
+        b.contains_points(&set, &mut out);
+        assert_eq!(out, [true, false, true, false, true, true]);
+        for (i, p) in points.iter().enumerate() {
+            assert_eq!(out[i], b.contains(*p));
+        }
+    }
+
+    #[test]
+    fn bulk_kernels_handle_an_empty_set() {
+        let set = Point2fSoa::<4>::default();
+        assert!(set.is_empty());
+        set.distances(Point2f::from_meters(1.0, 1.0), &mut []);
+        set.distances_squared(Point2f::from_meters(1.0, 1.0), &mut []);
+        let b = BBox2f::new(
+            Point2f::from_meters(0.0, 0.0),
+            Point2f::from_meters(1.0, 1.0),
+        );
+        b.contains_points(&set, &mut []);
+    }
+
+    /// Replaying a log recorded at a larger capacity must error, not panic.
+    #[test]
+    fn decode_rejects_len_over_capacity() {
+        let mut wide = Point2fSoa::<8>::default();
+        for i in 0..8 {
+            wide.push(Point2f::from_meters(i as f32, -(i as f32)));
+        }
+        let cfg = cu29::bincode::config::standard();
+        let bytes = cu29::bincode::encode_to_vec(&wide, cfg).expect("encode");
+
+        let narrow: Result<(Point2fSoa<4>, usize), _> =
+            cu29::bincode::decode_from_slice(&bytes, cfg);
+        assert!(narrow.is_err(), "expected a capacity error");
+
+        let (same, _): (Point2fSoa<8>, _) =
+            cu29::bincode::decode_from_slice(&bytes, cfg).expect("decode");
+        assert_eq!(same.len(), 8);
+        assert_eq!(same.get(7), wide.get(7));
     }
 }

--- a/components/payloads/cu_spatial_payloads/src/geometry.rs
+++ b/components/payloads/cu_spatial_payloads/src/geometry.rs
@@ -1,0 +1,216 @@
+//! The shared point vocabulary: unit-typed points, axis-aligned boxes, and
+//! the clearance query trait spatial components implement against.
+
+use bincode::{Decode, Encode};
+use core::fmt::Debug;
+use cu29::prelude::*;
+use cu29::units::si::f32::Length as Length32;
+use cu29::units::si::f64::Length as Length64;
+use cu29::units::si::length::meter;
+use serde::{Deserialize, Serialize};
+
+/// A 2D point with unit-typed coordinates.
+#[derive(
+    Default, Debug, Clone, Copy, PartialEq, Encode, Decode, Serialize, Deserialize, Reflect,
+)]
+pub struct Point2<L: Copy + Debug + 'static> {
+    pub x: L,
+    pub y: L,
+}
+
+/// A 3D point with unit-typed coordinates.
+#[derive(
+    Default, Debug, Clone, Copy, PartialEq, Encode, Decode, Serialize, Deserialize, Reflect,
+)]
+pub struct Point3<L: Copy + Debug + 'static> {
+    pub x: L,
+    pub y: L,
+    pub z: L,
+}
+
+pub type Point2f = Point2<Length32>;
+pub type Point2d = Point2<Length64>;
+pub type Point3f = Point3<Length32>;
+pub type Point3d = Point3<Length64>;
+
+impl<L: Copy + Debug + 'static> Point2<L> {
+    pub const fn new(x: L, y: L) -> Self {
+        Self { x, y }
+    }
+
+    /// The point lifted to 3D at height `z`.
+    pub fn with_z(self, z: L) -> Point3<L> {
+        Point3::new(self.x, self.y, z)
+    }
+}
+
+impl<L: Copy + Debug + 'static> Point3<L> {
+    pub const fn new(x: L, y: L, z: L) -> Self {
+        Self { x, y, z }
+    }
+
+    /// The planar projection: z dropped.
+    pub fn xy(self) -> Point2<L> {
+        Point2::new(self.x, self.y)
+    }
+}
+
+macro_rules! impl_point_metrics {
+    ($len:ty, $scalar:ty, $sqrt:path) => {
+        impl Point2<$len> {
+            pub fn from_meters(x: $scalar, y: $scalar) -> Self {
+                Self::new(<$len>::new::<meter>(x), <$len>::new::<meter>(y))
+            }
+
+            /// Euclidean distance to `other`.
+            pub fn distance(self, other: Self) -> $len {
+                let (dx, dy) = ((self.x - other.x).raw(), (self.y - other.y).raw());
+                <$len>::new::<meter>($sqrt(dx * dx + dy * dy))
+            }
+
+            /// The point at `ratio` of the way toward `other`: 0 is `self`,
+            /// 1 is `other`.
+            pub fn lerp(self, other: Self, ratio: $scalar) -> Self {
+                Self::new(
+                    self.x + (other.x - self.x) * ratio,
+                    self.y + (other.y - self.y) * ratio,
+                )
+            }
+        }
+
+        impl Point3<$len> {
+            pub fn from_meters(x: $scalar, y: $scalar, z: $scalar) -> Self {
+                Self::new(
+                    <$len>::new::<meter>(x),
+                    <$len>::new::<meter>(y),
+                    <$len>::new::<meter>(z),
+                )
+            }
+
+            /// Euclidean distance to `other`.
+            pub fn distance(self, other: Self) -> $len {
+                let (dx, dy, dz) = (
+                    (self.x - other.x).raw(),
+                    (self.y - other.y).raw(),
+                    (self.z - other.z).raw(),
+                );
+                <$len>::new::<meter>($sqrt(dx * dx + dy * dy + dz * dz))
+            }
+
+            /// The point at `ratio` of the way toward `other`: 0 is `self`,
+            /// 1 is `other`.
+            pub fn lerp(self, other: Self, ratio: $scalar) -> Self {
+                Self::new(
+                    self.x + (other.x - self.x) * ratio,
+                    self.y + (other.y - self.y) * ratio,
+                    self.z + (other.z - self.z) * ratio,
+                )
+            }
+        }
+    };
+}
+
+impl_point_metrics!(Length32, f32, libm::sqrtf);
+impl_point_metrics!(Length64, f64, libm::sqrt);
+
+/// An axis-aligned box; the point type carries the dimension.
+#[derive(
+    Default, Debug, Clone, Copy, PartialEq, Encode, Decode, Serialize, Deserialize, Reflect,
+)]
+pub struct Aabb<P: Copy + Debug + 'static> {
+    pub min: P,
+    pub max: P,
+}
+
+pub type Aabb2f = Aabb<Point2f>;
+pub type Aabb2d = Aabb<Point2d>;
+pub type Aabb3f = Aabb<Point3f>;
+pub type Aabb3d = Aabb<Point3d>;
+
+impl<P: Copy + Debug + 'static> Aabb<P> {
+    pub const fn new(min: P, max: P) -> Self {
+        Self { min, max }
+    }
+}
+
+impl<L: Copy + Debug + PartialOrd + 'static> Aabb<Point2<L>> {
+    /// True when `p` lies inside the box, boundary included.
+    pub fn contains(&self, p: Point2<L>) -> bool {
+        self.min.x <= p.x && p.x <= self.max.x && self.min.y <= p.y && p.y <= self.max.y
+    }
+}
+
+impl<L: Copy + Debug + PartialOrd + 'static> Aabb<Point3<L>> {
+    /// True when `p` lies inside the box, boundary included.
+    pub fn contains(&self, p: Point3<L>) -> bool {
+        self.min.x <= p.x
+            && p.x <= self.max.x
+            && self.min.y <= p.y
+            && p.y <= self.max.y
+            && self.min.z <= p.z
+            && p.z <= self.max.z
+    }
+}
+
+/// Clearance queries against the occupied geometry of a space.
+///
+/// The clearance is a signed distance: positive in free space, zero on a
+/// surface, negative inside an obstacle or out of bounds. What is free is the
+/// caller's predicate - `clearance(p) > robot_radius` - so one space serves
+/// robots of any size.
+pub trait Clearance {
+    /// The point type of the space, which fixes its dimension.
+    type Point: Copy;
+
+    /// Signed distance from `p` to the nearest occupied geometry.
+    fn clearance(&self, p: Self::Point) -> Length32;
+
+    /// Smallest clearance anywhere along the segment `a`-`b`.
+    fn clearance_segment(&self, a: Self::Point, b: Self::Point) -> Length32;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn point_distance_and_lerp() {
+        let a = Point2f::from_meters(1.0, 2.0);
+        let b = Point2f::from_meters(4.0, 6.0);
+        assert_eq!(a.distance(b).raw(), 5.0);
+        assert_eq!(a.lerp(b, 0.0), a);
+        assert_eq!(a.lerp(b, 1.0), b);
+        assert_eq!(a.lerp(b, 0.5), Point2f::from_meters(2.5, 4.0));
+
+        let a = Point3d::from_meters(1.0, 2.0, 3.0);
+        let b = Point3d::from_meters(3.0, 5.0, 9.0);
+        assert_eq!(a.distance(b).raw(), 7.0);
+        assert_eq!(a.lerp(b, 0.5), Point3d::from_meters(2.0, 3.5, 6.0));
+    }
+
+    #[test]
+    fn point_dimension_conversions() {
+        let p = Point3f::from_meters(1.0, 2.0, 3.0);
+        assert_eq!(p.xy(), Point2f::from_meters(1.0, 2.0));
+        assert_eq!(p.xy().with_z(p.z), p);
+    }
+
+    #[test]
+    fn aabb_contains_boundary_included() {
+        let b = Aabb2f::new(
+            Point2f::from_meters(0.0, 0.0),
+            Point2f::from_meters(2.0, 2.0),
+        );
+        assert!(b.contains(Point2f::from_meters(1.0, 1.0)));
+        assert!(b.contains(Point2f::from_meters(0.0, 2.0)));
+        assert!(!b.contains(Point2f::from_meters(-0.1, 1.0)));
+        assert!(!b.contains(Point2f::from_meters(1.0, 2.1)));
+
+        let b = Aabb3f::new(
+            Point3f::from_meters(0.0, 0.0, 0.0),
+            Point3f::from_meters(1.0, 1.0, 1.0),
+        );
+        assert!(b.contains(Point3f::from_meters(0.5, 0.5, 1.0)));
+        assert!(!b.contains(Point3f::from_meters(0.5, 0.5, 1.1)));
+    }
+}

--- a/components/payloads/cu_spatial_payloads/src/geometry.rs
+++ b/components/payloads/cu_spatial_payloads/src/geometry.rs
@@ -1,5 +1,5 @@
-//! The shared point vocabulary: unit-typed points, axis-aligned boxes, and
-//! the clearance query trait spatial components implement against.
+//! The shared point vocabulary: unit-typed points and axis-aligned bounding
+//! boxes spatial components compose over.
 
 use bincode::{Decode, Encode};
 use core::fmt::Debug;
@@ -10,6 +10,9 @@ use cu29::units::si::length::meter;
 use serde::{Deserialize, Serialize};
 
 /// A 2D point with unit-typed coordinates.
+///
+/// This is a scalar type; for large batches consider an SoA layout so bulk
+/// operations vectorize (see `cu29_soa_derive`).
 #[derive(
     Default, Debug, Clone, Copy, PartialEq, Encode, Decode, Serialize, Deserialize, Reflect,
 )]
@@ -19,6 +22,9 @@ pub struct Point2<L: Copy + Debug + 'static> {
 }
 
 /// A 3D point with unit-typed coordinates.
+///
+/// This is a scalar type; for large batches consider an SoA layout so bulk
+/// operations vectorize (see `cu29_soa_derive`).
 #[derive(
     Default, Debug, Clone, Copy, PartialEq, Encode, Decode, Serialize, Deserialize, Reflect,
 )]
@@ -32,6 +38,11 @@ pub type Point2f = Point2<Length32>;
 pub type Point2d = Point2<Length64>;
 pub type Point3f = Point3<Length32>;
 pub type Point3d = Point3<Length64>;
+
+/// A 2D point in pixel coordinates, for image-space geometry.
+pub type Point2u = Point2<u32>;
+/// A 2D point in signed pixel coordinates, for image-space offsets.
+pub type Point2i = Point2<i32>;
 
 impl<L: Copy + Debug + 'static> Point2<L> {
     pub const fn new(x: L, y: L) -> Self {
@@ -113,34 +124,42 @@ macro_rules! impl_point_metrics {
 impl_point_metrics!(Length32, f32, libm::sqrtf);
 impl_point_metrics!(Length64, f64, libm::sqrt);
 
-/// An axis-aligned box; the point type carries the dimension.
+/// An axis-aligned bounding box; the point type carries the dimension.
+///
+/// This is a scalar type; for large batches (e.g. detection anchors) consider
+/// an SoA layout so bulk operations vectorize (see `cu29_soa_derive`).
 #[derive(
     Default, Debug, Clone, Copy, PartialEq, Encode, Decode, Serialize, Deserialize, Reflect,
 )]
-pub struct Aabb<P: Copy + Debug + 'static> {
+pub struct BBox<P: Copy + Debug + 'static> {
     pub min: P,
     pub max: P,
 }
 
-pub type Aabb2f = Aabb<Point2f>;
-pub type Aabb2d = Aabb<Point2d>;
-pub type Aabb3f = Aabb<Point3f>;
-pub type Aabb3d = Aabb<Point3d>;
+pub type BBox2f = BBox<Point2f>;
+pub type BBox2d = BBox<Point2d>;
+pub type BBox3f = BBox<Point3f>;
+pub type BBox3d = BBox<Point3d>;
 
-impl<P: Copy + Debug + 'static> Aabb<P> {
+/// A 2D bounding box in pixel coordinates, for image-space geometry.
+pub type BBox2u = BBox<Point2u>;
+/// A 2D bounding box in signed pixel coordinates.
+pub type BBox2i = BBox<Point2i>;
+
+impl<P: Copy + Debug + 'static> BBox<P> {
     pub const fn new(min: P, max: P) -> Self {
         Self { min, max }
     }
 }
 
-impl<L: Copy + Debug + PartialOrd + 'static> Aabb<Point2<L>> {
+impl<L: Copy + Debug + PartialOrd + 'static> BBox<Point2<L>> {
     /// True when `p` lies inside the box, boundary included.
     pub fn contains(&self, p: Point2<L>) -> bool {
         self.min.x <= p.x && p.x <= self.max.x && self.min.y <= p.y && p.y <= self.max.y
     }
 }
 
-impl<L: Copy + Debug + PartialOrd + 'static> Aabb<Point3<L>> {
+impl<L: Copy + Debug + PartialOrd + 'static> BBox<Point3<L>> {
     /// True when `p` lies inside the box, boundary included.
     pub fn contains(&self, p: Point3<L>) -> bool {
         self.min.x <= p.x
@@ -150,23 +169,6 @@ impl<L: Copy + Debug + PartialOrd + 'static> Aabb<Point3<L>> {
             && self.min.z <= p.z
             && p.z <= self.max.z
     }
-}
-
-/// Clearance queries against the occupied geometry of a space.
-///
-/// The clearance is a signed distance: positive in free space, zero on a
-/// surface, negative inside an obstacle or out of bounds. What is free is the
-/// caller's predicate - `clearance(p) > robot_radius` - so one space serves
-/// robots of any size.
-pub trait Clearance {
-    /// The point type of the space, which fixes its dimension.
-    type Point: Copy;
-
-    /// Signed distance from `p` to the nearest occupied geometry.
-    fn clearance(&self, p: Self::Point) -> Length32;
-
-    /// Smallest clearance anywhere along the segment `a`-`b`.
-    fn clearance_segment(&self, a: Self::Point, b: Self::Point) -> Length32;
 }
 
 #[cfg(test)]
@@ -196,8 +198,8 @@ mod tests {
     }
 
     #[test]
-    fn aabb_contains_boundary_included() {
-        let b = Aabb2f::new(
+    fn bbox_contains_boundary_included() {
+        let b = BBox2f::new(
             Point2f::from_meters(0.0, 0.0),
             Point2f::from_meters(2.0, 2.0),
         );
@@ -206,11 +208,20 @@ mod tests {
         assert!(!b.contains(Point2f::from_meters(-0.1, 1.0)));
         assert!(!b.contains(Point2f::from_meters(1.0, 2.1)));
 
-        let b = Aabb3f::new(
+        let b = BBox3f::new(
             Point3f::from_meters(0.0, 0.0, 0.0),
             Point3f::from_meters(1.0, 1.0, 1.0),
         );
         assert!(b.contains(Point3f::from_meters(0.5, 0.5, 1.0)));
         assert!(!b.contains(Point3f::from_meters(0.5, 0.5, 1.1)));
+    }
+
+    #[test]
+    fn pixel_bbox_contains() {
+        let b = BBox2u::new(Point2u::new(10, 20), Point2u::new(110, 220));
+        assert!(b.contains(Point2u::new(10, 220)));
+        assert!(b.contains(Point2u::new(60, 120)));
+        assert!(!b.contains(Point2u::new(9, 120)));
+        assert!(!b.contains(Point2u::new(60, 221)));
     }
 }

--- a/components/payloads/cu_spatial_payloads/src/lib.rs
+++ b/components/payloads/cu_spatial_payloads/src/lib.rs
@@ -21,8 +21,8 @@ use glam::{Affine3A, DAffine3, DMat4, DVec3, Mat4, Vec3};
 
 mod geometry;
 pub use geometry::{
-    Aabb, Aabb2d, Aabb2f, Aabb3d, Aabb3f, Clearance, Point2, Point2d, Point2f, Point3, Point3d,
-    Point3f,
+    BBox, BBox2d, BBox2f, BBox2i, BBox2u, BBox3d, BBox3f, Point2, Point2d, Point2f, Point2i,
+    Point2u, Point3, Point3d, Point3f,
 };
 
 #[cfg(feature = "rerun")]

--- a/components/payloads/cu_spatial_payloads/src/lib.rs
+++ b/components/payloads/cu_spatial_payloads/src/lib.rs
@@ -21,8 +21,9 @@ use glam::{Affine3A, DAffine3, DMat4, DVec3, Mat4, Vec3};
 
 mod geometry;
 pub use geometry::{
-    BBox, BBox2d, BBox2f, BBox2i, BBox2u, BBox3d, BBox3f, Point2, Point2d, Point2f, Point2i,
-    Point2u, Point3, Point3d, Point3f,
+    BBox, BBox2d, BBox2f, BBox2i, BBox2u, BBox3d, BBox3f, Point2, Point2Iterator, Point2Soa,
+    Point2d, Point2dSoa, Point2f, Point2fSoa, Point2i, Point2iSoa, Point2u, Point2uSoa, Point3,
+    Point3Iterator, Point3Soa, Point3d, Point3dSoa, Point3f, Point3fSoa,
 };
 
 #[cfg(feature = "rerun")]
@@ -365,6 +366,38 @@ macro_rules! impl_transform_points {
                         <$len>::new::<meter>(m[1][0] * x + m[1][1] * y + m[1][2] * z),
                         <$len>::new::<meter>(m[2][0] * x + m[2][1] * y + m[2][2] * z),
                     )
+                }
+            }
+
+            /// Every point in the set mapped through the transform, in place.
+            ///
+            /// May differ from [`Self::transform_point`] by a rounding step.
+            pub fn transform_points<const N: usize>(&self, points: &mut Point3Soa<$len, N>) {
+                #[cfg(feature = "glam")]
+                let m = match &self.inner {
+                    TransformInner::$variant(affine) => {
+                        let r = &affine.matrix3;
+                        let t = affine.translation;
+                        [
+                            [r.x_axis.x, r.y_axis.x, r.z_axis.x, t.x],
+                            [r.x_axis.y, r.y_axis.y, r.z_axis.y, t.y],
+                            [r.x_axis.z, r.y_axis.z, r.z_axis.z, t.z],
+                        ]
+                    }
+                    _ => unreachable!(),
+                };
+                #[cfg(not(feature = "glam"))]
+                let m = [self.mat[0], self.mat[1], self.mat[2]];
+
+                let n = points.len();
+                for i in 0..n {
+                    let (x, y, z) = (points.x[i].raw(), points.y[i].raw(), points.z[i].raw());
+                    points.x[i] =
+                        <$len>::new::<meter>(m[0][0] * x + m[0][1] * y + m[0][2] * z + m[0][3]);
+                    points.y[i] =
+                        <$len>::new::<meter>(m[1][0] * x + m[1][1] * y + m[1][2] * z + m[1][3]);
+                    points.z[i] =
+                        <$len>::new::<meter>(m[2][0] * x + m[2][1] * y + m[2][2] * z + m[2][3]);
                 }
             }
         }
@@ -1117,6 +1150,25 @@ mod tests {
         assert_eq!(identity.transform_point(p), p);
         assert_eq!(identity.transform_vector(p), p);
         assert_eq!(identity.position(), Point3f::default());
+    }
+
+    #[test]
+    fn transform_points_matches_transform_point() {
+        let t = quarter_turn_and_shift();
+        let points = [
+            Point3f::from_meters(1.0, 0.0, 0.0),
+            Point3f::from_meters(-1.5, 2.0, 0.25),
+            Point3f::from_meters(0.0, 0.0, 0.0),
+        ];
+        let mut set = Point3fSoa::<4>::default();
+        for p in points {
+            set.push(p);
+        }
+
+        t.transform_points(&mut set);
+        for (i, p) in points.iter().enumerate() {
+            assert_point_close(set.get(i), t.transform_point(*p), 1e-5);
+        }
     }
 
     #[test]

--- a/components/payloads/cu_spatial_payloads/src/lib.rs
+++ b/components/payloads/cu_spatial_payloads/src/lib.rs
@@ -17,7 +17,13 @@ use cu29::units::si::length::meter;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "glam")]
-use glam::{Affine3A, DAffine3, DMat4, Mat4};
+use glam::{Affine3A, DAffine3, DMat4, DVec3, Mat4, Vec3};
+
+mod geometry;
+pub use geometry::{
+    Aabb, Aabb2d, Aabb2f, Aabb3d, Aabb3f, Clearance, Point2, Point2d, Point2f, Point3, Point3d,
+    Point3f,
+};
 
 #[cfg(feature = "rerun")]
 mod rerun_components;
@@ -266,6 +272,107 @@ impl<T: Copy + Debug + Default + 'static> TransformInner<T> {
 
 impl_transform_accessors!(f32, Length32, Angle32);
 impl_transform_accessors!(f64, Length64, Angle64);
+
+macro_rules! impl_transform_points {
+    ($ty:ty, $len:ty, $variant:ident, $vec:ty) => {
+        impl Transform3D<$ty> {
+            /// The translation as a point: where the pose sits in its parent
+            /// frame.
+            pub fn position(&self) -> Point3<$len> {
+                #[cfg(feature = "glam")]
+                {
+                    match &self.inner {
+                        TransformInner::$variant(affine) => {
+                            let t = affine.translation;
+                            Point3::new(
+                                <$len>::new::<meter>(t.x as $ty),
+                                <$len>::new::<meter>(t.y as $ty),
+                                <$len>::new::<meter>(t.z as $ty),
+                            )
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+                #[cfg(not(feature = "glam"))]
+                {
+                    Point3::new(
+                        <$len>::new::<meter>(self.mat[0][3]),
+                        <$len>::new::<meter>(self.mat[1][3]),
+                        <$len>::new::<meter>(self.mat[2][3]),
+                    )
+                }
+            }
+
+            /// `p` mapped through the transform: rotation, then translation.
+            pub fn transform_point(&self, p: Point3<$len>) -> Point3<$len> {
+                #[cfg(feature = "glam")]
+                {
+                    match &self.inner {
+                        TransformInner::$variant(affine) => {
+                            let out = affine.transform_point3(<$vec>::new(
+                                p.x.raw(),
+                                p.y.raw(),
+                                p.z.raw(),
+                            ));
+                            Point3::new(
+                                <$len>::new::<meter>(out.x),
+                                <$len>::new::<meter>(out.y),
+                                <$len>::new::<meter>(out.z),
+                            )
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+                #[cfg(not(feature = "glam"))]
+                {
+                    let m = &self.mat;
+                    let (x, y, z) = (p.x.raw(), p.y.raw(), p.z.raw());
+                    Point3::new(
+                        <$len>::new::<meter>(m[0][0] * x + m[0][1] * y + m[0][2] * z + m[0][3]),
+                        <$len>::new::<meter>(m[1][0] * x + m[1][1] * y + m[1][2] * z + m[1][3]),
+                        <$len>::new::<meter>(m[2][0] * x + m[2][1] * y + m[2][2] * z + m[2][3]),
+                    )
+                }
+            }
+
+            /// `v` mapped through the rotation only, for directions and
+            /// offsets.
+            pub fn transform_vector(&self, v: Point3<$len>) -> Point3<$len> {
+                #[cfg(feature = "glam")]
+                {
+                    match &self.inner {
+                        TransformInner::$variant(affine) => {
+                            let out = affine.transform_vector3(<$vec>::new(
+                                v.x.raw(),
+                                v.y.raw(),
+                                v.z.raw(),
+                            ));
+                            Point3::new(
+                                <$len>::new::<meter>(out.x),
+                                <$len>::new::<meter>(out.y),
+                                <$len>::new::<meter>(out.z),
+                            )
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+                #[cfg(not(feature = "glam"))]
+                {
+                    let m = &self.mat;
+                    let (x, y, z) = (v.x.raw(), v.y.raw(), v.z.raw());
+                    Point3::new(
+                        <$len>::new::<meter>(m[0][0] * x + m[0][1] * y + m[0][2] * z),
+                        <$len>::new::<meter>(m[1][0] * x + m[1][1] * y + m[1][2] * z),
+                        <$len>::new::<meter>(m[2][0] * x + m[2][1] * y + m[2][2] * z),
+                    )
+                }
+            }
+        }
+    };
+}
+
+impl_transform_points!(f32, Length32, F32, Vec3);
+impl_transform_points!(f64, Length64, F64, DVec3);
 
 impl<T: Copy + Debug + Default + 'static> Default for Transform3D<T> {
     fn default() -> Self {
@@ -946,6 +1053,70 @@ mod tests {
         assert_eq!(mat_transposed.w_axis.x, 5.0);
         assert_eq!(mat_transposed.w_axis.y, 6.0);
         assert_eq!(mat_transposed.w_axis.z, 7.0);
+    }
+
+    /// 90 degrees around z plus a (2, 3, 4) translation, in the layout the
+    /// active backend expects: glam stores column-major, the fallback
+    /// row-major.
+    fn quarter_turn_and_shift() -> Transform3D<f32> {
+        #[cfg(feature = "glam")]
+        {
+            Transform3D::from_matrix([
+                [0.0, 1.0, 0.0, 0.0],
+                [-1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [2.0, 3.0, 4.0, 1.0],
+            ])
+        }
+        #[cfg(not(feature = "glam"))]
+        {
+            Transform3D::from_matrix([
+                [0.0, -1.0, 0.0, 2.0],
+                [1.0, 0.0, 0.0, 3.0],
+                [0.0, 0.0, 1.0, 4.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ])
+        }
+    }
+
+    fn assert_point_close(lhs: Point3f, rhs: Point3f, eps: f32) {
+        assert!(
+            (lhs.x - rhs.x).raw().abs() <= eps
+                && (lhs.y - rhs.y).raw().abs() <= eps
+                && (lhs.z - rhs.z).raw().abs() <= eps,
+            "{lhs:?} differs from {rhs:?}"
+        );
+    }
+
+    #[test]
+    fn transform_point_rotates_and_translates() {
+        let t = quarter_turn_and_shift();
+        let p = Point3f::from_meters(1.0, 0.0, 0.0);
+        assert_point_close(
+            t.transform_point(p),
+            Point3f::from_meters(2.0, 4.0, 4.0),
+            1e-5,
+        );
+        assert_point_close(
+            t.transform_vector(p),
+            Point3f::from_meters(0.0, 1.0, 0.0),
+            1e-5,
+        );
+        assert_point_close(t.position(), Point3f::from_meters(2.0, 3.0, 4.0), 1e-5);
+    }
+
+    #[test]
+    fn transform_point_identity_is_a_fixed_point() {
+        let identity = Transform3D::<f32>::from_matrix([
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]);
+        let p = Point3f::from_meters(1.5, -2.0, 0.25);
+        assert_eq!(identity.transform_point(p), p);
+        assert_eq!(identity.transform_vector(p), p);
+        assert_eq!(identity.position(), Point3f::default());
     }
 
     #[test]

--- a/core/cu29_soa_derive/src/lib.rs
+++ b/core/cu29_soa_derive/src/lib.rs
@@ -151,6 +151,79 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
     };
 
     let name = &input.ident;
+    if let Some(lifetime) = input.generics.lifetimes().next() {
+        return syn::Error::new_spanned(lifetime, "lifetime parameters are not supported")
+            .to_compile_error()
+            .into();
+    }
+    if let Some(const_param) = input.generics.const_params().next() {
+        return syn::Error::new_spanned(const_param, "const parameters are not supported")
+            .to_compile_error()
+            .into();
+    }
+    if let Some(where_clause) = &input.generics.where_clause {
+        return syn::Error::new_spanned(where_clause, "where clauses are not supported")
+            .to_compile_error()
+            .into();
+    }
+    let ty_params: Vec<syn::TypeParam> = input
+        .generics
+        .type_params()
+        .cloned()
+        .map(|mut param| {
+            param.attrs.clear();
+            param.default = None;
+            param
+        })
+        .collect();
+    let ty_idents: Vec<syn::Ident> = ty_params.iter().map(|param| param.ident.clone()).collect();
+    // `N` is the generated capacity parameter.
+    if let Some(clashing) = ty_idents.iter().find(|ident| *ident == "N") {
+        return syn::Error::new_spanned(
+            clashing,
+            "a type parameter named `N` collides with the generated capacity parameter; rename it",
+        )
+        .to_compile_error()
+        .into();
+    }
+    let has_type_params = !ty_params.is_empty();
+
+    // Generic parameter lists for the generated items. With no type params on
+    // the input these collapse to today's `<const N: usize>` / `<N>` forms.
+    let soa_decl = quote!(<#(#ty_params,)* const N: usize>);
+    let soa_use = quote!(<#(#ty_idents,)* N>);
+    let iter_decl = quote!(<'a, #(#ty_params,)* const N: usize>);
+    let iter_use = quote!(<'a, #(#ty_idents,)* N>);
+    let iter_use_elided = quote!(<#(#ty_idents,)* N>);
+    let serde_decl = quote!(<'a, #(#ty_params,)* const N: usize>);
+    let serde_use = quote!(<'a, #(#ty_idents,)* N>);
+    let serde_use_anon = quote!(<'_, #(#ty_idents,)* N>);
+    let de_decl = quote!(<'de, #(#ty_params,)* const N: usize>);
+    let wire_decl = if has_type_params {
+        quote!(<#(#ty_params),*>)
+    } else {
+        quote!()
+    };
+    let wire_use = if has_type_params {
+        quote!(<#(#ty_idents),*>)
+    } else {
+        quote!()
+    };
+    let orig_ty = if has_type_params {
+        quote!(super::#name<#(#ty_idents),*>)
+    } else {
+        quote!(super::#name)
+    };
+    // Bounds on the input struct (e.g. `L: Copy + Debug`) may reference names
+    // from the parent scope, so pull that scope into the generated module.
+    let parent_scope_import = if has_type_params {
+        quote!(
+            #[allow(unused_imports)]
+            use super::*;
+        )
+    } else {
+        quote!()
+    };
     let module_name = format_ident!("{}_soa", name.to_string().to_lowercase());
     let soa_struct_name = format_ident!("{}Soa", name);
     let soa_storage_name = format_ident!("{}SoaStorage", name);
@@ -297,6 +370,14 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
             Ok(value) => value,
             Err(err) => return err.to_compile_error().into(),
         };
+        if nested && has_type_params {
+            return syn::Error::new_spanned(
+                field,
+                "#[soa(nested)] is not supported on generic structs",
+            )
+            .to_compile_error()
+            .into();
+        }
         let (storage_path, storage_wire_path) = if nested {
             match storage_paths(&field_type) {
                 Ok((storage_path, storage_wire_path)) => {
@@ -316,8 +397,14 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
             };
             let type_name = last_segment.ident.to_string();
             let path_str = path.to_token_stream().to_string();
+            let is_type_param = path.segments.len() == 1
+                && path.leading_colon.is_none()
+                && ty_idents.contains(&last_segment.ident);
 
-            if !is_primitive(&type_name) && !unique_import_names.contains(&path_str) {
+            if !is_primitive(&type_name)
+                && !is_type_param
+                && !unique_import_names.contains(&path_str)
+            {
                 unique_imports.push(path.clone());
                 unique_import_names.push(path_str);
             }
@@ -338,36 +425,6 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
     let soa_struct_name_iterator = format_ident!("{}Iterator", name);
     let storage_field_count = field_names.len();
     let field_count = storage_field_count + 1; // +1 for the len field
-
-    let iterator = quote! {
-        pub struct #soa_struct_name_iterator<'a, const N: usize> {
-            soa_struct: &'a #soa_struct_name<N>,
-            current: usize,
-        }
-
-        impl<'a, const N: usize> #soa_struct_name_iterator<'a, N> {
-            pub fn new(soa_struct: &'a #soa_struct_name<N>) -> Self {
-                Self {
-                    soa_struct,
-                    current: 0,
-                }
-            }
-        }
-
-        impl<'a, const N: usize> Iterator for #soa_struct_name_iterator<'a, N> {
-            type Item = super::#name;
-
-            fn next(&mut self) -> Option<Self::Item> {
-                if self.current < self.soa_struct.len {
-                    let item = self.soa_struct.get(self.current); // Reuse `get` method
-                    self.current += 1;
-                    Some(item)
-                } else {
-                    None
-                }
-            }
-        }
-    };
 
     // Shared between storage and soa (identical generated code)
     let mut field_decls = Vec::new();
@@ -390,6 +447,13 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
     let mut soa_wire_fields = Vec::new();
     let mut soa_wire_checks = Vec::new();
     let mut soa_wire_assignments = Vec::new();
+
+    // Bounds the generated impls need on generic field types; empty for
+    // non-generic inputs so their output is unchanged.
+    let mut generic_method_bounds = Vec::new();
+    let mut generic_encode_bounds = Vec::new();
+    let mut generic_decode_bounds = Vec::new();
+    let mut generic_default_bounds = Vec::new();
 
     // Storage-only fields
     let mut storage_encode_fields = Vec::new();
@@ -485,6 +549,12 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
             new_inits.push(quote!(#name: from_fn(|_| default.#name.clone())));
             default_inits.push(quote!(#name: from_fn(|_| #ty::default())));
             storage_clone_bounds.push(quote!(#ty: Clone,));
+            if has_type_params {
+                generic_method_bounds.push(quote!(#ty: Clone + Default,));
+                generic_encode_bounds.push(quote!(#ty: Encode,));
+                generic_decode_bounds.push(quote!(#ty: Decode<()> + Default,));
+                generic_default_bounds.push(quote!(#ty: Default,));
+            }
 
             accessors.push(quote! {
                 pub fn #name(&self) -> &[#ty] {
@@ -495,11 +565,11 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
                     &mut self.#name
                 }
 
-                pub fn #name_range(&self, range: std::ops::Range<usize>) -> &[#ty] {
+                pub fn #name_range(&self, range: core::ops::Range<usize>) -> &[#ty] {
                     &self.#name[range]
                 }
 
-                pub fn #name_range_mut(&mut self, range: std::ops::Range<usize>) -> &mut [#ty] {
+                pub fn #name_range_mut(&mut self, range: core::ops::Range<usize>) -> &mut [#ty] {
                     &mut self.#name[range]
                 }
             });
@@ -515,7 +585,7 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
 
             storage_encode_fields.push(quote! {
                 for _idx in 0..len {
-                    self.#name[_idx].encode(encoder)?;
+                    Encode::encode(&self.#name[_idx], encoder)?;
                 }
             });
             storage_decode_fields.push(quote! {
@@ -526,7 +596,7 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
 
             soa_encode_fields.push(quote! {
                 for _idx in 0..self.len {
-                    self.#name[_idx].encode(encoder)?;
+                    Encode::encode(&self.#name[_idx], encoder)?;
                 }
             });
             soa_decode_fields.push(quote! {
@@ -602,9 +672,72 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
     } else {
         quote!(where #(#soa_deserialize_bounds)*)
     };
+    let methods_where = if generic_method_bounds.is_empty() {
+        quote!()
+    } else {
+        quote!(where #(#generic_method_bounds)*)
+    };
+    let storage_methods_where = if generic_method_bounds.is_empty() {
+        quote!()
+    } else {
+        quote!(where #(#generic_method_bounds)* #(#generic_encode_bounds)* #(#generic_decode_bounds)*)
+    };
+    let encode_where = if generic_encode_bounds.is_empty() {
+        quote!()
+    } else {
+        quote!(where #(#generic_encode_bounds)*)
+    };
+    let decode_where = if generic_decode_bounds.is_empty() {
+        quote!()
+    } else {
+        quote!(where #(#generic_decode_bounds)*)
+    };
+    let default_where = if generic_default_bounds.is_empty() {
+        quote!()
+    } else {
+        quote!(where #(#generic_default_bounds)*)
+    };
+
+    let iterator = quote! {
+        pub struct #soa_struct_name_iterator #iter_decl {
+            soa_struct: &'a #soa_struct_name #soa_use,
+            current: usize,
+        }
+
+        impl #iter_decl #soa_struct_name_iterator #iter_use
+        #methods_where
+        {
+            pub fn new(soa_struct: &'a #soa_struct_name #soa_use) -> Self {
+                Self {
+                    soa_struct,
+                    current: 0,
+                }
+            }
+        }
+
+        impl #iter_decl Iterator for #soa_struct_name_iterator #iter_use
+        #methods_where
+        {
+            type Item = #orig_ty;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                if self.current < self.soa_struct.len {
+                    let item = self.soa_struct.get(self.current); // Reuse `get` method
+                    self.current += 1;
+                    Some(item)
+                } else {
+                    None
+                }
+            }
+        }
+    };
 
     let expanded = quote! {
         #visibility mod #module_name {
+            extern crate alloc;
+            use self::alloc::format;
+            use self::alloc::string::String;
+            use self::alloc::vec::Vec;
             use bincode::{Decode, Encode};
             use bincode::enc::Encoder;
             use bincode::de::Decoder;
@@ -613,41 +746,43 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
             use serde::Serialize;
             use serde::Serializer;
             use serde::ser::SerializeStruct;
-            use std::ops::{Index, IndexMut};
+            #parent_scope_import
             #( use super::#unique_imports; )*
             #reflect_import
             use core::array::from_fn;
 
             #[derive(Debug)]
-            #visibility struct #soa_storage_name<const N: usize> {
+            #visibility struct #soa_storage_name #soa_decl {
                 #(#field_decls,)*
             }
 
             #[doc(hidden)]
             #[derive(Deserialize)]
-            #visibility struct #soa_storage_wire_name {
+            #visibility struct #soa_storage_wire_name #wire_decl {
                 #(#storage_wire_fields)*
             }
 
             #[doc(hidden)]
-            #visibility struct #soa_storage_serde_name<'a, const N: usize> {
-                storage: &'a #soa_storage_name<N>,
+            #visibility struct #soa_storage_serde_name #serde_decl {
+                storage: &'a #soa_storage_name #soa_use,
                 len: usize,
             }
 
-            impl<const N: usize> #soa_storage_name<N> {
-                pub fn new(default: super::#name) -> Self {
+            impl #soa_decl #soa_storage_name #soa_use
+            #storage_methods_where
+            {
+                pub fn new(default: #orig_ty) -> Self {
                     Self {
                         #(#new_inits,)*
                     }
                 }
 
-                pub fn set(&mut self, index: usize, value: super::#name) {
+                pub fn set(&mut self, index: usize, value: #orig_ty) {
                     assert!(index < N, "Index out of bounds");
                     #(#set_fields)*
                 }
 
-                pub fn get(&self, index: usize) -> super::#name {
+                pub fn get(&self, index: usize) -> #orig_ty {
                     assert!(index < N, "Index out of bounds");
                     super::#name {
                         #(#get_fields)*
@@ -667,19 +802,25 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
                     decoder: &mut D,
                     len: usize,
                 ) -> Result<Self, DecodeError> {
+                    if len > N {
+                        return Err(DecodeError::ArrayLengthMismatch {
+                            required: N,
+                            found: len,
+                        });
+                    }
                     let mut result = Self::default();
                     #(#storage_decode_fields)*
                     Ok(result)
                 }
 
-                pub fn serialize_len(&self, len: usize) -> #soa_storage_serde_name<'_, N> {
+                pub fn serialize_len(&self, len: usize) -> #soa_storage_serde_name #serde_use_anon {
                     #soa_storage_serde_name {
                         storage: self,
                         len,
                     }
                 }
 
-                pub fn from_wire(wire: #soa_storage_wire_name, len: usize) -> Result<Self, String> {
+                pub fn from_wire(wire: #soa_storage_wire_name #wire_use, len: usize) -> Result<Self, String> {
                     let #soa_storage_wire_name { #( #field_names ),* } = wire;
 
                     if len > N {
@@ -700,7 +841,7 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
                 #(#accessors)*
             }
 
-            impl<'a, const N: usize> Serialize for #soa_storage_serde_name<'a, N>
+            impl #serde_decl Serialize for #soa_storage_serde_name #serde_use
             #storage_serialize_where
             {
                 fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -716,7 +857,9 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
                 }
             }
 
-            impl<const N: usize> Default for #soa_storage_name<N> {
+            impl #soa_decl Default for #soa_storage_name #soa_use
+            #default_where
+            {
                 fn default() -> Self {
                     Self {
                         #(#default_inits,)*
@@ -724,7 +867,7 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
                 }
             }
 
-            impl<const N: usize> Clone for #soa_storage_name<N>
+            impl #soa_decl Clone for #soa_storage_name #soa_use
             #storage_clone_where
             {
                 fn clone(&self) -> Self {
@@ -736,19 +879,14 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
 
             #[derive(Debug)]
             #soa_reflect_attrs
-            #visibility struct #soa_struct_name<const N: usize> {
+            #visibility struct #soa_struct_name #soa_decl {
                 pub len: usize,
                 #(#field_decls,)*
             }
 
-            impl<const N: usize> #soa_struct_name<N> {
-                pub fn new(default: super::#name) -> Self {
-                    Self {
-                        #(#new_inits,)*
-                        len: 0,
-                    }
-                }
-
+            // Kept free of the field bounds so callers don't inherit them
+            // just to ask for a length.
+            impl #soa_decl #soa_struct_name #soa_use {
                 pub fn len(&self) -> usize {
                     self.len
                 }
@@ -756,8 +894,19 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
                 pub fn is_empty(&self) -> bool {
                     self.len == 0
                 }
+            }
 
-                pub fn push(&mut self, value: super::#name) {
+            impl #soa_decl #soa_struct_name #soa_use
+            #methods_where
+            {
+                pub fn new(default: #orig_ty) -> Self {
+                    Self {
+                        #(#new_inits,)*
+                        len: 0,
+                    }
+                }
+
+                pub fn push(&mut self, value: #orig_ty) {
                     if self.len < N {
                         #(#soa_push_fields)*
                         self.len += 1;
@@ -766,7 +915,7 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
                     }
                 }
 
-                pub fn pop(&mut self) -> Option<super::#name> {
+                pub fn pop(&mut self) -> Option<#orig_ty> {
                     if self.len == 0 {
                         None
                     } else {
@@ -777,12 +926,12 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
                     }
                 }
 
-                pub fn set(&mut self, index: usize, value: super::#name) {
+                pub fn set(&mut self, index: usize, value: #orig_ty) {
                     assert!(index < self.len, "Index out of bounds");
                     #(#set_fields)*
                 }
 
-                pub fn get(&self, index: usize) -> super::#name {
+                pub fn get(&self, index: usize) -> #orig_ty {
                     assert!(index < self.len, "Index out of bounds");
                     super::#name {
                         #(#get_fields)*
@@ -801,31 +950,44 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
                     }
                 }
 
-                pub fn iter(&self) -> #soa_struct_name_iterator<N> {
+                pub fn iter(&self) -> #soa_struct_name_iterator #iter_use_elided {
                     #soa_struct_name_iterator::new(self)
                 }
 
                 #(#accessors)*
             }
 
-            impl<const N: usize> Encode for #soa_struct_name<N> {
+            impl #soa_decl Encode for #soa_struct_name #soa_use
+            #encode_where
+            {
                 fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-                    self.len.encode(encoder)?;
+                    Encode::encode(&self.len, encoder)?;
                     #(#soa_encode_fields)*
                     Ok(())
                 }
             }
 
-            impl<const N: usize> Decode<()> for #soa_struct_name<N> {
+            impl #soa_decl Decode<()> for #soa_struct_name #soa_use
+            #decode_where
+            {
                 fn decode<D: Decoder<Context = ()>>(decoder: &mut D) -> Result<Self, DecodeError> {
                     let mut result = Self::default();
                     result.len = Decode::decode(decoder)?;
+                    // `len` comes off the wire; check it before indexing.
+                    if result.len > N {
+                        return Err(DecodeError::ArrayLengthMismatch {
+                            required: N,
+                            found: result.len,
+                        });
+                    }
                     #(#soa_decode_fields)*
                     Ok(result)
                 }
             }
 
-            impl<const N: usize> Default for #soa_struct_name<N> {
+            impl #soa_decl Default for #soa_struct_name #soa_use
+            #default_where
+            {
                 fn default() -> Self {
                     Self {
                         #(#default_inits,)*
@@ -834,7 +996,7 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
                 }
             }
 
-            impl<const N: usize> Clone for #soa_struct_name<N>
+            impl #soa_decl Clone for #soa_struct_name #soa_use
             #storage_clone_where
             {
                 fn clone(&self) -> Self {
@@ -845,7 +1007,7 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
                 }
             }
 
-            impl<const N: usize> Serialize for #soa_struct_name<N>
+            impl #soa_decl Serialize for #soa_struct_name #soa_use
             #soa_serialize_where
             {
                 fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -860,7 +1022,7 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
                 }
             }
 
-            impl<'de, const N: usize> Deserialize<'de> for #soa_struct_name<N>
+            impl #de_decl Deserialize<'de> for #soa_struct_name #soa_use
             #soa_deserialize_where
             {
                 fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -868,7 +1030,7 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
                     D: serde::Deserializer<'de>,
                 {
                     #[derive(Deserialize)]
-                    struct #soa_struct_wire_name {
+                    struct #soa_struct_wire_name #wire_decl {
                         len: usize,
                         #(#soa_wire_fields)*
                     }
@@ -898,6 +1060,7 @@ pub fn derive_soa(input: TokenStream) -> TokenStream {
         #visibility use #module_name::#soa_struct_name;
         #visibility use #module_name::#soa_storage_name;
         #visibility use #module_name::#soa_storage_wire_name;
+        #visibility use #module_name::#soa_struct_name_iterator;
     };
 
     let tokens: TokenStream = expanded.into();

--- a/core/cu29_soa_derive/tests/proctest.rs
+++ b/core/cu29_soa_derive/tests/proctest.rs
@@ -1,8 +1,89 @@
 #[cfg(test)]
 mod tests {
     use bincode::{Decode, Encode, config::standard, decode_from_slice, encode_to_vec};
+    use core::fmt::Debug;
     use cu29_soa_derive::Soa;
     use serde_derive::{Deserialize, Serialize};
+
+    #[derive(
+        Debug, Clone, Copy, Default, PartialEq, Soa, Encode, Decode, Serialize, Deserialize,
+    )]
+    pub struct GXy<L: Copy + Debug + 'static> {
+        x: L,
+        y: L,
+    }
+
+    #[test]
+    fn test_generic_soa_roundtrips() {
+        let mut soa = GXySoa::<f32, 4>::default();
+        soa.push(GXy { x: 1.0, y: 2.0 });
+        soa.push(GXy { x: 3.0, y: 4.0 });
+        assert_eq!(soa.len(), 2);
+        assert_eq!(soa.x()[..2], [1.0, 3.0]);
+        assert_eq!(soa.get(1), GXy { x: 3.0, y: 4.0 });
+
+        soa.apply(|x, y| (x + 1.0, y + 1.0));
+        assert_eq!(soa.get(0), GXy { x: 2.0, y: 3.0 });
+
+        let items: Vec<GXy<f32>> = soa.iter().collect();
+        assert_eq!(items.len(), 2);
+
+        let json = serde_json::to_string(&soa).expect("serialize GXySoa");
+        let from_json: GXySoa<f32, 4> = serde_json::from_str(&json).expect("deserialize GXySoa");
+        assert_eq!(from_json.get(0), soa.get(0));
+
+        let encoded = encode_to_vec(&soa, standard()).expect("encode GXySoa");
+        let (decoded, _): (GXySoa<f32, 4>, _) =
+            decode_from_slice(&encoded, standard()).expect("decode GXySoa");
+        assert_eq!(decoded.len(), soa.len());
+        assert_eq!(decoded.get(1), soa.get(1));
+
+        let int_soa = GXySoa::<u32, 3>::new(GXy { x: 7, y: 8 });
+        assert_eq!(int_soa.x(), &[7, 7, 7]);
+    }
+
+    /// Decoding a blob recorded at a larger capacity must error, not panic.
+    #[test]
+    fn test_decode_rejects_len_over_capacity() {
+        let mut wide = GXySoa::<f32, 8>::default();
+        for i in 0..8 {
+            wide.push(GXy {
+                x: i as f32,
+                y: -(i as f32),
+            });
+        }
+        let encoded = encode_to_vec(&wide, standard()).expect("encode GXySoa");
+
+        let narrow: Result<(GXySoa<f32, 4>, usize), _> = decode_from_slice(&encoded, standard());
+        assert!(
+            matches!(
+                narrow,
+                Err(bincode::error::DecodeError::ArrayLengthMismatch {
+                    required: 4,
+                    found: 8
+                })
+            ),
+            "expected a capacity error, got {narrow:?}"
+        );
+
+        // Same length, same capacity: still fine.
+        let (same, _): (GXySoa<f32, 8>, _) =
+            decode_from_slice(&encoded, standard()).expect("decode GXySoa");
+        assert_eq!(same.len(), 8);
+        assert_eq!(same.get(7), wide.get(7));
+    }
+
+    /// `len()` must not require the field bounds the mutating methods need.
+    #[test]
+    fn test_len_is_free_of_field_bounds() {
+        fn len_of<T: Copy + Debug + 'static, const N: usize>(soa: &GXySoa<T, N>) -> usize {
+            soa.len()
+        }
+
+        let mut soa = GXySoa::<f32, 4>::default();
+        soa.push(GXy { x: 1.0, y: 2.0 });
+        assert_eq!(len_of(&soa), 1);
+    }
 
     #[derive(Debug, Clone, Default, PartialEq, Soa, Encode, Decode, Serialize, Deserialize)]
     pub struct Xyz {


### PR DESCRIPTION
Shared geometry vocabulary, split out of #1247 as requested in review (https://github.com/copper-project/copper-rs/pull/1247#discussion_r3713888734): planners and future world views should compose over one standard point, not re-invent it per component.

- `Point2<L>`/`Point3<L>` generic over the coordinate type, with `Point2f/2d/3f/3d` aliases over the f32/f64 `Length` wrappers and `Point2u/2i` pixel aliases for image-space geometry; `from_meters`, `distance`, `lerp`, `xy`/`with_z`.
- `BBox<P>` axis-aligned bounding boxes (`BBox2f/2d/3f/3d`, plus `BBox2u/2i` for images), `contains`.
- `Transform3D::transform_point` / `transform_vector` / `position`, implemented on the native backend path (glam affine when the feature is on, raw matrix otherwise).
- `no_std` kept; `sqrt` comes from `libm`, already used by `cu29-runtime` and `cu_peer_triangulation`.

Addressed from review:
- `Aabb` renamed to `BBox`.
- Integer coordinates: the structs are generic, `Point2u/2i` + `BBox2u/2i` aliases added for images.
- `Clearance` dropped from this crate as too specific; it moves into `cu_rrt_star` (#1247).
- SoA: scalar type docs now point large batches at an SoA layout. The SoA point/box types come in a small PR stacked on this one — `cu29_soa_derive` first needs to learn generic structs like `Point2<L>`, then bulk kernels (distance, lerp, box ops, `transform_points`) with AVX2/AVX512 codegen checked.

First consumer: #1247 switches `cu_rrt_star` to `Point2f`.

Noted while implementing, left out of scope: `Transform3D::translation()`/`rotation()` read row-major cells, but the glam backend (default feature) stores column-major, so they return zeros/transposed values when glam is enabled. The new ops avoid `to_matrix()` for that reason. Happy to file/fix separately.
