### PR TITLE
Bump master to 1.2.0-dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ cu29 = { path = "core/cu29" }
 soft_ratatui = { path = "vendor/soft_ratatui" }
 
 [workspace.package]
-version = "1.1.0-dev"
+version = "1.2.0-dev"
 authors = ["Guillaume Binet <gbin@gootz.net>"]
 edition = "2024"
 rust-version = "1.95"
@@ -205,59 +205,59 @@ no_individual_tags = true
 [workspace.dependencies]
 
 # Copper Core
-cu29 = { path = "core/cu29", version = "1.1.0-dev" } # default std
-cu29-build = { path = "core/cu29_build", version = "1.1.0-dev" }
-cu29-reflect-derive = { path = "core/cu29_reflect_derive", version = "1.1.0-dev" }
-cu29-clock = { path = "core/cu29_clock", default-features = false, version = "1.1.0-dev" }
-cu29-derive = { path = "core/cu29_derive", default-features = false, version = "1.1.0-dev" }
-cu29-export = { path = "core/cu29_export", version = "1.1.0-dev" } # std only
-cu29-helpers = { path = "core/cu29_helpers", version = "1.1.0-dev" } # compatibility stub
-cu29-intern-strs = { path = "core/cu29_intern_strs", version = "1.1.0-dev" } # std only
-cu29-log = { path = "core/cu29_log", default-features = false, version = "1.1.0-dev" }
-cu29-log-derive = { path = "core/cu29_log_derive", default-features = false, version = "1.1.0-dev" }
-cu29-log-runtime = { path = "core/cu29_log_runtime", default-features = false, version = "1.1.0-dev" }
-cu29-runtime = { path = "core/cu29_runtime", default-features = false, version = "1.1.0-dev" }
-cu29-soa-derive = { path = "core/cu29_soa_derive", default-features = false, version = "1.1.0-dev" }
-cu29-traits = { path = "core/cu29_traits", default-features = false, version = "1.1.0-dev" }
+cu29 = { path = "core/cu29", version = "1.2.0-dev" } # default std
+cu29-build = { path = "core/cu29_build", version = "1.2.0-dev" }
+cu29-reflect-derive = { path = "core/cu29_reflect_derive", version = "1.2.0-dev" }
+cu29-clock = { path = "core/cu29_clock", default-features = false, version = "1.2.0-dev" }
+cu29-derive = { path = "core/cu29_derive", default-features = false, version = "1.2.0-dev" }
+cu29-export = { path = "core/cu29_export", version = "1.2.0-dev" } # std only
+cu29-helpers = { path = "core/cu29_helpers", version = "1.2.0-dev" } # compatibility stub
+cu29-intern-strs = { path = "core/cu29_intern_strs", version = "1.2.0-dev" } # std only
+cu29-log = { path = "core/cu29_log", default-features = false, version = "1.2.0-dev" }
+cu29-log-derive = { path = "core/cu29_log_derive", default-features = false, version = "1.2.0-dev" }
+cu29-log-runtime = { path = "core/cu29_log_runtime", default-features = false, version = "1.2.0-dev" }
+cu29-runtime = { path = "core/cu29_runtime", default-features = false, version = "1.2.0-dev" }
+cu29-soa-derive = { path = "core/cu29_soa_derive", default-features = false, version = "1.2.0-dev" }
+cu29-traits = { path = "core/cu29_traits", default-features = false, version = "1.2.0-dev" }
 cu29-unifiedlog = { path = "core/cu29_unifiedlog", default-features = false, features = [
   "compact",
-], version = "1.1.0-dev" }
-cu29-units = { path = "core/cu29_units", version = "1.1.0-dev" }
-cu29-value = { path = "core/cu29_value", default-features = false, version = "1.1.0-dev" }
-cu-ffv1-codec = { path = "components/codecs/cu_ffv1_codec", version = "1.1.0-dev" }
-cu-linux-resources = { path = "components/res/cu_linux_resources", version = "1.1.0-dev" }
-cu-png-codec = { path = "components/codecs/cu_png_codec", version = "1.1.0-dev" }
-cu-rng = { path = "components/res/cu_rng", version = "1.1.0-dev" }
+], version = "1.2.0-dev" }
+cu29-units = { path = "core/cu29_units", version = "1.2.0-dev" }
+cu29-value = { path = "core/cu29_value", default-features = false, version = "1.2.0-dev" }
+cu-ffv1-codec = { path = "components/codecs/cu_ffv1_codec", version = "1.2.0-dev" }
+cu-linux-resources = { path = "components/res/cu_linux_resources", version = "1.2.0-dev" }
+cu-png-codec = { path = "components/codecs/cu_png_codec", version = "1.2.0-dev" }
+cu-rng = { path = "components/res/cu_rng", version = "1.2.0-dev" }
 
 # Copper components
