### PR TITLE
cu-transform: add const frame-typed transform composition

### DIFF
--- a/components/libs/cu_transform/README.md
+++ b/components/libs/cu_transform/README.md
@@ -15,6 +15,37 @@ orientation) transformations and velocity transformations.
 
 ## Usage
 
+### Const, frame-typed transforms
+
+Static robot geometry can be unit-checked and composed entirely at compile time. The XYZ angles
+are roll, pitch, and yaw; they are applied X, then Y, then Z. Add the timestamp only when publishing
+the transform at runtime. Direct unit values use SI base units (meters and radians):
+
+```rust
+use cu_transform::{BaseFrame, RobotFrame, TypedTransform3D, WorldFrame};
+use cu29::clock::CuTime;
+use cu29::units::si::f32::{Angle, Length};
+
+const WORLD_TO_BASE: TypedTransform3D<f32, WorldFrame, BaseFrame> =
+    TypedTransform3D::<f32, WorldFrame, BaseFrame>::from_translation_euler_xyz(
+        [Length { value: 0.0 }; 3],
+        [Angle { value: 0.0 }; 3],
+    );
+const BASE_TO_ROBOT: TypedTransform3D<f32, BaseFrame, RobotFrame> =
+    TypedTransform3D::<f32, BaseFrame, RobotFrame>::from_translation_euler_xyz(
+        [
+            Length { value: 0.12 },
+            Length { value: 0.0 },
+            Length { value: 0.0 },
+        ],
+        [Angle { value: 0.0 }; 3],
+    );
+const WORLD_TO_ROBOT: TypedTransform3D<f32, WorldFrame, RobotFrame> =
+    WORLD_TO_BASE.then(BASE_TO_ROBOT);
+
+let stamped = WORLD_TO_ROBOT.at(CuTime::from_nanos(1_000));
+```
+
 ### Transform Tree
 
 The transform tree maintains a hierarchical relationship between coordinate frames:

--- a/components/libs/cu_transform/src/frames.rs
+++ b/components/libs/cu_transform/src/frames.rs
@@ -24,7 +24,7 @@ pub struct FramePair<Parent: FrameId, Child: FrameId> {
 }
 
 impl<Parent: FrameId, Child: FrameId> FramePair<Parent, Child> {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             parent: std::marker::PhantomData,
             child: std::marker::PhantomData,

--- a/components/libs/cu_transform/src/lib.rs
+++ b/components/libs/cu_transform/src/lib.rs
@@ -22,7 +22,9 @@ pub use frames::{
 pub use frames::{BaseToRobot, RobotToCamera, RobotToImu, RobotToLidar, WorldToBase, WorldToRobot};
 pub use interpolation::interpolate_transforms;
 pub use transform::{ConstTransformBuffer, StampedTransform, TransformBuffer, TransformStore};
-pub use transform_payload::{FrameTransform, TypedTransform, TypedTransformBuffer};
+pub use transform_payload::{
+    FrameTransform, TypedTransform, TypedTransform3D, TypedTransformBuffer,
+};
 pub use tree::TransformTree;
 pub use velocity::VelocityTransform;
 

--- a/components/libs/cu_transform/src/transform_payload.rs
+++ b/components/libs/cu_transform/src/transform_payload.rs
@@ -11,6 +11,10 @@ use cu29::bevy_reflect;
 use cu29::clock::{CuTime, CuTimeRange, Tov};
 use cu29::cutask::CuStampedData;
 use cu29::prelude::{CuMsgPayload, Reflect};
+use cu29::units::si::f32::Angle as Angle32;
+use cu29::units::si::f32::Length as Length32;
+use cu29::units::si::f64::Angle as Angle64;
+use cu29::units::si::f64::Length as Length64;
 use num_traits;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -121,6 +125,145 @@ where
 
 /// Transforms are timestamped Relative transforms.
 pub type TypedStampedFrameTransform<T> = CuStampedData<Transform3D<T>, ()>;
+
+/// An unstamped transform with a frame relationship checked at compile time.
+///
+/// Unlike [`TypedTransform`], this type can be built and composed in constants. Add the time of
+/// validity at runtime with [`Self::at`].
+///
+/// # Example
+///
+/// ```
+/// use cu_transform::{RobotFrame, TypedTransform3D, WorldFrame};
+/// use cu29::units::si::f32::{Angle, Length};
+///
+/// const WORLD_TO_ROBOT: TypedTransform3D<f32, WorldFrame, RobotFrame> =
+///     TypedTransform3D::<f32, WorldFrame, RobotFrame>::from_translation_euler_xyz(
+///         [Length { value: 0.0 }; 3],
+///         [
+///             Angle { value: 0.0 },
+///             Angle { value: 0.0 },
+///             Angle {
+///                 value: core::f32::consts::FRAC_PI_2,
+///             },
+///         ],
+///     );
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct TypedTransform3D<T, Parent, Child>
+where
+    T: Copy + Debug + 'static,
+    Parent: FrameId,
+    Child: FrameId,
+{
+    transform: Transform3D<T>,
+    /// Frame relationship (zero-sized at runtime).
+    pub frames: FramePair<Parent, Child>,
+}
+
+impl<T, Parent, Child> TypedTransform3D<T, Parent, Child>
+where
+    T: Copy + Debug + 'static,
+    Parent: FrameId,
+    Child: FrameId,
+{
+    /// Wraps a transform with a compile-time frame relationship.
+    pub const fn new(transform: Transform3D<T>) -> Self {
+        Self {
+            transform,
+            frames: FramePair::new(),
+        }
+    }
+
+    /// Returns the underlying transform.
+    pub const fn transform(&self) -> &Transform3D<T> {
+        &self.transform
+    }
+
+    /// Adds a time of validity and creates the existing stamped transform message.
+    pub fn at(self, time: CuTime) -> TypedTransform<T, Parent, Child>
+    where
+        T: CuMsgPayload,
+    {
+        TypedTransform::new(self.transform, time)
+    }
+
+    /// Returns the parent frame ID.
+    pub const fn parent_id(&self) -> u32 {
+        Parent::ID
+    }
+
+    /// Returns the child frame ID.
+    pub const fn child_id(&self) -> u32 {
+        Child::ID
+    }
+
+    /// Returns the parent frame name.
+    pub const fn parent_name(&self) -> &'static str {
+        Parent::NAME
+    }
+
+    /// Returns the child frame name.
+    pub const fn child_name(&self) -> &'static str {
+        Child::NAME
+    }
+}
+
+macro_rules! impl_const_typed_transform {
+    ($ty:ty, $len:ty, $ang:ty) => {
+        impl<Parent, Child> TypedTransform3D<$ty, Parent, Child>
+        where
+            Parent: FrameId,
+            Child: FrameId,
+        {
+            /// Creates a typed transform from translation and XYZ Euler angles.
+            ///
+            /// `rotation` is `[roll_x, pitch_y, yaw_z]`. Rotations are applied X, then Y, then Z.
+            pub const fn from_translation_euler_xyz(
+                translation: [$len; 3],
+                rotation: [$ang; 3],
+            ) -> Self {
+                Self::new(Transform3D::<$ty>::from_translation_euler_xyz(
+                    translation,
+                    rotation,
+                ))
+            }
+
+            /// Composes this transform with the next frame relationship.
+            ///
+            /// The child frame of `self` must be the parent frame of `next`; incompatible frame
+            /// chains fail to compile.
+            ///
+            /// ```compile_fail
+            /// use cu_transform::{
+            ///     CameraFrame, RobotFrame, Transform3D, TypedTransform3D, WorldFrame,
+            /// };
+            ///
+            /// let world_to_robot =
+            ///     TypedTransform3D::<f32, WorldFrame, RobotFrame>::new(
+            ///         Transform3D::<f32>::identity(),
+            ///     );
+            /// let camera_to_robot =
+            ///     TypedTransform3D::<f32, CameraFrame, RobotFrame>::new(
+            ///         Transform3D::<f32>::identity(),
+            ///     );
+            /// let _ = world_to_robot.then(camera_to_robot);
+            /// ```
+            pub const fn then<Next>(
+                self,
+                next: TypedTransform3D<$ty, Child, Next>,
+            ) -> TypedTransform3D<$ty, Parent, Next>
+            where
+                Next: FrameId,
+            {
+                TypedTransform3D::new(self.transform.compose(next.transform))
+            }
+        }
+    };
+}
+
+impl_const_typed_transform!(f32, Length32, Angle32);
+impl_const_typed_transform!(f64, Length64, Angle64);
 
 /// A typed transform message that carries frame relationship information at compile time
 #[derive(Debug, Clone)]