-cu-ads7883-new = { path = "components/sources/cu_ads7883", version = "1.1.0-dev" }
-cu-ahrs = { path = "components/tasks/cu_ahrs", version = "1.1.0-dev" }
-cu-bdshot = { path = "components/bridges/cu_bdshot", version = "1.1.0-dev" }
-cu-bevymon = { path = "components/monitors/cu_bevymon", version = "1.1.0-dev" }
-cu-bmi088 = { path = "components/sources/cu_bmi088", version = "1.1.0-dev" }
-cu-consolemon = { path = "components/monitors/cu_consolemon", version = "1.1.0-dev" }
-cu-crsf = { path = "components/bridges/cu_crsf", version = "1.1.0-dev" }
-cu-dps310 = { path = "components/sources/cu_dps310", version = "1.1.0-dev" }
-cu-feetech = { path = "components/bridges/cu_feetech", version = "1.1.0-dev" }
-cu-gnss-ublox = { path = "components/sources/cu_gnss_ublox", version = "1.1.0-dev" }
-cu-gstreamer = { path = "components/sources/cu_gstreamer", version = "1.1.0-dev" }
-cu-ist8310 = { path = "components/sources/cu_ist8310", version = "1.1.0-dev" }
-cu-logmon = { path = "components/monitors/cu_logmon", version = "1.1.0-dev" }
-cu-micoairh743 = { path = "components/res/cu_micoairh743", version = "1.1.0-dev" }
-cu-msp-bridge = { path = "components/bridges/cu_msp_bridge", version = "1.1.0-dev" }
-cu-msp-lib = { path = "components/libs/cu_msp_lib", version = "1.1.0-dev" }
-cu-rp-encoder = { path = "components/sources/cu_rp_encoder", version = "1.1.0-dev" }
-cu-rp-sn754410-new = { path = "components/sinks/cu_rp_sn754410", version = "1.1.0-dev" }
-cu-rrt-star = { path = "components/tasks/cu_rrt_star", version = "1.1.0-dev" }
-cu-sdlogger = { path = "components/libs/cu_sdlogger", version = "1.1.0-dev" }
-cu-zenoh-bridge = { path = "components/bridges/cu_zenoh_bridge", version = "1.1.0-dev" }
+cu-ads7883-new = { path = "components/sources/cu_ads7883", version = "1.2.0-dev" }
+cu-ahrs = { path = "components/tasks/cu_ahrs", version = "1.2.0-dev" }
+cu-bdshot = { path = "components/bridges/cu_bdshot", version = "1.2.0-dev" }
+cu-bevymon = { path = "components/monitors/cu_bevymon", version = "1.2.0-dev" }
+cu-bmi088 = { path = "components/sources/cu_bmi088", version = "1.2.0-dev" }
+cu-consolemon = { path = "components/monitors/cu_consolemon", version = "1.2.0-dev" }
+cu-crsf = { path = "components/bridges/cu_crsf", version = "1.2.0-dev" }
+cu-dps310 = { path = "components/sources/cu_dps310", version = "1.2.0-dev" }
+cu-feetech = { path = "components/bridges/cu_feetech", version = "1.2.0-dev" }
+cu-gnss-ublox = { path = "components/sources/cu_gnss_ublox", version = "1.2.0-dev" }
+cu-gstreamer = { path = "components/sources/cu_gstreamer", version = "1.2.0-dev" }
+cu-ist8310 = { path = "components/sources/cu_ist8310", version = "1.2.0-dev" }
+cu-logmon = { path = "components/monitors/cu_logmon", version = "1.2.0-dev" }
+cu-micoairh743 = { path = "components/res/cu_micoairh743", version = "1.2.0-dev" }
+cu-msp-bridge = { path = "components/bridges/cu_msp_bridge", version = "1.2.0-dev" }
+cu-msp-lib = { path = "components/libs/cu_msp_lib", version = "1.2.0-dev" }
+cu-rp-encoder = { path = "components/sources/cu_rp_encoder", version = "1.2.0-dev" }
+cu-rp-sn754410-new = { path = "components/sinks/cu_rp_sn754410", version = "1.2.0-dev" }
+cu-rrt-star = { path = "components/tasks/cu_rrt_star", version = "1.2.0-dev" }
+cu-sdlogger = { path = "components/libs/cu_sdlogger", version = "1.2.0-dev" }
+cu-zenoh-bridge = { path = "components/bridges/cu_zenoh_bridge", version = "1.2.0-dev" }
 
 # Payload definitions
-cu-sensor-payloads = { path = "components/payloads/cu_sensor_payloads", version = "1.1.0-dev" }
-cu-gnss-payloads = { path = "components/payloads/cu_gnss_payloads", version = "1.1.0-dev" }
-cu-spatial-payloads = { path = "components/payloads/cu_spatial_payloads", version = "1.1.0-dev" }
-cu-ros2-payloads = { path = "components/payloads/cu_ros2_payloads", version = "1.1.0-dev" }
-cu-pid = { path = "components/tasks/cu_pid", version = "1.1.0-dev" }
+cu-sensor-payloads = { path = "components/payloads/cu_sensor_payloads", version = "1.2.0-dev" }
+cu-gnss-payloads = { path = "components/payloads/cu_gnss_payloads", version = "1.2.0-dev" }
+cu-spatial-payloads = { path = "components/payloads/cu_spatial_payloads", version = "1.2.0-dev" }
+cu-ros2-payloads = { path = "components/payloads/cu_ros2_payloads", version = "1.2.0-dev" }
+cu-pid = { path = "components/tasks/cu_pid", version = "1.2.0-dev" }
 
 # External serialization
 bincode = { package = "cu-bincode", version = "2.0", default-features = false, features = [

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@
 
 ```text
 Development:
-  master -> 1.1.0-dev
+  master -> 1.2.0-dev
 
 Release:
   tag v1.1.0

--- a/benchmarks/dora_caterpillar/Cargo.toml
+++ b/benchmarks/dora_caterpillar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-caterpillat"
-version = "1.1.0-dev"
+version = "1.2.0-dev"
 edition = "2021"
 
 [workspace]

--- a/benchmarks/horus_caterpillar/Cargo.toml
+++ b/benchmarks/horus_caterpillar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horus-caterpillar"
-version = "1.1.0-dev"
+version = "1.2.0-dev"
 edition = "2021"
 
 [workspace]

--- a/components/bridges/cu_bdshot/Cargo.toml
+++ b/components/bridges/cu_bdshot/Cargo.toml
@@ -19,7 +19,7 @@ environments = ["embedded"]
 embedded_targets = ["thumbv8m.main-none-eabihf"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
 rp235x-hal = { workspace = true, features = [
   "critical-section-impl",
 ], optional = true }

--- a/components/bridges/cu_crsf/Cargo.toml
+++ b/components/bridges/cu_crsf/Cargo.toml
@@ -18,7 +18,7 @@ domains = ["control/radio", "protocol/crsf"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
 crsf = "2.0.1"
 embedded-io = { version = "0.7.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }

--- a/components/bridges/cu_iceoryx2_bridge/Cargo.toml
+++ b/components/bridges/cu_iceoryx2_bridge/Cargo.toml
@@ -18,7 +18,7 @@ domains = ["middleware/iceoryx2"]
 environments = ["host"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
 iceoryx2 = { version = "0.9.0", default-features = false }
 bincode = { workspace = true }
 

--- a/components/bridges/cu_msp_bridge/Cargo.toml
+++ b/components/bridges/cu_msp_bridge/Cargo.toml
@@ -18,8 +18,8 @@ domains = ["control/flight", "protocol/msp"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
-cu-msp-lib = { path = "../../libs/cu_msp_lib", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
+cu-msp-lib = { path = "../../libs/cu_msp_lib", version = "1.2.0-dev", default-features = false, features = [
   "bincode",
 ] }
 embedded-io = { version = "0.7.1", default-features = false }

--- a/components/libs/cu_sdlogger/Cargo.toml
+++ b/components/libs/cu_sdlogger/Cargo.toml
@@ -18,7 +18,7 @@ domains = ["storage/logging"]
 environments = ["embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
 # HALs we target (e.g. stm32h7xx-hal 0.16) still vendor embedded-sdmmc 0.5, so keep it aligned to avoid dual versions.
 embedded-sdmmc = { version = "0.5", default-features = false, optional = true }
 # Some HALs (e.g. rp235x-hal) sit on embedded-hal 1.0 and need embedded-sdmmc 0.9.

--- a/components/libs/cu_transform/Cargo.toml
+++ b/components/libs/cu_transform/Cargo.toml
@@ -22,7 +22,7 @@ cu29 = { workspace = true }
 bincode = { workspace = true }
 serde = { workspace = true }
 
-cu-spatial-payloads = { path = "../../payloads/cu_spatial_payloads", version = "1.1.0-dev", features = [
+cu-spatial-payloads = { path = "../../payloads/cu_spatial_payloads", version = "1.2.0-dev", features = [
   "glam",
 ] }
 

--- a/components/libs/cu_tuimon/Cargo.toml
+++ b/components/libs/cu_tuimon/Cargo.toml
@@ -31,7 +31,7 @@ sysinfo_pane = [
 [dependencies]
 ansi-to-tui = { version = "8.0.0", default-features = false }
 compact_str = { workspace = true }
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "std",
 ] }
 cu29-log = { workspace = true, optional = true }

--- a/components/monitors/cu_bevymon/Cargo.toml
+++ b/components/monitors/cu_bevymon/Cargo.toml
@@ -36,10 +36,10 @@ bevy = { workspace = true, features = [
   "keyboard",
   "mouse",
 ] }
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "std",
 ] }
-cu-tuimon = { path = "../../libs/cu_tuimon", version = "1.1.0-dev", default-features = false, features = [
+cu-tuimon = { path = "../../libs/cu_tuimon", version = "1.2.0-dev", default-features = false, features = [
   "log_pane",
 ] }
 ratatui = { version = "0.30.0", default-features = false }

--- a/components/monitors/cu_consolemon/Cargo.toml
+++ b/components/monitors/cu_consolemon/Cargo.toml
@@ -25,7 +25,7 @@ sysinfo = ["cu-tuimon/sysinfo_pane"]
 
 [dependencies]
 cu29 = { workspace = true }
-cu-tuimon = { path = "../../libs/cu_tuimon", version = "1.1.0-dev", default-features = false }
+cu-tuimon = { path = "../../libs/cu_tuimon", version = "1.2.0-dev", default-features = false }
 compact_str = { workspace = true }
 ratatui = "0.30"
 ansi-to-tui = { version = "8.0.0", default-features = false }

--- a/components/monitors/cu_logmon/Cargo.toml
+++ b/components/monitors/cu_logmon/Cargo.toml
@@ -25,14 +25,14 @@ ignored = ["serde"]
 path = "src/lib.rs"
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
-cu29-log-runtime = { path = "../../../core/cu29_log_runtime", version = "1.1.0-dev", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
+cu29-log-runtime = { path = "../../../core/cu29_log_runtime", version = "1.2.0-dev", default-features = false }
 defmt = { workspace = true, optional = true }
 spin = { workspace = true }
 
 [dev-dependencies]
 log = { workspace = true }
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "log-level-info",
 ] }
 serde = { workspace = true }

--- a/components/monitors/cu_memmon/Cargo.toml
+++ b/components/monitors/cu_memmon/Cargo.toml
@@ -25,12 +25,12 @@ ignored = ["serde"]
 path = "src/lib.rs"
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
 spin = { workspace = true }
 
 [dev-dependencies]
 serde = { workspace = true }
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "log-level-info",
 ] }
 

--- a/components/monitors/cu_safetymon/Cargo.toml
+++ b/components/monitors/cu_safetymon/Cargo.toml
@@ -31,10 +31,10 @@ required-features = ["safety-ids"]
 path = "src/lib.rs"
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
 
 [dev-dependencies]
-cu-logmon = { path = "../cu_logmon", version = "1.1.0-dev", default-features = false, features = [
+cu-logmon = { path = "../cu_logmon", version = "1.2.0-dev", default-features = false, features = [
   "std",
 ] }
 

--- a/components/payloads/cu_gnss_payloads/Cargo.toml
+++ b/components/payloads/cu_gnss_payloads/Cargo.toml
@@ -20,10 +20,10 @@ environments = ["host", "embedded"]
 
 [dependencies]
 bincode = { workspace = true }
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "units",
 ] }
-cu-spatial-payloads = { path = "../cu_spatial_payloads", version = "1.1.0-dev", default-features = false }
+cu-spatial-payloads = { path = "../cu_spatial_payloads", version = "1.2.0-dev", default-features = false }
 serde = { workspace = true }
 
 [features]

--- a/components/payloads/cu_sensor_payloads/Cargo.toml
+++ b/components/payloads/cu_sensor_payloads/Cargo.toml
@@ -21,8 +21,8 @@ environments = ["host", "embedded"]
 [dependencies]
 bincode = { workspace = true }
 cu29-soa-derive = { workspace = true }
-cu29-clock = { path = "../../../core/cu29_clock", version = "1.1.0-dev", default-features = false }
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29-clock = { path = "../../../core/cu29_clock", version = "1.2.0-dev", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "units",
 ] }
 rerun = { workspace = true, optional = true }

--- a/components/payloads/cu_spatial_payloads/Cargo.toml
+++ b/components/payloads/cu_spatial_payloads/Cargo.toml
@@ -19,7 +19,7 @@ environments = ["host", "embedded"]
 
 [dependencies]
 bincode = { workspace = true }
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "units",
 ] }
 cu29-soa-derive = { workspace = true }

--- a/components/res/cu_linux_resources/Cargo.toml
+++ b/components/res/cu_linux_resources/Cargo.toml
@@ -19,7 +19,7 @@ environments = ["host"]
 host_os = ["linux"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "std",
 ] }
 embedded-hal = { version = "1.0.0", default-features = false }

--- a/components/res/cu_micoairh743/Cargo.toml
+++ b/components/res/cu_micoairh743/Cargo.toml
@@ -24,13 +24,13 @@ defmt = ["dep:defmt", "cu-bdshot/defmt", "stm32h7xx-hal/defmt"]
 textlogs = ["cu29/textlogs", "cu-bdshot/textlogs", "cu-sdlogger/textlogs"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
-cu-dps310 = { path = "../../sources/cu_dps310", version = "1.1.0-dev", default-features = false }
-cu-ist8310 = { path = "../../sources/cu_ist8310", version = "1.1.0-dev", default-features = false }
-cu-bdshot = { path = "../../bridges/cu_bdshot", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
+cu-dps310 = { path = "../../sources/cu_dps310", version = "1.2.0-dev", default-features = false }
+cu-ist8310 = { path = "../../sources/cu_ist8310", version = "1.2.0-dev", default-features = false }
+cu-bdshot = { path = "../../bridges/cu_bdshot", version = "1.2.0-dev", default-features = false, features = [
   "stm32h7",
 ] }
-cu-sdlogger = { path = "../../libs/cu_sdlogger", version = "1.1.0-dev" }
+cu-sdlogger = { path = "../../libs/cu_sdlogger", version = "1.2.0-dev" }
 cortex-m = { workspace = true, features = ["critical-section-single-core"] }
 defmt = { workspace = true, optional = true }
 embedded-hal = { version = "0.2.7", default-features = false }

--- a/components/res/cu_rng/Cargo.toml
+++ b/components/res/cu_rng/Cargo.toml
@@ -18,7 +18,7 @@ domains = ["resource/rng"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
 rand = { version = "0.10", default-features = false }
 rand_chacha = { version = "0.10", default-features = false }
 

--- a/components/sinks/cu_rp_sn754410/Cargo.toml
+++ b/components/sinks/cu_rp_sn754410/Cargo.toml
@@ -19,7 +19,7 @@ environments = ["host"]
 host_os = ["linux"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "std",
   "textlogs",
   "units",

--- a/components/sources/cu_ads7883/Cargo.toml
+++ b/components/sources/cu_ads7883/Cargo.toml
@@ -19,7 +19,7 @@ environments = ["host"]
 host_os = ["linux"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "std",
   "textlogs",
   "units",

--- a/components/sources/cu_bmi088/Cargo.toml
+++ b/components/sources/cu_bmi088/Cargo.toml
@@ -18,8 +18,8 @@ domains = ["sensor/imu"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.1.0-dev", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.2.0-dev", default-features = false }
 serde = { workspace = true }
 embedded-hal = { version = "0.2.7", default-features = false }
 

--- a/components/sources/cu_dps310/Cargo.toml
+++ b/components/sources/cu_dps310/Cargo.toml
@@ -18,8 +18,8 @@ domains = ["sensor/barometer"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.1.0-dev", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.2.0-dev", default-features = false }
 serde = { workspace = true }
 
 [features]

--- a/components/sources/cu_gnss_ublox/Cargo.toml
+++ b/components/sources/cu_gnss_ublox/Cargo.toml
@@ -19,9 +19,9 @@ domains = ["sensor/gnss"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
 cu-linux-resources = { workspace = true, optional = true }
-cu-gnss-payloads = { path = "../../payloads/cu_gnss_payloads", version = "1.1.0-dev", default-features = false }
+cu-gnss-payloads = { path = "../../payloads/cu_gnss_payloads", version = "1.2.0-dev", default-features = false }
 embedded-io = "0.7.1"
 
 [features]

--- a/components/sources/cu_hesai/Cargo.toml
+++ b/components/sources/cu_hesai/Cargo.toml
@@ -29,7 +29,7 @@ serde = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-cu-udp-inject = { path = "../../testing/cu_udp_inject", version = "1.1.0-dev" }
+cu-udp-inject = { path = "../../testing/cu_udp_inject", version = "1.2.0-dev" }
 serde = { workspace = true }
 
 [features]

--- a/components/sources/cu_ist8310/Cargo.toml
+++ b/components/sources/cu_ist8310/Cargo.toml
@@ -18,8 +18,8 @@ domains = ["sensor/magnetometer"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.1.0-dev", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.2.0-dev", default-features = false }
 
 [features]
 default = []

--- a/components/sources/cu_livox/Cargo.toml
+++ b/components/sources/cu_livox/Cargo.toml
@@ -28,7 +28,7 @@ serde = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-cu-udp-inject = { path = "../../testing/cu_udp_inject", version = "1.1.0-dev" }
+cu-udp-inject = { path = "../../testing/cu_udp_inject", version = "1.2.0-dev" }
 serde = { workspace = true }
 
 [features]

--- a/components/sources/cu_mpu9250/Cargo.toml
+++ b/components/sources/cu_mpu9250/Cargo.toml
@@ -18,10 +18,10 @@ domains = ["sensor/imu"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "units",
 ] }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.1.0-dev", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.2.0-dev", default-features = false }
 mpu9250 = { version = "0.25.0", default-features = false }
 serde = { workspace = true }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0.0", default-features = false }

--- a/components/sources/cu_rp_encoder/Cargo.toml
+++ b/components/sources/cu_rp_encoder/Cargo.toml
@@ -19,7 +19,7 @@ environments = ["host"]
 host_os = ["linux"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "std",
   "textlogs",
   "units",

--- a/components/sources/cu_ryuw122/Cargo.toml
+++ b/components/sources/cu_ryuw122/Cargo.toml
@@ -19,9 +19,9 @@ domains = ["sensor/uwb", "sensor/ranging"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
 cu-linux-resources = { workspace = true, optional = true }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.1.0-dev", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.2.0-dev", default-features = false }
 embedded-io = "0.7.1"
 
 [features]

--- a/components/sources/cu_sen0682/Cargo.toml
+++ b/components/sources/cu_sen0682/Cargo.toml
@@ -18,8 +18,8 @@ domains = ["sensor/lidar"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.1.0-dev", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.2.0-dev", default-features = false }
 cu-linux-resources = { workspace = true, optional = true }
 embedded-io = "0.7.1"
 

--- a/components/sources/cu_vlp16/Cargo.toml
+++ b/components/sources/cu_vlp16/Cargo.toml
@@ -24,7 +24,7 @@ velodyne-lidar = { version = "0.3.0", features = ["pcap", "parallel"] }
 # remove `nmea` for `velodyne-lidar` since it has conflicts for `dep:serde_with` with `dep:zenoh-config`
 
 [dev-dependencies]
-cu-udp-inject = { path = "../../testing/cu_udp_inject", version = "1.1.0-dev" }
+cu-udp-inject = { path = "../../testing/cu_udp_inject", version = "1.2.0-dev" }
 
 [build-dependencies]
 cu29-build = { workspace = true }

--- a/components/tasks/cu_ahrs/Cargo.toml
+++ b/components/tasks/cu_ahrs/Cargo.toml
@@ -40,10 +40,10 @@ textlogs = [
 ]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "units",
 ] }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.1.0-dev", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.2.0-dev", default-features = false }
 bincode = { workspace = true }
 serde = { workspace = true }
 uf-ahrs = { version = "=0.2.1", default-features = false }
@@ -66,7 +66,7 @@ rp235x-hal = { workspace = true, features = [
   "defmt",
 ], optional = true }
 spin = { workspace = true, optional = true }
-cu-mpu9250 = { path = "../../sources/cu_mpu9250", version = "1.1.0-dev", default-features = false, optional = true }
+cu-mpu9250 = { path = "../../sources/cu_mpu9250", version = "1.2.0-dev", default-features = false, optional = true }
 
 [[example]]
 name = "rp2350_copper"

--- a/components/tasks/cu_apriltag/Cargo.toml
+++ b/components/tasks/cu_apriltag/Cargo.toml
@@ -21,8 +21,8 @@ environments = ["host"]
 bincode = { workspace = true }
 cu29 = { workspace = true }
 serde = { workspace = true }
-cu-spatial-payloads = { path = "../../payloads/cu_spatial_payloads", version = "1.1.0-dev" }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.1.0-dev" }
+cu-spatial-payloads = { path = "../../payloads/cu_spatial_payloads", version = "1.2.0-dev" }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.2.0-dev" }
 
 [target.'cfg(unix)'.dependencies]
 apriltag = { version = "0.4.0" }

--- a/components/tasks/cu_dynthreshold/Cargo.toml
+++ b/components/tasks/cu_dynthreshold/Cargo.toml
@@ -21,8 +21,8 @@ environments = ["host"]
 [dependencies]
 gstreamer = { workspace = true, default-features = false, optional = true }
 cu29 = { workspace = true }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.1.0-dev" }
-cu-gstreamer = { path = "../../sources/cu_gstreamer", version = "1.1.0-dev", optional = true }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.2.0-dev" }
+cu-gstreamer = { path = "../../sources/cu_gstreamer", version = "1.2.0-dev", optional = true }
 
 [features]
 # The 'gst' feature includes dependencies for GStreamer support.

--- a/components/tasks/cu_peer_range_accumulator/Cargo.toml
+++ b/components/tasks/cu_peer_range_accumulator/Cargo.toml
@@ -18,8 +18,8 @@ domains = ["algorithm/ranging"]
 environments = ["host", "embedded"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.1.0-dev", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.2.0-dev", default-features = false }
 serde = { workspace = true }
 
 [features]

--- a/components/tasks/cu_peer_triangulation/Cargo.toml
+++ b/components/tasks/cu_peer_triangulation/Cargo.toml
@@ -19,10 +19,10 @@ environments = ["host", "embedded"]
 
 [dependencies]
 bincode = { workspace = true }
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "units",
 ] }
-cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.1.0-dev", default-features = false }
+cu-sensor-payloads = { path = "../../payloads/cu_sensor_payloads", version = "1.2.0-dev", default-features = false }
 libm = { version = "0.2", default-features = false }
 serde = { workspace = true }
 

--- a/components/tasks/cu_pid/Cargo.toml
+++ b/components/tasks/cu_pid/Cargo.toml
@@ -24,7 +24,7 @@ textlogs = ["cu29/textlogs"]
 reflect = ["cu29/reflect"]
 
 [dependencies]
-cu29 = { path = "../../../core/cu29", version = "1.1.0-dev", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
 bincode = { workspace = true }
 serde = { workspace = true }
 

--- a/components/tasks/cu_rrt_star/Cargo.toml
+++ b/components/tasks/cu_rrt_star/Cargo.toml
@@ -20,7 +20,7 @@ environments = ["host"]
 [dependencies]
 bincode = { workspace = true }
 cu-rng = { workspace = true }
-cu-spatial-payloads = { path = "../../payloads/cu_spatial_payloads", version = "1.1.0-dev", default-features = false }
+cu-spatial-payloads = { path = "../../payloads/cu_spatial_payloads", version = "1.2.0-dev", default-features = false }
 cu29 = { workspace = true }
 serde = { workspace = true }
 

--- a/core/cu29/Cargo.toml
+++ b/core/cu29/Cargo.toml
@@ -31,7 +31,7 @@ cu29-log-runtime = { workspace = true }
 cu29-reflect-derive = { workspace = true }
 cu29-runtime = { workspace = true }
 cu29-traits = { workspace = true }
-cu29-units = { path = "../cu29_units", version = "1.1.0-dev", default-features = false, optional = true }
+cu29-units = { path = "../cu29_units", version = "1.2.0-dev", default-features = false, optional = true }
 cu29-unifiedlog = { workspace = true }
 cu29-value = { workspace = true }
 defmt = { workspace = true, optional = true }

--- a/core/cu29_runtime/Cargo.toml
+++ b/core/cu29_runtime/Cargo.toml
@@ -30,7 +30,7 @@ cu29-log = { workspace = true }
 cu29-log-derive = { workspace = true }
 cu29-log-runtime = { workspace = true }                                                  # needed
 cu29-traits = { workspace = true }
-cu29-units = { path = "../cu29_units", version = "1.1.0-dev", default-features = false }
+cu29-units = { path = "../cu29_units", version = "1.2.0-dev", default-features = false }
 cu29-unifiedlog = { workspace = true }
 cu29-value = { workspace = true }
 

--- a/examples/cu_bevymon_demo/Cargo.toml
+++ b/examples/cu_bevymon_demo/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 
 [dependencies]
 bevy_ecs = { version = "0.19.0", default-features = false }
-cu29 = { path = "../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "std",
   "textlogs",
 ] }
@@ -34,7 +34,7 @@ bevy = { workspace = true, default-features = false, features = [
   "bevy_ui",
   "bevy_ui_render",
 ] }
-cu-bevymon = { path = "../../components/monitors/cu_bevymon", version = "1.1.0-dev" }
+cu-bevymon = { path = "../../components/monitors/cu_bevymon", version = "1.2.0-dev" }
 image = { workspace = true, default-features = false, features = ["png"] }
 winit = { version = "=0.30.13", default-features = false }
 
@@ -48,7 +48,7 @@ bevy = { workspace = true, default-features = false, features = [
   "bevy_ui",
   "bevy_ui_render",
 ] }
-cu-bevymon = { path = "../../components/monitors/cu_bevymon", version = "1.1.0-dev", default-features = false }
+cu-bevymon = { path = "../../components/monitors/cu_bevymon", version = "1.2.0-dev", default-features = false }
 
 [[bin]]
 name = "cu-bevymon-demo"

--- a/examples/cu_bridge_test/Cargo.toml
+++ b/examples/cu_bridge_test/Cargo.toml
@@ -25,7 +25,7 @@ cu29-unifiedlog = { workspace = true }
 bincode = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }
-cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.1.0-dev" }
+cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.2.0-dev" }
 
 [[bin]]
 name = "resim"

--- a/examples/cu_caterpillar/Cargo.toml
+++ b/examples/cu_caterpillar/Cargo.toml
@@ -39,8 +39,8 @@ cu29-export = { workspace = true, features = ["python", "mcap"] }
 serde = { workspace = true }
 cu29-unifiedlog = { workspace = true }
 
-cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.1.0-dev" } # needed
-cu-rp-gpio = { path = "../../components/sinks/cu_rp_gpio", version = "1.1.0-dev" }
+cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.2.0-dev" } # needed
+cu-rp-gpio = { path = "../../components/sinks/cu_rp_gpio", version = "1.2.0-dev" }
 
 
 [features]

--- a/examples/cu_config_constants/Cargo.toml
+++ b/examples/cu_config_constants/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 
 [dependencies]
 cu29 = { workspace = true }
-cu-transform = { path = "../../components/libs/cu_transform", version = "1.1.0-dev" }
+cu-transform = { path = "../../components/libs/cu_transform", version = "1.2.0-dev" }
 
 [build-dependencies]
 cu29-build = { workspace = true }

--- a/examples/cu_config_variation/Cargo.toml
+++ b/examples/cu_config_variation/Cargo.toml
@@ -14,8 +14,8 @@ repository.workspace = true
 publish = false
 [dependencies]
 cu29 = { workspace = true }
-cu-caterpillar = { path = "../cu_caterpillar", version = "1.1.0-dev" }
-cu-rp-gpio = { path = "../../components/sinks/cu_rp_gpio", version = "1.1.0-dev" }
+cu-caterpillar = { path = "../cu_caterpillar", version = "1.2.0-dev" }
+cu-rp-gpio = { path = "../../components/sinks/cu_rp_gpio", version = "1.2.0-dev" }
 serde = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/examples/cu_distributed_resim_demo/Cargo.toml
+++ b/examples/cu_distributed_resim_demo/Cargo.toml
@@ -18,7 +18,7 @@ default-run = "distributed-scout"
 cu29 = { workspace = true }
 cu29-export = { workspace = true }
 cu29-unifiedlog = { workspace = true }
-cu-zenoh-bridge = { path = "../../components/bridges/cu_zenoh_bridge", version = "1.1.0-dev" }
+cu-zenoh-bridge = { path = "../../components/bridges/cu_zenoh_bridge", version = "1.2.0-dev" }
 serde = { workspace = true }
 bincode = { workspace = true }
 

--- a/examples/cu_elrs_bdshot_demo/Cargo.toml
+++ b/examples/cu_elrs_bdshot_demo/Cargo.toml
@@ -23,19 +23,19 @@ embedded_targets = ["thumbv8m.main-none-eabihf"]
 buddy_system_allocator = { workspace = true, default-features = false, features = [
   "use_spin",
 ] }
-cu29 = { path = "../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "defmt",
   "log-level-debug",
   "textlogs",
 ] }
-cu-bdshot = { path = "../../components/bridges/cu_bdshot", version = "1.1.0-dev", default-features = false, features = [
+cu-bdshot = { path = "../../components/bridges/cu_bdshot", version = "1.2.0-dev", default-features = false, features = [
   "rp2350",
 ] }
-cu-crsf = { path = "../../components/bridges/cu_crsf", version = "1.1.0-dev", default-features = false, features = [
+cu-crsf = { path = "../../components/bridges/cu_crsf", version = "1.2.0-dev", default-features = false, features = [
   "defmt",
   "alloc",
 ] }
-cu-sdlogger = { path = "../../components/libs/cu_sdlogger", version = "1.1.0-dev", default-features = false, features = [
+cu-sdlogger = { path = "../../components/libs/cu_sdlogger", version = "1.2.0-dev", default-features = false, features = [
   "eh1",
 ] }
 cortex-m-rt = { workspace = true }

--- a/examples/cu_flight_controller/Cargo.toml
+++ b/examples/cu_flight_controller/Cargo.toml
@@ -31,31 +31,31 @@ bevy_ecs = { version = "0.19.0", default-features = false }
 ## Flight controller components
 
 ### Hardware
-cu-bdshot = { path = "../../components/bridges/cu_bdshot", version = "1.1.0-dev", default-features = false, optional = true }
-cu-crsf = { path = "../../components/bridges/cu_crsf", version = "1.1.0-dev", default-features = false, features = [
+cu-bdshot = { path = "../../components/bridges/cu_bdshot", version = "1.2.0-dev", default-features = false, optional = true }
+cu-crsf = { path = "../../components/bridges/cu_crsf", version = "1.2.0-dev", default-features = false, features = [
   "alloc",
 ], optional = true }
-cu-msp-bridge = { path = "../../components/bridges/cu_msp_bridge", version = "1.1.0-dev", default-features = false, features = [
+cu-msp-bridge = { path = "../../components/bridges/cu_msp_bridge", version = "1.2.0-dev", default-features = false, features = [
   "alloc",
 ], optional = true }
-cu-msp-lib = { path = "../../components/libs/cu_msp_lib", version = "1.1.0-dev", default-features = false, features = [
+cu-msp-lib = { path = "../../components/libs/cu_msp_lib", version = "1.2.0-dev", default-features = false, features = [
   "bincode",
 ] }
 cu-sdlogger = { workspace = true, optional = true }
 cu-micoairh743 = { workspace = true, optional = true }
-cu-logmon = { path = "../../components/monitors/cu_logmon", version = "1.1.0-dev", default-features = false, features = [
+cu-logmon = { path = "../../components/monitors/cu_logmon", version = "1.2.0-dev", default-features = false, features = [
   "color_log",
 ], optional = true }
-cu-ahrs = { path = "../../components/tasks/cu_ahrs", version = "1.1.0-dev", default-features = false, optional = true }
-cu-bmi088 = { path = "../../components/sources/cu_bmi088", version = "1.1.0-dev", default-features = false, optional = true }
-cu-dps310 = { path = "../../components/sources/cu_dps310", version = "1.1.0-dev", default-features = false, optional = true }
-cu-ist8310 = { path = "../../components/sources/cu_ist8310", version = "1.1.0-dev", default-features = false, optional = true }
-cu-gnss-payloads = { path = "../../components/payloads/cu_gnss_payloads", version = "1.1.0-dev", default-features = false, optional = true }
-cu-gnss-ublox = { path = "../../components/sources/cu_gnss_ublox", version = "1.1.0-dev", default-features = false, optional = true }
+cu-ahrs = { path = "../../components/tasks/cu_ahrs", version = "1.2.0-dev", default-features = false, optional = true }
+cu-bmi088 = { path = "../../components/sources/cu_bmi088", version = "1.2.0-dev", default-features = false, optional = true }
+cu-dps310 = { path = "../../components/sources/cu_dps310", version = "1.2.0-dev", default-features = false, optional = true }
+cu-ist8310 = { path = "../../components/sources/cu_ist8310", version = "1.2.0-dev", default-features = false, optional = true }
+cu-gnss-payloads = { path = "../../components/payloads/cu_gnss_payloads", version = "1.2.0-dev", default-features = false, optional = true }
+cu-gnss-ublox = { path = "../../components/sources/cu_gnss_ublox", version = "1.2.0-dev", default-features = false, optional = true }
 
 ### Algos
-cu-pid = { path = "../../components/tasks/cu_pid", version = "1.1.0-dev", default-features = false }
-cu-sensor-payloads = { path = "../../components/payloads/cu_sensor_payloads", version = "1.1.0-dev", default-features = false }
+cu-pid = { path = "../../components/tasks/cu_pid", version = "1.2.0-dev", default-features = false }
+cu-sensor-payloads = { path = "../../components/payloads/cu_sensor_payloads", version = "1.2.0-dev", default-features = false }
 bincode = { workspace = true }
 serde = { workspace = true }
 spin = { workspace = true }
@@ -65,8 +65,8 @@ libm = { version = "0.2", default-features = false }
 
 ## End-to-end compute dependencies
 cu-zed = { path = "../../../zed/components/sources/cu_zed", optional = true }
-cu-zenoh-bridge = { path = "../../components/bridges/cu_zenoh_bridge", version = "1.1.0-dev", optional = true }
-cu-ratelimit = { path = "../../components/tasks/cu_ratelimit", version = "1.1.0-dev", optional = true }
+cu-zenoh-bridge = { path = "../../components/bridges/cu_zenoh_bridge", version = "1.2.0-dev", optional = true }
+cu-ratelimit = { path = "../../components/tasks/cu_ratelimit", version = "1.2.0-dev", optional = true }
 
 ## Log reader depencies
 cu29-export = { workspace = true, optional = true }
@@ -86,7 +86,7 @@ avian3d = { workspace = true, default-features = false, features = [
   "parry-f32",
 ], optional = true }
 
-cu29 = { path = "../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "log-level-debug",
   "units",
 ], optional = true }
@@ -113,7 +113,7 @@ cortex-m = { workspace = true, features = [
 cu-vitfly = { path = "../../../cu-vitfly", default-features = false, optional = true }
 cu-consolemon = { workspace = true, optional = true }
 cu-bevymon = { workspace = true, optional = true }
-cu-memmon = { path = "../../components/monitors/cu_memmon", version = "1.1.0-dev", default-features = false, features = [
+cu-memmon = { path = "../../components/monitors/cu_memmon", version = "1.2.0-dev", default-features = false, features = [
   "std",
   "memory_monitoring",
 ], optional = true }
@@ -150,7 +150,7 @@ evdev = { version = "0.13.2", optional = true }
 winit = { version = "=0.30.13", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-cu-bevymon = { path = "../../components/monitors/cu_bevymon", version = "1.1.0-dev", default-features = false, optional = true }
+cu-bevymon = { path = "../../components/monitors/cu_bevymon", version = "1.2.0-dev", default-features = false, optional = true }
 bevy = { workspace = true, default-features = false, features = [
   "default_font",
   "bevy_render",

--- a/examples/cu_iceoryx2_bridge_demo/Cargo.toml
+++ b/examples/cu_iceoryx2_bridge_demo/Cargo.toml
@@ -17,7 +17,7 @@ default-run = "iceoryx2-ping"
 
 [dependencies]
 cu29 = { workspace = true }
-cu-iceoryx2-bridge = { path = "../../components/bridges/cu_iceoryx2_bridge", version = "1.1.0-dev" }
+cu-iceoryx2-bridge = { path = "../../components/bridges/cu_iceoryx2_bridge", version = "1.2.0-dev" }
 serde = { workspace = true }
 bincode = { workspace = true }
 tempfile = { workspace = true }

--- a/examples/cu_image_aligner/Cargo.toml
+++ b/examples/cu_image_aligner/Cargo.toml
@@ -18,8 +18,8 @@ publish = false
 cu29 = { workspace = true }
 cu29-clock = { workspace = true }
 tempfile = { workspace = true }
-cu-aligner = { path = "../../components/tasks/cu_aligner", version = "1.1.0-dev" }
-cu-sensor-payloads = { path = "../../components/payloads/cu_sensor_payloads", version = "1.1.0-dev" }
+cu-aligner = { path = "../../components/tasks/cu_aligner", version = "1.2.0-dev" }
+cu-sensor-payloads = { path = "../../components/payloads/cu_sensor_payloads", version = "1.2.0-dev" }
 paste = { workspace = true }
 serde = { workspace = true }
 

--- a/examples/cu_image_codec_demo/Cargo.toml
+++ b/examples/cu_image_codec_demo/Cargo.toml
@@ -35,7 +35,7 @@ logreader = ["ffv1", "dep:cu29-export"]
 
 [dependencies]
 cu-ffv1-codec = { workspace = true, optional = true, features = ["ffmpeg"] }
-cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.1.0-dev", optional = true }
+cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.2.0-dev", optional = true }
 cu-png-codec = { workspace = true, optional = true }
 cu-sensor-payloads = { workspace = true }
 cu29 = { workspace = true }

--- a/examples/cu_min_baremetal/Cargo.toml
+++ b/examples/cu_min_baremetal/Cargo.toml
@@ -32,7 +32,7 @@ required-features = ["std"]
 [dependencies]
 
 bincode = { workspace = true }
-cu29 = { path = "../../core/cu29", default-features = false, version = "1.1.0-dev", features = [
+cu29 = { path = "../../core/cu29", default-features = false, version = "1.2.0-dev", features = [
   "textlogs",
 ] } # default-features = false -> enables no-std for all cu29 dependencies
 serde = { workspace = true }

--- a/examples/cu_monitoring/Cargo.toml
+++ b/examples/cu_monitoring/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 [dependencies]
 cu29 = { workspace = true }
 serde = { workspace = true }
-cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.1.0-dev" }
+cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.2.0-dev" }
 
 [package.metadata.cargo-shear]
 ignored = ["serde"]

--- a/examples/cu_msp_bridge_loopback/Cargo.toml
+++ b/examples/cu_msp_bridge_loopback/Cargo.toml
@@ -19,9 +19,9 @@ path = "src/main.rs"
 [dependencies]
 cu29 = { workspace = true }
 cu-linux-resources = { workspace = true }
-cu-msp-bridge = { path = "../../components/bridges/cu_msp_bridge", version = "1.1.0-dev" }
-cu-msp-lib = { path = "../../components/libs/cu_msp_lib", version = "1.1.0-dev" }
-cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.1.0-dev" }
+cu-msp-bridge = { path = "../../components/bridges/cu_msp_bridge", version = "1.2.0-dev" }
+cu-msp-lib = { path = "../../components/libs/cu_msp_lib", version = "1.2.0-dev" }
+cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.2.0-dev" }
 nix = { workspace = true, default-features = false, features = ["term", "fs"] }
 serde = { workspace = true }
 ctrlc = { workspace = true }

--- a/examples/cu_parallel_mandelbrot/Cargo.toml
+++ b/examples/cu_parallel_mandelbrot/Cargo.toml
@@ -18,7 +18,7 @@ publish = false
 bincode = { workspace = true }
 cu29 = { workspace = true }
 cu29-export = { workspace = true, features = ["mcap"] }
-cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.1.0-dev" }
+cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.2.0-dev" }
 cu-sensor-payloads = { workspace = true }
 libc = { workspace = true }
 minifb = "0.28.0"

--- a/examples/cu_peer_triangulation/Cargo.toml
+++ b/examples/cu_peer_triangulation/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 
 [dependencies]
 cu29 = { workspace = true }
-cu-peer-range-accumulator = { path = "../../components/tasks/cu_peer_range_accumulator", version = "1.1.0-dev" }
-cu-peer-triangulation = { path = "../../components/tasks/cu_peer_triangulation", version = "1.1.0-dev" }
+cu-peer-range-accumulator = { path = "../../components/tasks/cu_peer_range_accumulator", version = "1.2.0-dev" }
+cu-peer-triangulation = { path = "../../components/tasks/cu_peer_triangulation", version = "1.2.0-dev" }
 cu-sensor-payloads = { workspace = true }
 
 [build-dependencies]

--- a/examples/cu_pointclouds/Cargo.toml
+++ b/examples/cu_pointclouds/Cargo.toml
@@ -15,8 +15,8 @@ publish = false
 [dependencies]
 cu29 = { workspace = true }
 tempfile = { workspace = true }
-cu-hesai = { path = "../../components/sources/cu_hesai", version = "1.1.0-dev" }
-cu-udp-inject = { path = "../../components/testing/cu_udp_inject", version = "1.1.0-dev" }
+cu-hesai = { path = "../../components/sources/cu_hesai", version = "1.2.0-dev" }
+cu-udp-inject = { path = "../../components/testing/cu_udp_inject", version = "1.2.0-dev" }
 rerun = { workspace = true }
 serde = { workspace = true }
 

--- a/examples/cu_python_task_demo/Cargo.toml
+++ b/examples/cu_python_task_demo/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 cu29 = { workspace = true, features = ["reflect"] }
-cu-python-task = { path = "../../components/tasks/cu_python_task", version = "1.1.0-dev" }
+cu-python-task = { path = "../../components/tasks/cu_python_task", version = "1.2.0-dev" }
 serde = { workspace = true }
 bincode = { workspace = true }
 tempfile = { workspace = true }

--- a/examples/cu_resources_test/Cargo.toml
+++ b/examples/cu_resources_test/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 clap = { workspace = true }
 cu29 = { workspace = true, features = ["log-level-debug"] }
 cu29-unifiedlog = { workspace = true }
-cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.1.0-dev" }
+cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.2.0-dev" }
 serde = { workspace = true }
 bincode = { workspace = true }
 parking_lot = "0.12"

--- a/examples/cu_ros2_bridge_demo/Cargo.toml
+++ b/examples/cu_ros2_bridge_demo/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 
 [dependencies]
 cu29 = { workspace = true }
-cu-ros2-bridge = { path = "../../components/bridges/cu_ros2_bridge", version = "1.1.0-dev" }
+cu-ros2-bridge = { path = "../../components/bridges/cu_ros2_bridge", version = "1.2.0-dev" }
 tempfile = { workspace = true }
 serde = { workspace = true }
 

--- a/examples/cu_rp2350_skeleton/Cargo.toml
+++ b/examples/cu_rp2350_skeleton/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cu-rp2350-skeleton"
-version = "1.1.0-dev"
+version = "1.2.0-dev"
 edition = "2024"
 rust-version = "1.95"
 description = "A minimal example of using Copper on a RP2350 microcontroller"
@@ -20,14 +20,14 @@ default-run = "main"
 
 publish = false
 [dependencies]
-cu29 = { path = "../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "log-level-debug",
   "textlogs",
 ] } # pick it up directly to build it no-std
 cu-sdlogger = { path = "../../components/libs/cu_sdlogger", default-features = false, features = [
   "eh1",
-], optional = true, version = "1.1.0-dev" }
-cu29-export = { path = "../../core/cu29_export", version = "1.1.0-dev", optional = true, default-features = false }
+], optional = true, version = "1.2.0-dev" }
+cu29-export = { path = "../../core/cu29_export", version = "1.2.0-dev", optional = true, default-features = false }
 bincode = { version = "2.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
@@ -103,4 +103,4 @@ firmware = [
 host = ["dep:cu29-export", "cu29/std", "bincode/std", "serde/std"]
 
 [build-dependencies]
-cu29-build = { path = "../../core/cu29_build", version = "1.1.0-dev" }
+cu29-build = { path = "../../core/cu29_build", version = "1.2.0-dev" }

--- a/examples/cu_rp_balancebot/Cargo.toml
+++ b/examples/cu_rp_balancebot/Cargo.toml
@@ -49,7 +49,7 @@ avian3d = { workspace = true, default-features = false, features = [
 cu29 = { workspace = true }
 cu-consolemon = { workspace = true }
 cu-bevymon = { workspace = true, optional = true }
-cu-memmon = { path = "../../components/monitors/cu_memmon", version = "1.1.0-dev", default-features = false, features = [
+cu-memmon = { path = "../../components/monitors/cu_memmon", version = "1.2.0-dev", default-features = false, features = [
   "std",
   "memory_monitoring",
 ], optional = true }
@@ -88,12 +88,12 @@ winit = { version = "=0.30.13", default-features = false, optional = true }
 bevy_anti_alias = { version = "0.19.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-cu29 = { path = "../../core/cu29", version = "1.1.0-dev", default-features = false, features = [
+cu29 = { path = "../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "std",
   "textlogs",
   "units",
 ] }
-cu-bevymon = { path = "../../components/monitors/cu_bevymon", version = "1.1.0-dev", default-features = false, optional = true }
+cu-bevymon = { path = "../../components/monitors/cu_bevymon", version = "1.2.0-dev", default-features = false, optional = true }
 bevy_anti_alias = { version = "0.19.0", optional = true }
 bevy = { workspace = true, default-features = false, features = [
   "default_font",

--- a/examples/cu_ryuw122_probe/Cargo.toml
+++ b/examples/cu_ryuw122_probe/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 clap = { workspace = true }
 ctrlc = { workspace = true }
 cu-linux-resources = { workspace = true }
-cu-ryuw122 = { path = "../../components/sources/cu_ryuw122", version = "1.1.0-dev" }
+cu-ryuw122 = { path = "../../components/sources/cu_ryuw122", version = "1.2.0-dev" }
 cu-sensor-payloads = { workspace = true }
 cu29 = { workspace = true }
 serialport = { workspace = true }

--- a/examples/cu_zenoh/Cargo.toml
+++ b/examples/cu_zenoh/Cargo.toml
@@ -14,7 +14,7 @@ description = "Copper example to use zenoh as a middleware."
 publish = false
 [dependencies]
 cu29 = { workspace = true }
-cu-zenoh-sink = { path = "../../components/sinks/cu_zenoh_sink", version = "1.1.0-dev" }
+cu-zenoh-sink = { path = "../../components/sinks/cu_zenoh_sink", version = "1.2.0-dev" }
 tempfile = { workspace = true }
 serde = { workspace = true }
 

--- a/examples/cu_zenoh_bridge_demo/Cargo.toml
+++ b/examples/cu_zenoh_bridge_demo/Cargo.toml
@@ -18,7 +18,7 @@ default-run = "zenoh-ping"
 [dependencies]
 cu29 = { workspace = true }
 cu29-export = { workspace = true }
-cu-zenoh-bridge = { path = "../../components/bridges/cu_zenoh_bridge", version = "1.1.0-dev" }
+cu-zenoh-bridge = { path = "../../components/bridges/cu_zenoh_bridge", version = "1.2.0-dev" }
 serde = { workspace = true }
 bincode = { workspace = true }
 

--- a/support/cargo_cubuild/Cargo.toml
+++ b/support/cargo_cubuild/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-cubuild"
 description = "A cargo tool to help with copper macro expansion errors."
 publish = false
-version = "1.1.0-dev"
+version = "1.2.0-dev"
 edition = "2024"
 rust-version = "1.95"
 license = "Apache-2.0"

--- a/support/cu_catalog/Cargo.toml
+++ b/support/cu_catalog/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cu-catalog"
 description = "Generate the Copper component catalog from RON source entries."
 publish = false
-version = "1.1.0-dev"
+version = "1.2.0-dev"
 edition = "2024"
 rust-version = "1.95"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- bump the workspace and internal Copper dependency versions from `1.1.0-dev` to `1.2.0-dev`
- update examples, benchmarks, and support crates to the new development version
- align `RELEASING.md` with the post-1.1 development branch state

## Validation

- `just pr-check`