@@ -422,7 +565,34 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::frames::{RobotFrame, WorldFrame};
+    use crate::frames::{BaseFrame, RobotFrame, WorldFrame};
+
+    const WORLD_TO_BASE: TypedTransform3D<f32, WorldFrame, BaseFrame> =
+        TypedTransform3D::<f32, WorldFrame, BaseFrame>::from_translation_euler_xyz(
+            [
+                Length32 { value: 1.0 },
+                Length32 { value: 2.0 },
+                Length32 { value: 0.0 },
+            ],
+            [
+                Angle32 { value: 0.0 },
+                Angle32 { value: 0.0 },
+                Angle32 {
+                    value: core::f32::consts::FRAC_PI_2,
+                },
+            ],
+        );
+    const BASE_TO_ROBOT: TypedTransform3D<f32, BaseFrame, RobotFrame> =
+        TypedTransform3D::<f32, BaseFrame, RobotFrame>::from_translation_euler_xyz(
+            [
+                Length32 { value: 1.0 },
+                Length32 { value: 0.0 },
+                Length32 { value: 0.0 },
+            ],
+            [Angle32 { value: 0.0 }; 3],
+        );
+    const WORLD_TO_ROBOT: TypedTransform3D<f32, WorldFrame, RobotFrame> =
+        WORLD_TO_BASE.then(BASE_TO_ROBOT);
     // Helper function to replace assert_relative_eq
     fn assert_approx_eq(actual: f32, expected: f32, epsilon: f32) {
         let diff = (actual - expected).abs();
@@ -435,6 +605,25 @@ mod tests {
 
     type WorldToRobotFrameTransform = TypedTransform<f32, WorldFrame, RobotFrame>;
     type WorldToRobotBuffer = TypedTransformBuffer<f32, WorldFrame, RobotFrame, 10>;
+
+    #[test]
+    fn test_const_typed_transform_composition_and_stamping() {
+        assert_eq!(
+            std::mem::size_of::<TypedTransform3D<f32, WorldFrame, RobotFrame>>(),
+            std::mem::size_of::<Transform3D<f32>>(),
+        );
+
+        let position = WORLD_TO_ROBOT.transform().position();
+        assert_approx_eq(position.x.raw(), 1.0, 1e-5);
+        assert_approx_eq(position.y.raw(), 3.0, 1e-5);
+        assert_approx_eq(position.z.raw(), 0.0, 1e-5);
+        assert_eq!(WORLD_TO_ROBOT.parent_id(), WorldFrame::ID);
+        assert_eq!(WORLD_TO_ROBOT.child_id(), RobotFrame::ID);
+
+        let stamped = WORLD_TO_ROBOT.at(CuTime::from_nanos(42));
+        assert_eq!(stamped.timestamp(), Some(CuTime::from_nanos(42)));
+        assert_approx_eq(stamped.transform().unwrap().position().y.raw(), 3.0, 1e-5);
+    }
 
     #[test]
     fn test_typed_transform_msg_creation() {

--- a/components/payloads/cu_spatial_payloads/src/lib.rs
+++ b/components/payloads/cu_spatial_payloads/src/lib.rs
@@ -8,6 +8,7 @@ use core::fmt::Debug;
 use core::ops::Mul;
 use cu29::prelude::*;
 use cu29::units::si::angle::degree;
+use cu29::units::si::f32::Angle as Angle32;
 use cu29::units::si::f32::Length as Length32;
 use cu29::units::si::f64::Angle as Angle64;
 use cu29::units::si::f64::Length as Length64;
@@ -15,7 +16,7 @@ use cu29::units::si::length::meter;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "glam")]
-use glam::{Affine3A, DAffine3, DMat4, DVec3, Mat4, Vec3};
+use glam::{Affine3A, DAffine3, DMat4, DVec3, Mat4, Vec3, Vec3A};
 
 mod geometry;
 pub use geometry::{
@@ -81,6 +82,186 @@ enum TransformInner<T: Copy + Debug + 'static> {
     F64(DAffine3),
     _Phantom(core::marker::PhantomData<T>),
 }
+
+const fn const_sin_cos(mut angle: f64) -> (f64, f64) {
+    const PI: f64 = core::f64::consts::PI;
+    const FRAC_PI_2: f64 = core::f64::consts::FRAC_PI_2;
+    const TAU: f64 = core::f64::consts::TAU;
+
+    angle %= TAU;
+    if angle > PI {
+        angle -= TAU;
+    } else if angle < -PI {
+        angle += TAU;
+    }
+
+    let mut cos_sign = 1.0;
+    if angle > FRAC_PI_2 {
+        angle = PI - angle;
+        cos_sign = -1.0;
+    } else if angle < -FRAC_PI_2 {
+        angle = -PI - angle;
+        cos_sign = -1.0;
+    }
+
+    // After range reduction to [-pi/2, pi/2], Taylor terms through x^21 for sine and x^20 for
+    // cosine keep the approximation below the f64 regression tolerance used by this crate.
+    let x2 = angle * angle;
+    let mut sin_poly = 1.0 / 51_090_942_171_709_440_000.0;
+    sin_poly = -1.0 / 121_645_100_408_832_000.0 + x2 * sin_poly;
+    sin_poly = 1.0 / 355_687_428_096_000.0 + x2 * sin_poly;
+    sin_poly = -1.0 / 1_307_674_368_000.0 + x2 * sin_poly;
+    sin_poly = 1.0 / 6_227_020_800.0 + x2 * sin_poly;
+    sin_poly = -1.0 / 39_916_800.0 + x2 * sin_poly;
+    sin_poly = 1.0 / 362_880.0 + x2 * sin_poly;
+    sin_poly = -1.0 / 5_040.0 + x2 * sin_poly;
+    sin_poly = 1.0 / 120.0 + x2 * sin_poly;
+    sin_poly = -1.0 / 6.0 + x2 * sin_poly;
+    let sin = angle * (1.0 + x2 * sin_poly);
+
+    let mut cos_poly = 1.0 / 2_432_902_008_176_640_000.0;
+    cos_poly = -1.0 / 6_402_373_705_728_000.0 + x2 * cos_poly;
+    cos_poly = 1.0 / 20_922_789_888_000.0 + x2 * cos_poly;
+    cos_poly = -1.0 / 87_178_291_200.0 + x2 * cos_poly;
+    cos_poly = 1.0 / 479_001_600.0 + x2 * cos_poly;
+    cos_poly = -1.0 / 3_628_800.0 + x2 * cos_poly;
+    cos_poly = 1.0 / 40_320.0 + x2 * cos_poly;
+    cos_poly = -1.0 / 720.0 + x2 * cos_poly;
+    cos_poly = 1.0 / 24.0 + x2 * cos_poly;
+    cos_poly = -1.0 / 2.0 + x2 * cos_poly;
+    let cos = 1.0 + x2 * cos_poly;
+
+    (sin, cos_sign * cos)
+}
+
+macro_rules! impl_const_transform {
+    ($ty:ty, $len:ty, $ang:ty, $variant:ident, $affine:ty, $vec:ty) => {
+        impl Transform3D<$ty> {
+            const fn from_rows(rows: [[$ty; 4]; 3]) -> Self {
+                #[cfg(feature = "glam")]
+                {
+                    Self {
+                        inner: TransformInner::$variant(<$affine>::from_cols(
+                            <$vec>::new(rows[0][0], rows[1][0], rows[2][0]),
+                            <$vec>::new(rows[0][1], rows[1][1], rows[2][1]),
+                            <$vec>::new(rows[0][2], rows[1][2], rows[2][2]),
+                            <$vec>::new(rows[0][3], rows[1][3], rows[2][3]),
+                        )),
+                    }
+                }
+                #[cfg(not(feature = "glam"))]
+                {
+                    Self {
+                        mat: [
+                            rows[0],
+                            rows[1],
+                            rows[2],
+                            [0.0 as $ty, 0.0 as $ty, 0.0 as $ty, 1.0 as $ty],
+                        ],
+                    }
+                }
+            }
+
+            const fn rows(self) -> [[$ty; 4]; 3] {
+                #[cfg(feature = "glam")]
+                {
+                    match self.inner {
+                        TransformInner::$variant(affine) => {
+                            let r = affine.matrix3;
+                            let x = r.x_axis.to_array();
+                            let y = r.y_axis.to_array();
+                            let z = r.z_axis.to_array();
+                            let t = affine.translation.to_array();
+                            [
+                                [x[0], y[0], z[0], t[0]],
+                                [x[1], y[1], z[1], t[1]],
+                                [x[2], y[2], z[2], t[2]],
+                            ]
+                        }
+                        _ => panic!("invalid Transform3D storage variant"),
+                    }
+                }
+                #[cfg(not(feature = "glam"))]
+                {
+                    [self.mat[0], self.mat[1], self.mat[2]]
+                }
+            }
+
+            /// Creates the identity transform during const evaluation.
+            pub const fn identity() -> Self {
+                Self::from_rows([
+                    [1.0 as $ty, 0.0 as $ty, 0.0 as $ty, 0.0 as $ty],
+                    [0.0 as $ty, 1.0 as $ty, 0.0 as $ty, 0.0 as $ty],
+                    [0.0 as $ty, 0.0 as $ty, 1.0 as $ty, 0.0 as $ty],
+                ])
+            }
+
+            /// Creates a transform from unit-typed translation and XYZ Euler angles.
+            ///
+            /// `rotation` is `[roll_x, pitch_y, yaw_z]`. Rotations are applied X, then Y, then Z,
+            /// producing `Rz * Ry * Rx` for column vectors. Translation is applied last.
+            /// Const unit values use their SI base representation: meters and radians.
+            pub const fn from_translation_euler_xyz(
+                translation: [$len; 3],
+                rotation: [$ang; 3],
+            ) -> Self {
+                let (sx, cx) = const_sin_cos(rotation[0].value as f64);
+                let (sy, cy) = const_sin_cos(rotation[1].value as f64);
+                let (sz, cz) = const_sin_cos(rotation[2].value as f64);
+                let sx = sx as $ty;
+                let cx = cx as $ty;
+                let sy = sy as $ty;
+                let cy = cy as $ty;
+                let sz = sz as $ty;
+                let cz = cz as $ty;
+
+                Self::from_rows([
+                    [
+                        cy * cz,
+                        cz * sx * sy - cx * sz,
+                        sx * sz + cx * cz * sy,
+                        translation[0].value,
+                    ],
+                    [
+                        cy * sz,
+                        cx * cz + sx * sy * sz,
+                        cx * sy * sz - cz * sx,
+                        translation[1].value,
+                    ],
+                    [-sy, cy * sx, cx * cy, translation[2].value],
+                ])
+            }
+
+            /// Composes `self` with `rhs` during const evaluation.
+            ///
+            /// The returned transform applies `rhs` first and then `self`, matching `self * rhs`.
+            pub const fn compose(self, rhs: Self) -> Self {
+                let lhs = self.rows();
+                let rhs = rhs.rows();
+                let mut result = [[0.0 as $ty; 4]; 3];
+                let mut row = 0;
+                while row < 3 {
+                    let mut column = 0;
+                    while column < 3 {
+                        result[row][column] = lhs[row][0] * rhs[0][column]
+                            + lhs[row][1] * rhs[1][column]
+                            + lhs[row][2] * rhs[2][column];
+                        column += 1;
+                    }
+                    result[row][3] = lhs[row][0] * rhs[0][3]
+                        + lhs[row][1] * rhs[1][3]
+                        + lhs[row][2] * rhs[2][3]
+                        + lhs[row][3];
+                    row += 1;
+                }
+                Self::from_rows(result)
+            }
+        }
+    };
+}
+
+impl_const_transform!(f32, Length32, Angle32, F32, Affine3A, Vec3A);
+impl_const_transform!(f64, Length64, Angle64, F64, DAffine3, DVec3);
 
 pub type Pose<T> = Transform3D<T>;
 
@@ -750,6 +931,47 @@ pub use faer_integration::*;
 mod tests {
     use super::*;
 
+    const CONST_PARENT_TO_INTERMEDIATE: Transform3D<f32> =
+        Transform3D::<f32>::from_translation_euler_xyz(
+            [
+                Length32 { value: 1.0 },
+                Length32 { value: 2.0 },
+                Length32 { value: 3.0 },
+            ],
+            [
+                Angle32 { value: 0.0 },
+                Angle32 { value: 0.0 },
+                Angle32 {
+                    value: core::f32::consts::FRAC_PI_2,
+                },
+            ],
+        );
+    const CONST_INTERMEDIATE_TO_CHILD: Transform3D<f32> =
+        Transform3D::<f32>::from_translation_euler_xyz(
+            [
+                Length32 { value: 1.0 },
+                Length32 { value: 0.0 },
+                Length32 { value: 0.0 },
+            ],
+            [Angle32 { value: 0.0 }; 3],
+        );
+    const CONST_PARENT_TO_CHILD: Transform3D<f32> =
+        CONST_PARENT_TO_INTERMEDIATE.compose(CONST_INTERMEDIATE_TO_CHILD);
+    const CONST_TRANSFORM_F64: Transform3D<f64> = Transform3D::<f64>::from_translation_euler_xyz(
+        [Length64 { value: 0.0 }; 3],
+        [
+            Angle64 {
+                value: core::f64::consts::PI / 6.0,
+            },
+            Angle64 {
+                value: -core::f64::consts::PI / 9.0,
+            },
+            Angle64 {
+                value: core::f64::consts::PI / 18.0,
+            },
+        ],
+    );
+
     fn assert_matrix_close<const N: usize, T: Copy + Into<f64>>(
         lhs: [[T; N]; N],
         rhs: [[T; N]; N],
@@ -769,6 +991,41 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn const_sin_cos_matches_runtime_trigonometry() {
+        for step in -64..=64 {
+            let angle = f64::from(step) * core::f64::consts::PI / 8.0;
+            let (actual_sin, actual_cos) = const_sin_cos(angle);
+            let (expected_sin, expected_cos) = angle.sin_cos();
+            assert!((actual_sin - expected_sin).abs() <= 1e-14);
+            assert!((actual_cos - expected_cos).abs() <= 1e-14);
+        }
+    }
+
+    #[test]
+    fn const_transform_construction_and_composition_are_semantic() {
+        assert_point_close(
+            CONST_PARENT_TO_CHILD.position(),
+            Point3f::from_meters(1.0, 3.0, 3.0),
+            1e-5,
+        );
+        assert_point_close(
+            CONST_PARENT_TO_CHILD.transform_vector(Point3f::from_meters(1.0, 0.0, 0.0)),
+            Point3f::from_meters(0.0, 1.0, 0.0),
+            1e-5,
+        );
+
+        let point = Point3::new(
+            Length64::new::<meter>(1.0),
+            Length64::new::<meter>(2.0),
+            Length64::new::<meter>(3.0),
+        );
+        let transformed = CONST_TRANSFORM_F64.transform_vector(point);
+        assert!(transformed.x.raw().is_finite());
+        assert!(transformed.y.raw().is_finite());
+        assert!(transformed.z.raw().is_finite());
     }
 
     #[test]

--- a/components/sinks/cu_rp_sn754410/src/lib.rs
+++ b/components/sinks/cu_rp_sn754410/src/lib.rs
@@ -194,7 +194,7 @@ impl CuSinkTask for SN754410 {
 
         let power_ratio = power.power.get::<ratio>();
         let deadzone_compensated = if power_ratio != 0.0f32 {
-            // proportinally on the [deadzone, 1.0] range
+            // proportionally on the [deadzone, 1.0] range
             let deadzone = self.deadzone;
             if power_ratio > 0.0 {
                 deadzone + (1.0 - deadzone) * power_ratio


### PR DESCRIPTION
Make static robot geometry unit-aware, frame-safe, and const constructible:

- add const Transform3D identity, unit-typed XYZ Euler construction, and composition for f32/f64
- keep the explicit convention roll X, pitch Y, yaw Z, applied as Rz * Ry * Rx
- add zero-overhead TypedTransform3D<Scalar, Parent, Child> for compile-time frame chaining
- enforce compatible intermediate frames through then() types
- bridge static transforms into the existing stamped TypedTransform with at(timestamp)
- use a private no_std const trig implementation, checked against runtime sin_cos
- construct backend-native affine storage directly, avoiding raw matrix-layout differences

The new typed wrapper has the same size as Transform3D and adds no allocation, runtime lookup, or unit metadata.
