### PR TITLE
feat(runtime): typestate lifecycle wrapper for CuApplication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -387,7 +387,7 @@ simplelog = "0.12"
 socket2 = "0.6"
 stm32h7xx-hal = { version = "0.16.0", default-features = false }
 strfmt = "0.2"
-zenoh = { version = "1.7.0", default-features = false }
+zenoh = { version = "~1.10.0", default-features = false }
 
 [workspace.metadata.cargo-shear]
 ignored = ["cu-consolemon"]

--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -2,10 +2,10 @@ pub mod cu29_runtime
 pub mod cu29_runtime::app
 pub struct cu29_runtime::app::CuAppLifecycle<S, L, A, State>
 impl<S, L, A, State> cu29_runtime::app::CuAppLifecycle<S, L, A, State> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuApplication<S, L>, State: cu29_runtime::app::Startable
-pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::run(self) -> cu29_runtime::app::TransitionResult<S, L, A, cu29_runtime::app::Stopped>
-pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::start_all_tasks(self) -> cu29_runtime::app::TransitionResult<S, L, A, cu29_runtime::app::Running>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::run_until_shutdown(self) -> cu29_runtime::app::TransitionResult<S, L, A, cu29_runtime::app::Stopped>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::start(self) -> cu29_runtime::app::TransitionResult<S, L, A, cu29_runtime::app::Running>
 impl<S, L, A, State> cu29_runtime::app::CuAppLifecycle<S, L, A, State> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuApplication<S, L>, State: cu29_runtime::app::Stoppable
-pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::stop_all_tasks(self) -> cu29_runtime::app::TransitionResult<S, L, A, cu29_runtime::app::Stopped>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::stop(self) -> cu29_runtime::app::TransitionResult<S, L, A, cu29_runtime::app::Stopped>
 impl<S, L, A, State> cu29_runtime::app::CuAppLifecycle<S, L, A, State>
 pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::inner(&self) -> &A
 pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::into_inner(self) -> A
@@ -16,12 +16,24 @@ impl<S, L, A> cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Runn
 pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Running>::run_one_iteration(&mut self) -> cu29_traits::CuResult<()>
 impl<S, L, A, State> core::fmt::Debug for cu29_runtime::app::CuAppLifecycle<S, L, A, State>
 pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<S, L, A, State> core::ops::deref::Deref for cu29_runtime::app::CuAppLifecycle<S, L, A, State>
+pub type cu29_runtime::app::CuAppLifecycle<S, L, A, State>::Target = A
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::deref(&self) -> &A
+impl<S, L, A> core::ops::deref::DerefMut for cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::deref_mut(&mut self) -> &mut A
+impl<S, L, A> cu29_runtime::app::CuApplication<S, L> for cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuApplication<S, L>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::get_original_config() -> alloc::string::String
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::restore_keyframe(&mut self, freezer: &cu29_runtime::curuntime::KeyFrame) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::run(&mut self) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::run_one_iteration(&mut self) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::start_all_tasks(&mut self) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::stop_all_tasks(&mut self) -> cu29_traits::CuResult<()>
 pub struct cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>
 impl<S, L, A, State> cu29_runtime::app::CuSimAppLifecycle<S, L, A, State> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuSimApplication<S, L>, State: cu29_runtime::app::Startable
-pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>::run(self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(<A as cu29_runtime::app::CuSimApplication<S, L>>::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_runtime::app::SimTransitionResult<S, L, A, cu29_runtime::app::Stopped>
-pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>::start_all_tasks(self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(<A as cu29_runtime::app::CuSimApplication<S, L>>::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_runtime::app::SimTransitionResult<S, L, A, cu29_runtime::app::Running>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>::run_until_shutdown(self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(<A as cu29_runtime::app::CuSimApplication<S, L>>::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_runtime::app::SimTransitionResult<S, L, A, cu29_runtime::app::Stopped>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>::start(self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(<A as cu29_runtime::app::CuSimApplication<S, L>>::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_runtime::app::SimTransitionResult<S, L, A, cu29_runtime::app::Running>
 impl<S, L, A, State> cu29_runtime::app::CuSimAppLifecycle<S, L, A, State> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuSimApplication<S, L>, State: cu29_runtime::app::Stoppable
-pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>::stop_all_tasks(self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(<A as cu29_runtime::app::CuSimApplication<S, L>>::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_runtime::app::SimTransitionResult<S, L, A, cu29_runtime::app::Stopped>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>::stop(self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(<A as cu29_runtime::app::CuSimApplication<S, L>>::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_runtime::app::SimTransitionResult<S, L, A, cu29_runtime::app::Stopped>
 impl<S, L, A, State> cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>
 pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>::inner(&self) -> &A
 pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>::into_inner(self) -> A
@@ -31,6 +43,20 @@ impl<S, L, A> cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::R
 pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Running>::run_one_iteration(&mut self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(<A as cu29_runtime::app::CuSimApplication<S, L>>::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_traits::CuResult<()>
 impl<S, L, A, State> core::fmt::Debug for cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>
 pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<S, L, A, State> core::ops::deref::Deref for cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>
+pub type cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>::Target = A
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>::deref(&self) -> &A
+impl<S, L, A> core::ops::deref::DerefMut for cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::deref_mut(&mut self) -> &mut A
+impl<S, L, A> cu29_runtime::app::CuSimApplication<S, L> for cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuSimApplication<S, L>
+pub type cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::Step<'z> = <A as cu29_runtime::app::CuSimApplication<S, L>>::Step
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::get_original_config() -> alloc::string::String
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::mission_id() -> core::option::Option<&'static str>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::restore_keyframe(&mut self, freezer: &cu29_runtime::curuntime::KeyFrame) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::run(&mut self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(Self::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::run_one_iteration(&mut self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(Self::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::start_all_tasks(&mut self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(Self::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::stop_all_tasks(&mut self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(Self::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_traits::CuResult<()>
 pub struct cu29_runtime::app::Faulted
 impl cu29_runtime::app::Stoppable for cu29_runtime::app::Faulted
 pub struct cu29_runtime::app::Initialized
@@ -73,6 +99,13 @@ pub fn cu29_runtime::app::CuApplication::run(&mut self) -> cu29_traits::CuResult
 pub fn cu29_runtime::app::CuApplication::run_one_iteration(&mut self) -> cu29_traits::CuResult<()>
 pub fn cu29_runtime::app::CuApplication::start_all_tasks(&mut self) -> cu29_traits::CuResult<()>
 pub fn cu29_runtime::app::CuApplication::stop_all_tasks(&mut self) -> cu29_traits::CuResult<()>
+impl<S, L, A> cu29_runtime::app::CuApplication<S, L> for cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuApplication<S, L>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::get_original_config() -> alloc::string::String
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::restore_keyframe(&mut self, freezer: &cu29_runtime::curuntime::KeyFrame) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::run(&mut self) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::run_one_iteration(&mut self) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::start_all_tasks(&mut self) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::stop_all_tasks(&mut self) -> cu29_traits::CuResult<()>
 pub trait cu29_runtime::app::CuDistributedReplayApplication<S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static>: cu29_runtime::app::CuRecordedReplayApplication<S, L> + cu29_runtime::app::CuSubsystemMetadata
 pub fn cu29_runtime::app::CuDistributedReplayApplication::build_distributed_replay(clock: cu29_clock::RobotClock, unified_logger: alloc::sync::Arc<std::sync::poison::mutex::Mutex<L>>, instance_id: u32, config_override: core::option::Option<cu29_runtime::config::CuConfig>) -> cu29_traits::CuResult<Self> where Self: core::marker::Sized
 pub trait cu29_runtime::app::CuRecordedReplayApplication<S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static>: cu29_runtime::app::CuSimApplication<S, L>
@@ -87,6 +120,15 @@ pub fn cu29_runtime::app::CuSimApplication::run(&mut self, sim_callback: &mut im
 pub fn cu29_runtime::app::CuSimApplication::run_one_iteration(&mut self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(Self::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_traits::CuResult<()>
 pub fn cu29_runtime::app::CuSimApplication::start_all_tasks(&mut self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(Self::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_traits::CuResult<()>
 pub fn cu29_runtime::app::CuSimApplication::stop_all_tasks(&mut self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(Self::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_traits::CuResult<()>
+impl<S, L, A> cu29_runtime::app::CuSimApplication<S, L> for cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuSimApplication<S, L>
+pub type cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::Step<'z> = <A as cu29_runtime::app::CuSimApplication<S, L>>::Step
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::get_original_config() -> alloc::string::String
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::mission_id() -> core::option::Option<&'static str>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::restore_keyframe(&mut self, freezer: &cu29_runtime::curuntime::KeyFrame) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::run(&mut self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(Self::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::run_one_iteration(&mut self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(Self::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::start_all_tasks(&mut self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(Self::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_traits::CuResult<()>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::stop_all_tasks(&mut self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(Self::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_traits::CuResult<()>
 pub trait cu29_runtime::app::CuStdApplication: cu29_runtime::app::CuApplication<cu29_unifiedlog::memmap::MmapSectionStorage, cu29_unifiedlog::memmap::MmapUnifiedLoggerWrite>
 impl<T> cu29_runtime::app::CuStdApplication for T where T: cu29_runtime::app::CuApplication<cu29_unifiedlog::memmap::MmapSectionStorage, cu29_unifiedlog::memmap::MmapUnifiedLoggerWrite>
 pub trait cu29_runtime::app::CuSubsystemMetadata

--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -1,5 +1,39 @@
 pub mod cu29_runtime
 pub mod cu29_runtime::app
+pub struct cu29_runtime::app::CuAppLifecycle<S, L, A, State>
+impl<S, L, A, State> cu29_runtime::app::CuAppLifecycle<S, L, A, State> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuApplication<S, L>, State: cu29_runtime::app::Startable
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::run(self) -> cu29_runtime::app::TransitionResult<S, L, A, cu29_runtime::app::Stopped>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::start_all_tasks(self) -> cu29_runtime::app::TransitionResult<S, L, A, cu29_runtime::app::Running>
+impl<S, L, A, State> cu29_runtime::app::CuAppLifecycle<S, L, A, State> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuApplication<S, L>, State: cu29_runtime::app::Stoppable
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::stop_all_tasks(self) -> cu29_runtime::app::TransitionResult<S, L, A, cu29_runtime::app::Stopped>
+impl<S, L, A, State> cu29_runtime::app::CuAppLifecycle<S, L, A, State>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::inner(&self) -> &A
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::into_inner(self) -> A
+impl<S, L, A> cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuApplication<S, L>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::new(app: A) -> Self
+impl<S, L, A> cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Running> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuApplication<S, L>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Running>::run_one_iteration(&mut self) -> cu29_traits::CuResult<()>
+impl<S, L, A, State> core::fmt::Debug for cu29_runtime::app::CuAppLifecycle<S, L, A, State>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct cu29_runtime::app::Faulted
+impl cu29_runtime::app::Stoppable for cu29_runtime::app::Faulted
+pub struct cu29_runtime::app::Initialized
+impl cu29_runtime::app::Startable for cu29_runtime::app::Initialized
+pub struct cu29_runtime::app::LifecycleError<S, L, A>
+pub cu29_runtime::app::LifecycleError::app: cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Faulted>
+pub cu29_runtime::app::LifecycleError::error: cu29_traits::CuError
+impl<S, L, A> core::convert::From<cu29_runtime::app::LifecycleError<S, L, A>> for cu29_traits::CuError
+pub fn cu29_traits::CuError::from(value: cu29_runtime::app::LifecycleError<S, L, A>) -> Self
+impl<S, L, A> core::error::Error for cu29_runtime::app::LifecycleError<S, L, A>
+pub fn cu29_runtime::app::LifecycleError<S, L, A>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl<S, L, A> core::fmt::Debug for cu29_runtime::app::LifecycleError<S, L, A>
+pub fn cu29_runtime::app::LifecycleError<S, L, A>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<S, L, A> core::fmt::Display for cu29_runtime::app::LifecycleError<S, L, A>
+pub fn cu29_runtime::app::LifecycleError<S, L, A>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct cu29_runtime::app::Running
+impl cu29_runtime::app::Stoppable for cu29_runtime::app::Running
+pub struct cu29_runtime::app::Stopped
+impl cu29_runtime::app::Startable for cu29_runtime::app::Stopped
 pub struct cu29_runtime::app::Subsystem
 impl cu29_runtime::app::Subsystem
 pub const fn cu29_runtime::app::Subsystem::code(self) -> u16
@@ -33,6 +67,14 @@ pub fn cu29_runtime::app::CuSubsystemMetadata::subsystem() -> cu29_runtime::app:
 pub trait cu29_runtime::app::CurrentRuntimeCopperList<P: cu29_traits::CopperListTuple>
 pub fn cu29_runtime::app::CurrentRuntimeCopperList::current_runtime_copperlist_bytes(&self) -> core::option::Option<&[u8]>
 pub fn cu29_runtime::app::CurrentRuntimeCopperList::set_current_runtime_copperlist_bytes(&mut self, snapshot: core::option::Option<alloc::vec::Vec<u8>>)
+pub trait cu29_runtime::app::Startable: cu29_runtime::app::sealed::Sealed
+impl cu29_runtime::app::Startable for cu29_runtime::app::Initialized
+impl cu29_runtime::app::Startable for cu29_runtime::app::Stopped
+pub trait cu29_runtime::app::Stoppable: cu29_runtime::app::sealed::Sealed
+impl cu29_runtime::app::Stoppable for cu29_runtime::app::Faulted
+impl cu29_runtime::app::Stoppable for cu29_runtime::app::Running
+pub type cu29_runtime::app::CuStdAppLifecycle<A, State> = cu29_runtime::app::CuAppLifecycle<cu29_unifiedlog::memmap::MmapSectionStorage, cu29_unifiedlog::memmap::MmapUnifiedLoggerWrite, A, State>
+pub type cu29_runtime::app::TransitionResult<S, L, A, Next> = core::result::Result<cu29_runtime::app::CuAppLifecycle<S, L, A, Next>, cu29_runtime::app::LifecycleError<S, L, A>>
 pub mod cu29_runtime::config
 pub use cu29_runtime::config::Incoming
 pub use cu29_runtime::config::Outgoing

--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -10,11 +10,27 @@ impl<S, L, A, State> cu29_runtime::app::CuAppLifecycle<S, L, A, State>
 pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::inner(&self) -> &A
 pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::into_inner(self) -> A
 impl<S, L, A> cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuApplication<S, L>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::inner_mut(&mut self) -> &mut A
 pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::new(app: A) -> Self
 impl<S, L, A> cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Running> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuApplication<S, L>
 pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Running>::run_one_iteration(&mut self) -> cu29_traits::CuResult<()>
 impl<S, L, A, State> core::fmt::Debug for cu29_runtime::app::CuAppLifecycle<S, L, A, State>
 pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>
+impl<S, L, A, State> cu29_runtime::app::CuSimAppLifecycle<S, L, A, State> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuSimApplication<S, L>, State: cu29_runtime::app::Startable
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>::run(self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(<A as cu29_runtime::app::CuSimApplication<S, L>>::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_runtime::app::SimTransitionResult<S, L, A, cu29_runtime::app::Stopped>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>::start_all_tasks(self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(<A as cu29_runtime::app::CuSimApplication<S, L>>::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_runtime::app::SimTransitionResult<S, L, A, cu29_runtime::app::Running>
+impl<S, L, A, State> cu29_runtime::app::CuSimAppLifecycle<S, L, A, State> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuSimApplication<S, L>, State: cu29_runtime::app::Stoppable
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>::stop_all_tasks(self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(<A as cu29_runtime::app::CuSimApplication<S, L>>::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_runtime::app::SimTransitionResult<S, L, A, cu29_runtime::app::Stopped>
+impl<S, L, A, State> cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>::inner(&self) -> &A
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>::into_inner(self) -> A
+impl<S, L, A> cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuSimApplication<S, L>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::new(app: A) -> Self
+impl<S, L, A> cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Running> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuSimApplication<S, L>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Running>::run_one_iteration(&mut self, sim_callback: &mut impl for<'z> core::ops::function::FnMut(<A as cu29_runtime::app::CuSimApplication<S, L>>::Step) -> cu29_runtime::simulation::SimOverride) -> cu29_traits::CuResult<()>
+impl<S, L, A, State> core::fmt::Debug for cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>
+pub fn cu29_runtime::app::CuSimAppLifecycle<S, L, A, State>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct cu29_runtime::app::Faulted
 impl cu29_runtime::app::Stoppable for cu29_runtime::app::Faulted
 pub struct cu29_runtime::app::Initialized
@@ -32,6 +48,17 @@ impl<S, L, A> core::fmt::Display for cu29_runtime::app::LifecycleError<S, L, A>
 pub fn cu29_runtime::app::LifecycleError<S, L, A>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct cu29_runtime::app::Running
 impl cu29_runtime::app::Stoppable for cu29_runtime::app::Running
+pub struct cu29_runtime::app::SimLifecycleError<S, L, A>
+pub cu29_runtime::app::SimLifecycleError::app: cu29_runtime::app::CuSimAppLifecycle<S, L, A, cu29_runtime::app::Faulted>
+pub cu29_runtime::app::SimLifecycleError::error: cu29_traits::CuError
+impl<S, L, A> core::convert::From<cu29_runtime::app::SimLifecycleError<S, L, A>> for cu29_traits::CuError
+pub fn cu29_traits::CuError::from(value: cu29_runtime::app::SimLifecycleError<S, L, A>) -> Self
+impl<S, L, A> core::error::Error for cu29_runtime::app::SimLifecycleError<S, L, A>
+pub fn cu29_runtime::app::SimLifecycleError<S, L, A>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl<S, L, A> core::fmt::Debug for cu29_runtime::app::SimLifecycleError<S, L, A>
+pub fn cu29_runtime::app::SimLifecycleError<S, L, A>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<S, L, A> core::fmt::Display for cu29_runtime::app::SimLifecycleError<S, L, A>
+pub fn cu29_runtime::app::SimLifecycleError<S, L, A>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct cu29_runtime::app::Stopped
 impl cu29_runtime::app::Startable for cu29_runtime::app::Stopped
 pub struct cu29_runtime::app::Subsystem
@@ -74,6 +101,8 @@ pub trait cu29_runtime::app::Stoppable: cu29_runtime::app::sealed::Sealed
 impl cu29_runtime::app::Stoppable for cu29_runtime::app::Faulted
 impl cu29_runtime::app::Stoppable for cu29_runtime::app::Running
 pub type cu29_runtime::app::CuStdAppLifecycle<A, State> = cu29_runtime::app::CuAppLifecycle<cu29_unifiedlog::memmap::MmapSectionStorage, cu29_unifiedlog::memmap::MmapUnifiedLoggerWrite, A, State>
+pub type cu29_runtime::app::CuStdSimAppLifecycle<A, State> = cu29_runtime::app::CuSimAppLifecycle<cu29_unifiedlog::memmap::MmapSectionStorage, cu29_unifiedlog::memmap::MmapUnifiedLoggerWrite, A, State>
+pub type cu29_runtime::app::SimTransitionResult<S, L, A, Next> = core::result::Result<cu29_runtime::app::CuSimAppLifecycle<S, L, A, Next>, cu29_runtime::app::SimLifecycleError<S, L, A>>
 pub type cu29_runtime::app::TransitionResult<S, L, A, Next> = core::result::Result<cu29_runtime::app::CuAppLifecycle<S, L, A, Next>, cu29_runtime::app::LifecycleError<S, L, A>>
 pub mod cu29_runtime::config
 pub use cu29_runtime::config::Incoming

--- a/benchmarks/cu_async_cl_io_bench/src/main.rs
+++ b/benchmarks/cu_async_cl_io_bench/src/main.rs
@@ -161,8 +161,8 @@ fn main() -> CuResult<()> {
     let app = App::builder()
         .with_log_path(&logger_path, Some((args.slab_mib as usize) * 1024 * 1024))?
         .with_config(config)
-        .build_app()?;
-    let mut app = app.start_all_tasks()?;
+        .build()?;
+    let mut app = app.start()?;
 
     for _ in 0..args.warmup {
         app.run_one_iteration()?;
@@ -178,7 +178,7 @@ fn main() -> CuResult<()> {
     }
     let total_elapsed = benchmark_start.elapsed();
 
-    app.stop_all_tasks()?;
+    app.stop()?;
 
     let mut jitter_ns = samples_ns
         .windows(2)

--- a/benchmarks/cu_async_cl_io_bench/src/main.rs
+++ b/benchmarks/cu_async_cl_io_bench/src/main.rs
@@ -158,11 +158,11 @@ fn main() -> CuResult<()> {
     logging.keyframe_interval = Some(args.keyframe_interval);
     let copperlist_count = logging.copperlist_count.unwrap_or(2);
 
-    let mut app = App::builder()
+    let app = App::builder()
         .with_log_path(&logger_path, Some((args.slab_mib as usize) * 1024 * 1024))?
         .with_config(config)
-        .build()?;
-    app.start_all_tasks()?;
+        .build_app()?;
+    let mut app = app.start_all_tasks()?;
 
     for _ in 0..args.warmup {
         app.run_one_iteration()?;

--- a/benchmarks/cu_dorabench/src/main.rs
+++ b/benchmarks/cu_dorabench/src/main.rs
@@ -21,10 +21,10 @@ fn main() {
     let application = DoraBench::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create application.");
 
-    if let Err(error) = application.run() {
+    if let Err(error) = application.run_until_shutdown() {
         debug!("Application Ended: {}", error.error)
     }
 }

--- a/benchmarks/cu_dorabench/src/main.rs
+++ b/benchmarks/cu_dorabench/src/main.rs
@@ -18,13 +18,13 @@ fn main() {
         fs::create_dir_all(parent).expect("Failed to create logs directory");
     }
 
-    let mut application = DoraBench::builder()
+    let application = DoraBench::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create application.");
 
     if let Err(error) = application.run() {
-        debug!("Application Ended: {}", error)
+        debug!("Application Ended: {}", error.error)
     }
 }

--- a/benchmarks/cu_zenoh_bridge_bench/src/bin/rx.rs
+++ b/benchmarks/cu_zenoh_bridge_bench/src/bin/rx.rs
@@ -49,20 +49,19 @@ fn drive() -> CuResult<()> {
         transport_details,
         options.log_path.display(),
     );
-    let mut app = RxApp::builder()
+    let app = RxApp::builder()
         .with_log_path(&options.log_path, SLAB_SIZE)?
         .with_instance_id(options.instance_id)
         .with_config(config)
-        .build()?;
-    app.start_all_tasks()?;
+        .build_app()?;
     println!(
         "RX ready: subscribed on route={} {}",
         summary.route,
         summary.transport_details(),
     );
-    let run_result = app.run();
-    let stop_result = app.stop_all_tasks();
-    run_result?;
-    stop_result?;
+    // `run` drives the full start/iterate/stop cycle; the typestate rejects
+    // the extra start_all_tasks/stop_all_tasks calls this benchmark used to
+    // make around it (a double start/stop at runtime).
+    app.run()?;
     Ok(())
 }

--- a/benchmarks/cu_zenoh_bridge_bench/src/bin/rx.rs
+++ b/benchmarks/cu_zenoh_bridge_bench/src/bin/rx.rs
@@ -53,7 +53,7 @@ fn drive() -> CuResult<()> {
         .with_log_path(&options.log_path, SLAB_SIZE)?
         .with_instance_id(options.instance_id)
         .with_config(config)
-        .build_app()?;
+        .build()?;
     println!(
         "RX ready: subscribed on route={} {}",
         summary.route,
@@ -62,6 +62,6 @@ fn drive() -> CuResult<()> {
     // `run` drives the full start/iterate/stop cycle; the typestate rejects
     // the extra start_all_tasks/stop_all_tasks calls this benchmark used to
     // make around it (a double start/stop at runtime).
-    app.run()?;
+    app.run_until_shutdown()?;
     Ok(())
 }

--- a/benchmarks/cu_zenoh_bridge_bench/src/bin/tx.rs
+++ b/benchmarks/cu_zenoh_bridge_bench/src/bin/tx.rs
@@ -47,20 +47,19 @@ fn drive() -> CuResult<()> {
         transport_details,
         options.log_path.display(),
     );
-    let mut app = TxApp::builder()
+    let app = TxApp::builder()
         .with_log_path(&options.log_path, SLAB_SIZE)?
         .with_instance_id(options.instance_id)
         .with_config(config)
-        .build()?;
-    app.start_all_tasks()?;
+        .build_app()?;
     println!(
         "TX ready: publishing every 10ms on route={} {}",
         summary.route,
         summary.transport_details(),
     );
-    let run_result = app.run();
-    let stop_result = app.stop_all_tasks();
-    run_result?;
-    stop_result?;
+    // `run` drives the full start/iterate/stop cycle; the typestate rejects
+    // the extra start_all_tasks/stop_all_tasks calls this benchmark used to
+    // make around it (a double start/stop at runtime).
+    app.run()?;
     Ok(())
 }

--- a/benchmarks/cu_zenoh_bridge_bench/src/bin/tx.rs
+++ b/benchmarks/cu_zenoh_bridge_bench/src/bin/tx.rs
@@ -51,7 +51,7 @@ fn drive() -> CuResult<()> {
         .with_log_path(&options.log_path, SLAB_SIZE)?
         .with_instance_id(options.instance_id)
         .with_config(config)
-        .build_app()?;
+        .build()?;
     println!(
         "TX ready: publishing every 10ms on route={} {}",
         summary.route,
@@ -60,6 +60,6 @@ fn drive() -> CuResult<()> {
     // `run` drives the full start/iterate/stop cycle; the typestate rejects
     // the extra start_all_tasks/stop_all_tasks calls this benchmark used to
     // make around it (a double start/stop at runtime).
-    app.run()?;
+    app.run_until_shutdown()?;
     Ok(())
 }

--- a/components/monitors/cu_logmon/examples/copper_app.rs
+++ b/components/monitors/cu_logmon/examples/copper_app.rs
@@ -113,13 +113,13 @@ fn main() {
 
     info!("Logger created at {}", &logger_path);
 
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create runtime");
-    info!("Starting app at {}", application.clock().now());
-    application
+    info!("Starting app at {}", application.inner().clock().now());
+    let mut application = application
         .start_all_tasks()
         .expect("Failed to start application.");
 
@@ -132,8 +132,8 @@ fn main() {
         std::thread::sleep(Duration::from_millis(50));
     }
 
-    application
+    let application = application
         .stop_all_tasks()
         .expect("Failed to stop application.");
-    info!("App stopped at {}", application.clock().now());
+    info!("App stopped at {}", application.inner().clock().now());
 }

--- a/components/monitors/cu_logmon/examples/copper_app.rs
+++ b/components/monitors/cu_logmon/examples/copper_app.rs
@@ -116,12 +116,10 @@ fn main() {
     let application = App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create runtime");
-    info!("Starting app at {}", application.inner().clock().now());
-    let mut application = application
-        .start_all_tasks()
-        .expect("Failed to start application.");
+    info!("Starting app at {}", application.clock().now());
+    let mut application = application.start().expect("Failed to start application.");
 
     // Run a fixed number of iterations so the monitor has time to emit a few lines,
     // then exit cleanly.
@@ -132,8 +130,6 @@ fn main() {
         std::thread::sleep(Duration::from_millis(50));
     }
 
-    let application = application
-        .stop_all_tasks()
-        .expect("Failed to stop application.");
-    info!("App stopped at {}", application.inner().clock().now());
+    let application = application.stop().expect("Failed to stop application.");
+    info!("App stopped at {}", application.clock().now());
 }

--- a/components/monitors/cu_memmon/examples/copper_app.rs
+++ b/components/monitors/cu_memmon/examples/copper_app.rs
@@ -110,13 +110,13 @@ fn main() {
 
     info!("Logger created at {}", &logger_path);
 
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create runtime");
-    info!("Starting app at {}", application.clock().now());
-    application
+    info!("Starting app at {}", application.inner().clock().now());
+    let mut application = application
         .start_all_tasks()
         .expect("Failed to start application.");
 
@@ -127,8 +127,8 @@ fn main() {
         std::thread::sleep(Duration::from_millis(25));
     }
 
-    application
+    let application = application
         .stop_all_tasks()
         .expect("Failed to stop application.");
-    info!("App stopped at {}", application.clock().now());
+    info!("App stopped at {}", application.inner().clock().now());
 }

--- a/components/monitors/cu_memmon/examples/copper_app.rs
+++ b/components/monitors/cu_memmon/examples/copper_app.rs
@@ -113,12 +113,10 @@ fn main() {
     let application = App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create runtime");
-    info!("Starting app at {}", application.inner().clock().now());
-    let mut application = application
-        .start_all_tasks()
-        .expect("Failed to start application.");
+    info!("Starting app at {}", application.clock().now());
+    let mut application = application.start().expect("Failed to start application.");
 
     for _ in 0..60 {
         application
@@ -127,8 +125,6 @@ fn main() {
         std::thread::sleep(Duration::from_millis(25));
     }
 
-    let application = application
-        .stop_all_tasks()
-        .expect("Failed to stop application.");
-    info!("App stopped at {}", application.inner().clock().now());
+    let application = application.stop().expect("Failed to stop application.");
+    info!("App stopped at {}", application.clock().now());
 }

--- a/components/sinks/cu_rp_sn754410/tests/sn754410_tester.rs
+++ b/components/sinks/cu_rp_sn754410/tests/sn754410_tester.rs
@@ -15,13 +15,16 @@ fn test_driver_with_hardware() {
         .with_clock(clock.clone())
         .with_log_path(&logger_path, None)
         .expect("Failed to setup logger.")
-        .build()
-        .expect("Failed to create runtime.");
+        .build_app()
+        .expect("Failed to create runtime.")
+        .start_all_tasks()
+        .expect("Failed to start tasks.");
     debug!("Running... starting clock: {}.", clock.now());
     for _ in 0..1000 {
         application
             .run_one_iteration()
             .expect("Failed to run application.");
     }
+    application.stop_all_tasks().expect("Failed to stop tasks.");
     debug!("End of program: {}.", clock.now());
 }

--- a/components/sinks/cu_rp_sn754410/tests/sn754410_tester.rs
+++ b/components/sinks/cu_rp_sn754410/tests/sn754410_tester.rs
@@ -15,9 +15,9 @@ fn test_driver_with_hardware() {
         .with_clock(clock.clone())
         .with_log_path(&logger_path, None)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create runtime.")
-        .start_all_tasks()
+        .start()
         .expect("Failed to start tasks.");
     debug!("Running... starting clock: {}.", clock.now());
     for _ in 0..1000 {
@@ -25,6 +25,6 @@ fn test_driver_with_hardware() {
             .run_one_iteration()
             .expect("Failed to run application.");
     }
-    application.stop_all_tasks().expect("Failed to stop tasks.");
+    application.stop().expect("Failed to stop tasks.");
     debug!("End of program: {}.", clock.now());
 }

--- a/components/sources/cu_ads7883/tests/ads7883_tester.rs
+++ b/components/sources/cu_ads7883/tests/ads7883_tester.rs
@@ -37,9 +37,9 @@ fn test_driver_with_hardware() {
         .with_clock(clock.clone())
         .with_log_path(&logger_path, None)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create runtime.")
-        .start_all_tasks()
+        .start()
         .expect("Failed to start tasks.");
     debug!("Running... starting clock: {}.", clock.now());
     for _ in 0..1000 {
@@ -47,6 +47,6 @@ fn test_driver_with_hardware() {
             .run_one_iteration()
             .expect("Failed to run application.");
     }
-    application.stop_all_tasks().expect("Failed to stop tasks.");
+    application.stop().expect("Failed to stop tasks.");
     debug!("End of program: {}.", clock.now());
 }

--- a/components/sources/cu_ads7883/tests/ads7883_tester.rs
+++ b/components/sources/cu_ads7883/tests/ads7883_tester.rs
@@ -37,13 +37,16 @@ fn test_driver_with_hardware() {
         .with_clock(clock.clone())
         .with_log_path(&logger_path, None)
         .expect("Failed to setup logger.")
-        .build()
-        .expect("Failed to create runtime.");
+        .build_app()
+        .expect("Failed to create runtime.")
+        .start_all_tasks()
+        .expect("Failed to start tasks.");
     debug!("Running... starting clock: {}.", clock.now());
     for _ in 0..1000 {
         application
             .run_one_iteration()
             .expect("Failed to run application.");
     }
+    application.stop_all_tasks().expect("Failed to stop tasks.");
     debug!("End of program: {}.", clock.now());
 }

--- a/components/sources/cu_gstreamer/tests/gstreamer_tester.rs
+++ b/components/sources/cu_gstreamer/tests/gstreamer_tester.rs
@@ -64,14 +64,14 @@ mod tests {
         let logger_path = tmp_dir.path().join("caterpillar.copper");
         debug!("Logger created at {}.", &logger_path);
         debug!("Creating application... ");
-        let mut application = GStreamerTestApp::builder()
+        let application = GStreamerTestApp::builder()
             .with_log_path(&logger_path, None)
             .expect("Failed to setup logger.")
-            .build()
+            .build_app()
             .expect("Failed to create runtime.");
 
         debug!("Running...");
-        application
+        let mut application = application
             .start_all_tasks()
             .expect("Failed to start tasks.");
         for _ in 0..1000 {

--- a/components/sources/cu_gstreamer/tests/gstreamer_tester.rs
+++ b/components/sources/cu_gstreamer/tests/gstreamer_tester.rs
@@ -67,22 +67,18 @@ mod tests {
         let application = GStreamerTestApp::builder()
             .with_log_path(&logger_path, None)
             .expect("Failed to setup logger.")
-            .build_app()
+            .build()
             .expect("Failed to create runtime.");
 
         debug!("Running...");
-        let mut application = application
-            .start_all_tasks()
-            .expect("Failed to start tasks.");
+        let mut application = application.start().expect("Failed to start tasks.");
         for _ in 0..1000 {
             application
                 .run_one_iteration()
                 .expect("Failed to run application.");
             sleep(Duration::from_millis(100)); // avoid zapping through 1000 buffers before the first image arrived
         }
-        application
-            .stop_all_tasks()
-            .expect("Failed to start tasks.");
+        application.stop().expect("Failed to start tasks.");
 
         debug!("End of program.");
     }

--- a/components/sources/cu_hesai/tests/hesai_tester.rs
+++ b/components/sources/cu_hesai/tests/hesai_tester.rs
@@ -104,14 +104,17 @@ fn main() {
         .with_clock(clock.clone())
         .with_log_path(&logger_path, None)
         .expect("Failed to setup logger.")
-        .build()
-        .expect("Failed to create runtime.");
+        .build_app()
+        .expect("Failed to create runtime.")
+        .start_all_tasks()
+        .expect("Failed to start tasks.");
     debug!("Running... starting clock: {}.", clock.now());
     for _ in 0..900 {
         application
             .run_one_iteration()
             .expect("Failed to run application.");
     }
+    application.stop_all_tasks().expect("Failed to stop tasks.");
     debug!("End of program: {}.", clock.now());
     thread::sleep(Duration::from_secs(1));
 }

--- a/components/sources/cu_hesai/tests/hesai_tester.rs
+++ b/components/sources/cu_hesai/tests/hesai_tester.rs
@@ -104,9 +104,9 @@ fn main() {
         .with_clock(clock.clone())
         .with_log_path(&logger_path, None)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create runtime.")
-        .start_all_tasks()
+        .start()
         .expect("Failed to start tasks.");
     debug!("Running... starting clock: {}.", clock.now());
     for _ in 0..900 {
@@ -114,7 +114,7 @@ fn main() {
             .run_one_iteration()
             .expect("Failed to run application.");
     }
-    application.stop_all_tasks().expect("Failed to stop tasks.");
+    application.stop().expect("Failed to stop tasks.");
     debug!("End of program: {}.", clock.now());
     thread::sleep(Duration::from_secs(1));
 }

--- a/components/sources/cu_livox/tests/livox_tester.rs
+++ b/components/sources/cu_livox/tests/livox_tester.rs
@@ -102,9 +102,9 @@ fn main() {
         .with_clock(clock.clone())
         .with_log_path(&logger_path, None)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create runtime.")
-        .start_all_tasks()
+        .start()
         .expect("Failed to start tasks.");
     debug!("Running... starting clock: {}.", clock.now());
     for _ in 0..20 {
@@ -112,7 +112,7 @@ fn main() {
             .run_one_iteration()
             .expect("Failed to run application.");
     }
-    application.stop_all_tasks().expect("Failed to stop tasks.");
+    application.stop().expect("Failed to stop tasks.");
     debug!("End of program: {}.", clock.now());
     thread::sleep(Duration::from_secs(1));
 }

--- a/components/sources/cu_livox/tests/livox_tester.rs
+++ b/components/sources/cu_livox/tests/livox_tester.rs
@@ -102,14 +102,17 @@ fn main() {
         .with_clock(clock.clone())
         .with_log_path(&logger_path, None)
         .expect("Failed to setup logger.")
-        .build()
-        .expect("Failed to create runtime.");
+        .build_app()
+        .expect("Failed to create runtime.")
+        .start_all_tasks()
+        .expect("Failed to start tasks.");
     debug!("Running... starting clock: {}.", clock.now());
     for _ in 0..20 {
         application
             .run_one_iteration()
             .expect("Failed to run application.");
     }
+    application.stop_all_tasks().expect("Failed to stop tasks.");
     debug!("End of program: {}.", clock.now());
     thread::sleep(Duration::from_secs(1));
 }

--- a/components/sources/cu_sen0682/examples/usb_probe.rs
+++ b/components/sources/cu_sen0682/examples/usb_probe.rs
@@ -261,9 +261,9 @@ fn run() -> CuResult<()> {
     let app = UsbProbeApp::builder()
         .with_config(config)
         .with_log_path(&log_path, Some(32 * 1024 * 1024))?
-        .build_app()?;
-    let clock = app.inner().clock();
-    let mut app = app.start_all_tasks()?;
+        .build()?;
+    let clock = app.clock();
+    let mut app = app.start()?;
 
     let running = Arc::new(AtomicBool::new(true));
     let running_for_signal = Arc::clone(&running);
@@ -300,7 +300,7 @@ fn run() -> CuResult<()> {
         thread::sleep(Duration::from_millis(5));
     }
 
-    app.stop_all_tasks()?;
+    app.stop()?;
 
     if let Some(err) = run_error {
         return Err(err);

--- a/components/sources/cu_sen0682/examples/usb_probe.rs
+++ b/components/sources/cu_sen0682/examples/usb_probe.rs
@@ -258,12 +258,12 @@ fn run() -> CuResult<()> {
         .map_err(|err| CuError::new_with_cause("failed to create temporary log directory", err))?;
     let log_path = log_dir.path().join("cu_sen0682_usb_probe.copper");
 
-    let mut app = UsbProbeApp::builder()
+    let app = UsbProbeApp::builder()
         .with_config(config)
         .with_log_path(&log_path, Some(32 * 1024 * 1024))?
-        .build()?;
-    let clock = app.clock();
-    app.start_all_tasks()?;
+        .build_app()?;
+    let clock = app.inner().clock();
+    let mut app = app.start_all_tasks()?;
 
     let running = Arc::new(AtomicBool::new(true));
     let running_for_signal = Arc::clone(&running);

--- a/components/sources/cu_sen0682/examples/usb_rerun.rs
+++ b/components/sources/cu_sen0682/examples/usb_rerun.rs
@@ -124,9 +124,9 @@ fn run() -> CuResult<()> {
     let mut config = cu29::read_configuration("examples/usb_rerun.ron")?;
     override_serial_resource(&mut config, &port);
 
-    let app = UsbRerunApp::builder().with_config(config).build_app()?;
-    let clock = app.inner().clock();
-    let mut app = app.start_all_tasks()?;
+    let app = UsbRerunApp::builder().with_config(config).build()?;
+    let clock = app.clock();
+    let mut app = app.start()?;
 
     let running = Arc::new(AtomicBool::new(true));
     let running_for_signal = Arc::clone(&running);
@@ -171,7 +171,7 @@ fn run() -> CuResult<()> {
         thread::sleep(Duration::from_millis(5));
     }
 
-    app.stop_all_tasks()?;
+    app.stop()?;
 
     if let Some(err) = run_error {
         return Err(err);

--- a/components/sources/cu_sen0682/examples/usb_rerun.rs
+++ b/components/sources/cu_sen0682/examples/usb_rerun.rs
@@ -124,9 +124,9 @@ fn run() -> CuResult<()> {
     let mut config = cu29::read_configuration("examples/usb_rerun.ron")?;
     override_serial_resource(&mut config, &port);
 
-    let mut app = UsbRerunApp::builder().with_config(config).build()?;
-    let clock = app.clock();
-    app.start_all_tasks()?;
+    let app = UsbRerunApp::builder().with_config(config).build_app()?;
+    let clock = app.inner().clock();
+    let mut app = app.start_all_tasks()?;
 
     let running = Arc::new(AtomicBool::new(true));
     let running_for_signal = Arc::clone(&running);

--- a/components/sources/cu_wt901/tests/wt901_tester.rs
+++ b/components/sources/cu_wt901/tests/wt901_tester.rs
@@ -39,14 +39,17 @@ fn main() {
         .with_clock(clock.clone())
         .with_log_path(&logger_path, None)
         .expect("Failed to setup logger.")
-        .build()
-        .expect("Failed to create runtime.");
+        .build_app()
+        .expect("Failed to create runtime.")
+        .start_all_tasks()
+        .expect("Failed to start tasks.");
     debug!("Running... starting clock: {}.", clock.now());
     for _ in 0..1000 {
         application
             .run_one_iteration()
             .expect("Failed to run application.");
     }
+    application.stop_all_tasks().expect("Failed to stop tasks.");
     debug!("End of program: {}.", clock.now());
     sleep(Duration::from_secs(1));
 }

--- a/components/sources/cu_wt901/tests/wt901_tester.rs
+++ b/components/sources/cu_wt901/tests/wt901_tester.rs
@@ -39,9 +39,9 @@ fn main() {
         .with_clock(clock.clone())
         .with_log_path(&logger_path, None)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create runtime.")
-        .start_all_tasks()
+        .start()
         .expect("Failed to start tasks.");
     debug!("Running... starting clock: {}.", clock.now());
     for _ in 0..1000 {
@@ -49,7 +49,7 @@ fn main() {
             .run_one_iteration()
             .expect("Failed to run application.");
     }
-    application.stop_all_tasks().expect("Failed to stop tasks.");
+    application.stop().expect("Failed to stop tasks.");
     debug!("End of program: {}.", clock.now());
     sleep(Duration::from_secs(1));
 }

--- a/components/tasks/cu_rrt_star/tests/rrt_star_tester.rs
+++ b/components/tasks/cu_rrt_star/tests/rrt_star_tester.rs
@@ -106,12 +106,12 @@ impl CuSinkTask for ComparisonSink {
 /// Runs the whole application once and returns what the sink saw, one entry
 /// per copperlist.
 fn run(logger_path: &std::path::Path) -> Vec<PlanReport> {
-    let mut application = DualPolicyTester::builder()
+    let application = DualPolicyTester::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create application.");
-    application
+    let mut application = application
         .start_all_tasks()
         .expect("Failed to start application.");
     for _ in 0..ITERATIONS {

--- a/components/tasks/cu_rrt_star/tests/rrt_star_tester.rs
+++ b/components/tasks/cu_rrt_star/tests/rrt_star_tester.rs
@@ -109,19 +109,15 @@ fn run(logger_path: &std::path::Path) -> Vec<PlanReport> {
     let application = DualPolicyTester::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create application.");
-    let mut application = application
-        .start_all_tasks()
-        .expect("Failed to start application.");
+    let mut application = application.start().expect("Failed to start application.");
     for _ in 0..ITERATIONS {
         application
             .run_one_iteration()
             .expect("Failed to run application.");
     }
-    application
-        .stop_all_tasks()
-        .expect("Failed to stop application.");
+    application.stop().expect("Failed to stop application.");
     take_reports()
 }
 

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -5561,7 +5561,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         } else {
                             builder
                         };
-                        builder.with_sim_callback(&mut noop).build()
+                        builder.with_sim_callback(&mut noop).build_impl()
                     }
                 }
             })
@@ -5788,15 +5788,31 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
             // sim mode
             Some(quote! {
                         impl #application_name {
+                            #[deprecated(
+                                since = "1.2.0",
+                                note = "build with `build_app()` and use the lifecycle handle instead"
+                            )]
                             pub fn start_all_tasks(&mut self, sim_callback: &mut impl FnMut(SimStep) -> SimOverride) -> CuResult<()> {
                                 <Self as #app_trait<MmapSectionStorage, UnifiedLoggerWrite>>::start_all_tasks(self, sim_callback)
                             }
+                            #[deprecated(
+                                since = "1.2.0",
+                                note = "build with `build_app()` and use the lifecycle handle instead"
+                            )]
                             pub fn run_one_iteration(&mut self, sim_callback: &mut impl FnMut(SimStep) -> SimOverride) -> CuResult<()> {
                                 <Self as #app_trait<MmapSectionStorage, UnifiedLoggerWrite>>::run_one_iteration(self, sim_callback)
                             }
+                            #[deprecated(
+                                since = "1.2.0",
+                                note = "build with `build_app()` and use the lifecycle handle instead"
+                            )]
                             pub fn run(&mut self, sim_callback: &mut impl FnMut(SimStep) -> SimOverride) -> CuResult<()> {
                                 <Self as #app_trait<MmapSectionStorage, UnifiedLoggerWrite>>::run(self, sim_callback)
                             }
+                            #[deprecated(
+                                since = "1.2.0",
+                                note = "build with `build_app()` and use the lifecycle handle instead"
+                            )]
                             pub fn stop_all_tasks(&mut self, sim_callback: &mut impl FnMut(SimStep) -> SimOverride) -> CuResult<()> {
                                 <Self as #app_trait<MmapSectionStorage, UnifiedLoggerWrite>>::stop_all_tasks(self, sim_callback)
                             }
@@ -5819,15 +5835,31 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
             // std and normal mode, we use the memory mapped starage for those
             Some(quote! {
                         impl #application_name {
+                            #[deprecated(
+                                since = "1.2.0",
+                                note = "build with `build_app()` and use the lifecycle handle instead"
+                            )]
                             pub fn start_all_tasks(&mut self) -> CuResult<()> {
                                 <Self as #app_trait<MmapSectionStorage, UnifiedLoggerWrite>>::start_all_tasks(self)
                             }
+                            #[deprecated(
+                                since = "1.2.0",
+                                note = "build with `build_app()` and use the lifecycle handle instead"
+                            )]
                             pub fn run_one_iteration(&mut self) -> CuResult<()> {
                                 <Self as #app_trait<MmapSectionStorage, UnifiedLoggerWrite>>::run_one_iteration(self)
                             }
+                            #[deprecated(
+                                since = "1.2.0",
+                                note = "build with `build_app()` and use the lifecycle handle instead"
+                            )]
                             pub fn run(&mut self) -> CuResult<()> {
                                 <Self as #app_trait<MmapSectionStorage, UnifiedLoggerWrite>>::run(self)
                             }
+                            #[deprecated(
+                                since = "1.2.0",
+                                note = "build with `build_app()` and use the lifecycle handle instead"
+                            )]
                             pub fn stop_all_tasks(&mut self) -> CuResult<()> {
                                 <Self as #app_trait<MmapSectionStorage, UnifiedLoggerWrite>>::stop_all_tasks(self)
                             }
@@ -5835,6 +5867,18 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
             })
         } else {
             None // if no-std, let the user figure our the correct logger type they need to provide anyway.
+        };
+
+        let (builder_build_app_return, builder_build_app_wrap) = if sim_mode {
+            (
+                quote! { cu29::prelude::app::CuSimAppLifecycle<S, L, #application_name> },
+                quote! { cu29::prelude::app::CuSimAppLifecycle },
+            )
+        } else {
+            (
+                quote! { cu29::prelude::app::CuAppLifecycle<S, L, #application_name> },
+                quote! { cu29::prelude::app::CuAppLifecycle },
+            )
         };
 
         let application_builder = Some(quote! {
@@ -5895,8 +5939,25 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 #builder_with_log_path_method
                 #builder_sim_callback_method
 
+                /// Builds the application without lifecycle tracking.
                 #[allow(dead_code)]
+                #[deprecated(
+                    since = "1.2.0",
+                    note = "use `build_app()` to get a lifecycle-checked application handle"
+                )]
                 pub fn build(self) -> CuResult<#application_name> {
+                    self.build_impl()
+                }
+
+                /// Builds the application wrapped in its compile-time checked
+                /// lifecycle, in the `Initialized` state: start it with
+                /// `start_all_tasks()` or drive the full cycle with `run()`.
+                #[allow(dead_code)]
+                pub fn build_app(self) -> CuResult<#builder_build_app_return> {
+                    Ok(#builder_build_app_wrap::new(self.build_impl()?))
+                }
+
+                fn build_impl(self) -> CuResult<#application_name> {
                     let clock = self
                         .clock
                         .ok_or(CuError::from("Clock missing from builder"))?;

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -3828,30 +3828,38 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
         let (run_one_iteration, start_all_tasks, stop_all_tasks, run) = if sim_mode {
             (
                 quote! {
+                    #[allow(deprecated)] // implements the deprecated raw trait method
                     fn run_one_iteration(&mut self, sim_callback: &mut impl FnMut(SimStep) -> SimOverride) -> CuResult<()>
                 },
                 quote! {
+                    #[allow(deprecated)] // implements the deprecated raw trait method
                     fn start_all_tasks(&mut self, sim_callback: &mut impl FnMut(SimStep) -> SimOverride) -> CuResult<()>
                 },
                 quote! {
+                    #[allow(deprecated)] // implements the deprecated raw trait method
                     fn stop_all_tasks(&mut self, sim_callback: &mut impl FnMut(SimStep) -> SimOverride) -> CuResult<()>
                 },
                 quote! {
+                    #[allow(deprecated)] // implements the deprecated raw trait method
                     fn run(&mut self, sim_callback: &mut impl FnMut(SimStep) -> SimOverride) -> CuResult<()>
                 },
             )
         } else {
             (
                 quote! {
+                    #[allow(deprecated)] // implements the deprecated raw trait method
                     fn run_one_iteration(&mut self) -> CuResult<()>
                 },
                 quote! {
+                    #[allow(deprecated)] // implements the deprecated raw trait method
                     fn start_all_tasks(&mut self) -> CuResult<()>
                 },
                 quote! {
+                    #[allow(deprecated)] // implements the deprecated raw trait method
                     fn stop_all_tasks(&mut self) -> CuResult<()>
                 },
                 quote! {
+                    #[allow(deprecated)] // implements the deprecated raw trait method
                     fn run(&mut self) -> CuResult<()>
                 },
             )
@@ -5491,6 +5499,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 {
                     type RecordedDataSet = #mission_mod::CuStampedDataSet;
 
+                    #[allow(deprecated)] // replays via the deprecated raw iteration on purpose
                     fn replay_recorded_copperlist(
                         &mut self,
                         clock_mock: &RobotClockMock,
@@ -5790,29 +5799,33 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         impl #application_name {
                             #[deprecated(
                                 since = "1.2.0",
-                                note = "build with `build_app()` and use the lifecycle handle instead"
+                                note = "use the typed lifecycle handle returned by `build()` instead"
                             )]
+                            #[allow(deprecated)] // forwards to the deprecated raw trait method
                             pub fn start_all_tasks(&mut self, sim_callback: &mut impl FnMut(SimStep) -> SimOverride) -> CuResult<()> {
                                 <Self as #app_trait<MmapSectionStorage, UnifiedLoggerWrite>>::start_all_tasks(self, sim_callback)
                             }
                             #[deprecated(
                                 since = "1.2.0",
-                                note = "build with `build_app()` and use the lifecycle handle instead"
+                                note = "use the typed lifecycle handle returned by `build()` instead"
                             )]
+                            #[allow(deprecated)] // forwards to the deprecated raw trait method
                             pub fn run_one_iteration(&mut self, sim_callback: &mut impl FnMut(SimStep) -> SimOverride) -> CuResult<()> {
                                 <Self as #app_trait<MmapSectionStorage, UnifiedLoggerWrite>>::run_one_iteration(self, sim_callback)
                             }
                             #[deprecated(
                                 since = "1.2.0",
-                                note = "build with `build_app()` and use the lifecycle handle instead"
+                                note = "use the typed lifecycle handle returned by `build()` instead"
                             )]
+                            #[allow(deprecated)] // forwards to the deprecated raw trait method
                             pub fn run(&mut self, sim_callback: &mut impl FnMut(SimStep) -> SimOverride) -> CuResult<()> {
                                 <Self as #app_trait<MmapSectionStorage, UnifiedLoggerWrite>>::run(self, sim_callback)
                             }
                             #[deprecated(
                                 since = "1.2.0",
-                                note = "build with `build_app()` and use the lifecycle handle instead"
+                                note = "use the typed lifecycle handle returned by `build()` instead"
                             )]
+                            #[allow(deprecated)] // forwards to the deprecated raw trait method
                             pub fn stop_all_tasks(&mut self, sim_callback: &mut impl FnMut(SimStep) -> SimOverride) -> CuResult<()> {
                                 <Self as #app_trait<MmapSectionStorage, UnifiedLoggerWrite>>::stop_all_tasks(self, sim_callback)
                             }
@@ -5837,29 +5850,33 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         impl #application_name {
                             #[deprecated(
                                 since = "1.2.0",
-                                note = "build with `build_app()` and use the lifecycle handle instead"
+                                note = "use the typed lifecycle handle returned by `build()` instead"
                             )]
+                            #[allow(deprecated)] // forwards to the deprecated raw trait method
                             pub fn start_all_tasks(&mut self) -> CuResult<()> {
                                 <Self as #app_trait<MmapSectionStorage, UnifiedLoggerWrite>>::start_all_tasks(self)
                             }
                             #[deprecated(
                                 since = "1.2.0",
-                                note = "build with `build_app()` and use the lifecycle handle instead"
+                                note = "use the typed lifecycle handle returned by `build()` instead"
                             )]
+                            #[allow(deprecated)] // forwards to the deprecated raw trait method
                             pub fn run_one_iteration(&mut self) -> CuResult<()> {
                                 <Self as #app_trait<MmapSectionStorage, UnifiedLoggerWrite>>::run_one_iteration(self)
                             }
                             #[deprecated(
                                 since = "1.2.0",
-                                note = "build with `build_app()` and use the lifecycle handle instead"
+                                note = "use the typed lifecycle handle returned by `build()` instead"
                             )]
+                            #[allow(deprecated)] // forwards to the deprecated raw trait method
                             pub fn run(&mut self) -> CuResult<()> {
                                 <Self as #app_trait<MmapSectionStorage, UnifiedLoggerWrite>>::run(self)
                             }
                             #[deprecated(
                                 since = "1.2.0",
-                                note = "build with `build_app()` and use the lifecycle handle instead"
+                                note = "use the typed lifecycle handle returned by `build()` instead"
                             )]
+                            #[allow(deprecated)] // forwards to the deprecated raw trait method
                             pub fn stop_all_tasks(&mut self) -> CuResult<()> {
                                 <Self as #app_trait<MmapSectionStorage, UnifiedLoggerWrite>>::stop_all_tasks(self)
                             }
@@ -5939,21 +5956,13 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 #builder_with_log_path_method
                 #builder_sim_callback_method
 
-                /// Builds the application without lifecycle tracking.
-                #[allow(dead_code)]
-                #[deprecated(
-                    since = "1.2.0",
-                    note = "use `build_app()` to get a lifecycle-checked application handle"
-                )]
-                pub fn build(self) -> CuResult<#application_name> {
-                    self.build_impl()
-                }
-
                 /// Builds the application wrapped in its compile-time checked
                 /// lifecycle, in the `Initialized` state: start it with
-                /// `start_all_tasks()` or drive the full cycle with `run()`.
+                /// `start()` or drive the full cycle with `run_until_shutdown()`.
+                /// The pre-typestate lifecycle methods remain callable on the
+                /// returned handle (with deprecation warnings) until Copper 2.0.
                 #[allow(dead_code)]
-                pub fn build_app(self) -> CuResult<#builder_build_app_return> {
+                pub fn build(self) -> CuResult<#builder_build_app_return> {
                     Ok(#builder_build_app_wrap::new(self.build_impl()?))
                 }
 

--- a/core/cu29_derive/tests/compile_fail/lifecycle/reuse_after_start.rs
+++ b/core/cu29_derive/tests/compile_fail/lifecycle/reuse_after_start.rs
@@ -1,0 +1,11 @@
+//! Lifecycle transitions consume the handle: reusing the pre-start handle
+//! after `start_all_tasks` must fail to compile (use of moved value).
+
+use cu29::prelude::*;
+
+fn reuse_after_start<A: CuStdApplication>(app: CuStdAppLifecycle<A>) {
+    let _running = app.start_all_tasks();
+    let _ = app.start_all_tasks();
+}
+
+fn main() {}

--- a/core/cu29_derive/tests/compile_fail/lifecycle/reuse_after_start.rs
+++ b/core/cu29_derive/tests/compile_fail/lifecycle/reuse_after_start.rs
@@ -1,11 +1,11 @@
 //! Lifecycle transitions consume the handle: reusing the pre-start handle
-//! after `start_all_tasks` must fail to compile (use of moved value).
+//! after `start` must fail to compile (use of moved value).
 
 use cu29::prelude::*;
 
 fn reuse_after_start<A: CuStdApplication>(app: CuStdAppLifecycle<A>) {
-    let _running = app.start_all_tasks();
-    let _ = app.start_all_tasks();
+    let _running = app.start();
+    let _ = app.start();
 }
 
 fn main() {}

--- a/core/cu29_derive/tests/compile_fail/lifecycle/reuse_after_start.stderr
+++ b/core/cu29_derive/tests/compile_fail/lifecycle/reuse_after_start.stderr
@@ -3,13 +3,13 @@ error[E0382]: use of moved value: `app`
   |
 6 | fn reuse_after_start<A: CuStdApplication>(app: CuStdAppLifecycle<A>) {
   |                                           --- move occurs because `app` has type `CuAppLifecycle<MmapSectionStorage, MmapUnifiedLoggerWrite, A>`, which does not implement the `Copy` trait
-7 |     let _running = app.start_all_tasks();
-  |                        ----------------- `app` moved due to this method call
-8 |     let _ = app.start_all_tasks();
+7 |     let _running = app.start();
+  |                        ------- `app` moved due to this method call
+8 |     let _ = app.start();
   |             ^^^ value used here after move
   |
-note: `CuAppLifecycle::<S, L, A, State>::start_all_tasks` takes ownership of the receiver `self`, which moves `app`
+note: `CuAppLifecycle::<S, L, A, State>::start` takes ownership of the receiver `self`, which moves `app`
  --> $WORKSPACE/core/cu29_runtime/src/app.rs
   |
-  |     pub fn start_all_tasks(mut self) -> TransitionResult<S, L, A, Running> {
-  |                                ^^^^
+  |     pub fn start(mut self) -> TransitionResult<S, L, A, Running> {
+  |                      ^^^^

--- a/core/cu29_derive/tests/compile_fail/lifecycle/reuse_after_start.stderr
+++ b/core/cu29_derive/tests/compile_fail/lifecycle/reuse_after_start.stderr
@@ -1,0 +1,15 @@
+error[E0382]: use of moved value: `app`
+ --> tests/compile_fail/lifecycle/reuse_after_start.rs:8:13
+  |
+6 | fn reuse_after_start<A: CuStdApplication>(app: CuStdAppLifecycle<A>) {
+  |                                           --- move occurs because `app` has type `CuAppLifecycle<MmapSectionStorage, MmapUnifiedLoggerWrite, A>`, which does not implement the `Copy` trait
+7 |     let _running = app.start_all_tasks();
+  |                        ----------------- `app` moved due to this method call
+8 |     let _ = app.start_all_tasks();
+  |             ^^^ value used here after move
+  |
+note: `CuAppLifecycle::<S, L, A, State>::start_all_tasks` takes ownership of the receiver `self`, which moves `app`
+ --> $WORKSPACE/core/cu29_runtime/src/app.rs
+  |
+  |     pub fn start_all_tasks(mut self) -> TransitionResult<S, L, A, Running> {
+  |                                ^^^^

--- a/core/cu29_derive/tests/compile_fail/lifecycle/start_running_app.rs
+++ b/core/cu29_derive/tests/compile_fail/lifecycle/start_running_app.rs
@@ -1,11 +1,11 @@
 //! Starting an application that is already `Running` must fail to compile:
-//! `start_all_tasks` is only available from the `Initialized` and `Stopped`
-//! typestates (see the `Startable` on_unimplemented note naming the fix).
+//! `start` is only available from the `Initialized` and `Stopped` typestates
+//! (see the `Startable` on_unimplemented note naming the fix).
 
 use cu29::prelude::*;
 
 fn double_start<A: CuStdApplication>(app: CuStdAppLifecycle<A, Running>) {
-    let _ = app.start_all_tasks();
+    let _ = app.start();
 }
 
 fn main() {}

--- a/core/cu29_derive/tests/compile_fail/lifecycle/start_running_app.rs
+++ b/core/cu29_derive/tests/compile_fail/lifecycle/start_running_app.rs
@@ -1,0 +1,11 @@
+//! Starting an application that is already `Running` must fail to compile:
+//! `start_all_tasks` is only available from the `Initialized` and `Stopped`
+//! typestates (see the `Startable` on_unimplemented note naming the fix).
+
+use cu29::prelude::*;
+
+fn double_start<A: CuStdApplication>(app: CuStdAppLifecycle<A, Running>) {
+    let _ = app.start_all_tasks();
+}
+
+fn main() {}

--- a/core/cu29_derive/tests/compile_fail/lifecycle/start_running_app.stderr
+++ b/core/cu29_derive/tests/compile_fail/lifecycle/start_running_app.stderr
@@ -1,0 +1,13 @@
+error[E0599]: the method `start_all_tasks` exists for struct `CuAppLifecycle<MmapSectionStorage, MmapUnifiedLoggerWrite, A, cu29::prelude::Running>`, but its trait bounds were not satisfied
+ --> tests/compile_fail/lifecycle/start_running_app.rs:8:17
+  |
+8 |     let _ = app.start_all_tasks();
+  |                 ^^^^^^^^^^^^^^^
+  |
+ ::: $WORKSPACE/core/cu29_runtime/src/app.rs
+  |
+  | pub struct Running;
+  | ------------------ doesn't satisfy `cu29::prelude::Running: Startable`
+  |
+  = note: the following trait bounds were not satisfied:
+          `cu29::prelude::Running: Startable`

--- a/core/cu29_derive/tests/compile_fail/lifecycle/start_running_app.stderr
+++ b/core/cu29_derive/tests/compile_fail/lifecycle/start_running_app.stderr
@@ -1,8 +1,8 @@
-error[E0599]: the method `start_all_tasks` exists for struct `CuAppLifecycle<MmapSectionStorage, MmapUnifiedLoggerWrite, A, cu29::prelude::Running>`, but its trait bounds were not satisfied
+error[E0599]: the method `start` exists for struct `CuAppLifecycle<MmapSectionStorage, MmapUnifiedLoggerWrite, A, cu29::prelude::Running>`, but its trait bounds were not satisfied
  --> tests/compile_fail/lifecycle/start_running_app.rs:8:17
   |
-8 |     let _ = app.start_all_tasks();
-  |                 ^^^^^^^^^^^^^^^
+8 |     let _ = app.start();
+  |                 ^^^^^ method cannot be called due to unsatisfied trait bounds
   |
  ::: $WORKSPACE/core/cu29_runtime/src/app.rs
   |
@@ -11,3 +11,12 @@ error[E0599]: the method `start_all_tasks` exists for struct `CuAppLifecycle<Mma
   |
   = note: the following trait bounds were not satisfied:
           `cu29::prelude::Running: Startable`
+  = help: items from traits can only be used if the trait is implemented and in scope
+  = note: the following traits define an item `start`, perhaps you need to implement one of them:
+          candidate #1: `CuAnytimeTask`
+          candidate #2: `cu29::prelude::CuBridge`
+          candidate #3: `cu29::prelude::CuMonitor`
+          candidate #4: `cu29::prelude::CuSinkTask`
+          candidate #5: `cu29::prelude::CuSrcTask`
+          candidate #6: `cu29::prelude::CuTask`
+          candidate #7: `fixedbitset::range::IndexRange`

--- a/core/cu29_derive/tests/compile_pass/lifecycle/full_lifecycle.rs
+++ b/core/cu29_derive/tests/compile_pass/lifecycle/full_lifecycle.rs
@@ -1,0 +1,30 @@
+//! The legal lifecycle flows must compile: start/iterate/stop, restart from
+//! `Stopped` (mission chaining), full `run`, and cleanup from `Faulted`.
+
+use cu29::prelude::*;
+
+fn start_iterate_stop_restart<A: CuStdApplication>(app: CuStdAppLifecycle<A>) -> CuResult<()> {
+    let mut running = app.start_all_tasks()?;
+    running.run_one_iteration()?;
+    let stopped = running.stop_all_tasks()?;
+
+    // Restarting a stopped application is legal.
+    let running = stopped.start_all_tasks()?;
+    running.stop_all_tasks()?;
+    Ok(())
+}
+
+fn run_full_lifecycle<A: CuStdApplication>(app: CuStdAppLifecycle<A>) -> CuResult<()> {
+    let stopped = app.run()?;
+    // A stopped application can run again.
+    stopped.run()?;
+    Ok(())
+}
+
+fn cleanup_after_failed_start<A: CuStdApplication>(app: CuStdAppLifecycle<A>) {
+    if let Err(failed) = app.start_all_tasks() {
+        // The error hands the application back, typed Faulted: cleanup is
+        // still possible and nothing is lost.
+        let _ = failed.app.stop_all_tasks();
+    }
+}

--- a/core/cu29_derive/tests/compile_pass/lifecycle/full_lifecycle.rs
+++ b/core/cu29_derive/tests/compile_pass/lifecycle/full_lifecycle.rs
@@ -1,30 +1,31 @@
 //! The legal lifecycle flows must compile: start/iterate/stop, restart from
-//! `Stopped` (mission chaining), full `run`, and cleanup from `Faulted`.
+//! `Stopped` (mission chaining), full `run_until_shutdown`, and cleanup from
+//! `Faulted`.
 
 use cu29::prelude::*;
 
 fn start_iterate_stop_restart<A: CuStdApplication>(app: CuStdAppLifecycle<A>) -> CuResult<()> {
-    let mut running = app.start_all_tasks()?;
+    let mut running = app.start()?;
     running.run_one_iteration()?;
-    let stopped = running.stop_all_tasks()?;
+    let stopped = running.stop()?;
 
     // Restarting a stopped application is legal.
-    let running = stopped.start_all_tasks()?;
-    running.stop_all_tasks()?;
+    let running = stopped.start()?;
+    running.stop()?;
     Ok(())
 }
 
 fn run_full_lifecycle<A: CuStdApplication>(app: CuStdAppLifecycle<A>) -> CuResult<()> {
-    let stopped = app.run()?;
+    let stopped = app.run_until_shutdown()?;
     // A stopped application can run again.
-    stopped.run()?;
+    stopped.run_until_shutdown()?;
     Ok(())
 }
 
 fn cleanup_after_failed_start<A: CuStdApplication>(app: CuStdAppLifecycle<A>) {
-    if let Err(failed) = app.start_all_tasks() {
+    if let Err(failed) = app.start() {
         // The error hands the application back, typed Faulted: cleanup is
         // still possible and nothing is lost.
-        let _ = failed.app.stop_all_tasks();
+        let _ = failed.app.stop();
     }
 }

--- a/core/cu29_derive/tests/compile_pass/lifecycle/legacy_shape.rs
+++ b/core/cu29_derive/tests/compile_pass/lifecycle/legacy_shape.rs
@@ -1,0 +1,15 @@
+//! Pre-typestate code keeps its shape: the raw (deprecated) lifecycle API is
+//! still callable on the `Initialized` handle that `build()` returns, so
+//! legacy programs compile unchanged and only pick up deprecation warnings.
+
+use cu29::prelude::*;
+
+#[allow(deprecated)]
+fn legacy_flow<A: CuStdApplication>(mut app: CuStdAppLifecycle<A>) -> CuResult<()> {
+    app.start_all_tasks()?;
+    app.run_one_iteration()?;
+    app.stop_all_tasks()?;
+    Ok(())
+}
+
+fn main() {}

--- a/core/cu29_runtime/src/app.rs
+++ b/core/cu29_runtime/src/app.rs
@@ -16,6 +16,7 @@ use std::vec::Vec;
 
 #[cfg(not(feature = "std"))]
 mod imp {
+    pub use alloc::boxed::Box;
     pub use alloc::string::String;
 }
 
@@ -344,8 +345,13 @@ impl Stoppable for Faulted {}
 /// available (deprecated on the generated application) for framework-level
 /// harnesses such as replay engines; [`into_inner`](CuAppLifecycle::into_inner)
 /// drops back to that level when needed.
+///
+/// The application is boxed internally: generated applications embed their
+/// copperlist pools and can be megabytes, so the consuming transitions move a
+/// pointer instead of the application itself (which in debug builds would
+/// blow through a test thread's stack).
 pub struct CuAppLifecycle<S, L, A, State = Initialized> {
-    app: A,
+    app: Box<A>,
     _lifecycle: PhantomData<(S, L, State)>,
 }
 
@@ -426,7 +432,7 @@ impl<S, L, A, State> CuAppLifecycle<S, L, A, State> {
     /// Consumes the wrapper and returns the application, dropping the
     /// compile-time lifecycle tracking.
     pub fn into_inner(self) -> A {
-        self.app
+        *self.app
     }
 }
 
@@ -439,7 +445,7 @@ where
     /// Wraps a freshly built application in the `Initialized` state.
     pub fn new(app: A) -> Self {
         CuAppLifecycle {
-            app,
+            app: Box::new(app),
             _lifecycle: PhantomData,
         }
     }
@@ -532,7 +538,7 @@ where
 /// `restore_keyframe`) are framework-level and stay on the raw traits.
 #[cfg(feature = "std")]
 pub struct CuSimAppLifecycle<S, L, A, State = Initialized> {
-    app: A,
+    app: Box<A>,
     _lifecycle: PhantomData<(S, L, State)>,
 }
 
@@ -618,7 +624,7 @@ impl<S, L, A, State> CuSimAppLifecycle<S, L, A, State> {
     /// Consumes the wrapper and returns the application, dropping the
     /// compile-time lifecycle tracking.
     pub fn into_inner(self) -> A {
-        self.app
+        *self.app
     }
 }
 
@@ -632,7 +638,7 @@ where
     /// Wraps a freshly built simulation application in the `Initialized` state.
     pub fn new(app: A) -> Self {
         CuSimAppLifecycle {
-            app,
+            app: Box::new(app),
             _lifecycle: PhantomData,
         }
     }

--- a/core/cu29_runtime/src/app.rs
+++ b/core/cu29_runtime/src/app.rs
@@ -94,6 +94,10 @@ pub trait CuApplication<S: SectionStorage, L: UnifiedLogWrite<S> + 'static> {
     /// * `Ok(())` - If all tasks are started successfully.
     /// * `Err(CuResult)` - If an error occurs while attempting to start one
     ///   or more tasks.
+    #[deprecated(
+        since = "1.2.0",
+        note = "use the typed transition `start()` on the handle returned by `build()`"
+    )]
     fn start_all_tasks(&mut self) -> CuResult<()>;
 
     /// Executes a single iteration of copper-generated runtime (generating and logging one copperlist)
@@ -103,6 +107,10 @@ pub trait CuApplication<S: SectionStorage, L: UnifiedLogWrite<S> + 'static> {
     /// * `CuResult<()>` - Returns `Ok(())` if the iteration completes successfully, or an error
     ///   wrapped in `CuResult` if something goes wrong during execution.
     ///
+    #[deprecated(
+        since = "1.2.0",
+        note = "use `run_one_iteration()` on the Running handle from `build()?.start()?`"
+    )]
     fn run_one_iteration(&mut self) -> CuResult<()>;
 
     /// Runs indefinitely looping over run_one_iteration
@@ -113,6 +121,10 @@ pub trait CuApplication<S: SectionStorage, L: UnifiedLogWrite<S> + 'static> {
     /// operation.
     /// - On success, the result is `Ok(())`.
     /// - On failure, an appropriate error wrapped in `CuResult` is returned.
+    #[deprecated(
+        since = "1.2.0",
+        note = "use the typed transition `run_until_shutdown()` on the handle returned by `build()`"
+    )]
     fn run(&mut self) -> CuResult<()>;
 
     /// Stops all tasks managed by the application/runtime.
@@ -124,6 +136,10 @@ pub trait CuApplication<S: SectionStorage, L: UnifiedLogWrite<S> + 'static> {
     /// - On success, the result is `Ok(())`.
     /// - On failure, an appropriate error wrapped in `CuResult` is returned.
     ///
+    #[deprecated(
+        since = "1.2.0",
+        note = "use the typed transition `stop()` on the Running handle"
+    )]
     fn stop_all_tasks(&mut self) -> CuResult<()>;
 
     /// Restore all tasks from the given frozen state
@@ -160,6 +176,10 @@ pub trait CuSimApplication<S: SectionStorage, L: UnifiedLogWrite<S> + 'static> {
     /// * `Ok(())` - If all tasks are started successfully.
     /// * `Err(CuResult)` - If an error occurs while attempting to start one
     ///   or more tasks.
+    #[deprecated(
+        since = "1.2.0",
+        note = "use the typed transition `start()` on the handle returned by `build()`"
+    )]
     fn start_all_tasks(
         &mut self,
         sim_callback: &mut impl for<'z> FnMut(Self::Step<'z>) -> SimOverride,
@@ -174,6 +194,10 @@ pub trait CuSimApplication<S: SectionStorage, L: UnifiedLogWrite<S> + 'static> {
     ///
     /// * `CuResult<()>` - Returns `Ok(())` if the iteration completes successfully, or an error
     ///   wrapped in `CuResult` if something goes wrong during execution.
+    #[deprecated(
+        since = "1.2.0",
+        note = "use `run_one_iteration()` on the Running handle from `build()?.start()?`"
+    )]
     fn run_one_iteration(
         &mut self,
         sim_callback: &mut impl for<'z> FnMut(Self::Step<'z>) -> SimOverride,
@@ -190,6 +214,10 @@ pub trait CuSimApplication<S: SectionStorage, L: UnifiedLogWrite<S> + 'static> {
     /// operation.
     /// - On success, the result is `Ok(())`.
     /// - On failure, an appropriate error wrapped in `CuResult` is returned.
+    #[deprecated(
+        since = "1.2.0",
+        note = "use the typed transition `run_until_shutdown()` on the handle returned by `build()`"
+    )]
     fn run(
         &mut self,
         sim_callback: &mut impl for<'z> FnMut(Self::Step<'z>) -> SimOverride,
@@ -206,6 +234,10 @@ pub trait CuSimApplication<S: SectionStorage, L: UnifiedLogWrite<S> + 'static> {
     /// operation.
     /// - On success, the result is `Ok(())`.
     /// - On failure, an appropriate error wrapped in `CuResult` is returned.
+    #[deprecated(
+        since = "1.2.0",
+        note = "use the typed transition `stop()` on the Running handle"
+    )]
     fn stop_all_tasks(
         &mut self,
         sim_callback: &mut impl for<'z> FnMut(Self::Step<'z>) -> SimOverride,
@@ -323,16 +355,16 @@ impl Stoppable for Faulted {}
 /// transitions that are legal from it.
 ///
 /// ```text
-///                 start_all_tasks
+///                      start
 ///   Initialized ------------------> Running <---+
 ///        |                            |  |      | run_one_iteration
-///        | run                        |  +------+
-///        |                            | stop_all_tasks
+///        | run_until_shutdown         |  +------+
+///        |                            | stop
 ///        +--------> Stopped <---------+
 ///                    |   ^
-///                    |   | stop_all_tasks (cleanup)
+///                    |   | stop (cleanup)
 ///        (restart)   |  Faulted <--- any failed transition
-///                    +---> start_all_tasks / run again
+///                    +---> start / run_until_shutdown again
 /// ```
 ///
 /// Transitions consume the wrapper and return it typed with the new state, so
@@ -472,7 +504,8 @@ where
     ///
     /// On failure the application may be partially started; it is returned
     /// typed `Faulted` inside the error so it can be cleaned up.
-    pub fn start_all_tasks(mut self) -> TransitionResult<S, L, A, Running> {
+    #[allow(deprecated)] // forwards to the raw trait, deprecated for direct use only
+    pub fn start(mut self) -> TransitionResult<S, L, A, Running> {
         match self.app.start_all_tasks() {
             Ok(()) => Ok(self.into_state()),
             Err(error) => Err(LifecycleError {
@@ -484,7 +517,8 @@ where
 
     /// Runs the full lifecycle (start, iterate until shutdown, stop),
     /// transitioning to `Stopped` on success.
-    pub fn run(mut self) -> TransitionResult<S, L, A, Stopped> {
+    #[allow(deprecated)] // forwards to the raw trait, deprecated for direct use only
+    pub fn run_until_shutdown(mut self) -> TransitionResult<S, L, A, Stopped> {
         match self.app.run() {
             Ok(()) => Ok(self.into_state()),
             Err(error) => Err(LifecycleError {
@@ -504,6 +538,7 @@ where
     /// Executes one iteration of the runtime. An iteration error does not
     /// change the lifecycle state: the caller decides whether to keep
     /// iterating or stop.
+    #[allow(deprecated)] // forwards to the raw trait, deprecated for direct use only
     pub fn run_one_iteration(&mut self) -> CuResult<()> {
         self.app.run_one_iteration()
     }
@@ -519,7 +554,8 @@ where
     /// Stops all tasks, transitioning to `Stopped`. From `Faulted` this is a
     /// best-effort cleanup. On failure the application is handed back typed
     /// `Faulted` again.
-    pub fn stop_all_tasks(mut self) -> TransitionResult<S, L, A, Stopped> {
+    #[allow(deprecated)] // forwards to the raw trait, deprecated for direct use only
+    pub fn stop(mut self) -> TransitionResult<S, L, A, Stopped> {
         match self.app.stop_all_tasks() {
             Ok(()) => Ok(self.into_state()),
             Err(error) => Err(LifecycleError {
@@ -527,6 +563,61 @@ where
                 app: self.into_state(),
             }),
         }
+    }
+}
+
+/// Read access to the wrapped application in every lifecycle state, so
+/// conveniences like `app.clock()` keep working without ceremony.
+impl<S, L, A, State> core::ops::Deref for CuAppLifecycle<S, L, A, State> {
+    type Target = A;
+
+    fn deref(&self) -> &A {
+        &self.app
+    }
+}
+
+/// Mutable access only before the application is started: after a typed
+/// start, raw mutable access could bypass the lifecycle guarantees.
+impl<S, L, A> core::ops::DerefMut for CuAppLifecycle<S, L, A, Initialized> {
+    fn deref_mut(&mut self) -> &mut A {
+        &mut self.app
+    }
+}
+
+/// Legacy escape hatch: the raw (deprecated) lifecycle API remains callable
+/// on what `build()` returns, so pre-typestate code compiles unchanged and
+/// only picks up deprecation warnings. Raw calls do not advance the
+/// typestate; mixing them with typed transitions is outside the typestate
+/// guarantees.
+#[allow(deprecated)]
+impl<S, L, A> CuApplication<S, L> for CuAppLifecycle<S, L, A, Initialized>
+where
+    S: SectionStorage,
+    L: UnifiedLogWrite<S> + 'static,
+    A: CuApplication<S, L>,
+{
+    fn get_original_config() -> String {
+        A::get_original_config()
+    }
+
+    fn start_all_tasks(&mut self) -> CuResult<()> {
+        self.app.start_all_tasks()
+    }
+
+    fn run_one_iteration(&mut self) -> CuResult<()> {
+        self.app.run_one_iteration()
+    }
+
+    fn run(&mut self) -> CuResult<()> {
+        self.app.run()
+    }
+
+    fn stop_all_tasks(&mut self) -> CuResult<()> {
+        self.app.stop_all_tasks()
+    }
+
+    fn restore_keyframe(&mut self, freezer: &KeyFrame) -> CuResult<()> {
+        self.app.restore_keyframe(freezer)
     }
 }
 
@@ -656,7 +747,8 @@ where
     ///
     /// On failure the application may be partially started; it is returned
     /// typed `Faulted` inside the error so it can be cleaned up.
-    pub fn start_all_tasks(
+    #[allow(deprecated)] // forwards to the raw trait, deprecated for direct use only
+    pub fn start(
         mut self,
         sim_callback: &mut impl for<'z> FnMut(<A as CuSimApplication<S, L>>::Step<'z>) -> SimOverride,
     ) -> SimTransitionResult<S, L, A, Running> {
@@ -671,7 +763,8 @@ where
 
     /// Runs the full lifecycle (start, iterate until shutdown, stop),
     /// transitioning to `Stopped` on success.
-    pub fn run(
+    #[allow(deprecated)] // forwards to the raw trait, deprecated for direct use only
+    pub fn run_until_shutdown(
         mut self,
         sim_callback: &mut impl for<'z> FnMut(<A as CuSimApplication<S, L>>::Step<'z>) -> SimOverride,
     ) -> SimTransitionResult<S, L, A, Stopped> {
@@ -695,6 +788,7 @@ where
     /// Executes one iteration of the runtime. An iteration error does not
     /// change the lifecycle state: the caller decides whether to keep
     /// iterating or stop.
+    #[allow(deprecated)] // forwards to the raw trait, deprecated for direct use only
     pub fn run_one_iteration(
         &mut self,
         sim_callback: &mut impl for<'z> FnMut(<A as CuSimApplication<S, L>>::Step<'z>) -> SimOverride,
@@ -714,7 +808,8 @@ where
     /// Stops all tasks, transitioning to `Stopped`. From `Faulted` this is a
     /// best-effort cleanup. On failure the application is handed back typed
     /// `Faulted` again.
-    pub fn stop_all_tasks(
+    #[allow(deprecated)] // forwards to the raw trait, deprecated for direct use only
+    pub fn stop(
         mut self,
         sim_callback: &mut impl for<'z> FnMut(<A as CuSimApplication<S, L>>::Step<'z>) -> SimOverride,
     ) -> SimTransitionResult<S, L, A, Stopped> {
@@ -725,6 +820,79 @@ where
                 app: self.into_state(),
             }),
         }
+    }
+}
+
+/// Read access to the wrapped application in every lifecycle state.
+#[cfg(feature = "std")]
+impl<S, L, A, State> core::ops::Deref for CuSimAppLifecycle<S, L, A, State> {
+    type Target = A;
+
+    fn deref(&self) -> &A {
+        &self.app
+    }
+}
+
+/// Mutable access only before the application is started, mirroring
+/// [`CuAppLifecycle`].
+#[cfg(feature = "std")]
+impl<S, L, A> core::ops::DerefMut for CuSimAppLifecycle<S, L, A, Initialized> {
+    fn deref_mut(&mut self) -> &mut A {
+        &mut self.app
+    }
+}
+
+/// Legacy escape hatch mirroring the [`CuApplication`] impl on
+/// [`CuAppLifecycle`]: pre-typestate simulation code compiles unchanged
+/// against what `build()` returns and only picks up deprecation warnings.
+#[cfg(feature = "std")]
+#[allow(deprecated)]
+impl<S, L, A> CuSimApplication<S, L> for CuSimAppLifecycle<S, L, A, Initialized>
+where
+    S: SectionStorage,
+    L: UnifiedLogWrite<S> + 'static,
+    A: CuSimApplication<S, L>,
+{
+    type Step<'z> = <A as CuSimApplication<S, L>>::Step<'z>;
+
+    fn get_original_config() -> String {
+        A::get_original_config()
+    }
+
+    fn mission_id() -> Option<&'static str> {
+        A::mission_id()
+    }
+
+    fn start_all_tasks(
+        &mut self,
+        sim_callback: &mut impl for<'z> FnMut(Self::Step<'z>) -> SimOverride,
+    ) -> CuResult<()> {
+        self.app.start_all_tasks(sim_callback)
+    }
+
+    fn run_one_iteration(
+        &mut self,
+        sim_callback: &mut impl for<'z> FnMut(Self::Step<'z>) -> SimOverride,
+    ) -> CuResult<()> {
+        self.app.run_one_iteration(sim_callback)
+    }
+
+    fn run(
+        &mut self,
+        sim_callback: &mut impl for<'z> FnMut(Self::Step<'z>) -> SimOverride,
+    ) -> CuResult<()> {
+        self.app.run(sim_callback)
+    }
+
+    fn stop_all_tasks(
+        &mut self,
+        sim_callback: &mut impl for<'z> FnMut(Self::Step<'z>) -> SimOverride,
+    ) -> CuResult<()> {
+        self.app.stop_all_tasks(sim_callback)
+    }
+
+    fn restore_keyframe(&mut self, freezer: &KeyFrame) -> CuResult<()> {
+        self.app.restore_keyframe(freezer)
     }
 }
 
@@ -742,6 +910,7 @@ mod lifecycle_tests {
         fail_stop: bool,
     }
 
+    #[allow(deprecated)] // mocks implement the deprecated raw trait methods
     impl<S: SectionStorage, L: UnifiedLogWrite<S> + 'static> CuApplication<S, L> for MockApp {
         fn get_original_config() -> String {
             String::new()
@@ -786,14 +955,14 @@ mod lifecycle_tests {
     #[test]
     fn full_cycle_with_restart() {
         let app = Lifecycle::new(MockApp::default());
-        let mut running = app.start_all_tasks().unwrap();
+        let mut running = app.start().unwrap();
         running.run_one_iteration().unwrap();
         running.run_one_iteration().unwrap();
-        let stopped = running.stop_all_tasks().unwrap();
+        let stopped = running.stop().unwrap();
 
         // Restarting a stopped application is legal (mission chaining).
-        let running = stopped.start_all_tasks().unwrap();
-        let stopped = running.stop_all_tasks().unwrap();
+        let running = stopped.start().unwrap();
+        let stopped = running.stop().unwrap();
 
         let mock = stopped.into_inner();
         assert_eq!(mock.started, 2);
@@ -804,8 +973,8 @@ mod lifecycle_tests {
     #[test]
     fn run_transitions_to_stopped_and_can_run_again() {
         let app = Lifecycle::new(MockApp::default());
-        let stopped = app.run().unwrap();
-        let stopped = stopped.run().unwrap();
+        let stopped = app.run_until_shutdown().unwrap();
+        let stopped = stopped.run_until_shutdown().unwrap();
         assert_eq!(stopped.inner().runs, 2);
     }
 
@@ -815,11 +984,11 @@ mod lifecycle_tests {
             fail_start: true,
             ..Default::default()
         });
-        let err = app.start_all_tasks().unwrap_err();
+        let err = app.start().unwrap_err();
         assert!(err.error.to_string().contains("mock start failure"));
 
         // The only legal transition from Faulted is the cleanup.
-        let stopped = err.app.stop_all_tasks().unwrap();
+        let stopped = err.app.stop().unwrap();
         let mock = stopped.into_inner();
         assert_eq!(mock.started, 0);
         assert_eq!(mock.stopped, 1);
@@ -831,8 +1000,8 @@ mod lifecycle_tests {
             fail_stop: true,
             ..Default::default()
         });
-        let running = app.start_all_tasks().unwrap();
-        let err = running.stop_all_tasks().unwrap_err();
+        let running = app.start().unwrap();
+        let err = running.stop().unwrap_err();
         assert!(err.error.to_string().contains("mock stop failure"));
     }
 
@@ -843,7 +1012,7 @@ mod lifecycle_tests {
                 fail_start: true,
                 ..Default::default()
             });
-            let _running = app.start_all_tasks()?;
+            let _running = app.start()?;
             Ok(())
         }
         let error = drive().unwrap_err();
@@ -860,6 +1029,7 @@ mod lifecycle_tests {
 
     struct MockStep;
 
+    #[allow(deprecated)] // mocks implement the deprecated raw trait methods
     impl<S: SectionStorage, L: UnifiedLogWrite<S> + 'static> CuSimApplication<S, L> for MockSimApp {
         type Step<'z> = MockStep;
 
@@ -921,9 +1091,9 @@ mod lifecycle_tests {
         };
 
         let app = SimLifecycle::new(MockSimApp::default());
-        let mut running = app.start_all_tasks(&mut cb).unwrap();
+        let mut running = app.start(&mut cb).unwrap();
         running.run_one_iteration(&mut cb).unwrap();
-        let stopped = running.stop_all_tasks(&mut cb).unwrap();
+        let stopped = running.stop(&mut cb).unwrap();
 
         let mock = stopped.into_inner();
         assert_eq!(mock.started, 1);
@@ -939,9 +1109,9 @@ mod lifecycle_tests {
             fail_start: true,
             ..Default::default()
         });
-        let err = app.start_all_tasks(&mut cb).unwrap_err();
+        let err = app.start(&mut cb).unwrap_err();
         assert!(err.error.to_string().contains("mock sim start failure"));
-        let stopped = err.app.stop_all_tasks(&mut cb).unwrap();
+        let stopped = err.app.stop(&mut cb).unwrap();
         assert_eq!(stopped.inner().stopped, 1);
     }
 }

--- a/core/cu29_runtime/src/app.rs
+++ b/core/cu29_runtime/src/app.rs
@@ -339,8 +339,11 @@ impl Stoppable for Faulted {}
 /// the application is handed back inside [`LifecycleError`], typed [`Faulted`],
 /// so cleanup is still possible and nothing is lost.
 ///
-/// This wrapper is opt-in: the underlying [`CuApplication`] methods remain
-/// available on the unwrapped application for existing code.
+/// This is the default construction path: the generated application builder
+/// hands one out from `build_app()`. The raw [`CuApplication`] methods remain
+/// available (deprecated on the generated application) for framework-level
+/// harnesses such as replay engines; [`into_inner`](CuAppLifecycle::into_inner)
+/// drops back to that level when needed.
 pub struct CuAppLifecycle<S, L, A, State = Initialized> {
     app: A,
     _lifecycle: PhantomData<(S, L, State)>,
@@ -440,6 +443,16 @@ where
             _lifecycle: PhantomData,
         }
     }
+
+    /// Mutable access to the wrapped application, only before it is started.
+    ///
+    /// This exists for pre-start configuration (attaching monitors,
+    /// inspecting the runtime...). Once started, only the read-only
+    /// [`inner`](CuAppLifecycle::inner) view remains available so the
+    /// lifecycle transitions cannot be bypassed mid-flight.
+    pub fn inner_mut(&mut self) -> &mut A {
+        &mut self.app
+    }
 }
 
 impl<S, L, A, State> CuAppLifecycle<S, L, A, State>
@@ -504,6 +517,204 @@ where
         match self.app.stop_all_tasks() {
             Ok(()) => Ok(self.into_state()),
             Err(error) => Err(LifecycleError {
+                error,
+                app: self.into_state(),
+            }),
+        }
+    }
+}
+
+/// Compile-time enforced lifecycle for a [`CuSimApplication`].
+///
+/// Simulation counterpart of [`CuAppLifecycle`]: same states and transitions,
+/// with each transition threading the `sim_callback` the simulation runtime
+/// requires. Replay primitives (`replay_recorded_copperlist`,
+/// `restore_keyframe`) are framework-level and stay on the raw traits.
+#[cfg(feature = "std")]
+pub struct CuSimAppLifecycle<S, L, A, State = Initialized> {
+    app: A,
+    _lifecycle: PhantomData<(S, L, State)>,
+}
+
+#[cfg(feature = "std")]
+impl<S, L, A, State> fmt::Debug for CuSimAppLifecycle<S, L, A, State> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CuSimAppLifecycle")
+            .field("state", &core::any::type_name::<State>())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Convenience alias for simulation applications using the default std
+/// unified logger, mirroring [`CuStdAppLifecycle`].
+#[cfg(feature = "std")]
+pub type CuStdSimAppLifecycle<A, State = Initialized> =
+    CuSimAppLifecycle<MmapSectionStorage, cu29_unifiedlog::UnifiedLoggerWrite, A, State>;
+
+/// Result of a simulation lifecycle transition: on success the application
+/// typed with its new state, on failure [`SimLifecycleError`] carrying the
+/// application typed [`Faulted`].
+#[cfg(feature = "std")]
+pub type SimTransitionResult<S, L, A, Next> =
+    Result<CuSimAppLifecycle<S, L, A, Next>, SimLifecycleError<S, L, A>>;
+
+/// A failed simulation lifecycle transition, mirroring [`LifecycleError`].
+#[cfg(feature = "std")]
+pub struct SimLifecycleError<S, L, A> {
+    /// The error reported by the underlying application.
+    pub error: CuError,
+    /// The application, in the `Faulted` state. Call `stop_all_tasks` on it to clean up.
+    pub app: CuSimAppLifecycle<S, L, A, Faulted>,
+}
+
+#[cfg(feature = "std")]
+impl<S, L, A> fmt::Debug for SimLifecycleError<S, L, A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SimLifecycleError")
+            .field("error", &self.error)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(feature = "std")]
+impl<S, L, A> fmt::Display for SimLifecycleError<S, L, A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "lifecycle transition failed: {}", self.error)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<S, L, A> core::error::Error for SimLifecycleError<S, L, A> {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
+/// Allows `?` in functions returning `CuResult` when the faulted application
+/// does not need to be recovered.
+#[cfg(feature = "std")]
+impl<S, L, A> From<SimLifecycleError<S, L, A>> for CuError {
+    fn from(value: SimLifecycleError<S, L, A>) -> Self {
+        value.error
+    }
+}
+
+#[cfg(feature = "std")]
+impl<S, L, A, State> CuSimAppLifecycle<S, L, A, State> {
+    /// Rewraps the application under a new typestate. Private: state changes
+    /// only happen through the lifecycle transitions.
+    fn into_state<Next>(self) -> CuSimAppLifecycle<S, L, A, Next> {
+        CuSimAppLifecycle {
+            app: self.app,
+            _lifecycle: PhantomData,
+        }
+    }
+
+    /// Read-only access to the wrapped application.
+    pub fn inner(&self) -> &A {
+        &self.app
+    }
+
+    /// Consumes the wrapper and returns the application, dropping the
+    /// compile-time lifecycle tracking.
+    pub fn into_inner(self) -> A {
+        self.app
+    }
+}
+
+#[cfg(feature = "std")]
+impl<S, L, A> CuSimAppLifecycle<S, L, A, Initialized>
+where
+    S: SectionStorage,
+    L: UnifiedLogWrite<S> + 'static,
+    A: CuSimApplication<S, L>,
+{
+    /// Wraps a freshly built simulation application in the `Initialized` state.
+    pub fn new(app: A) -> Self {
+        CuSimAppLifecycle {
+            app,
+            _lifecycle: PhantomData,
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<S, L, A, State> CuSimAppLifecycle<S, L, A, State>
+where
+    S: SectionStorage,
+    L: UnifiedLogWrite<S> + 'static,
+    A: CuSimApplication<S, L>,
+    State: Startable,
+{
+    /// Starts all tasks, transitioning to `Running`.
+    ///
+    /// On failure the application may be partially started; it is returned
+    /// typed `Faulted` inside the error so it can be cleaned up.
+    pub fn start_all_tasks(
+        mut self,
+        sim_callback: &mut impl for<'z> FnMut(<A as CuSimApplication<S, L>>::Step<'z>) -> SimOverride,
+    ) -> SimTransitionResult<S, L, A, Running> {
+        match self.app.start_all_tasks(sim_callback) {
+            Ok(()) => Ok(self.into_state()),
+            Err(error) => Err(SimLifecycleError {
+                error,
+                app: self.into_state(),
+            }),
+        }
+    }
+
+    /// Runs the full lifecycle (start, iterate until shutdown, stop),
+    /// transitioning to `Stopped` on success.
+    pub fn run(
+        mut self,
+        sim_callback: &mut impl for<'z> FnMut(<A as CuSimApplication<S, L>>::Step<'z>) -> SimOverride,
+    ) -> SimTransitionResult<S, L, A, Stopped> {
+        match self.app.run(sim_callback) {
+            Ok(()) => Ok(self.into_state()),
+            Err(error) => Err(SimLifecycleError {
+                error,
+                app: self.into_state(),
+            }),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<S, L, A> CuSimAppLifecycle<S, L, A, Running>
+where
+    S: SectionStorage,
+    L: UnifiedLogWrite<S> + 'static,
+    A: CuSimApplication<S, L>,
+{
+    /// Executes one iteration of the runtime. An iteration error does not
+    /// change the lifecycle state: the caller decides whether to keep
+    /// iterating or stop.
+    pub fn run_one_iteration(
+        &mut self,
+        sim_callback: &mut impl for<'z> FnMut(<A as CuSimApplication<S, L>>::Step<'z>) -> SimOverride,
+    ) -> CuResult<()> {
+        self.app.run_one_iteration(sim_callback)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<S, L, A, State> CuSimAppLifecycle<S, L, A, State>
+where
+    S: SectionStorage,
+    L: UnifiedLogWrite<S> + 'static,
+    A: CuSimApplication<S, L>,
+    State: Stoppable,
+{
+    /// Stops all tasks, transitioning to `Stopped`. From `Faulted` this is a
+    /// best-effort cleanup. On failure the application is handed back typed
+    /// `Faulted` again.
+    pub fn stop_all_tasks(
+        mut self,
+        sim_callback: &mut impl for<'z> FnMut(<A as CuSimApplication<S, L>>::Step<'z>) -> SimOverride,
+    ) -> SimTransitionResult<S, L, A, Stopped> {
+        match self.app.stop_all_tasks(sim_callback) {
+            Ok(()) => Ok(self.into_state()),
+            Err(error) => Err(SimLifecycleError {
                 error,
                 app: self.into_state(),
             }),
@@ -631,5 +842,100 @@ mod lifecycle_tests {
         }
         let error = drive().unwrap_err();
         assert!(error.to_string().contains("mock start failure"));
+    }
+
+    #[derive(Default)]
+    struct MockSimApp {
+        started: u32,
+        stopped: u32,
+        iterations: u32,
+        fail_start: bool,
+    }
+
+    struct MockStep;
+
+    impl<S: SectionStorage, L: UnifiedLogWrite<S> + 'static> CuSimApplication<S, L> for MockSimApp {
+        type Step<'z> = MockStep;
+
+        fn get_original_config() -> String {
+            String::new()
+        }
+
+        fn start_all_tasks(
+            &mut self,
+            sim_callback: &mut impl for<'z> FnMut(Self::Step<'z>) -> SimOverride,
+        ) -> CuResult<()> {
+            if self.fail_start {
+                return Err("mock sim start failure".into());
+            }
+            let _ = sim_callback(MockStep);
+            self.started += 1;
+            Ok(())
+        }
+
+        fn run_one_iteration(
+            &mut self,
+            sim_callback: &mut impl for<'z> FnMut(Self::Step<'z>) -> SimOverride,
+        ) -> CuResult<()> {
+            let _ = sim_callback(MockStep);
+            self.iterations += 1;
+            Ok(())
+        }
+
+        fn run(
+            &mut self,
+            sim_callback: &mut impl for<'z> FnMut(Self::Step<'z>) -> SimOverride,
+        ) -> CuResult<()> {
+            let _ = sim_callback(MockStep);
+            Ok(())
+        }
+
+        fn stop_all_tasks(
+            &mut self,
+            sim_callback: &mut impl for<'z> FnMut(Self::Step<'z>) -> SimOverride,
+        ) -> CuResult<()> {
+            let _ = sim_callback(MockStep);
+            self.stopped += 1;
+            Ok(())
+        }
+
+        fn restore_keyframe(&mut self, _freezer: &KeyFrame) -> CuResult<()> {
+            Ok(())
+        }
+    }
+
+    type SimLifecycle = CuStdSimAppLifecycle<MockSimApp>;
+
+    #[test]
+    fn sim_full_cycle_threads_the_callback() {
+        let mut callback_calls = 0u32;
+        let mut cb = |_step: MockStep| -> SimOverride {
+            callback_calls += 1;
+            SimOverride::ExecuteByRuntime
+        };
+
+        let app = SimLifecycle::new(MockSimApp::default());
+        let mut running = app.start_all_tasks(&mut cb).unwrap();
+        running.run_one_iteration(&mut cb).unwrap();
+        let stopped = running.stop_all_tasks(&mut cb).unwrap();
+
+        let mock = stopped.into_inner();
+        assert_eq!(mock.started, 1);
+        assert_eq!(mock.iterations, 1);
+        assert_eq!(mock.stopped, 1);
+        assert_eq!(callback_calls, 3);
+    }
+
+    #[test]
+    fn sim_failed_start_hands_back_a_faulted_app_for_cleanup() {
+        let mut cb = |_step: MockStep| -> SimOverride { SimOverride::ExecuteByRuntime };
+        let app = SimLifecycle::new(MockSimApp {
+            fail_start: true,
+            ..Default::default()
+        });
+        let err = app.start_all_tasks(&mut cb).unwrap_err();
+        assert!(err.error.to_string().contains("mock sim start failure"));
+        let stopped = err.app.stop_all_tasks(&mut cb).unwrap();
+        assert_eq!(stopped.inner().stopped, 1);
     }
 }

--- a/core/cu29_runtime/src/app.rs
+++ b/core/cu29_runtime/src/app.rs
@@ -1,6 +1,8 @@
 use crate::curuntime::KeyFrame;
+use core::fmt;
+use core::marker::PhantomData;
 use cu29_traits::CopperListTuple;
-use cu29_traits::CuResult;
+use cu29_traits::{CuError, CuResult};
 use cu29_unifiedlog::{SectionStorage, UnifiedLogWrite};
 
 #[cfg(feature = "std")]
@@ -265,4 +267,369 @@ pub trait CuDistributedReplayApplication<S: SectionStorage, L: UnifiedLogWrite<S
     ) -> CuResult<Self>
     where
         Self: Sized;
+}
+
+/// Typestate marker: the application is built but its tasks have not been started yet.
+pub struct Initialized;
+
+/// Typestate marker: tasks are started and iterations can be executed.
+pub struct Running;
+
+/// Typestate marker: tasks are stopped. The application can be started again,
+/// which is useful to chain missions within the same process.
+pub struct Stopped;
+
+/// Typestate marker: a lifecycle transition failed and the application may be
+/// partially started or partially stopped. The only way forward is a
+/// best-effort cleanup through `stop_all_tasks`.
+pub struct Faulted;
+
+mod sealed {
+    /// Seals the lifecycle state traits so external code cannot add new states
+    /// and bypass the transitions enforced by [`CuAppLifecycle`](super::CuAppLifecycle).
+    pub trait Sealed {}
+    impl Sealed for super::Initialized {}
+    impl Sealed for super::Running {}
+    impl Sealed for super::Stopped {}
+    impl Sealed for super::Faulted {}
+}
+
+/// Lifecycle states from which the application tasks can be started (`Initialized`, `Stopped`).
+#[diagnostic::on_unimplemented(
+    message = "the application cannot be started from the `{Self}` lifecycle state",
+    label = "`start_all_tasks` and `run` require an `Initialized` or `Stopped` application",
+    note = "a `Running` application is already started and a `Faulted` application must first be cleaned up with `stop_all_tasks`"
+)]
+pub trait Startable: sealed::Sealed {}
+impl Startable for Initialized {}
+impl Startable for Stopped {}
+
+/// Lifecycle states from which the application tasks can be stopped (`Running`, `Faulted`).
+#[diagnostic::on_unimplemented(
+    message = "the application cannot be stopped from the `{Self}` lifecycle state",
+    label = "`stop_all_tasks` requires a `Running` or `Faulted` application",
+    note = "start the application first with `start_all_tasks`"
+)]
+pub trait Stoppable: sealed::Sealed {}
+impl Stoppable for Running {}
+impl Stoppable for Faulted {}
+
+/// Compile-time enforced lifecycle for a [`CuApplication`].
+///
+/// Wrapping an application moves lifecycle mistakes (double start, iterating
+/// before start, mixing `start_all_tasks` with `run`...) from runtime surprises
+/// to compile errors: each state is a distinct type exposing only the
+/// transitions that are legal from it.
+///
+/// ```text
+///                 start_all_tasks
+///   Initialized ------------------> Running <---+
+///        |                            |  |      | run_one_iteration
+///        | run                        |  +------+
+///        |                            | stop_all_tasks
+///        +--------> Stopped <---------+
+///                    |   ^
+///                    |   | stop_all_tasks (cleanup)
+///        (restart)   |  Faulted <--- any failed transition
+///                    +---> start_all_tasks / run again
+/// ```
+///
+/// Transitions consume the wrapper and return it typed with the new state, so
+/// a stale pre-transition handle cannot be reused. When a transition fails,
+/// the application is handed back inside [`LifecycleError`], typed [`Faulted`],
+/// so cleanup is still possible and nothing is lost.
+///
+/// This wrapper is opt-in: the underlying [`CuApplication`] methods remain
+/// available on the unwrapped application for existing code.
+pub struct CuAppLifecycle<S, L, A, State = Initialized> {
+    app: A,
+    _lifecycle: PhantomData<(S, L, State)>,
+}
+
+impl<S, L, A, State> fmt::Debug for CuAppLifecycle<S, L, A, State> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CuAppLifecycle")
+            .field("state", &core::any::type_name::<State>())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Convenience alias for applications using the default std unified logger,
+/// mirroring [`CuStdApplication`].
+#[cfg(feature = "std")]
+pub type CuStdAppLifecycle<A, State = Initialized> =
+    CuAppLifecycle<MmapSectionStorage, cu29_unifiedlog::UnifiedLoggerWrite, A, State>;
+
+/// Result of a lifecycle transition: on success the application typed with its
+/// new state, on failure [`LifecycleError`] carrying the application typed [`Faulted`].
+pub type TransitionResult<S, L, A, Next> =
+    Result<CuAppLifecycle<S, L, A, Next>, LifecycleError<S, L, A>>;
+
+/// A failed lifecycle transition.
+///
+/// Because transitions consume the application by value, the failure path hands
+/// it back typed as [`Faulted`]: `app` only exposes `stop_all_tasks` for
+/// best-effort cleanup.
+pub struct LifecycleError<S, L, A> {
+    /// The error reported by the underlying application.
+    pub error: CuError,
+    /// The application, in the `Faulted` state. Call `stop_all_tasks` on it to clean up.
+    pub app: CuAppLifecycle<S, L, A, Faulted>,
+}
+
+impl<S, L, A> fmt::Debug for LifecycleError<S, L, A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LifecycleError")
+            .field("error", &self.error)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<S, L, A> fmt::Display for LifecycleError<S, L, A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "lifecycle transition failed: {}", self.error)
+    }
+}
+
+impl<S, L, A> core::error::Error for LifecycleError<S, L, A> {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
+/// Allows `?` in functions returning `CuResult` when the faulted application
+/// does not need to be recovered.
+impl<S, L, A> From<LifecycleError<S, L, A>> for CuError {
+    fn from(value: LifecycleError<S, L, A>) -> Self {
+        value.error
+    }
+}
+
+impl<S, L, A, State> CuAppLifecycle<S, L, A, State> {
+    /// Rewraps the application under a new typestate. Private: state changes
+    /// only happen through the lifecycle transitions.
+    fn into_state<Next>(self) -> CuAppLifecycle<S, L, A, Next> {
+        CuAppLifecycle {
+            app: self.app,
+            _lifecycle: PhantomData,
+        }
+    }
+
+    /// Read-only access to the wrapped application.
+    pub fn inner(&self) -> &A {
+        &self.app
+    }
+
+    /// Consumes the wrapper and returns the application, dropping the
+    /// compile-time lifecycle tracking.
+    pub fn into_inner(self) -> A {
+        self.app
+    }
+}
+
+impl<S, L, A> CuAppLifecycle<S, L, A, Initialized>
+where
+    S: SectionStorage,
+    L: UnifiedLogWrite<S> + 'static,
+    A: CuApplication<S, L>,
+{
+    /// Wraps a freshly built application in the `Initialized` state.
+    pub fn new(app: A) -> Self {
+        CuAppLifecycle {
+            app,
+            _lifecycle: PhantomData,
+        }
+    }
+}
+
+impl<S, L, A, State> CuAppLifecycle<S, L, A, State>
+where
+    S: SectionStorage,
+    L: UnifiedLogWrite<S> + 'static,
+    A: CuApplication<S, L>,
+    State: Startable,
+{
+    /// Starts all tasks, transitioning to `Running`.
+    ///
+    /// On failure the application may be partially started; it is returned
+    /// typed `Faulted` inside the error so it can be cleaned up.
+    pub fn start_all_tasks(mut self) -> TransitionResult<S, L, A, Running> {
+        match self.app.start_all_tasks() {
+            Ok(()) => Ok(self.into_state()),
+            Err(error) => Err(LifecycleError {
+                error,
+                app: self.into_state(),
+            }),
+        }
+    }
+
+    /// Runs the full lifecycle (start, iterate until shutdown, stop),
+    /// transitioning to `Stopped` on success.
+    pub fn run(mut self) -> TransitionResult<S, L, A, Stopped> {
+        match self.app.run() {
+            Ok(()) => Ok(self.into_state()),
+            Err(error) => Err(LifecycleError {
+                error,
+                app: self.into_state(),
+            }),
+        }
+    }
+}
+
+impl<S, L, A> CuAppLifecycle<S, L, A, Running>
+where
+    S: SectionStorage,
+    L: UnifiedLogWrite<S> + 'static,
+    A: CuApplication<S, L>,
+{
+    /// Executes one iteration of the runtime. An iteration error does not
+    /// change the lifecycle state: the caller decides whether to keep
+    /// iterating or stop.
+    pub fn run_one_iteration(&mut self) -> CuResult<()> {
+        self.app.run_one_iteration()
+    }
+}
+
+impl<S, L, A, State> CuAppLifecycle<S, L, A, State>
+where
+    S: SectionStorage,
+    L: UnifiedLogWrite<S> + 'static,
+    A: CuApplication<S, L>,
+    State: Stoppable,
+{
+    /// Stops all tasks, transitioning to `Stopped`. From `Faulted` this is a
+    /// best-effort cleanup. On failure the application is handed back typed
+    /// `Faulted` again.
+    pub fn stop_all_tasks(mut self) -> TransitionResult<S, L, A, Stopped> {
+        match self.app.stop_all_tasks() {
+            Ok(()) => Ok(self.into_state()),
+            Err(error) => Err(LifecycleError {
+                error,
+                app: self.into_state(),
+            }),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod lifecycle_tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct MockApp {
+        started: u32,
+        stopped: u32,
+        iterations: u32,
+        runs: u32,
+        fail_start: bool,
+        fail_stop: bool,
+    }
+
+    impl<S: SectionStorage, L: UnifiedLogWrite<S> + 'static> CuApplication<S, L> for MockApp {
+        fn get_original_config() -> String {
+            String::new()
+        }
+
+        fn start_all_tasks(&mut self) -> CuResult<()> {
+            if self.fail_start {
+                return Err("mock start failure".into());
+            }
+            self.started += 1;
+            Ok(())
+        }
+
+        fn run_one_iteration(&mut self) -> CuResult<()> {
+            self.iterations += 1;
+            Ok(())
+        }
+
+        fn run(&mut self) -> CuResult<()> {
+            if self.fail_start {
+                return Err("mock run failure".into());
+            }
+            self.runs += 1;
+            Ok(())
+        }
+
+        fn stop_all_tasks(&mut self) -> CuResult<()> {
+            if self.fail_stop {
+                return Err("mock stop failure".into());
+            }
+            self.stopped += 1;
+            Ok(())
+        }
+
+        fn restore_keyframe(&mut self, _freezer: &KeyFrame) -> CuResult<()> {
+            Ok(())
+        }
+    }
+
+    type Lifecycle = CuStdAppLifecycle<MockApp>;
+
+    #[test]
+    fn full_cycle_with_restart() {
+        let app = Lifecycle::new(MockApp::default());
+        let mut running = app.start_all_tasks().unwrap();
+        running.run_one_iteration().unwrap();
+        running.run_one_iteration().unwrap();
+        let stopped = running.stop_all_tasks().unwrap();
+
+        // Restarting a stopped application is legal (mission chaining).
+        let running = stopped.start_all_tasks().unwrap();
+        let stopped = running.stop_all_tasks().unwrap();
+
+        let mock = stopped.into_inner();
+        assert_eq!(mock.started, 2);
+        assert_eq!(mock.iterations, 2);
+        assert_eq!(mock.stopped, 2);
+    }
+
+    #[test]
+    fn run_transitions_to_stopped_and_can_run_again() {
+        let app = Lifecycle::new(MockApp::default());
+        let stopped = app.run().unwrap();
+        let stopped = stopped.run().unwrap();
+        assert_eq!(stopped.inner().runs, 2);
+    }
+
+    #[test]
+    fn failed_start_hands_back_a_faulted_app_for_cleanup() {
+        let app = Lifecycle::new(MockApp {
+            fail_start: true,
+            ..Default::default()
+        });
+        let err = app.start_all_tasks().unwrap_err();
+        assert!(err.error.to_string().contains("mock start failure"));
+
+        // The only legal transition from Faulted is the cleanup.
+        let stopped = err.app.stop_all_tasks().unwrap();
+        let mock = stopped.into_inner();
+        assert_eq!(mock.started, 0);
+        assert_eq!(mock.stopped, 1);
+    }
+
+    #[test]
+    fn failed_stop_hands_back_a_faulted_app() {
+        let app = Lifecycle::new(MockApp {
+            fail_stop: true,
+            ..Default::default()
+        });
+        let running = app.start_all_tasks().unwrap();
+        let err = running.stop_all_tasks().unwrap_err();
+        assert!(err.error.to_string().contains("mock stop failure"));
+    }
+
+    #[test]
+    fn lifecycle_error_propagates_with_question_mark() {
+        fn drive() -> CuResult<()> {
+            let app = Lifecycle::new(MockApp {
+                fail_start: true,
+                ..Default::default()
+            });
+            let _running = app.start_all_tasks()?;
+            Ok(())
+        }
+        let error = drive().unwrap_err();
+        assert!(error.to_string().contains("mock start failure"));
+    }
 }

--- a/core/cu29_runtime/src/debug.rs
+++ b/core/cu29_runtime/src/debug.rs
@@ -247,6 +247,8 @@ where
         &mut self.app
     }
 
+    // Framework replay engine: drives the raw (app-deprecated) lifecycle on purpose.
+    #[allow(deprecated)]
     fn ensure_started(&mut self) -> CuResult<()> {
         if self.started {
             return Ok(());
@@ -568,6 +570,8 @@ where
         }
     }
 
+    // Framework replay engine: drives the raw (app-deprecated) lifecycle on purpose.
+    #[allow(deprecated)]
     fn replay_range(&mut self, start: usize, end: usize) -> CuResult<usize>
     where
         App: CurrentRuntimeCopperList<P>,

--- a/core/cu29_runtime/src/distributed_replay.rs
+++ b/core/cu29_runtime/src/distributed_replay.rs
@@ -398,6 +398,8 @@ where
         Ok(nodes)
     }
 
+    // Framework replay engine: drives the raw (app-deprecated) lifecycle on purpose.
+    #[allow(deprecated)]
     fn ensure_started(&mut self) -> CuResult<()> {
         if self.started {
             return Ok(());
@@ -599,6 +601,8 @@ where
         self.goto_index(target_idx)
     }
 
+    // Framework replay engine: drives the raw (app-deprecated) lifecycle on purpose.
+    #[allow(deprecated)]
     fn shutdown(&mut self) -> CuResult<()> {
         if !self.started {
             return Ok(());

--- a/core/cu29_runtime/src/remote_debug.rs
+++ b/core/cu29_runtime/src/remote_debug.rs
@@ -1416,10 +1416,10 @@ fn initialize_remote_debug_shm_provider(
     loop {
         match session.get_shm_provider() {
             ShmProviderState::Ready(provider) => return Ok(provider),
-            ShmProviderState::Initializing if started.elapsed() < SHM_PROVIDER_INIT_TIMEOUT => {
+            ShmProviderState::Initializing(_) if started.elapsed() < SHM_PROVIDER_INIT_TIMEOUT => {
                 std::thread::sleep(SHM_PROVIDER_INIT_POLL_INTERVAL);
             }
-            ShmProviderState::Initializing => {
+            ShmProviderState::Initializing(_) => {
                 return Err(CuError::from(format!(
                     "RemoteDebug server timed out after {:?} initializing its mandatory \
                      shared-memory provider",

--- a/core/cu29_runtime/tests/async_keyframes.rs
+++ b/core/cu29_runtime/tests/async_keyframes.rs
@@ -156,17 +156,17 @@ fn continuously_busy_async_workers_produce_complete_keyframes() -> CuResult<()> 
         .map_err(|error| CuError::new_with_cause("create temp directory failed", error))?;
     let log_path = temp_dir.path().join("async_keyframes.copper");
     let logger = build_logger(&log_path)?;
-    let mut app = AsyncKeyframeApp::builder()
+    let app = AsyncKeyframeApp::builder()
         .with_logger::<MmapSectionStorage, MmapUnifiedLoggerWrite>(logger)
         .build()?;
 
-    app.start_all_tasks()?;
+    let mut running = app.start()?;
     for _ in 0..ITERATIONS {
-        app.run_one_iteration()?;
+        running.run_one_iteration()?;
         std::thread::sleep(Duration::from_millis(5));
     }
-    app.stop_all_tasks()?;
-    drop(app);
+    let stopped = running.stop()?;
+    drop(stopped);
 
     let UnifiedLogger::Read(reader) = UnifiedLoggerBuilder::new()
         .file_base_name(&log_path)

--- a/core/cu29_runtime/tests/bridge_empty_tx.rs
+++ b/core/cu29_runtime/tests/bridge_empty_tx.rs
@@ -167,11 +167,11 @@ fn bridge_tx_empty_messages_are_skipped_by_default() -> CuResult<()> {
     EMPTY_PAYLOAD_SENDS.store(0, Ordering::Relaxed);
 
     let (clock, _mock) = RobotClock::mock();
-    let mut app = BridgeEmptyTxApp::builder().with_clock(clock).build()?;
+    let app = BridgeEmptyTxApp::builder().with_clock(clock).build_app()?;
 
-    app.start_all_tasks()?;
-    app.run_one_iteration()?;
-    app.stop_all_tasks()?;
+    let mut running = app.start_all_tasks()?;
+    running.run_one_iteration()?;
+    running.stop_all_tasks()?;
 
     assert_eq!(EMPTY_DEFAULT_SENDS.load(Ordering::Relaxed), 0);
     assert_eq!(EMPTY_PUBLISH_SENDS.load(Ordering::Relaxed), 1);

--- a/core/cu29_runtime/tests/bridge_empty_tx.rs
+++ b/core/cu29_runtime/tests/bridge_empty_tx.rs
@@ -167,11 +167,11 @@ fn bridge_tx_empty_messages_are_skipped_by_default() -> CuResult<()> {
     EMPTY_PAYLOAD_SENDS.store(0, Ordering::Relaxed);
 
     let (clock, _mock) = RobotClock::mock();
-    let app = BridgeEmptyTxApp::builder().with_clock(clock).build_app()?;
+    let app = BridgeEmptyTxApp::builder().with_clock(clock).build()?;
 
-    let mut running = app.start_all_tasks()?;
+    let mut running = app.start()?;
     running.run_one_iteration()?;
-    running.stop_all_tasks()?;
+    running.stop()?;
 
     assert_eq!(EMPTY_DEFAULT_SENDS.load(Ordering::Relaxed), 0);
     assert_eq!(EMPTY_PUBLISH_SENDS.load(Ordering::Relaxed), 1);

--- a/core/cu29_runtime/tests/replay_anytime.rs
+++ b/core/cu29_runtime/tests/replay_anytime.rs
@@ -353,19 +353,19 @@ fn record_run(log_path: &Path) -> CuResult<()> {
     let (clock, clock_mock) = RobotClock::mock();
     let mut noop = |_step: default::SimStep<'_>| SimOverride::ExecuteByRuntime;
 
-    let mut app = AnytimeReplayApp::builder()
+    let app = AnytimeReplayApp::builder()
         .with_clock(clock)
         .with_log_path(log_path, LOG_SLAB_SIZE)?
         .with_sim_callback(&mut noop)
-        .build()?;
+        .build_app()?;
 
-    app.start_all_tasks(&mut noop)?;
+    let mut app = app.start_all_tasks(&mut noop)?;
     for index in 0..ITERATIONS {
         clock_mock.set_value(index * DT_NANOS);
         app.run_one_iteration(&mut noop)?;
     }
+    // stop consumes the handle; the returned Stopped app drops here, flushing the logger.
     app.stop_all_tasks(&mut noop)?;
-    drop(app);
     Ok(())
 }
 
@@ -374,7 +374,7 @@ fn record_run(log_path: &Path) -> CuResult<()> {
 /// two anytime nodes to the runtime, so their base and refine quanta execute for
 /// real against the recorded input.
 fn resim_one(
-    app: &mut AnytimeReplayApp,
+    app: &mut CuStdSimAppLifecycle<AnytimeReplayApp, Running>,
     clock_mock: &RobotClockMock,
     recorded: &RecordedCl,
 ) -> CuResult<()> {
@@ -396,18 +396,18 @@ fn resim_run(recorded: &[RecordedCl], log_path: &Path) -> CuResult<()> {
     let (clock, clock_mock) = RobotClock::mock();
     let mut noop = |_step: default::SimStep<'_>| SimOverride::ExecuteByRuntime;
 
-    let mut app = AnytimeReplayApp::builder()
+    let app = AnytimeReplayApp::builder()
         .with_clock(clock)
         .with_log_path(log_path, LOG_SLAB_SIZE)?
         .with_sim_callback(&mut noop)
-        .build()?;
+        .build_app()?;
 
-    app.start_all_tasks(&mut noop)?;
+    let mut app = app.start_all_tasks(&mut noop)?;
     for copperlist in recorded {
         resim_one(&mut app, &clock_mock, copperlist)?;
     }
+    // stop consumes the handle; the returned Stopped app drops here, flushing the logger.
     app.stop_all_tasks(&mut noop)?;
-    drop(app);
     Ok(())
 }
 

--- a/core/cu29_runtime/tests/replay_anytime.rs
+++ b/core/cu29_runtime/tests/replay_anytime.rs
@@ -357,15 +357,15 @@ fn record_run(log_path: &Path) -> CuResult<()> {
         .with_clock(clock)
         .with_log_path(log_path, LOG_SLAB_SIZE)?
         .with_sim_callback(&mut noop)
-        .build_app()?;
+        .build()?;
 
-    let mut app = app.start_all_tasks(&mut noop)?;
+    let mut app = app.start(&mut noop)?;
     for index in 0..ITERATIONS {
         clock_mock.set_value(index * DT_NANOS);
         app.run_one_iteration(&mut noop)?;
     }
     // stop consumes the handle; the returned Stopped app drops here, flushing the logger.
-    app.stop_all_tasks(&mut noop)?;
+    app.stop(&mut noop)?;
     Ok(())
 }
 
@@ -400,14 +400,14 @@ fn resim_run(recorded: &[RecordedCl], log_path: &Path) -> CuResult<()> {
         .with_clock(clock)
         .with_log_path(log_path, LOG_SLAB_SIZE)?
         .with_sim_callback(&mut noop)
-        .build_app()?;
+        .build()?;
 
-    let mut app = app.start_all_tasks(&mut noop)?;
+    let mut app = app.start(&mut noop)?;
     for copperlist in recorded {
         resim_one(&mut app, &clock_mock, copperlist)?;
     }
     // stop consumes the handle; the returned Stopped app drops here, flushing the logger.
-    app.stop_all_tasks(&mut noop)?;
+    app.stop(&mut noop)?;
     Ok(())
 }
 

--- a/core/cu29_runtime/tests/replay_primitives.rs
+++ b/core/cu29_runtime/tests/replay_primitives.rs
@@ -17,7 +17,11 @@ use cu29_unifiedlog::{UnifiedLogger, UnifiedLoggerBuilder, UnifiedLoggerIOReader
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
+
+/// The logger runtime is a process-wide singleton: serialize the tests that
+/// each build a full application so they do not race its initialization.
+static TEST_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 #[derive(Default, Debug, Clone, Encode, Decode, Serialize, Deserialize, Reflect)]
 struct CounterMsg {
@@ -195,7 +199,8 @@ fn record_reference_run(
         .with_clock(clock)
         .with_logger::<MmapSectionStorage, MmapUnifiedLoggerWrite>(logger)
         .with_sim_callback(&mut noop)
-        .build()?;
+        .build()?
+        .into_inner();
 
     app.start_all_tasks(&mut noop)?;
     app.run_one_iteration(&mut noop)?;
@@ -222,7 +227,8 @@ fn replay_run(
         .with_clock(clock)
         .with_logger::<MmapSectionStorage, MmapUnifiedLoggerWrite>(logger)
         .with_sim_callback(&mut noop)
-        .build()?;
+        .build()?
+        .into_inner();
 
     app.start_all_tasks(&mut noop)?;
     app.replay_recorded_copperlist(&clock_mock, recorded_cl, keyframe)?;
@@ -240,6 +246,9 @@ fn replay_run(
 
 #[test]
 fn replay_recorded_copperlist_reproduces_copperlist_and_keyframe() -> CuResult<()> {
+    let _guard = TEST_MUTEX
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
     let temp_dir = tempfile::tempdir()
         .map_err(|e| cu29::CuError::new_with_cause("create temp dir failed", e))?;
     let record_path = temp_dir.path().join("recorded.copper");
@@ -258,6 +267,9 @@ fn replay_recorded_copperlist_reproduces_copperlist_and_keyframe() -> CuResult<(
 
 #[test]
 fn replay_recorded_copperlist_without_keyframe_uses_recorded_timestamp() -> CuResult<()> {
+    let _guard = TEST_MUTEX
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
     let temp_dir = tempfile::tempdir()
         .map_err(|e| cu29::CuError::new_with_cause("create temp dir failed", e))?;
     let record_path = temp_dir.path().join("recorded_no_kf.copper");
@@ -278,6 +290,9 @@ fn replay_recorded_copperlist_without_keyframe_uses_recorded_timestamp() -> CuRe
 
 #[test]
 fn builder_propagates_instance_id_into_runtime() -> CuResult<()> {
+    let _guard = TEST_MUTEX
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
     let temp_dir = tempfile::tempdir()
         .map_err(|e| cu29::CuError::new_with_cause("create temp dir failed", e))?;
     let log_path = temp_dir.path().join("instance_id_runtime.copper");
@@ -290,7 +305,8 @@ fn builder_propagates_instance_id_into_runtime() -> CuResult<()> {
         .with_logger::<MmapSectionStorage, MmapUnifiedLoggerWrite>(logger)
         .with_instance_id(42)
         .with_sim_callback(&mut noop)
-        .build()?;
+        .build()?
+        .into_inner();
 
     assert_eq!(app.copper_runtime_mut().instance_id(), 42);
     Ok(())

--- a/core/cu29_runtime/tests/replay_primitives.rs
+++ b/core/cu29_runtime/tests/replay_primitives.rs
@@ -1,3 +1,7 @@
+// Replay-primitive tests: drive the raw (app-deprecated) lifecycle API on
+// purpose, because replay interleaves recorded-copperlist injection with a
+// started app in ways the lifecycle typestate deliberately does not expose.
+#![allow(deprecated)]
 #![cfg(all(test, feature = "std"))]
 
 use bincode::{Decode, Encode, config::standard, encode_to_vec};

--- a/core/cu29_runtime/tests/sim_bridge.rs
+++ b/core/cu29_runtime/tests/sim_bridge.rs
@@ -252,11 +252,11 @@ fn bridge_sim_callbacks_fire_and_override() -> CuResult<()> {
         .with_clock(robot_clock.clone())
         .with_logger::<MmapSectionStorage, MmapUnifiedLoggerWrite>(logger)
         .with_sim_callback(&mut sim_cb)
-        .build_app()?;
+        .build()?;
 
-    let mut running = app.start_all_tasks(&mut sim_cb)?;
+    let mut running = app.start(&mut sim_cb)?;
     running.run_one_iteration(&mut sim_cb)?;
-    running.stop_all_tasks(&mut sim_cb)?;
+    running.stop(&mut sim_cb)?;
 
     // Bridge lifecycle start+stop observed
     assert_eq!(lifecycle_calls, 2);

--- a/core/cu29_runtime/tests/sim_bridge.rs
+++ b/core/cu29_runtime/tests/sim_bridge.rs
@@ -248,15 +248,15 @@ fn bridge_sim_callbacks_fire_and_override() -> CuResult<()> {
         }
     };
 
-    let mut app = App::builder()
+    let app = App::builder()
         .with_clock(robot_clock.clone())
         .with_logger::<MmapSectionStorage, MmapUnifiedLoggerWrite>(logger)
         .with_sim_callback(&mut sim_cb)
-        .build()?;
+        .build_app()?;
 
-    app.start_all_tasks(&mut sim_cb)?;
-    app.run_one_iteration(&mut sim_cb)?;
-    app.stop_all_tasks(&mut sim_cb)?;
+    let mut running = app.start_all_tasks(&mut sim_cb)?;
+    running.run_one_iteration(&mut sim_cb)?;
+    running.stop_all_tasks(&mut sim_cb)?;
 
     // Bridge lifecycle start+stop observed
     assert_eq!(lifecycle_calls, 2);

--- a/core/cu29_runtime/tests/sim_bridge.rs
+++ b/core/cu29_runtime/tests/sim_bridge.rs
@@ -185,13 +185,13 @@ mod recording {
     struct RealApp {}
 
     pub(super) fn record(logger: Arc<Mutex<MmapUnifiedLoggerWrite>>) -> CuResult<()> {
-        let mut app = RealApp::builder()
+        let app = RealApp::builder()
             .with_logger::<MmapSectionStorage, MmapUnifiedLoggerWrite>(logger)
             .build()?;
-        app.start_all_tasks()?;
-        app.run_one_iteration()?;
-        app.run_one_iteration()?;
-        app.stop_all_tasks()?;
+        let mut running = app.start()?;
+        running.run_one_iteration()?;
+        running.run_one_iteration()?;
+        running.stop()?;
         Ok(())
     }
 }
@@ -208,6 +208,10 @@ mod run_in_sim {
     struct RunInSimApp {}
 
     #[test]
+    // Drives the raw (deprecated) sim lifecycle on purpose: restoring a keyframe
+    // into a started app is a replay primitive the lifecycle typestate
+    // deliberately does not expose.
+    #[allow(deprecated)]
     fn nonzero_bridge_keyframe_matches_linear_debug_replay() -> CuResult<()> {
         let temp_dir = tempfile::tempdir()
             .map_err(|error| CuError::new_with_cause("create temp log dir failed", error))?;
@@ -303,6 +307,10 @@ fn read_first_keyframe(path: &Path) -> CuResult<KeyFrame> {
 }
 
 #[test]
+// Drives the raw (deprecated) sim lifecycle on purpose: restoring a keyframe
+// into a started app is a replay primitive the lifecycle typestate
+// deliberately does not expose.
+#[allow(deprecated)]
 fn sim_restore_skips_substituted_bridge_frame() -> CuResult<()> {
     let temp_dir = tempfile::tempdir()
         .map_err(|error| CuError::new_with_cause("create temp log dir failed", error))?;

--- a/core/cu29_runtime/tests/sim_substituted_keyframes.rs
+++ b/core/cu29_runtime/tests/sim_substituted_keyframes.rs
@@ -128,13 +128,13 @@ mod recording {
     struct RealApp {}
 
     pub(super) fn record(logger: Arc<Mutex<MmapUnifiedLoggerWrite>>) -> CuResult<()> {
-        let mut app = RealApp::builder()
+        let app = RealApp::builder()
             .with_logger::<MmapSectionStorage, MmapUnifiedLoggerWrite>(logger)
             .build()?;
-        app.start_all_tasks()?;
-        app.run_one_iteration()?;
-        app.run_one_iteration()?;
-        app.stop_all_tasks()?;
+        let mut running = app.start()?;
+        running.run_one_iteration()?;
+        running.run_one_iteration()?;
+        running.stop()?;
         Ok(())
     }
 }
@@ -158,6 +158,10 @@ fn build_logger(path: &Path) -> CuResult<Arc<Mutex<MmapUnifiedLoggerWrite>>> {
 }
 
 #[test]
+// Drives the raw (deprecated) sim lifecycle on purpose: restoring a keyframe
+// into a started app is a replay primitive the lifecycle typestate
+// deliberately does not expose.
+#[allow(deprecated)]
 fn sim_restore_skips_substituted_source_and_sink_but_thaws_regular_task() -> CuResult<()> {
     let temp_dir = tempfile::tempdir()
         .map_err(|error| CuError::new_with_cause("create temp directory failed", error))?;

--- a/examples/cu_anytime_rrt_star/src/main.rs
+++ b/examples/cu_anytime_rrt_star/src/main.rs
@@ -39,12 +39,12 @@ fn main() {
     let application = App::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create application.");
     // `run` starts the tasks itself; the typestate wrapper rejects the manual
     // start_all_tasks call this example used to make before it.
     // Paced by `runtime.rate_target_hz` in the RON; stops on Ctrl-C.
-    if let Err(error) = application.run() {
+    if let Err(error) = application.run_until_shutdown() {
         eprintln!("Error while running: {}", error.error);
     }
 }

--- a/examples/cu_anytime_rrt_star/src/main.rs
+++ b/examples/cu_anytime_rrt_star/src/main.rs
@@ -39,12 +39,12 @@ fn main() {
     let application = App::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create application.");
     // `run` starts the tasks itself; the typestate wrapper rejects the manual
     // start_all_tasks call this example used to make before it.
     // Paced by `runtime.rate_target_hz` in the RON; stops on Ctrl-C.
-    if let Err(error) = CuStdAppLifecycle::new(application).run() {
+    if let Err(error) = application.run() {
         eprintln!("Error while running: {}", error.error);
     }
 }

--- a/examples/cu_anytime_rrt_star/src/main.rs
+++ b/examples/cu_anytime_rrt_star/src/main.rs
@@ -36,16 +36,15 @@ fn main() {
         fs::create_dir_all(parent).expect("Failed to create logs directory");
     }
 
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
-    application
-        .start_all_tasks()
-        .expect("Failed to start application.");
+    // `run` starts the tasks itself; the typestate wrapper rejects the manual
+    // start_all_tasks call this example used to make before it.
     // Paced by `runtime.rate_target_hz` in the RON; stops on Ctrl-C.
-    if let Err(error) = application.run() {
-        eprintln!("Error while running: {error}");
+    if let Err(error) = CuStdAppLifecycle::new(application).run() {
+        eprintln!("Error while running: {}", error.error);
     }
 }

--- a/examples/cu_anytime_task/src/main.rs
+++ b/examples/cu_anytime_task/src/main.rs
@@ -204,9 +204,9 @@ fn main() {
     let application = App::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create application.");
-    let mut running = CuStdAppLifecycle::new(application)
+    let mut running = application
         .start_all_tasks()
         .expect("Failed to start application.");
     // Three copperlists for the foreground chain; keep polling until the

--- a/examples/cu_anytime_task/src/main.rs
+++ b/examples/cu_anytime_task/src/main.rs
@@ -204,11 +204,9 @@ fn main() {
     let application = App::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create application.");
-    let mut running = application
-        .start_all_tasks()
-        .expect("Failed to start application.");
+    let mut running = application.start().expect("Failed to start application.");
     // Three copperlists for the foreground chain; keep polling until the
     // backgrounded node's first job comes back from its worker thread.
     for iteration in 0..100 {
@@ -223,9 +221,7 @@ fn main() {
             break;
         }
     }
-    running
-        .stop_all_tasks()
-        .expect("Failed to stop application.");
+    running.stop().expect("Failed to stop application.");
 
     let background = tasks::BACKGROUND_RECORDED
         .lock()

--- a/examples/cu_anytime_task/src/main.rs
+++ b/examples/cu_anytime_task/src/main.rs
@@ -201,18 +201,18 @@ fn main() {
     {
         fs::create_dir_all(parent).expect("Failed to create logs directory");
     }
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
-    application
+    let mut running = CuStdAppLifecycle::new(application)
         .start_all_tasks()
         .expect("Failed to start application.");
     // Three copperlists for the foreground chain; keep polling until the
     // backgrounded node's first job comes back from its worker thread.
     for iteration in 0..100 {
-        application
+        running
             .run_one_iteration()
             .expect("Failed to run application.");
         let landed = !tasks::BACKGROUND_RECORDED
@@ -223,7 +223,7 @@ fn main() {
             break;
         }
     }
-    application
+    running
         .stop_all_tasks()
         .expect("Failed to stop application.");
 

--- a/examples/cu_background_task/src/main.rs
+++ b/examples/cu_background_task/src/main.rs
@@ -92,16 +92,15 @@ fn main() {
     let application = App::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create application.");
-    debug!(
-        "Running... starting clock: {}.",
-        application.inner().clock().now()
-    );
+    debug!("Running... starting clock: {}.", application.clock().now());
     // `run` drives the full start/iterate/stop cycle; the typestate wrapper
     // makes the previous extra start_all_tasks/stop_all_tasks calls around it
     // a compile error instead of a double start/stop at runtime.
-    let stopped = application.run().expect("Failed to run application.");
-    debug!("End of program: {}.", stopped.inner().clock().now());
+    let stopped = application
+        .run_until_shutdown()
+        .expect("Failed to run application.");
+    debug!("End of program: {}.", stopped.clock().now());
     // check if the logger file is at least 1 section in length
 }

--- a/examples/cu_background_task/src/main.rs
+++ b/examples/cu_background_task/src/main.rs
@@ -89,19 +89,18 @@ fn main() {
     }
     debug!("Logger created at {}.", path = &logger_path);
     debug!("Creating application... ");
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
     debug!("Running... starting clock: {}.", application.clock().now());
-    application
-        .start_all_tasks()
-        .expect("Failed to start application.");
-    application.run().expect("Failed to run application.");
-    application
-        .stop_all_tasks()
-        .expect("Failed to stop application.");
-    debug!("End of program: {}.", application.clock().now());
+    // `run` drives the full start/iterate/stop cycle; the typestate wrapper
+    // makes the previous extra start_all_tasks/stop_all_tasks calls around it
+    // a compile error instead of a double start/stop at runtime.
+    let stopped = CuStdAppLifecycle::new(application)
+        .run()
+        .expect("Failed to run application.");
+    debug!("End of program: {}.", stopped.inner().clock().now());
     // check if the logger file is at least 1 section in length
 }

--- a/examples/cu_background_task/src/main.rs
+++ b/examples/cu_background_task/src/main.rs
@@ -92,15 +92,16 @@ fn main() {
     let application = App::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create application.");
-    debug!("Running... starting clock: {}.", application.clock().now());
+    debug!(
+        "Running... starting clock: {}.",
+        application.inner().clock().now()
+    );
     // `run` drives the full start/iterate/stop cycle; the typestate wrapper
     // makes the previous extra start_all_tasks/stop_all_tasks calls around it
     // a compile error instead of a double start/stop at runtime.
-    let stopped = CuStdAppLifecycle::new(application)
-        .run()
-        .expect("Failed to run application.");
+    let stopped = application.run().expect("Failed to run application.");
     debug!("End of program: {}.", stopped.inner().clock().now());
     // check if the logger file is at least 1 section in length
 }

--- a/examples/cu_baremetal_safety/src/lib.rs
+++ b/examples/cu_baremetal_safety/src/lib.rs
@@ -458,10 +458,12 @@ pub mod harness {
         ) -> CuResult<(Vec<String>, Vec<String>)> {
             super::events::reset();
 
-            let app = App::builder().with_log_path(logger_path, None)?.build()?;
+            let app = App::builder()
+                .with_log_path(logger_path, None)?
+                .build_app()?;
             let build_events = super::events::snapshot();
 
-            let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
+            let mut running = app.start_all_tasks()?;
             running.run_one_iteration()?;
             running.stop_all_tasks()?;
 
@@ -482,10 +484,12 @@ pub mod harness {
         ) -> CuResult<(Vec<String>, Vec<String>, Vec<String>, Vec<String>)> {
             super::events::reset();
 
-            let app = App::builder().with_log_path(logger_path, None)?.build()?;
+            let app = App::builder()
+                .with_log_path(logger_path, None)?
+                .build_app()?;
             let build_events = super::events::snapshot();
 
-            let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
+            let mut running = app.start_all_tasks()?;
             let after_start = super::events::snapshot();
 
             running.run_one_iteration()?;

--- a/examples/cu_baremetal_safety/src/lib.rs
+++ b/examples/cu_baremetal_safety/src/lib.rs
@@ -458,14 +458,12 @@ pub mod harness {
         ) -> CuResult<(Vec<String>, Vec<String>)> {
             super::events::reset();
 
-            let app = App::builder()
-                .with_log_path(logger_path, None)?
-                .build_app()?;
+            let app = App::builder().with_log_path(logger_path, None)?.build()?;
             let build_events = super::events::snapshot();
 
-            let mut running = app.start_all_tasks()?;
+            let mut running = app.start()?;
             running.run_one_iteration()?;
-            running.stop_all_tasks()?;
+            running.stop()?;
 
             let runtime_events = super::slice_from(&super::events::snapshot(), build_events.len());
             Ok((build_events, runtime_events))
@@ -484,18 +482,16 @@ pub mod harness {
         ) -> CuResult<(Vec<String>, Vec<String>, Vec<String>, Vec<String>)> {
             super::events::reset();
 
-            let app = App::builder()
-                .with_log_path(logger_path, None)?
-                .build_app()?;
+            let app = App::builder().with_log_path(logger_path, None)?.build()?;
             let build_events = super::events::snapshot();
 
-            let mut running = app.start_all_tasks()?;
+            let mut running = app.start()?;
             let after_start = super::events::snapshot();
 
             running.run_one_iteration()?;
             let after_run = super::events::snapshot();
 
-            running.stop_all_tasks()?;
+            running.stop()?;
             let after_stop = super::events::snapshot();
 
             Ok((

--- a/examples/cu_baremetal_safety/src/lib.rs
+++ b/examples/cu_baremetal_safety/src/lib.rs
@@ -458,12 +458,12 @@ pub mod harness {
         ) -> CuResult<(Vec<String>, Vec<String>)> {
             super::events::reset();
 
-            let mut app = App::builder().with_log_path(logger_path, None)?.build()?;
+            let app = App::builder().with_log_path(logger_path, None)?.build()?;
             let build_events = super::events::snapshot();
 
-            app.start_all_tasks()?;
-            app.run_one_iteration()?;
-            app.stop_all_tasks()?;
+            let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
+            running.run_one_iteration()?;
+            running.stop_all_tasks()?;
 
             let runtime_events = super::slice_from(&super::events::snapshot(), build_events.len());
             Ok((build_events, runtime_events))
@@ -482,16 +482,16 @@ pub mod harness {
         ) -> CuResult<(Vec<String>, Vec<String>, Vec<String>, Vec<String>)> {
             super::events::reset();
 
-            let mut app = App::builder().with_log_path(logger_path, None)?.build()?;
+            let app = App::builder().with_log_path(logger_path, None)?.build()?;
             let build_events = super::events::snapshot();
 
-            app.start_all_tasks()?;
+            let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
             let after_start = super::events::snapshot();
 
-            app.run_one_iteration()?;
+            running.run_one_iteration()?;
             let after_run = super::events::snapshot();
 
-            app.stop_all_tasks()?;
+            running.stop_all_tasks()?;
             let after_stop = super::events::snapshot();
 
             Ok((

--- a/examples/cu_bevymon_demo/src/main.rs
+++ b/examples/cu_bevymon_demo/src/main.rs
@@ -153,15 +153,15 @@ fn build_copper_driver() -> (CopperDriver, MonitorModel) {
 
     let mut copper_app = BevyMonDemoApp::builder()
         .with_logger::<DemoSectionStorage, DemoUnifiedLogger>(unified_logger)
-        .build()
+        .build_app()
         .expect("Failed to create Copper runtime.");
 
-    // The lifecycle wrapper only hands out shared access to the wrapped app,
-    // so grab the monitor model before wrapping.
-    let monitor_model = copper_app.copper_runtime_mut().monitor.model();
+    // Pre-start configuration goes through inner_mut(), only available in the
+    // Initialized state.
+    let monitor_model = copper_app.inner_mut().copper_runtime_mut().monitor.model();
 
     let driver = CopperDriver {
-        state: CopperState::Initialized(CuAppLifecycle::new(copper_app)),
+        state: CopperState::Initialized(copper_app),
         iteration_timer: Timer::from_seconds(1.0 / COPPER_TICK_HZ, TimerMode::Repeating),
     };
     (driver, monitor_model)

--- a/examples/cu_bevymon_demo/src/main.rs
+++ b/examples/cu_bevymon_demo/src/main.rs
@@ -153,12 +153,12 @@ fn build_copper_driver() -> (CopperDriver, MonitorModel) {
 
     let mut copper_app = BevyMonDemoApp::builder()
         .with_logger::<DemoSectionStorage, DemoUnifiedLogger>(unified_logger)
-        .build_app()
+        .build()
         .expect("Failed to create Copper runtime.");
 
-    // Pre-start configuration goes through inner_mut(), only available in the
+    // Pre-start mutable access works through DerefMut, only available in the
     // Initialized state.
-    let monitor_model = copper_app.inner_mut().copper_runtime_mut().monitor.model();
+    let monitor_model = copper_app.copper_runtime_mut().monitor.model();
 
     let driver = CopperDriver {
         state: CopperState::Initialized(copper_app),
@@ -172,9 +172,7 @@ fn start_copper_runtime(mut copper: ResMut<CopperDriver>) {
     else {
         return;
     };
-    let running = app
-        .start_all_tasks()
-        .expect("Failed to start Copper demo tasks.");
+    let running = app.start().expect("Failed to start Copper demo tasks.");
     copper.state = CopperState::Running(running);
     info!("Copper BevyMon demo runtime started.");
 }
@@ -552,9 +550,7 @@ fn stop_copper_on_exit(mut exit_events: MessageReader<AppExit>, mut copper: ResM
         };
 
         info!("Stopping Copper BevyMon demo runtime.");
-        let stopped = app
-            .stop_all_tasks()
-            .expect("Failed to stop Copper demo tasks.");
+        let stopped = app.stop().expect("Failed to stop Copper demo tasks.");
         let _ = stopped.into_inner().log_shutdown_completed();
     }
 }

--- a/examples/cu_bevymon_demo/src/main.rs
+++ b/examples/cu_bevymon_demo/src/main.rs
@@ -10,7 +10,7 @@ use bevy::render::render_resource::{TextureDimension, TextureFormat, TextureUsag
 use bevy::ui::Node as UiNode;
 use cu_bevymon::{
     CuBevyMonFocus, CuBevyMonPlugin, CuBevyMonSplitLayoutConfig, CuBevyMonSplitStyle,
-    CuBevyMonSurface, CuBevyMonTexture, MonitorUiOptions, spawn_split_layout,
+    CuBevyMonSurface, CuBevyMonTexture, MonitorModel, MonitorUiOptions, spawn_split_layout,
 };
 use cu29::prelude::*;
 use cu29::prelude::{debug, error, info};
@@ -64,11 +64,22 @@ struct LayoutSpawned(bool);
 #[derive(Resource)]
 struct SplitUiCamera(Entity);
 
+type DemoLifecycle<State> =
+    CuAppLifecycle<DemoSectionStorage, DemoUnifiedLogger, BevyMonDemoApp, State>;
+
+/// The Copper lifecycle spread across Bevy systems: transitions consume the
+/// wrapper, so the driver holds the current state and swaps it on transition.
+/// This replaces the old `started: bool` flag.
+enum CopperState {
+    Initialized(DemoLifecycle<Initialized>),
+    Running(DemoLifecycle<Running>),
+    Stopped,
+}
+
 #[derive(Resource)]
 struct CopperDriver {
-    copper_app: BevyMonDemoApp,
+    state: CopperState,
     iteration_timer: Timer,
-    started: bool,
 }
 
 #[derive(Resource)]
@@ -89,8 +100,7 @@ impl Default for DemoCameraRig {
 }
 
 fn main() {
-    let mut copper = build_copper_driver();
-    let monitor_model = copper.copper_app.copper_runtime_mut().monitor.model();
+    let (copper, monitor_model) = build_copper_driver();
 
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(WindowPlugin {
@@ -131,7 +141,7 @@ fn main() {
     app.run();
 }
 
-fn build_copper_driver() -> CopperDriver {
+fn build_copper_driver() -> (CopperDriver, MonitorModel) {
     let unified_logger = build_unified_logger().expect("Failed to create demo logger.");
 
     #[cfg(target_arch = "wasm32")]
@@ -141,24 +151,31 @@ fn build_copper_driver() -> CopperDriver {
 
     debug!("Creating Copper BevyMon demo application.");
 
-    let copper_app = BevyMonDemoApp::builder()
+    let mut copper_app = BevyMonDemoApp::builder()
         .with_logger::<DemoSectionStorage, DemoUnifiedLogger>(unified_logger)
         .build()
         .expect("Failed to create Copper runtime.");
 
-    CopperDriver {
-        copper_app,
+    // The lifecycle wrapper only hands out shared access to the wrapped app,
+    // so grab the monitor model before wrapping.
+    let monitor_model = copper_app.copper_runtime_mut().monitor.model();
+
+    let driver = CopperDriver {
+        state: CopperState::Initialized(CuAppLifecycle::new(copper_app)),
         iteration_timer: Timer::from_seconds(1.0 / COPPER_TICK_HZ, TimerMode::Repeating),
-        started: false,
-    }
+    };
+    (driver, monitor_model)
 }
 
 fn start_copper_runtime(mut copper: ResMut<CopperDriver>) {
-    <BevyMonDemoApp as CuApplication<DemoSectionStorage, DemoUnifiedLogger>>::start_all_tasks(
-        &mut copper.copper_app,
-    )
-    .expect("Failed to start Copper demo tasks.");
-    copper.started = true;
+    let CopperState::Initialized(app) = std::mem::replace(&mut copper.state, CopperState::Stopped)
+    else {
+        return;
+    };
+    let running = app
+        .start_all_tasks()
+        .expect("Failed to start Copper demo tasks.");
+    copper.state = CopperState::Running(running);
     info!("Copper BevyMon demo runtime started.");
 }
 
@@ -504,40 +521,40 @@ fn run_copper_iteration(
     mut copper: ResMut<CopperDriver>,
     mut exit_writer: MessageWriter<AppExit>,
 ) {
-    if !copper.started {
+    let CopperDriver {
+        state,
+        iteration_timer,
+    } = &mut *copper;
+    let CopperState::Running(app) = state else {
+        return;
+    };
+
+    if !iteration_timer.tick(time.delta()).just_finished() {
         return;
     }
 
-    if !copper.iteration_timer.tick(time.delta()).just_finished() {
-        return;
-    }
-
-    if let Err(err) =
-        <BevyMonDemoApp as CuApplication<DemoSectionStorage, DemoUnifiedLogger>>::run_one_iteration(
-            &mut copper.copper_app,
-        )
-    {
+    if let Err(err) = app.run_one_iteration() {
         error!(
             "Copper demo stopped after runtime error: {}",
             err.to_string()
         );
+        // An iteration error leaves the app Running; request an exit and let
+        // stop_copper_on_exit shut the tasks down cleanly.
         exit_writer.write(AppExit::Success);
-        copper.started = false;
     }
 }
 
 fn stop_copper_on_exit(mut exit_events: MessageReader<AppExit>, mut copper: ResMut<CopperDriver>) {
     if exit_events.read().next().is_some() {
-        if !copper.started {
+        let CopperState::Running(app) = std::mem::replace(&mut copper.state, CopperState::Stopped)
+        else {
             return;
-        }
+        };
 
         info!("Stopping Copper BevyMon demo runtime.");
-        <BevyMonDemoApp as CuApplication<DemoSectionStorage, DemoUnifiedLogger>>::stop_all_tasks(
-            &mut copper.copper_app,
-        )
-        .expect("Failed to stop Copper demo tasks.");
-        let _ = copper.copper_app.log_shutdown_completed();
-        copper.started = false;
+        let stopped = app
+            .stop_all_tasks()
+            .expect("Failed to stop Copper demo tasks.");
+        let _ = stopped.into_inner().log_shutdown_completed();
     }
 }

--- a/examples/cu_bridge_test/src/lib.rs
+++ b/examples/cu_bridge_test/src/lib.rs
@@ -381,9 +381,9 @@ mod tests {
 
         events::reset();
         let app = builder(&log_path, clock).expect("build app");
-        let mut running = app.start_all_tasks().expect("start");
+        let mut running = app.start().expect("start");
         running.run_one_iteration().expect("run");
-        running.stop_all_tasks().expect("stop");
+        running.stop().expect("stop");
         events::take()
     }
 
@@ -415,7 +415,7 @@ mod tests {
                 .with_clock(clock)
                 .with_log_path(log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
-                .build_app()
+                .build()
         });
         assert_eq!(events, vec!["alpha.rx.ingress", "beta.tx.egress"]);
     }
@@ -428,7 +428,7 @@ mod tests {
                 .with_clock(clock)
                 .with_log_path(log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
-                .build_app()
+                .build()
         });
         assert_eq!(events, vec!["alpha.rx.loop", "alpha.tx.loop"]);
     }
@@ -441,7 +441,7 @@ mod tests {
                 .with_clock(clock)
                 .with_log_path(log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
-                .build_app()
+                .build()
         });
         assert_eq!(events, vec!["source_to_bridge.process", "beta.tx.from_src"]);
     }
@@ -454,7 +454,7 @@ mod tests {
                 .with_clock(clock)
                 .with_log_path(log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
-                .build_app()
+                .build()
         });
         assert_eq!(events, vec!["alpha.rx.to_sink", "sink_from_bridge.process"]);
     }
@@ -467,7 +467,7 @@ mod tests {
                 .with_clock(clock)
                 .with_log_path(log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
-                .build_app()
+                .build()
         });
         assert_eq!(
             events,
@@ -491,11 +491,11 @@ mod tests {
                 .with_clock(clock.clone())
                 .with_log_path(&log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
-                .build_app()
+                .build()
                 .expect("build app");
-            let mut running = app.start_all_tasks().expect("start");
+            let mut running = app.start().expect("start");
             running.run_one_iteration().expect("run");
-            running.stop_all_tasks().expect("stop");
+            running.stop().expect("stop");
         }
 
         let UnifiedLogger::Read(read_logger) = UnifiedLoggerBuilder::new()
@@ -545,11 +545,11 @@ mod tests {
                 .with_clock(clock.clone())
                 .with_log_path(&log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
-                .build_app()
+                .build()
                 .unwrap();
-            let mut running = app.start_all_tasks().unwrap();
+            let mut running = app.start().unwrap();
             running.run_one_iteration().unwrap();
-            running.stop_all_tasks().unwrap();
+            running.stop().unwrap();
         }
         let first = events::take();
         assert_eq!(first, vec!["alpha.rx.ingress", "beta.tx.egress"]);
@@ -559,11 +559,11 @@ mod tests {
                 .with_clock(clock)
                 .with_log_path(&log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
-                .build_app()
+                .build()
                 .unwrap();
-            let mut running = app.start_all_tasks().unwrap();
+            let mut running = app.start().unwrap();
             running.run_one_iteration().unwrap();
-            running.stop_all_tasks().unwrap();
+            running.stop().unwrap();
         }
         let second = events::take();
         assert_eq!(second, vec!["alpha.rx.loop", "alpha.tx.loop"]);

--- a/examples/cu_bridge_test/src/lib.rs
+++ b/examples/cu_bridge_test/src/lib.rs
@@ -367,7 +367,12 @@ mod tests {
 
     fn run_mission<AppBuilderFn, App>(builder: AppBuilderFn) -> Vec<&'static str>
     where
-        AppBuilderFn: FnOnce(&std::path::Path, RobotClock) -> CuResult<App>,
+        AppBuilderFn: FnOnce(
+            &std::path::Path,
+            RobotClock,
+        ) -> CuResult<
+            CuAppLifecycle<MmapSectionStorage, UnifiedLoggerWrite, App>,
+        >,
         App: CuApplication<MmapSectionStorage, UnifiedLoggerWrite>,
     {
         let temp_dir = TempDir::new().expect("temp dir");
@@ -376,11 +381,7 @@ mod tests {
 
         events::reset();
         let app = builder(&log_path, clock).expect("build app");
-        // The lifecycle wrapper pins S/L, so the UFCS disambiguation the raw
-        // trait calls needed is no longer necessary.
-        let mut running = CuAppLifecycle::<MmapSectionStorage, UnifiedLoggerWrite, App>::new(app)
-            .start_all_tasks()
-            .expect("start");
+        let mut running = app.start_all_tasks().expect("start");
         running.run_one_iteration().expect("run");
         running.stop_all_tasks().expect("stop");
         events::take()
@@ -414,7 +415,7 @@ mod tests {
                 .with_clock(clock)
                 .with_log_path(log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
-                .build()
+                .build_app()
         });
         assert_eq!(events, vec!["alpha.rx.ingress", "beta.tx.egress"]);
     }
@@ -427,7 +428,7 @@ mod tests {
                 .with_clock(clock)
                 .with_log_path(log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
-                .build()
+                .build_app()
         });
         assert_eq!(events, vec!["alpha.rx.loop", "alpha.tx.loop"]);
     }
@@ -440,7 +441,7 @@ mod tests {
                 .with_clock(clock)
                 .with_log_path(log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
-                .build()
+                .build_app()
         });
         assert_eq!(events, vec!["source_to_bridge.process", "beta.tx.from_src"]);
     }
@@ -453,7 +454,7 @@ mod tests {
                 .with_clock(clock)
                 .with_log_path(log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
-                .build()
+                .build_app()
         });
         assert_eq!(events, vec!["alpha.rx.to_sink", "sink_from_bridge.process"]);
     }
@@ -466,7 +467,7 @@ mod tests {
                 .with_clock(clock)
                 .with_log_path(log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
-                .build()
+                .build_app()
         });
         assert_eq!(
             events,
@@ -490,11 +491,9 @@ mod tests {
                 .with_clock(clock.clone())
                 .with_log_path(&log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
-                .build()
+                .build_app()
                 .expect("build app");
-            let mut running = CuStdAppLifecycle::new(app)
-                .start_all_tasks()
-                .expect("start");
+            let mut running = app.start_all_tasks().expect("start");
             running.run_one_iteration().expect("run");
             running.stop_all_tasks().expect("stop");
         }
@@ -546,9 +545,9 @@ mod tests {
                 .with_clock(clock.clone())
                 .with_log_path(&log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
-                .build()
+                .build_app()
                 .unwrap();
-            let mut running = CuStdAppLifecycle::new(app).start_all_tasks().unwrap();
+            let mut running = app.start_all_tasks().unwrap();
             running.run_one_iteration().unwrap();
             running.stop_all_tasks().unwrap();
         }
@@ -560,9 +559,9 @@ mod tests {
                 .with_clock(clock)
                 .with_log_path(&log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
-                .build()
+                .build_app()
                 .unwrap();
-            let mut running = CuStdAppLifecycle::new(app).start_all_tasks().unwrap();
+            let mut running = app.start_all_tasks().unwrap();
             running.run_one_iteration().unwrap();
             running.stop_all_tasks().unwrap();
         }

--- a/examples/cu_bridge_test/src/lib.rs
+++ b/examples/cu_bridge_test/src/lib.rs
@@ -375,13 +375,14 @@ mod tests {
         let clock = RobotClock::default();
 
         events::reset();
-        let mut app = builder(&log_path, clock).expect("build app");
-        <App as CuApplication<MmapSectionStorage, UnifiedLoggerWrite>>::start_all_tasks(&mut app)
+        let app = builder(&log_path, clock).expect("build app");
+        // The lifecycle wrapper pins S/L, so the UFCS disambiguation the raw
+        // trait calls needed is no longer necessary.
+        let mut running = CuAppLifecycle::<MmapSectionStorage, UnifiedLoggerWrite, App>::new(app)
+            .start_all_tasks()
             .expect("start");
-        <App as CuApplication<MmapSectionStorage, UnifiedLoggerWrite>>::run_one_iteration(&mut app)
-            .expect("run");
-        <App as CuApplication<MmapSectionStorage, UnifiedLoggerWrite>>::stop_all_tasks(&mut app)
-            .expect("stop");
+        running.run_one_iteration().expect("run");
+        running.stop_all_tasks().expect("stop");
         events::take()
     }
 
@@ -485,15 +486,17 @@ mod tests {
         let clock = RobotClock::default();
 
         {
-            let mut app = super::BridgeTaskSameApp::builder()
+            let app = super::BridgeTaskSameApp::builder()
                 .with_clock(clock.clone())
                 .with_log_path(&log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
                 .build()
                 .expect("build app");
-            app.start_all_tasks().expect("start");
-            app.run_one_iteration().expect("run");
-            app.stop_all_tasks().expect("stop");
+            let mut running = CuStdAppLifecycle::new(app)
+                .start_all_tasks()
+                .expect("start");
+            running.run_one_iteration().expect("run");
+            running.stop_all_tasks().expect("stop");
         }
 
         let UnifiedLogger::Read(read_logger) = UnifiedLoggerBuilder::new()
@@ -539,29 +542,29 @@ mod tests {
 
         events::reset();
         {
-            let mut app = super::BridgeOnlyABApp::builder()
+            let app = super::BridgeOnlyABApp::builder()
                 .with_clock(clock.clone())
                 .with_log_path(&log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
                 .build()
                 .unwrap();
-            app.start_all_tasks().unwrap();
-            app.run_one_iteration().unwrap();
-            app.stop_all_tasks().unwrap();
+            let mut running = CuStdAppLifecycle::new(app).start_all_tasks().unwrap();
+            running.run_one_iteration().unwrap();
+            running.stop_all_tasks().unwrap();
         }
         let first = events::take();
         assert_eq!(first, vec!["alpha.rx.ingress", "beta.tx.egress"]);
 
         {
-            let mut app = super::BridgeLoopbackApp::builder()
+            let app = super::BridgeLoopbackApp::builder()
                 .with_clock(clock)
                 .with_log_path(&log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
                 .build()
                 .unwrap();
-            app.start_all_tasks().unwrap();
-            app.run_one_iteration().unwrap();
-            app.stop_all_tasks().unwrap();
+            let mut running = CuStdAppLifecycle::new(app).start_all_tasks().unwrap();
+            running.run_one_iteration().unwrap();
+            running.stop_all_tasks().unwrap();
         }
         let second = events::take();
         assert_eq!(second, vec!["alpha.rx.loop", "alpha.tx.loop"]);

--- a/examples/cu_bridge_test/src/main.rs
+++ b/examples/cu_bridge_test/src/main.rs
@@ -18,13 +18,14 @@ struct Cli {
     mission: MissionArg,
 }
 
-fn run_once<App>(app: &mut App) -> CuResult<()>
+fn run_once<App>(app: App) -> CuResult<()>
 where
     App: CuApplication<MmapSectionStorage, UnifiedLoggerWrite>,
 {
-    app.start_all_tasks()?;
-    app.run()?;
-    app.stop_all_tasks()?;
+    // `run` drives the full start/iterate/stop cycle; the typestate wrapper
+    // makes the previous extra start_all_tasks/stop_all_tasks calls around it
+    // a compile error instead of a double start/stop at runtime.
+    CuAppLifecycle::new(app).run()?;
     Ok(())
 }
 
@@ -50,40 +51,40 @@ fn drive() -> CuResult<()> {
 
     match args.mission {
         MissionArg::BridgeOnlyAb => {
-            let mut app = BridgeOnlyABApp::builder()
+            let app = BridgeOnlyABApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
                 .build()?;
-            run_once(&mut app)?;
+            run_once(app)?;
         }
         MissionArg::BridgeLoopback => {
-            let mut app = BridgeLoopbackApp::builder()
+            let app = BridgeLoopbackApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
                 .build()?;
-            run_once(&mut app)?;
+            run_once(app)?;
         }
         MissionArg::SourceToBridge => {
-            let mut app = SourceToBridgeApp::builder()
+            let app = SourceToBridgeApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
                 .build()?;
-            run_once(&mut app)?;
+            run_once(app)?;
         }
         MissionArg::BridgeToSink => {
-            let mut app = BridgeToSinkApp::builder()
+            let app = BridgeToSinkApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
                 .build()?;
-            run_once(&mut app)?;
+            run_once(app)?;
         }
         MissionArg::BridgeTaskSame => {
-            let mut app = BridgeTaskSameApp::builder()
+            let app = BridgeTaskSameApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
                 .build()?;
-            run_once(&mut app)?;
+            run_once(app)?;
         }
         MissionArg::BridgeFanout => {
-            let mut app = BridgeFanoutApp::builder()
+            let app = BridgeFanoutApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
                 .build()?;
-            run_once(&mut app)?;
+            run_once(app)?;
         }
     }
 

--- a/examples/cu_bridge_test/src/main.rs
+++ b/examples/cu_bridge_test/src/main.rs
@@ -18,14 +18,14 @@ struct Cli {
     mission: MissionArg,
 }
 
-fn run_once<App>(app: App) -> CuResult<()>
+fn run_once<App>(app: CuAppLifecycle<MmapSectionStorage, UnifiedLoggerWrite, App>) -> CuResult<()>
 where
     App: CuApplication<MmapSectionStorage, UnifiedLoggerWrite>,
 {
-    // `run` drives the full start/iterate/stop cycle; the typestate wrapper
-    // makes the previous extra start_all_tasks/stop_all_tasks calls around it
-    // a compile error instead of a double start/stop at runtime.
-    CuAppLifecycle::new(app).run()?;
+    // `run` drives the full start/iterate/stop cycle; the typestate rejects
+    // the extra start_all_tasks/stop_all_tasks calls this example used to
+    // make around it (a double start/stop at runtime).
+    app.run()?;
     Ok(())
 }
 
@@ -53,37 +53,37 @@ fn drive() -> CuResult<()> {
         MissionArg::BridgeOnlyAb => {
             let app = BridgeOnlyABApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
-                .build()?;
+                .build_app()?;
             run_once(app)?;
         }
         MissionArg::BridgeLoopback => {
             let app = BridgeLoopbackApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
-                .build()?;
+                .build_app()?;
             run_once(app)?;
         }
         MissionArg::SourceToBridge => {
             let app = SourceToBridgeApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
-                .build()?;
+                .build_app()?;
             run_once(app)?;
         }
         MissionArg::BridgeToSink => {
             let app = BridgeToSinkApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
-                .build()?;
+                .build_app()?;
             run_once(app)?;
         }
         MissionArg::BridgeTaskSame => {
             let app = BridgeTaskSameApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
-                .build()?;
+                .build_app()?;
             run_once(app)?;
         }
         MissionArg::BridgeFanout => {
             let app = BridgeFanoutApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
-                .build()?;
+                .build_app()?;
             run_once(app)?;
         }
     }

--- a/examples/cu_bridge_test/src/main.rs
+++ b/examples/cu_bridge_test/src/main.rs
@@ -25,7 +25,7 @@ where
     // `run` drives the full start/iterate/stop cycle; the typestate rejects
     // the extra start_all_tasks/stop_all_tasks calls this example used to
     // make around it (a double start/stop at runtime).
-    app.run()?;
+    app.run_until_shutdown()?;
     Ok(())
 }
 
@@ -53,37 +53,37 @@ fn drive() -> CuResult<()> {
         MissionArg::BridgeOnlyAb => {
             let app = BridgeOnlyABApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
-                .build_app()?;
+                .build()?;
             run_once(app)?;
         }
         MissionArg::BridgeLoopback => {
             let app = BridgeLoopbackApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
-                .build_app()?;
+                .build()?;
             run_once(app)?;
         }
         MissionArg::SourceToBridge => {
             let app = SourceToBridgeApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
-                .build_app()?;
+                .build()?;
             run_once(app)?;
         }
         MissionArg::BridgeToSink => {
             let app = BridgeToSinkApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
-                .build_app()?;
+                .build()?;
             run_once(app)?;
         }
         MissionArg::BridgeTaskSame => {
             let app = BridgeTaskSameApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
-                .build_app()?;
+                .build()?;
             run_once(app)?;
         }
         MissionArg::BridgeFanout => {
             let app = BridgeFanoutApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
-                .build_app()?;
+                .build()?;
             run_once(app)?;
         }
     }

--- a/examples/cu_bridge_test/src/resim.rs
+++ b/examples/cu_bridge_test/src/resim.rs
@@ -166,8 +166,8 @@ macro_rules! resim_default {
             .with_clock($robot_clock)
             .with_log_path($output_path, LOG_SLAB_SIZE)?
             .with_sim_callback(&mut default_cb)
-            .build_app()?;
-        let mut app = app.start_all_tasks(&mut default_cb)?;
+            .build()?;
+        let mut app = app.start(&mut default_cb)?;
 
         let mut reader = open_copperlist_reader($input_log_path)?;
         for entry in copperlists_reader::<$app::CuStampedDataSet>(&mut reader) {
@@ -176,7 +176,7 @@ macro_rules! resim_default {
             app.run_one_iteration(&mut sim_cb)?;
         }
 
-        app.stop_all_tasks(&mut default_cb)?;
+        app.stop(&mut default_cb)?;
         Ok(())
     }};
 }
@@ -225,8 +225,8 @@ fn resim_source_to_bridge(
         .with_clock(clock)
         .with_log_path(output_path, LOG_SLAB_SIZE)?
         .with_sim_callback(&mut default_cb)
-        .build_app()?;
-    let mut app = app.start_all_tasks(&mut default_cb)?;
+        .build()?;
+    let mut app = app.start(&mut default_cb)?;
 
     let mut reader = open_copperlist_reader(input_log_path)?;
     for entry in copperlists_reader::<SourceToBridge::CuStampedDataSet>(&mut reader) {
@@ -235,7 +235,7 @@ fn resim_source_to_bridge(
         app.run_one_iteration(&mut sim_cb)?;
     }
 
-    app.stop_all_tasks(&mut default_cb)?;
+    app.stop(&mut default_cb)?;
     Ok(())
 }
 
@@ -263,8 +263,8 @@ fn resim_bridge_to_sink(
         .with_clock(clock)
         .with_log_path(output_path, LOG_SLAB_SIZE)?
         .with_sim_callback(&mut default_cb)
-        .build_app()?;
-    let mut app = app.start_all_tasks(&mut default_cb)?;
+        .build()?;
+    let mut app = app.start(&mut default_cb)?;
 
     let mut reader = open_copperlist_reader(input_log_path)?;
     for entry in copperlists_reader::<BridgeToSink::CuStampedDataSet>(&mut reader) {
@@ -273,7 +273,7 @@ fn resim_bridge_to_sink(
         app.run_one_iteration(&mut sim_cb)?;
     }
 
-    app.stop_all_tasks(&mut default_cb)?;
+    app.stop(&mut default_cb)?;
     Ok(())
 }
 
@@ -301,8 +301,8 @@ fn resim_bridge_task_same(
         .with_clock(clock)
         .with_log_path(output_path, LOG_SLAB_SIZE)?
         .with_sim_callback(&mut default_cb)
-        .build_app()?;
-    let mut app = app.start_all_tasks(&mut default_cb)?;
+        .build()?;
+    let mut app = app.start(&mut default_cb)?;
 
     let mut reader = open_copperlist_reader(input_log_path)?;
     for entry in copperlists_reader::<BridgeTaskSame::CuStampedDataSet>(&mut reader) {
@@ -311,7 +311,7 @@ fn resim_bridge_task_same(
         app.run_one_iteration(&mut sim_cb)?;
     }
 
-    app.stop_all_tasks(&mut default_cb)?;
+    app.stop(&mut default_cb)?;
     Ok(())
 }
 
@@ -346,7 +346,7 @@ macro_rules! define_remote_debug_mission {
                 .with_clock(clock.clone())
                 .with_log_path(replay_log_base, LOG_SLAB_SIZE)?
                 .with_sim_callback(&mut default_cb)
-                .build_app()?;
+                .build()?;
             // The replay session engine drives the raw lifecycle itself.
             Ok((app.into_inner(), clock, clock_mock))
         }

--- a/examples/cu_bridge_test/src/resim.rs
+++ b/examples/cu_bridge_test/src/resim.rs
@@ -162,12 +162,12 @@ fn open_copperlist_reader(log_path: &Path) -> CuResult<UnifiedLoggerIOReader> {
 macro_rules! resim_default {
     ($app:ident, $output_path:expr, $robot_clock:expr, $clock_mock:expr, $input_log_path:expr) => {{
         let mut default_cb = |_step: $app::SimStep<'_>| SimOverride::ExecuteByRuntime;
-        let mut app = $app::BridgeSchedulerReSim::builder()
+        let app = $app::BridgeSchedulerReSim::builder()
             .with_clock($robot_clock)
             .with_log_path($output_path, LOG_SLAB_SIZE)?
             .with_sim_callback(&mut default_cb)
-            .build()?;
-        app.start_all_tasks(&mut default_cb)?;
+            .build_app()?;
+        let mut app = app.start_all_tasks(&mut default_cb)?;
 
         let mut reader = open_copperlist_reader($input_log_path)?;
         for entry in copperlists_reader::<$app::CuStampedDataSet>(&mut reader) {
@@ -221,12 +221,12 @@ fn resim_source_to_bridge(
     input_log_path: &Path,
 ) -> CuResult<()> {
     let mut default_cb = |_step: SourceToBridge::SimStep<'_>| SimOverride::ExecuteByRuntime;
-    let mut app = SourceToBridge::BridgeSchedulerReSim::builder()
+    let app = SourceToBridge::BridgeSchedulerReSim::builder()
         .with_clock(clock)
         .with_log_path(output_path, LOG_SLAB_SIZE)?
         .with_sim_callback(&mut default_cb)
-        .build()?;
-    app.start_all_tasks(&mut default_cb)?;
+        .build_app()?;
+    let mut app = app.start_all_tasks(&mut default_cb)?;
 
     let mut reader = open_copperlist_reader(input_log_path)?;
     for entry in copperlists_reader::<SourceToBridge::CuStampedDataSet>(&mut reader) {
@@ -259,12 +259,12 @@ fn resim_bridge_to_sink(
     input_log_path: &Path,
 ) -> CuResult<()> {
     let mut default_cb = |_step: BridgeToSink::SimStep<'_>| SimOverride::ExecuteByRuntime;
-    let mut app = BridgeToSink::BridgeSchedulerReSim::builder()
+    let app = BridgeToSink::BridgeSchedulerReSim::builder()
         .with_clock(clock)
         .with_log_path(output_path, LOG_SLAB_SIZE)?
         .with_sim_callback(&mut default_cb)
-        .build()?;
-    app.start_all_tasks(&mut default_cb)?;
+        .build_app()?;
+    let mut app = app.start_all_tasks(&mut default_cb)?;
 
     let mut reader = open_copperlist_reader(input_log_path)?;
     for entry in copperlists_reader::<BridgeToSink::CuStampedDataSet>(&mut reader) {
@@ -297,12 +297,12 @@ fn resim_bridge_task_same(
     input_log_path: &Path,
 ) -> CuResult<()> {
     let mut default_cb = |_step: BridgeTaskSame::SimStep<'_>| SimOverride::ExecuteByRuntime;
-    let mut app = BridgeTaskSame::BridgeSchedulerReSim::builder()
+    let app = BridgeTaskSame::BridgeSchedulerReSim::builder()
         .with_clock(clock)
         .with_log_path(output_path, LOG_SLAB_SIZE)?
         .with_sim_callback(&mut default_cb)
-        .build()?;
-    app.start_all_tasks(&mut default_cb)?;
+        .build_app()?;
+    let mut app = app.start_all_tasks(&mut default_cb)?;
 
     let mut reader = open_copperlist_reader(input_log_path)?;
     for entry in copperlists_reader::<BridgeTaskSame::CuStampedDataSet>(&mut reader) {
@@ -346,8 +346,9 @@ macro_rules! define_remote_debug_mission {
                 .with_clock(clock.clone())
                 .with_log_path(replay_log_base, LOG_SLAB_SIZE)?
                 .with_sim_callback(&mut default_cb)
-                .build()?;
-            Ok((app, clock, clock_mock))
+                .build_app()?;
+            // The replay session engine drives the raw lifecycle itself.
+            Ok((app.into_inner(), clock, clock_mock))
         }
 
         fn $build_callback<'a>(

--- a/examples/cu_caterpillar/src/determinism.rs
+++ b/examples/cu_caterpillar/src/determinism.rs
@@ -85,11 +85,11 @@ fn record_run(log_base: &Path, iterations: usize, dt_ticks: u64) -> CuResult<()>
         .with_clock(clock.clone())
         .with_log_path(log_base, slab_size)?
         .with_sim_callback(&mut record_callback)
-        .build_app()
+        .build()
         .expect("failed to build app");
 
     let mut running = app
-        .start_all_tasks(&mut record_callback)
+        .start(&mut record_callback)
         .expect("failed to start tasks");
 
     for i in 0..iterations {
@@ -100,7 +100,7 @@ fn record_run(log_base: &Path, iterations: usize, dt_ticks: u64) -> CuResult<()>
     }
 
     running
-        .stop_all_tasks(&mut record_callback)
+        .stop(&mut record_callback)
         .expect("failed to stop tasks");
 
     Ok(())
@@ -208,11 +208,11 @@ fn resim_run(input_log_base: &Path, output_log_base: &Path) -> CuResult<()> {
         .with_clock(clock.clone())
         .with_log_path(output_log_base, slab_size)?
         .with_sim_callback(&mut init_cb)
-        .build_app()
+        .build()
         .expect("failed to build resim app");
 
     let mut app = app
-        .start_all_tasks(&mut init_cb)
+        .start(&mut init_cb)
         .expect("failed to start tasks (resim)");
 
     let UnifiedLogger::Read(dl) = UnifiedLoggerBuilder::new()
@@ -230,7 +230,7 @@ fn resim_run(input_log_base: &Path, output_log_base: &Path) -> CuResult<()> {
         resim_one_copperlist(&mut app, &mut clock_mock, cl);
     }
 
-    app.stop_all_tasks(&mut init_cb)
+    app.stop(&mut init_cb)
         .expect("failed to stop tasks (resim)");
 
     Ok(())

--- a/examples/cu_caterpillar/src/determinism.rs
+++ b/examples/cu_caterpillar/src/determinism.rs
@@ -81,23 +81,26 @@ fn record_run(log_base: &Path, iterations: usize, dt_ticks: u64) -> CuResult<()>
         }
     };
 
-    let mut app = CaterpillarDeterminismApp::builder()
+    let app = CaterpillarDeterminismApp::builder()
         .with_clock(clock.clone())
         .with_log_path(log_base, slab_size)?
         .with_sim_callback(&mut record_callback)
-        .build()
+        .build_app()
         .expect("failed to build app");
 
-    app.start_all_tasks(&mut record_callback)
+    let mut running = app
+        .start_all_tasks(&mut record_callback)
         .expect("failed to start tasks");
 
     for i in 0..iterations {
         clock_mock.set_value(dt_ticks.saturating_mul(i as u64));
-        app.run_one_iteration(&mut record_callback)
+        running
+            .run_one_iteration(&mut record_callback)
             .expect("run_one_iteration failed");
     }
 
-    app.stop_all_tasks(&mut record_callback)
+    running
+        .stop_all_tasks(&mut record_callback)
         .expect("failed to stop tasks");
 
     Ok(())
@@ -146,7 +149,7 @@ fn read_keyframe_stream_encoded(log_base: &Path) -> CuResult<Vec<Vec<u8>>> {
 }
 
 fn resim_one_copperlist(
-    app: &mut CaterpillarDeterminismApp,
+    app: &mut CuStdSimAppLifecycle<CaterpillarDeterminismApp, Running>,
     robot_clock_mock: &mut RobotClockMock,
     copper_list: CopperList<default::CuStampedDataSet>,
 ) {
@@ -201,14 +204,15 @@ fn resim_run(input_log_base: &Path, output_log_base: &Path) -> CuResult<()> {
         SimOverride::ExecuteByRuntime
     }
 
-    let mut app = CaterpillarDeterminismApp::builder()
+    let app = CaterpillarDeterminismApp::builder()
         .with_clock(clock.clone())
         .with_log_path(output_log_base, slab_size)?
         .with_sim_callback(&mut init_cb)
-        .build()
+        .build_app()
         .expect("failed to build resim app");
 
-    app.start_all_tasks(&mut init_cb)
+    let mut app = app
+        .start_all_tasks(&mut init_cb)
         .expect("failed to start tasks (resim)");
 
     let UnifiedLogger::Read(dl) = UnifiedLoggerBuilder::new()

--- a/examples/cu_caterpillar/src/main.rs
+++ b/examples/cu_caterpillar/src/main.rs
@@ -17,13 +17,13 @@ fn main() {
         fs::create_dir_all(parent).expect("Failed to create logs directory");
     }
 
-    let mut application = CaterpillarApplication::builder()
+    let application = CaterpillarApplication::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
 
-    if let Err(error) = application.run() {
-        debug!("Application Ended: {}", error)
+    if let Err(error) = CuStdAppLifecycle::new(application).run() {
+        debug!("Application Ended: {}", error.error)
     }
 }

--- a/examples/cu_caterpillar/src/main.rs
+++ b/examples/cu_caterpillar/src/main.rs
@@ -20,10 +20,10 @@ fn main() {
     let application = CaterpillarApplication::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create application.");
 
-    if let Err(error) = CuStdAppLifecycle::new(application).run() {
+    if let Err(error) = application.run() {
         debug!("Application Ended: {}", error.error)
     }
 }

--- a/examples/cu_caterpillar/src/main.rs
+++ b/examples/cu_caterpillar/src/main.rs
@@ -20,10 +20,10 @@ fn main() {
     let application = CaterpillarApplication::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create application.");
 
-    if let Err(error) = application.run() {
+    if let Err(error) = application.run_until_shutdown() {
         debug!("Application Ended: {}", error.error)
     }
 }

--- a/examples/cu_caterpillar/src/resim.rs
+++ b/examples/cu_caterpillar/src/resim.rs
@@ -179,7 +179,8 @@ fn make_app(log_base: &Path) -> CuResult<(CaterpillarReSim, RobotClock, RobotClo
         .with_clock(robot_clock.clone())
         .with_log_path(log_base, REPLAY_LOG_SLAB_SIZE)?
         .with_sim_callback(&mut default_callback)
-        .build()?;
+        .build()?
+        .into_inner();
     Ok((copper_app, robot_clock, robot_clock_mock))
 }
 

--- a/examples/cu_caterpillar/src/resim.rs
+++ b/examples/cu_caterpillar/src/resim.rs
@@ -1,3 +1,8 @@
+// Replay harness: drives the raw (app-deprecated) lifecycle API on purpose.
+// Replay needs mid-flight runtime access (keyframe locking, forced
+// timestamps) that the lifecycle typestate deliberately does not expose.
+#![allow(deprecated)]
+
 pub mod tasks;
 
 use cu29::prelude::app::CuSimApplication;

--- a/examples/cu_config_variation/src/main.rs
+++ b/examples/cu_config_variation/src/main.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 #[copper_runtime(config = "copperconfig.ron")]
 struct MyApp {}
 
-fn run_once(app: MyApp) -> CuResult<()> {
-    let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
+fn run_once(app: CuStdAppLifecycle<MyApp>) -> CuResult<()> {
+    let mut running = app.start_all_tasks()?;
     running.run_one_iteration()?;
     running.stop_all_tasks()?;
     Ok(())
@@ -29,7 +29,7 @@ fn main() {
             .with_log_path(&logger_path, None)
             .expect("Failed to setup logger.")
             .with_config(copperconfig.clone())
-            .build()
+            .build_app()
             .expect("Failed to create application.");
         run_once(application).expect("Failed to run application.");
 
@@ -49,7 +49,7 @@ fn main() {
             .with_log_path(&logger_path, None)
             .expect("Failed to setup logger.")
             .with_config(copperconfig.clone())
-            .build()
+            .build_app()
             .expect("Failed to create application.");
         run_once(application).expect("Failed to run application.");
     }

--- a/examples/cu_config_variation/src/main.rs
+++ b/examples/cu_config_variation/src/main.rs
@@ -5,9 +5,9 @@ use std::path::{Path, PathBuf};
 struct MyApp {}
 
 fn run_once(app: CuStdAppLifecycle<MyApp>) -> CuResult<()> {
-    let mut running = app.start_all_tasks()?;
+    let mut running = app.start()?;
     running.run_one_iteration()?;
-    running.stop_all_tasks()?;
+    running.stop()?;
     Ok(())
 }
 
@@ -29,7 +29,7 @@ fn main() {
             .with_log_path(&logger_path, None)
             .expect("Failed to setup logger.")
             .with_config(copperconfig.clone())
-            .build_app()
+            .build()
             .expect("Failed to create application.");
         run_once(application).expect("Failed to run application.");
 
@@ -49,7 +49,7 @@ fn main() {
             .with_log_path(&logger_path, None)
             .expect("Failed to setup logger.")
             .with_config(copperconfig.clone())
-            .build_app()
+            .build()
             .expect("Failed to create application.");
         run_once(application).expect("Failed to run application.");
     }

--- a/examples/cu_config_variation/src/main.rs
+++ b/examples/cu_config_variation/src/main.rs
@@ -4,10 +4,10 @@ use std::path::{Path, PathBuf};
 #[copper_runtime(config = "copperconfig.ron")]
 struct MyApp {}
 
-fn run_once(app: &mut MyApp) -> CuResult<()> {
-    app.start_all_tasks()?;
-    app.run_one_iteration()?;
-    app.stop_all_tasks()?;
+fn run_once(app: MyApp) -> CuResult<()> {
+    let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
+    running.run_one_iteration()?;
+    running.stop_all_tasks()?;
     Ok(())
 }
 
@@ -24,14 +24,14 @@ fn main() {
 
     // First run with the base configuration
     {
-        let mut application = MyApp::builder()
+        let application = MyApp::builder()
             .with_clock(clock.clone())
             .with_log_path(&logger_path, None)
             .expect("Failed to setup logger.")
             .with_config(copperconfig.clone())
             .build()
             .expect("Failed to create application.");
-        run_once(&mut application).expect("Failed to run application.");
+        run_once(application).expect("Failed to run application.");
 
         // everything will be teared down here
     }
@@ -44,13 +44,13 @@ fn main() {
             node.set_param("pin", 42);
         }
 
-        let mut application = MyApp::builder()
+        let application = MyApp::builder()
             .with_clock(clock.clone())
             .with_log_path(&logger_path, None)
             .expect("Failed to setup logger.")
             .with_config(copperconfig.clone())
             .build()
             .expect("Failed to create application.");
-        run_once(&mut application).expect("Failed to run application.");
+        run_once(application).expect("Failed to run application.");
     }
 }

--- a/examples/cu_debug_session/src/main.rs
+++ b/examples/cu_debug_session/src/main.rs
@@ -156,7 +156,8 @@ fn record_log() -> CuResult<()> {
         .with_clock(clock.clone())
         .with_log_path(Path::new(LOG_PATH), LOG_SLAB_SIZE)?
         .with_sim_callback(&mut sim_cb)
-        .build()?;
+        .build()?
+        .into_inner();
 
     app.start_all_tasks(&mut sim_cb)?;
     // Record enough iterations to span multiple log sections and exercise indexing.
@@ -176,7 +177,8 @@ fn run_debug_session() -> CuResult<()> {
         .with_clock(clock.clone())
         .with_log_path(Path::new(REPLAY_LOG_PATH), REPLAY_LOG_SLAB_SIZE)?
         .with_sim_callback(&mut sim_cb)
-        .build()?;
+        .build()?
+        .into_inner();
 
     // Time extractor from recorded copperlist.
     fn time_of(cl: &CopperList<default::CuStampedDataSet>) -> Option<CuTime> {

--- a/examples/cu_debug_session/src/main.rs
+++ b/examples/cu_debug_session/src/main.rs
@@ -1,3 +1,8 @@
+// Replay harness: drives the raw (app-deprecated) lifecycle API on purpose.
+// Replay needs mid-flight runtime access (keyframe locking, forced
+// timestamps) that the lifecycle typestate deliberately does not expose.
+#![allow(deprecated)]
+
 use cu29::bincode::de::Decoder;
 use cu29::bincode::enc::Encoder;
 use cu29::bincode::error::{DecodeError, EncodeError};

--- a/examples/cu_distributed_resim_demo/src/bin/control.rs
+++ b/examples/cu_distributed_resim_demo/src/bin/control.rs
@@ -30,15 +30,15 @@ fn drive() -> CuResult<()> {
     let app = ControlApp::builder()
         .with_log_path(&options.log_path, LOG_SLAB_SIZE)?
         .with_instance_id(options.instance_id)
-        .build_app()?;
-    let mut app = app.start_all_tasks()?;
+        .build()?;
+    let mut app = app.start()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {
             app.run_one_iteration()?;
             sleep_period(options.period);
         }
-        app.stop_all_tasks()?;
+        app.stop()?;
         return Ok(());
     }
 

--- a/examples/cu_distributed_resim_demo/src/bin/control.rs
+++ b/examples/cu_distributed_resim_demo/src/bin/control.rs
@@ -31,7 +31,7 @@ fn drive() -> CuResult<()> {
         .with_log_path(&options.log_path, LOG_SLAB_SIZE)?
         .with_instance_id(options.instance_id)
         .build_app()?;
-    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
+    let mut app = app.start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {

--- a/examples/cu_distributed_resim_demo/src/bin/control.rs
+++ b/examples/cu_distributed_resim_demo/src/bin/control.rs
@@ -30,7 +30,7 @@ fn drive() -> CuResult<()> {
     let app = ControlApp::builder()
         .with_log_path(&options.log_path, LOG_SLAB_SIZE)?
         .with_instance_id(options.instance_id)
-        .build()?;
+        .build_app()?;
     let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {

--- a/examples/cu_distributed_resim_demo/src/bin/control.rs
+++ b/examples/cu_distributed_resim_demo/src/bin/control.rs
@@ -27,11 +27,11 @@ fn main() {
 
 fn drive() -> CuResult<()> {
     let options = parse_run_options("control.copper", DEFAULT_CONTROL_PERIOD_MS)?;
-    let mut app = ControlApp::builder()
+    let app = ControlApp::builder()
         .with_log_path(&options.log_path, LOG_SLAB_SIZE)?
         .with_instance_id(options.instance_id)
         .build()?;
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {

--- a/examples/cu_distributed_resim_demo/src/bin/plan.rs
+++ b/examples/cu_distributed_resim_demo/src/bin/plan.rs
@@ -30,15 +30,15 @@ fn drive() -> CuResult<()> {
     let app = PlanApp::builder()
         .with_log_path(&options.log_path, LOG_SLAB_SIZE)?
         .with_instance_id(options.instance_id)
-        .build_app()?;
-    let mut app = app.start_all_tasks()?;
+        .build()?;
+    let mut app = app.start()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {
             app.run_one_iteration()?;
             sleep_period(options.period);
         }
-        app.stop_all_tasks()?;
+        app.stop()?;
         return Ok(());
     }
 

--- a/examples/cu_distributed_resim_demo/src/bin/plan.rs
+++ b/examples/cu_distributed_resim_demo/src/bin/plan.rs
@@ -30,7 +30,7 @@ fn drive() -> CuResult<()> {
     let app = PlanApp::builder()
         .with_log_path(&options.log_path, LOG_SLAB_SIZE)?
         .with_instance_id(options.instance_id)
-        .build()?;
+        .build_app()?;
     let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {

--- a/examples/cu_distributed_resim_demo/src/bin/plan.rs
+++ b/examples/cu_distributed_resim_demo/src/bin/plan.rs
@@ -27,11 +27,11 @@ fn main() {
 
 fn drive() -> CuResult<()> {
     let options = parse_run_options("plan.copper", DEFAULT_PLAN_PERIOD_MS)?;
-    let mut app = PlanApp::builder()
+    let app = PlanApp::builder()
         .with_log_path(&options.log_path, LOG_SLAB_SIZE)?
         .with_instance_id(options.instance_id)
         .build()?;
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {

--- a/examples/cu_distributed_resim_demo/src/bin/plan.rs
+++ b/examples/cu_distributed_resim_demo/src/bin/plan.rs
@@ -31,7 +31,7 @@ fn drive() -> CuResult<()> {
         .with_log_path(&options.log_path, LOG_SLAB_SIZE)?
         .with_instance_id(options.instance_id)
         .build_app()?;
-    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
+    let mut app = app.start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {

--- a/examples/cu_distributed_resim_demo/src/bin/scout.rs
+++ b/examples/cu_distributed_resim_demo/src/bin/scout.rs
@@ -30,15 +30,15 @@ fn drive() -> CuResult<()> {
     let app = ScoutApp::builder()
         .with_log_path(&options.log_path, LOG_SLAB_SIZE)?
         .with_instance_id(options.instance_id)
-        .build_app()?;
-    let mut app = app.start_all_tasks()?;
+        .build()?;
+    let mut app = app.start()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {
             app.run_one_iteration()?;
             sleep_period(options.period);
         }
-        app.stop_all_tasks()?;
+        app.stop()?;
         return Ok(());
     }
 

--- a/examples/cu_distributed_resim_demo/src/bin/scout.rs
+++ b/examples/cu_distributed_resim_demo/src/bin/scout.rs
@@ -30,7 +30,7 @@ fn drive() -> CuResult<()> {
     let app = ScoutApp::builder()
         .with_log_path(&options.log_path, LOG_SLAB_SIZE)?
         .with_instance_id(options.instance_id)
-        .build()?;
+        .build_app()?;
     let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {

--- a/examples/cu_distributed_resim_demo/src/bin/scout.rs
+++ b/examples/cu_distributed_resim_demo/src/bin/scout.rs
@@ -31,7 +31,7 @@ fn drive() -> CuResult<()> {
         .with_log_path(&options.log_path, LOG_SLAB_SIZE)?
         .with_instance_id(options.instance_id)
         .build_app()?;
-    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
+    let mut app = app.start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {

--- a/examples/cu_distributed_resim_demo/src/bin/scout.rs
+++ b/examples/cu_distributed_resim_demo/src/bin/scout.rs
@@ -27,11 +27,11 @@ fn main() {
 
 fn drive() -> CuResult<()> {
     let options = parse_run_options("scout.copper", DEFAULT_SCOUT_PERIOD_MS)?;
-    let mut app = ScoutApp::builder()
+    let app = ScoutApp::builder()
         .with_log_path(&options.log_path, LOG_SLAB_SIZE)?
         .with_instance_id(options.instance_id)
         .build()?;
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {

--- a/examples/cu_elrs_bdshot_demo/src/main.rs
+++ b/examples/cu_elrs_bdshot_demo/src/main.rs
@@ -226,17 +226,14 @@ fn main() -> ! {
         EMMCLogger::new(sd, blk_id, blk_len).expect("Could not create EMMC logger"),
     ));
 
-    let mut app = BdshotDemoApp::builder()
+    let app = BdshotDemoApp::builder()
         .with_clock(clock)
         .with_logger::<EMMCSectionStorage<TSPimodoriSdCard>, EMMCLogger<TSPimodoriSdCard>>(writer)
-        .build()
+        .build_app()
         .unwrap();
     info!("Starting cu-bdshot-demo...");
 
-    let _ = <BdshotDemoApp as CuApplication<
-        EMMCSectionStorage<TSPimodoriSdCard>,
-        EMMCLogger<TSPimodoriSdCard>,
-    >>::run(&mut app);
+    let _ = app.run();
     error!("Copper crashed.");
     #[allow(clippy::empty_loop)]
     loop {}

--- a/examples/cu_elrs_bdshot_demo/src/main.rs
+++ b/examples/cu_elrs_bdshot_demo/src/main.rs
@@ -229,11 +229,11 @@ fn main() -> ! {
     let app = BdshotDemoApp::builder()
         .with_clock(clock)
         .with_logger::<EMMCSectionStorage<TSPimodoriSdCard>, EMMCLogger<TSPimodoriSdCard>>(writer)
-        .build_app()
+        .build()
         .unwrap();
     info!("Starting cu-bdshot-demo...");
 
-    let _ = app.run();
+    let _ = app.run_until_shutdown();
     error!("Copper crashed.");
     #[allow(clippy::empty_loop)]
     loop {}

--- a/examples/cu_feature_gated_camera/src/main.rs
+++ b/examples/cu_feature_gated_camera/src/main.rs
@@ -30,12 +30,13 @@ mod app {
                 .map_err(|error| CuError::new_with_cause("creating log directory", error))?;
         }
 
-        let mut app = CameraApp::builder()
+        let app = CameraApp::builder()
             .with_log_path(&log_path, Some(16 * 1024 * 1024))?
             .build()?;
-        app.start_all_tasks()?;
-        app.run_one_iteration()?;
-        app.stop_all_tasks()
+        let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
+        running.run_one_iteration()?;
+        running.stop_all_tasks()?;
+        Ok(())
     }
 }
 

--- a/examples/cu_feature_gated_camera/src/main.rs
+++ b/examples/cu_feature_gated_camera/src/main.rs
@@ -32,10 +32,10 @@ mod app {
 
         let app = CameraApp::builder()
             .with_log_path(&log_path, Some(16 * 1024 * 1024))?
-            .build_app()?;
-        let mut running = app.start_all_tasks()?;
+            .build()?;
+        let mut running = app.start()?;
         running.run_one_iteration()?;
-        running.stop_all_tasks()?;
+        running.stop()?;
         Ok(())
     }
 }

--- a/examples/cu_feature_gated_camera/src/main.rs
+++ b/examples/cu_feature_gated_camera/src/main.rs
@@ -32,8 +32,8 @@ mod app {
 
         let app = CameraApp::builder()
             .with_log_path(&log_path, Some(16 * 1024 * 1024))?
-            .build()?;
-        let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
+            .build_app()?;
+        let mut running = app.start_all_tasks()?;
         running.run_one_iteration()?;
         running.stop_all_tasks()?;
         Ok(())

--- a/examples/cu_feetech_demo/src/main.rs
+++ b/examples/cu_feetech_demo/src/main.rs
@@ -19,11 +19,13 @@ use leader_follower::FeetechDemoApp as LeaderFollowerApp;
 
 const SLAB_SIZE: Option<usize> = Some(64 * 1024 * 1024);
 
-fn run_mission<App>(app: App) -> CuResult<()>
+fn run_mission<App>(
+    app: CuAppLifecycle<memmap::MmapSectionStorage, UnifiedLoggerWrite, App>,
+) -> CuResult<()>
 where
     App: CuApplication<memmap::MmapSectionStorage, UnifiedLoggerWrite>,
 {
-    CuAppLifecycle::new(app).run()?;
+    app.run()?;
     Ok(())
 }
 
@@ -48,7 +50,7 @@ fn main() {
             let app = ArmPublisherApp::builder()
                 .with_log_path(logger_path, SLAB_SIZE)
                 .expect("Failed to setup logger.")
-                .build()
+                .build_app()
                 .unwrap_or_else(|e| {
                     print_setup_help(&e);
                     std::process::exit(1);
@@ -62,7 +64,7 @@ fn main() {
             let app = LeaderFollowerApp::builder()
                 .with_log_path(logger_path, SLAB_SIZE)
                 .expect("Failed to setup logger.")
-                .build()
+                .build_app()
                 .unwrap_or_else(|e| {
                     print_setup_help(&e);
                     std::process::exit(1);

--- a/examples/cu_feetech_demo/src/main.rs
+++ b/examples/cu_feetech_demo/src/main.rs
@@ -19,11 +19,12 @@ use leader_follower::FeetechDemoApp as LeaderFollowerApp;
 
 const SLAB_SIZE: Option<usize> = Some(64 * 1024 * 1024);
 
-fn run_mission<App>(app: &mut App) -> CuResult<()>
+fn run_mission<App>(app: App) -> CuResult<()>
 where
     App: CuApplication<memmap::MmapSectionStorage, UnifiedLoggerWrite>,
 {
-    app.run()
+    CuAppLifecycle::new(app).run()?;
+    Ok(())
 }
 
 fn main() {
@@ -44,7 +45,7 @@ fn main() {
     match mission.as_str() {
         "arm_publisher" => {
             debug!("Starting ARM_PUBLISHER mission – reading positions.");
-            let mut app = ArmPublisherApp::builder()
+            let app = ArmPublisherApp::builder()
                 .with_log_path(logger_path, SLAB_SIZE)
                 .expect("Failed to setup logger.")
                 .build()
@@ -52,13 +53,13 @@ fn main() {
                     print_setup_help(&e);
                     std::process::exit(1);
                 });
-            if let Err(e) = run_mission(&mut app) {
+            if let Err(e) = run_mission(app) {
                 debug!("Arm publisher ended: {}", e);
             }
         }
         "leader_follower" => {
             debug!("Starting LEADER_FOLLOWER mission – leader drives follower.");
-            let mut app = LeaderFollowerApp::builder()
+            let app = LeaderFollowerApp::builder()
                 .with_log_path(logger_path, SLAB_SIZE)
                 .expect("Failed to setup logger.")
                 .build()
@@ -66,7 +67,7 @@ fn main() {
                     print_setup_help(&e);
                     std::process::exit(1);
                 });
-            if let Err(e) = run_mission(&mut app) {
+            if let Err(e) = run_mission(app) {
                 debug!("Leader-follower ended: {}", e);
             }
         }

--- a/examples/cu_feetech_demo/src/main.rs
+++ b/examples/cu_feetech_demo/src/main.rs
@@ -25,7 +25,7 @@ fn run_mission<App>(
 where
     App: CuApplication<memmap::MmapSectionStorage, UnifiedLoggerWrite>,
 {
-    app.run()?;
+    app.run_until_shutdown()?;
     Ok(())
 }
 
@@ -50,7 +50,7 @@ fn main() {
             let app = ArmPublisherApp::builder()
                 .with_log_path(logger_path, SLAB_SIZE)
                 .expect("Failed to setup logger.")
-                .build_app()
+                .build()
                 .unwrap_or_else(|e| {
                     print_setup_help(&e);
                     std::process::exit(1);
@@ -64,7 +64,7 @@ fn main() {
             let app = LeaderFollowerApp::builder()
                 .with_log_path(logger_path, SLAB_SIZE)
                 .expect("Failed to setup logger.")
-                .build_app()
+                .build()
                 .unwrap_or_else(|e| {
                     print_setup_help(&e);
                     std::process::exit(1);

--- a/examples/cu_flight_controller/src/compute.rs
+++ b/examples/cu_flight_controller/src/compute.rs
@@ -21,8 +21,9 @@ fn main() {
 }
 
 fn drive() -> CuResult<()> {
-    let mut app = ComputeApp::builder()
+    let app = ComputeApp::builder()
         .with_log_path("logs/compute.copper", LOG_SLAB_SIZE)?
         .build()?;
-    app.run()
+    CuStdAppLifecycle::new(app).run()?;
+    Ok(())
 }

--- a/examples/cu_flight_controller/src/compute.rs
+++ b/examples/cu_flight_controller/src/compute.rs
@@ -23,7 +23,7 @@ fn main() {
 fn drive() -> CuResult<()> {
     let app = ComputeApp::builder()
         .with_log_path("logs/compute.copper", LOG_SLAB_SIZE)?
-        .build()?;
-    CuStdAppLifecycle::new(app).run()?;
+        .build_app()?;
+    app.run()?;
     Ok(())
 }

--- a/examples/cu_flight_controller/src/compute.rs
+++ b/examples/cu_flight_controller/src/compute.rs
@@ -23,7 +23,7 @@ fn main() {
 fn drive() -> CuResult<()> {
     let app = ComputeApp::builder()
         .with_log_path("logs/compute.copper", LOG_SLAB_SIZE)?
-        .build_app()?;
-    app.run()?;
+        .build()?;
+    app.run_until_shutdown()?;
     Ok(())
 }

--- a/examples/cu_flight_controller/src/compute_resim.rs
+++ b/examples/cu_flight_controller/src/compute_resim.rs
@@ -80,9 +80,10 @@ fn app_factory(
         .with_clock(clock.clone())
         .with_log_path(replay_log_base, REPLAY_LOG_SLAB_SIZE)?
         .with_sim_callback(&mut default_callback)
-        .build()?;
+        .build_app()?;
 
-    Ok((app, clock, clock_mock))
+    // The replay session engine drives the raw lifecycle itself.
+    Ok((app.into_inner(), clock, clock_mock))
 }
 
 fn build_callback<'a>(

--- a/examples/cu_flight_controller/src/compute_resim.rs
+++ b/examples/cu_flight_controller/src/compute_resim.rs
@@ -80,7 +80,7 @@ fn app_factory(
         .with_clock(clock.clone())
         .with_log_path(replay_log_base, REPLAY_LOG_SLAB_SIZE)?
         .with_sim_callback(&mut default_callback)
-        .build_app()?;
+        .build()?;
 
     // The replay session engine drives the raw lifecycle itself.
     Ok((app.into_inner(), clock, clock_mock))

--- a/examples/cu_flight_controller/src/main.rs
+++ b/examples/cu_flight_controller/src/main.rs
@@ -89,11 +89,11 @@ fn main() -> ! {
         .with_clock(clock)
         .with_logger::<LogStorage, Logger>(writer)
         .with_resources(move |_| Ok(resources.resources))
-        .build()
+        .build_app()
     {
-        Ok(mut app) => {
+        Ok(app) => {
             log_heap_stats("before-run");
-            let _ = <FlightControllerApp as CuApplication<LogStorage, Logger>>::run(&mut app);
+            let _ = app.run();
         }
         Err(err) => {
             error!("App init failed: {}", &err);

--- a/examples/cu_flight_controller/src/main.rs
+++ b/examples/cu_flight_controller/src/main.rs
@@ -89,11 +89,11 @@ fn main() -> ! {
         .with_clock(clock)
         .with_logger::<LogStorage, Logger>(writer)
         .with_resources(move |_| Ok(resources.resources))
-        .build_app()
+        .build()
     {
         Ok(app) => {
             log_heap_stats("before-run");
-            let _ = app.run();
+            let _ = app.run_until_shutdown();
         }
         Err(err) => {
             error!("App init failed: {}", &err);

--- a/examples/cu_flight_controller/src/resim.rs
+++ b/examples/cu_flight_controller/src/resim.rs
@@ -72,7 +72,7 @@ fn app_factory(
         .with_clock(clock.clone())
         .with_log_path(replay_log_base, REPLAY_LOG_SLAB_SIZE)?
         .with_sim_callback(&mut default_callback)
-        .build_app()?;
+        .build()?;
 
     // The replay session engine drives the raw lifecycle itself.
     Ok((app.into_inner(), clock, clock_mock))

--- a/examples/cu_flight_controller/src/resim.rs
+++ b/examples/cu_flight_controller/src/resim.rs
@@ -72,9 +72,10 @@ fn app_factory(
         .with_clock(clock.clone())
         .with_log_path(replay_log_base, REPLAY_LOG_SLAB_SIZE)?
         .with_sim_callback(&mut default_callback)
-        .build()?;
+        .build_app()?;
 
-    Ok((app, clock, clock_mock))
+    // The replay session engine drives the raw lifecycle itself.
+    Ok((app.into_inner(), clock, clock_mock))
 }
 
 fn build_callback<'a>(

--- a/examples/cu_flight_controller/src/sim.rs
+++ b/examples/cu_flight_controller/src/sim.rs
@@ -1,3 +1,8 @@
+// Simulation engine: drives the raw (app-deprecated) lifecycle API on purpose.
+// It needs mid-flight runtime access that the lifecycle typestate
+// deliberately does not expose.
+#![allow(deprecated)]
+
 #[cfg(feature = "sim")]
 extern crate alloc;
 

--- a/examples/cu_flight_controller/src/sim.rs
+++ b/examples/cu_flight_controller/src/sim.rs
@@ -152,7 +152,8 @@ mod mcu_copper {
                 .expect("failed to create logger")
                 .with_sim_callback(&mut default_callback)
                 .build()
-                .expect("failed to create runtime");
+                .expect("failed to create runtime")
+                .into_inner();
             Self { app }
         }
 
@@ -162,7 +163,8 @@ mod mcu_copper {
                 .with_clock(clock.clone())
                 .with_sim_callback(&mut default_callback)
                 .build()
-                .expect("failed to create runtime");
+                .expect("failed to create runtime")
+                .into_inner();
             Self { app }
         }
 
@@ -176,7 +178,8 @@ mod mcu_copper {
                 .with_logger::<BevyMonSectionStorage, BevyMonUnifiedLogger>(logger)
                 .with_sim_callback(&mut default_callback)
                 .build()
-                .expect("failed to create runtime");
+                .expect("failed to create runtime")
+                .into_inner();
             Self { app }
         }
 
@@ -368,7 +371,8 @@ mod compute_copper {
                 .expect("failed to create compute logger")
                 .with_sim_callback(&mut default_callback)
                 .build()
-                .expect("failed to create compute runtime");
+                .expect("failed to create compute runtime")
+                .into_inner();
             Self {
                 app,
                 zed_store,
@@ -382,7 +386,8 @@ mod compute_copper {
                 .with_clock(clock.clone())
                 .with_sim_callback(&mut default_callback)
                 .build()
-                .expect("failed to create compute runtime");
+                .expect("failed to create compute runtime")
+                .into_inner();
             Self {
                 app,
                 zed_store,

--- a/examples/cu_gnss_ublox_demo/src/main.rs
+++ b/examples/cu_gnss_ublox_demo/src/main.rs
@@ -25,9 +25,9 @@ fn run() -> CuResult<()> {
 
     let app = CuGnssUbloxDemo::builder()
         .with_log_path(&log_path, Some(16 * 1024 * 1024))?
-        .build()?;
-    let clock = app.clock();
-    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
+        .build_app()?;
+    let clock = app.inner().clock();
+    let mut app = app.start_all_tasks()?;
 
     let running = Arc::new(AtomicBool::new(true));
     let running_for_signal = Arc::clone(&running);

--- a/examples/cu_gnss_ublox_demo/src/main.rs
+++ b/examples/cu_gnss_ublox_demo/src/main.rs
@@ -25,9 +25,9 @@ fn run() -> CuResult<()> {
 
     let app = CuGnssUbloxDemo::builder()
         .with_log_path(&log_path, Some(16 * 1024 * 1024))?
-        .build_app()?;
-    let clock = app.inner().clock();
-    let mut app = app.start_all_tasks()?;
+        .build()?;
+    let clock = app.clock();
+    let mut app = app.start()?;
 
     let running = Arc::new(AtomicBool::new(true));
     let running_for_signal = Arc::clone(&running);
@@ -59,7 +59,7 @@ fn run() -> CuResult<()> {
         thread::sleep(Duration::from_millis(5));
     }
 
-    app.stop_all_tasks()?;
+    app.stop()?;
 
     if let Some(err) = run_error {
         return Err(err);

--- a/examples/cu_gnss_ublox_demo/src/main.rs
+++ b/examples/cu_gnss_ublox_demo/src/main.rs
@@ -23,11 +23,11 @@ fn run() -> CuResult<()> {
         .map_err(|e| CuError::new_with_cause("failed to create temporary log directory", e))?;
     let log_path = log_dir.path().join("cu_gnss_ublox_demo.copper");
 
-    let mut app = CuGnssUbloxDemo::builder()
+    let app = CuGnssUbloxDemo::builder()
         .with_log_path(&log_path, Some(16 * 1024 * 1024))?
         .build()?;
     let clock = app.clock();
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     let running = Arc::new(AtomicBool::new(true));
     let running_for_signal = Arc::clone(&running);

--- a/examples/cu_human_pose/src/main.rs
+++ b/examples/cu_human_pose/src/main.rs
@@ -47,12 +47,12 @@ fn main() {
     let application = YoloPoseDemoApplication::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to set up Copper logging")
-        .build()
+        .build_app()
         .expect("Failed to build application");
 
     // `run` starts the tasks itself; the typestate wrapper rejects the manual
     // start_all_tasks call this example used to make before it.
-    if let Err(e) = CuStdAppLifecycle::new(application).run() {
+    if let Err(e) = application.run() {
         error!("Error during iteration: {}", e.error.to_string());
     }
 }

--- a/examples/cu_human_pose/src/main.rs
+++ b/examples/cu_human_pose/src/main.rs
@@ -44,18 +44,15 @@ fn main() {
     }
 
     // Build the application from RON config
-    let mut application = YoloPoseDemoApplication::builder()
+    let application = YoloPoseDemoApplication::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to set up Copper logging")
         .build()
         .expect("Failed to build application");
 
-    // Start all tasks
-    application
-        .start_all_tasks()
-        .expect("Failed to start tasks");
-
-    if let Err(e) = application.run() {
-        error!("Error during iteration: {}", e.to_string());
+    // `run` starts the tasks itself; the typestate wrapper rejects the manual
+    // start_all_tasks call this example used to make before it.
+    if let Err(e) = CuStdAppLifecycle::new(application).run() {
+        error!("Error during iteration: {}", e.error.to_string());
     }
 }

--- a/examples/cu_human_pose/src/main.rs
+++ b/examples/cu_human_pose/src/main.rs
@@ -47,12 +47,12 @@ fn main() {
     let application = YoloPoseDemoApplication::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to set up Copper logging")
-        .build_app()
+        .build()
         .expect("Failed to build application");
 
     // `run` starts the tasks itself; the typestate wrapper rejects the manual
     // start_all_tasks call this example used to make before it.
-    if let Err(e) = application.run() {
+    if let Err(e) = application.run_until_shutdown() {
         error!("Error during iteration: {}", e.error.to_string());
     }
 }

--- a/examples/cu_iceoryx2_bridge_demo/src/bin/ping.rs
+++ b/examples/cu_iceoryx2_bridge_demo/src/bin/ping.rs
@@ -30,10 +30,10 @@ fn drive() -> CuResult<()> {
     let tmp_dir = tempfile::TempDir::new().expect("could not create temp dir");
     let logger_path = tmp_dir.path().join("iceoryx2_ping.copper");
 
-    let mut app = PingApp::builder()
+    let app = PingApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)?
         .build()?;
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     loop {
         app.run_one_iteration()?;

--- a/examples/cu_iceoryx2_bridge_demo/src/bin/ping.rs
+++ b/examples/cu_iceoryx2_bridge_demo/src/bin/ping.rs
@@ -32,8 +32,8 @@ fn drive() -> CuResult<()> {
 
     let app = PingApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)?
-        .build()?;
-    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
+        .build_app()?;
+    let mut app = app.start_all_tasks()?;
 
     loop {
         app.run_one_iteration()?;

--- a/examples/cu_iceoryx2_bridge_demo/src/bin/ping.rs
+++ b/examples/cu_iceoryx2_bridge_demo/src/bin/ping.rs
@@ -32,8 +32,8 @@ fn drive() -> CuResult<()> {
 
     let app = PingApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)?
-        .build_app()?;
-    let mut app = app.start_all_tasks()?;
+        .build()?;
+    let mut app = app.start()?;
 
     loop {
         app.run_one_iteration()?;

--- a/examples/cu_iceoryx2_bridge_demo/src/bin/pong.rs
+++ b/examples/cu_iceoryx2_bridge_demo/src/bin/pong.rs
@@ -32,8 +32,8 @@ fn drive() -> CuResult<()> {
 
     let app = PongApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)?
-        .build()?;
-    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
+        .build_app()?;
+    let mut app = app.start_all_tasks()?;
 
     loop {
         app.run_one_iteration()?;

--- a/examples/cu_iceoryx2_bridge_demo/src/bin/pong.rs
+++ b/examples/cu_iceoryx2_bridge_demo/src/bin/pong.rs
@@ -30,10 +30,10 @@ fn drive() -> CuResult<()> {
     let tmp_dir = tempfile::TempDir::new().expect("could not create temp dir");
     let logger_path = tmp_dir.path().join("iceoryx2_pong.copper");
 
-    let mut app = PongApp::builder()
+    let app = PongApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)?
         .build()?;
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     loop {
         app.run_one_iteration()?;

--- a/examples/cu_iceoryx2_bridge_demo/src/bin/pong.rs
+++ b/examples/cu_iceoryx2_bridge_demo/src/bin/pong.rs
@@ -32,8 +32,8 @@ fn drive() -> CuResult<()> {
 
     let app = PongApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)?
-        .build_app()?;
-    let mut app = app.start_all_tasks()?;
+        .build()?;
+    let mut app = app.start()?;
 
     loop {
         app.run_one_iteration()?;

--- a/examples/cu_image_aligner/src/main.rs
+++ b/examples/cu_image_aligner/src/main.rs
@@ -17,11 +17,14 @@ fn main() {
     let application = ImageAlignerApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create runtime.");
-    debug!("Running... starting clock: {}.", application.clock().now());
+    debug!(
+        "Running... starting clock: {}.",
+        application.inner().clock().now()
+    );
 
-    let mut running = CuStdAppLifecycle::new(application)
+    let mut running = application
         .start_all_tasks()
         .expect("Failed to start tasks.");
     for _ in 0..ITERATIONS {

--- a/examples/cu_image_aligner/src/main.rs
+++ b/examples/cu_image_aligner/src/main.rs
@@ -14,20 +14,20 @@ fn main() {
     debug!("Logger created at {}.", path = &logger_path);
     debug!("Creating application...");
 
-    let mut application = ImageAlignerApp::builder()
+    let application = ImageAlignerApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create runtime.");
     debug!("Running... starting clock: {}.", application.clock().now());
 
-    application
+    let mut running = CuStdAppLifecycle::new(application)
         .start_all_tasks()
         .expect("Failed to start tasks.");
     for _ in 0..ITERATIONS {
-        application
+        running
             .run_one_iteration()
             .expect("Failed to run iteration.");
     }
-    debug!("End of program: {}.", application.clock().now());
+    debug!("End of program: {}.", running.inner().clock().now());
 }

--- a/examples/cu_image_aligner/src/main.rs
+++ b/examples/cu_image_aligner/src/main.rs
@@ -17,20 +17,15 @@ fn main() {
     let application = ImageAlignerApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create runtime.");
-    debug!(
-        "Running... starting clock: {}.",
-        application.inner().clock().now()
-    );
+    debug!("Running... starting clock: {}.", application.clock().now());
 
-    let mut running = application
-        .start_all_tasks()
-        .expect("Failed to start tasks.");
+    let mut running = application.start().expect("Failed to start tasks.");
     for _ in 0..ITERATIONS {
         running
             .run_one_iteration()
             .expect("Failed to run iteration.");
     }
-    debug!("End of program: {}.", running.inner().clock().now());
+    debug!("End of program: {}.", running.clock().now());
 }

--- a/examples/cu_image_codec_demo/src/consolemon.rs
+++ b/examples/cu_image_codec_demo/src/consolemon.rs
@@ -27,10 +27,10 @@ pub fn main() {
     let application = ImageCodecDemoConsolemonApp::builder()
         .with_log_path(&log_path, Some(64 * 1024 * 1024))
         .expect("Failed to setup Copper log")
-        .build_app()
+        .build()
         .expect("Failed to create application");
 
-    if let Err(err) = application.run() {
+    if let Err(err) = application.run_until_shutdown() {
         if err.error.message() != "Exiting..." {
             let err = err.error;
             error!("{err:?}");

--- a/examples/cu_image_codec_demo/src/consolemon.rs
+++ b/examples/cu_image_codec_demo/src/consolemon.rs
@@ -24,14 +24,15 @@ pub fn main() {
         std::fs::create_dir_all(parent).expect("Failed to create log directory");
     }
 
-    let mut application = ImageCodecDemoConsolemonApp::builder()
+    let application = ImageCodecDemoConsolemonApp::builder()
         .with_log_path(&log_path, Some(64 * 1024 * 1024))
         .expect("Failed to setup Copper log")
         .build()
         .expect("Failed to create application");
 
-    if let Err(err) = application.run() {
-        if err.message() != "Exiting..." {
+    if let Err(err) = CuStdAppLifecycle::new(application).run() {
+        if err.error.message() != "Exiting..." {
+            let err = err.error;
             error!("{err:?}");
         }
     }

--- a/examples/cu_image_codec_demo/src/consolemon.rs
+++ b/examples/cu_image_codec_demo/src/consolemon.rs
@@ -27,10 +27,10 @@ pub fn main() {
     let application = ImageCodecDemoConsolemonApp::builder()
         .with_log_path(&log_path, Some(64 * 1024 * 1024))
         .expect("Failed to setup Copper log")
-        .build()
+        .build_app()
         .expect("Failed to create application");
 
-    if let Err(err) = CuStdAppLifecycle::new(application).run() {
+    if let Err(err) = application.run() {
         if err.error.message() != "Exiting..." {
             let err = err.error;
             error!("{err:?}");

--- a/examples/cu_image_codec_demo/src/main.rs
+++ b/examples/cu_image_codec_demo/src/main.rs
@@ -23,11 +23,9 @@ mod real {
         let application = ImageCodecDemoApp::builder()
             .with_log_path(&log_path, Some(64 * 1024 * 1024))
             .expect("Failed to setup Copper log")
-            .build_app()
+            .build()
             .expect("Failed to create application");
-        let mut running = application
-            .start_all_tasks()
-            .expect("Failed to start tasks");
+        let mut running = application.start().expect("Failed to start tasks");
 
         for _ in 0..180 {
             running

--- a/examples/cu_image_codec_demo/src/main.rs
+++ b/examples/cu_image_codec_demo/src/main.rs
@@ -23,9 +23,9 @@ mod real {
         let application = ImageCodecDemoApp::builder()
             .with_log_path(&log_path, Some(64 * 1024 * 1024))
             .expect("Failed to setup Copper log")
-            .build()
+            .build_app()
             .expect("Failed to create application");
-        let mut running = CuStdAppLifecycle::new(application)
+        let mut running = application
             .start_all_tasks()
             .expect("Failed to start tasks");
 

--- a/examples/cu_image_codec_demo/src/main.rs
+++ b/examples/cu_image_codec_demo/src/main.rs
@@ -20,17 +20,17 @@ mod real {
             std::fs::create_dir_all(parent).expect("Failed to create log directory");
         }
 
-        let mut application = ImageCodecDemoApp::builder()
+        let application = ImageCodecDemoApp::builder()
             .with_log_path(&log_path, Some(64 * 1024 * 1024))
             .expect("Failed to setup Copper log")
             .build()
             .expect("Failed to create application");
-        application
+        let mut running = CuStdAppLifecycle::new(application)
             .start_all_tasks()
             .expect("Failed to start tasks");
 
         for _ in 0..180 {
-            application
+            running
                 .run_one_iteration()
                 .expect("Failed to run iteration");
         }

--- a/examples/cu_instance_overrides_demo/src/main.rs
+++ b/examples/cu_instance_overrides_demo/src/main.rs
@@ -133,8 +133,8 @@ fn drive() -> CuResult<()> {
     let app = App::builder()
         .with_log_path(&logger_path, None)?
         .with_instance_id(instance_id)
-        .build()?;
-    let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
+        .build_app()?;
+    let mut running = app.start_all_tasks()?;
     running.run_one_iteration()?;
     running.stop_all_tasks()?;
     Ok(())

--- a/examples/cu_instance_overrides_demo/src/main.rs
+++ b/examples/cu_instance_overrides_demo/src/main.rs
@@ -130,12 +130,12 @@ fn drive() -> CuResult<()> {
             .map_err(|err| CuError::new_with_cause("failed to create log directory", err))?;
     }
 
-    let mut app = App::builder()
+    let app = App::builder()
         .with_log_path(&logger_path, None)?
         .with_instance_id(instance_id)
         .build()?;
-    app.start_all_tasks()?;
-    app.run_one_iteration()?;
-    app.stop_all_tasks()?;
+    let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
+    running.run_one_iteration()?;
+    running.stop_all_tasks()?;
     Ok(())
 }

--- a/examples/cu_instance_overrides_demo/src/main.rs
+++ b/examples/cu_instance_overrides_demo/src/main.rs
@@ -133,9 +133,9 @@ fn drive() -> CuResult<()> {
     let app = App::builder()
         .with_log_path(&logger_path, None)?
         .with_instance_id(instance_id)
-        .build_app()?;
-    let mut running = app.start_all_tasks()?;
+        .build()?;
+    let mut running = app.start()?;
     running.run_one_iteration()?;
-    running.stop_all_tasks()?;
+    running.stop()?;
     Ok(())
 }

--- a/examples/cu_logging_size/src/main.rs
+++ b/examples/cu_logging_size/src/main.rs
@@ -79,10 +79,13 @@ fn main() {
     debug!("Creating application... ");
     let application = App::builder()
         .with_logger::<memmap::MmapSectionStorage, UnifiedLoggerWrite>(unified_logger.clone())
-        .build()
+        .build_app()
         .expect("Failed to create application.");
-    debug!("Running... starting clock: {}.", application.clock().now());
-    let mut running = CuStdAppLifecycle::new(application)
+    debug!(
+        "Running... starting clock: {}.",
+        application.inner().clock().now()
+    );
+    let mut running = application
         .start_all_tasks()
         .expect("Failed to start application.");
     running

--- a/examples/cu_logging_size/src/main.rs
+++ b/examples/cu_logging_size/src/main.rs
@@ -77,21 +77,21 @@ fn main() {
     let unified_logger = Arc::new(Mutex::new(logger));
     debug!("Logger created at {}.", path = &logger_path);
     debug!("Creating application... ");
-    let mut application = App::builder()
+    let application = App::builder()
         .with_logger::<memmap::MmapSectionStorage, UnifiedLoggerWrite>(unified_logger.clone())
         .build()
         .expect("Failed to create application.");
     debug!("Running... starting clock: {}.", application.clock().now());
-    application
+    let mut running = CuStdAppLifecycle::new(application)
         .start_all_tasks()
         .expect("Failed to start application.");
-    application
+    running
         .run_one_iteration()
         .expect("Failed to run application.");
-    application
+    let stopped = running
         .stop_all_tasks()
         .expect("Failed to stop application.");
-    debug!("End of program: {}.", application.clock().now());
+    debug!("End of program: {}.", stopped.inner().clock().now());
     // check if the logger file is at least 1 section in length
 
     // change the end of the logger_path from copper to _0.copper

--- a/examples/cu_logging_size/src/main.rs
+++ b/examples/cu_logging_size/src/main.rs
@@ -79,22 +79,15 @@ fn main() {
     debug!("Creating application... ");
     let application = App::builder()
         .with_logger::<memmap::MmapSectionStorage, UnifiedLoggerWrite>(unified_logger.clone())
-        .build_app()
+        .build()
         .expect("Failed to create application.");
-    debug!(
-        "Running... starting clock: {}.",
-        application.inner().clock().now()
-    );
-    let mut running = application
-        .start_all_tasks()
-        .expect("Failed to start application.");
+    debug!("Running... starting clock: {}.", application.clock().now());
+    let mut running = application.start().expect("Failed to start application.");
     running
         .run_one_iteration()
         .expect("Failed to run application.");
-    let stopped = running
-        .stop_all_tasks()
-        .expect("Failed to stop application.");
-    debug!("End of program: {}.", stopped.inner().clock().now());
+    let stopped = running.stop().expect("Failed to stop application.");
+    debug!("End of program: {}.", stopped.clock().now());
     // check if the logger file is at least 1 section in length
 
     // change the end of the logger_path from copper to _0.copper

--- a/examples/cu_min_baremetal/src/main.rs
+++ b/examples/cu_min_baremetal/src/main.rs
@@ -96,11 +96,11 @@ pub extern "C" fn main() {
     let app = MinimalNoStdApp::builder()
         .with_clock(clock)
         .with_logger::<NoopSectionStorage, NoopLogger>(writer)
-        .build()
+        .build_app()
         .unwrap();
-    // CuAppLifecycle is no_std-compatible; naming S/L on the wrapper replaces
-    // the UFCS disambiguation the raw trait call needed.
-    let _ = CuAppLifecycle::<NoopSectionStorage, NoopLogger, _>::new(app).run();
+    // build_app works in no_std too: the lifecycle handle replaces the UFCS
+    // disambiguation the raw trait call needed.
+    let _ = app.run();
 }
 
 #[cfg(feature = "std")]
@@ -112,19 +112,19 @@ fn main() {
     const SLAB_SIZE: Option<usize> = Some(4096 * 1024 * 1024);
 
     let logger_path = PathBuf::from("logs/nostd.copper");
-    if let Some(parent) = logger_path.parent() {
-        if !parent.exists() {
-            fs::create_dir_all(parent).expect("Failed to create logs directory");
-        }
+    if let Some(parent) = logger_path.parent()
+        && !parent.exists()
+    {
+        fs::create_dir_all(parent).expect("Failed to create logs directory");
     }
 
     let application = MinimalNoStdApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create application.");
 
-    if let Err(error) = CuStdAppLifecycle::new(application).run() {
+    if let Err(error) = application.run() {
         debug!("Application Ended: {}", error.error)
     }
 }

--- a/examples/cu_min_baremetal/src/main.rs
+++ b/examples/cu_min_baremetal/src/main.rs
@@ -93,12 +93,14 @@ pub extern "C" fn main() {
         },
     );
     let writer = Arc::new(Mutex::new(NoopLogger::new()));
-    let mut app = MinimalNoStdApp::builder()
+    let app = MinimalNoStdApp::builder()
         .with_clock(clock)
         .with_logger::<NoopSectionStorage, NoopLogger>(writer)
         .build()
         .unwrap();
-    let _ = <MinimalNoStdApp as CuApplication<NoopSectionStorage, NoopLogger>>::run(&mut app);
+    // CuAppLifecycle is no_std-compatible; naming S/L on the wrapper replaces
+    // the UFCS disambiguation the raw trait call needed.
+    let _ = CuAppLifecycle::<NoopSectionStorage, NoopLogger, _>::new(app).run();
 }
 
 #[cfg(feature = "std")]
@@ -116,13 +118,13 @@ fn main() {
         }
     }
 
-    let mut application = MinimalNoStdApp::builder()
+    let application = MinimalNoStdApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
 
-    if let Err(error) = application.run() {
-        debug!("Application Ended: {}", error)
+    if let Err(error) = CuStdAppLifecycle::new(application).run() {
+        debug!("Application Ended: {}", error.error)
     }
 }

--- a/examples/cu_min_baremetal/src/main.rs
+++ b/examples/cu_min_baremetal/src/main.rs
@@ -96,11 +96,11 @@ pub extern "C" fn main() {
     let app = MinimalNoStdApp::builder()
         .with_clock(clock)
         .with_logger::<NoopSectionStorage, NoopLogger>(writer)
-        .build_app()
+        .build()
         .unwrap();
     // build_app works in no_std too: the lifecycle handle replaces the UFCS
     // disambiguation the raw trait call needed.
-    let _ = app.run();
+    let _ = app.run_until_shutdown();
 }
 
 #[cfg(feature = "std")]
@@ -121,10 +121,10 @@ fn main() {
     let application = MinimalNoStdApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create application.");
 
-    if let Err(error) = application.run() {
+    if let Err(error) = application.run_until_shutdown() {
         debug!("Application Ended: {}", error.error)
     }
 }

--- a/examples/cu_missions/src/main.rs
+++ b/examples/cu_missions/src/main.rs
@@ -11,11 +11,13 @@ use B::App as MissionBApp;
 
 const SLAB_SIZE: Option<usize> = Some(10 * 1024 * 1024);
 
-fn run_once<App>(app: App) -> CuResult<()>
+fn run_once<App>(
+    app: CuAppLifecycle<memmap::MmapSectionStorage, UnifiedLoggerWrite, App>,
+) -> CuResult<()>
 where
     App: CuApplication<memmap::MmapSectionStorage, UnifiedLoggerWrite>,
 {
-    let mut running = CuAppLifecycle::new(app).start_all_tasks()?;
+    let mut running = app.start_all_tasks()?;
     running.run_one_iteration()?;
     running.stop_all_tasks()?;
     Ok(())
@@ -35,7 +37,7 @@ fn main() {
             .with_clock(clock.clone())
             .with_log_path(&logger_path, SLAB_SIZE)
             .expect("Failed to setup logger.")
-            .build()
+            .build_app()
             .expect("Failed to create runtime");
         run_once(application_a).expect("Failed to run mission A.");
     }
@@ -47,7 +49,7 @@ fn main() {
             .with_clock(clock.clone())
             .with_log_path(&logger_path, SLAB_SIZE)
             .expect("Failed to setup logger.")
-            .build()
+            .build_app()
             .expect("Failed to create runtime");
         run_once(application_b).expect("Failed to run mission B.");
     }

--- a/examples/cu_missions/src/main.rs
+++ b/examples/cu_missions/src/main.rs
@@ -11,13 +11,13 @@ use B::App as MissionBApp;
 
 const SLAB_SIZE: Option<usize> = Some(10 * 1024 * 1024);
 
-fn run_once<App>(app: &mut App) -> CuResult<()>
+fn run_once<App>(app: App) -> CuResult<()>
 where
     App: CuApplication<memmap::MmapSectionStorage, UnifiedLoggerWrite>,
 {
-    app.start_all_tasks()?;
-    app.run_one_iteration()?;
-    app.stop_all_tasks()?;
+    let mut running = CuAppLifecycle::new(app).start_all_tasks()?;
+    running.run_one_iteration()?;
+    running.stop_all_tasks()?;
     Ok(())
 }
 
@@ -31,25 +31,25 @@ fn main() {
     debug!("Running... starting clock: {}.", clock.now());
     debug!("Starting Mission A.");
     {
-        let mut application_a = MissionAApp::builder()
+        let application_a = MissionAApp::builder()
             .with_clock(clock.clone())
             .with_log_path(&logger_path, SLAB_SIZE)
             .expect("Failed to setup logger.")
             .build()
             .expect("Failed to create runtime");
-        run_once(&mut application_a).expect("Failed to run mission A.");
+        run_once(application_a).expect("Failed to run mission A.");
     }
 
     debug!("Starting Mission B.");
     // Note if you don't end the tasks, you'll be up for a bad time because tasks can hog some resources.
     {
-        let mut application_b = MissionBApp::builder()
+        let application_b = MissionBApp::builder()
             .with_clock(clock.clone())
             .with_log_path(&logger_path, SLAB_SIZE)
             .expect("Failed to setup logger.")
             .build()
             .expect("Failed to create runtime");
-        run_once(&mut application_b).expect("Failed to run mission B.");
+        run_once(application_b).expect("Failed to run mission B.");
     }
 
     debug!("End of program: {}.", clock.now());

--- a/examples/cu_missions/src/main.rs
+++ b/examples/cu_missions/src/main.rs
@@ -17,9 +17,9 @@ fn run_once<App>(
 where
     App: CuApplication<memmap::MmapSectionStorage, UnifiedLoggerWrite>,
 {
-    let mut running = app.start_all_tasks()?;
+    let mut running = app.start()?;
     running.run_one_iteration()?;
-    running.stop_all_tasks()?;
+    running.stop()?;
     Ok(())
 }
 
@@ -37,7 +37,7 @@ fn main() {
             .with_clock(clock.clone())
             .with_log_path(&logger_path, SLAB_SIZE)
             .expect("Failed to setup logger.")
-            .build_app()
+            .build()
             .expect("Failed to create runtime");
         run_once(application_a).expect("Failed to run mission A.");
     }
@@ -49,7 +49,7 @@ fn main() {
             .with_clock(clock.clone())
             .with_log_path(&logger_path, SLAB_SIZE)
             .expect("Failed to setup logger.")
-            .build_app()
+            .build()
             .expect("Failed to create runtime");
         run_once(application_b).expect("Failed to run mission B.");
     }

--- a/examples/cu_monitoring/src/main.rs
+++ b/examples/cu_monitoring/src/main.rs
@@ -118,15 +118,14 @@ fn main() {
     let application = App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create runtime");
-    debug!(
-        "Running... starting clock: {}.",
-        application.inner().clock().now()
-    );
+    debug!("Running... starting clock: {}.", application.clock().now());
     // `run` drives the full start/iterate/stop cycle; the typestate wrapper
     // makes the previous extra start_all_tasks/stop_all_tasks calls around it
     // a compile error instead of a double start/stop at runtime.
-    let stopped = application.run().expect("Failed to run application.");
-    debug!("End of program: {}.", stopped.inner().clock().now());
+    let stopped = application
+        .run_until_shutdown()
+        .expect("Failed to run application.");
+    debug!("End of program: {}.", stopped.clock().now());
 }

--- a/examples/cu_monitoring/src/main.rs
+++ b/examples/cu_monitoring/src/main.rs
@@ -115,18 +115,17 @@ fn main() {
 
     debug!("Logger created at {}.", path = &logger_path);
     debug!("Creating application... ");
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create runtime");
     debug!("Running... starting clock: {}.", application.clock().now());
-    application
-        .start_all_tasks()
-        .expect("Failed to start application.");
-    application.run().expect("Failed to run application.");
-    application
-        .stop_all_tasks()
-        .expect("Failed to stop application.");
-    debug!("End of program: {}.", application.clock().now());
+    // `run` drives the full start/iterate/stop cycle; the typestate wrapper
+    // makes the previous extra start_all_tasks/stop_all_tasks calls around it
+    // a compile error instead of a double start/stop at runtime.
+    let stopped = CuStdAppLifecycle::new(application)
+        .run()
+        .expect("Failed to run application.");
+    debug!("End of program: {}.", stopped.inner().clock().now());
 }

--- a/examples/cu_monitoring/src/main.rs
+++ b/examples/cu_monitoring/src/main.rs
@@ -118,14 +118,15 @@ fn main() {
     let application = App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create runtime");
-    debug!("Running... starting clock: {}.", application.clock().now());
+    debug!(
+        "Running... starting clock: {}.",
+        application.inner().clock().now()
+    );
     // `run` drives the full start/iterate/stop cycle; the typestate wrapper
     // makes the previous extra start_all_tasks/stop_all_tasks calls around it
     // a compile error instead of a double start/stop at runtime.
-    let stopped = CuStdAppLifecycle::new(application)
-        .run()
-        .expect("Failed to run application.");
+    let stopped = application.run().expect("Failed to run application.");
     debug!("End of program: {}.", stopped.inner().clock().now());
 }

--- a/examples/cu_msp_bridge_loopback/src/main.rs
+++ b/examples/cu_msp_bridge_loopback/src/main.rs
@@ -50,9 +50,9 @@ fn drive() -> CuResult<()> {
     let app = CuMspBridgeLoopbackApp::builder()
         .with_log_path(&logger_path, Some(16 * 1024 * 1024))?
         .with_config(config)
-        .build()?;
+        .build_app()?;
 
-    let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
+    let mut running = app.start_all_tasks()?;
     for i in 0..3 {
         debug!("Running iteration {}", i);
         running.run_one_iteration()?;

--- a/examples/cu_msp_bridge_loopback/src/main.rs
+++ b/examples/cu_msp_bridge_loopback/src/main.rs
@@ -50,9 +50,9 @@ fn drive() -> CuResult<()> {
     let app = CuMspBridgeLoopbackApp::builder()
         .with_log_path(&logger_path, Some(16 * 1024 * 1024))?
         .with_config(config)
-        .build_app()?;
+        .build()?;
 
-    let mut running = app.start_all_tasks()?;
+    let mut running = app.start()?;
     for i in 0..3 {
         debug!("Running iteration {}", i);
         running.run_one_iteration()?;
@@ -61,7 +61,7 @@ fn drive() -> CuResult<()> {
         }
         thread::sleep(Duration::from_millis(10));
     }
-    running.stop_all_tasks()?;
+    running.stop()?;
 
     if !tasks::state::was_validated() {
         return Err(CuError::from(

--- a/examples/cu_msp_bridge_loopback/src/main.rs
+++ b/examples/cu_msp_bridge_loopback/src/main.rs
@@ -47,21 +47,21 @@ fn drive() -> CuResult<()> {
     emulator.configure_bridge(&mut config)?;
     install_ctrlc_cleanup(emulator.symlink_path.clone())?;
 
-    let mut app = CuMspBridgeLoopbackApp::builder()
+    let app = CuMspBridgeLoopbackApp::builder()
         .with_log_path(&logger_path, Some(16 * 1024 * 1024))?
         .with_config(config)
         .build()?;
 
-    app.start_all_tasks()?;
+    let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
     for i in 0..3 {
         debug!("Running iteration {}", i);
-        app.run_one_iteration()?;
+        running.run_one_iteration()?;
         if tasks::state::was_validated() {
             break;
         }
         thread::sleep(Duration::from_millis(10));
     }
-    app.stop_all_tasks()?;
+    running.stop_all_tasks()?;
 
     if !tasks::state::was_validated() {
         return Err(CuError::from(

--- a/examples/cu_multi_output/src/main.rs
+++ b/examples/cu_multi_output/src/main.rs
@@ -174,9 +174,9 @@ fn main() {
     let application = App::builder()
         .with_log_path(&logger_path, None)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create application.");
-    let mut running = CuStdAppLifecycle::new(application)
+    let mut running = application
         .start_all_tasks()
         .expect("Failed to start application.");
     running

--- a/examples/cu_multi_output/src/main.rs
+++ b/examples/cu_multi_output/src/main.rs
@@ -171,18 +171,18 @@ fn main() {
     let tmp_dir = tempfile::TempDir::new().expect("Could not create temporary directory");
     let logger_path = tmp_dir.path().join("logger.copper");
 
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(&logger_path, None)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
-    application
+    let mut running = CuStdAppLifecycle::new(application)
         .start_all_tasks()
         .expect("Failed to start application.");
-    application
+    running
         .run_one_iteration()
         .expect("Failed to run application.");
-    application
+    running
         .stop_all_tasks()
         .expect("Failed to stop application.");
 

--- a/examples/cu_multi_output/src/main.rs
+++ b/examples/cu_multi_output/src/main.rs
@@ -174,17 +174,13 @@ fn main() {
     let application = App::builder()
         .with_log_path(&logger_path, None)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create application.");
-    let mut running = application
-        .start_all_tasks()
-        .expect("Failed to start application.");
+    let mut running = application.start().expect("Failed to start application.");
     running
         .run_one_iteration()
         .expect("Failed to run application.");
-    running
-        .stop_all_tasks()
-        .expect("Failed to stop application.");
+    running.stop().expect("Failed to stop application.");
 
     assert_eq!(LAST_I32.load(Ordering::SeqCst), 42);
     assert!(LAST_BOOL.load(Ordering::SeqCst));

--- a/examples/cu_multisources/src/main.rs
+++ b/examples/cu_multisources/src/main.rs
@@ -17,9 +17,11 @@ fn main() {
     let application = MultiSourceApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create runtime.");
 
-    application.run().expect("Failed to run application.");
+    application
+        .run_until_shutdown()
+        .expect("Failed to run application.");
     sleep(Duration::from_secs(1));
 }

--- a/examples/cu_multisources/src/main.rs
+++ b/examples/cu_multisources/src/main.rs
@@ -14,12 +14,14 @@ fn main() {
     let logger_path = tmp_dir.path().join("caterpillar.copper");
     debug!("Logger created at {}.", path = &logger_path);
     debug!("Creating application... ");
-    let mut application = MultiSourceApp::builder()
+    let application = MultiSourceApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create runtime.");
 
-    application.run().expect("Failed to run application.");
+    CuStdAppLifecycle::new(application)
+        .run()
+        .expect("Failed to run application.");
     sleep(Duration::from_secs(1));
 }

--- a/examples/cu_multisources/src/main.rs
+++ b/examples/cu_multisources/src/main.rs
@@ -17,11 +17,9 @@ fn main() {
     let application = MultiSourceApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create runtime.");
 
-    CuStdAppLifecycle::new(application)
-        .run()
-        .expect("Failed to run application.");
+    application.run().expect("Failed to run application.");
     sleep(Duration::from_secs(1));
 }

--- a/examples/cu_multisources_structs/src/main.rs
+++ b/examples/cu_multisources_structs/src/main.rs
@@ -21,18 +21,21 @@ fn main() {
     }
     debug!("Logger created at {}.", &logger_path);
     debug!("Creating application... ");
-    let mut application = SimTestApplication::builder()
+    let application = SimTestApplication::builder()
         .with_sim_callback(&mut default_callback)
         .with_log_path(logger_path, PREALLOCATED_STORAGE_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create application.");
-    debug!("Running... starting clock: {}.", application.clock().now());
+    debug!(
+        "Running... starting clock: {}.",
+        application.inner().clock().now()
+    );
 
-    application
+    let stopped = application
         .run(&mut default_callback)
         .expect("Failed to run application.");
-    debug!("End of program: {}.", application.clock().now());
+    debug!("End of program: {}.", stopped.inner().clock().now());
     sleep(Duration::from_secs(1));
 }
 

--- a/examples/cu_multisources_structs/src/main.rs
+++ b/examples/cu_multisources_structs/src/main.rs
@@ -25,17 +25,14 @@ fn main() {
         .with_sim_callback(&mut default_callback)
         .with_log_path(logger_path, PREALLOCATED_STORAGE_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create application.");
-    debug!(
-        "Running... starting clock: {}.",
-        application.inner().clock().now()
-    );
+    debug!("Running... starting clock: {}.", application.clock().now());
 
     let stopped = application
-        .run(&mut default_callback)
+        .run_until_shutdown(&mut default_callback)
         .expect("Failed to run application.");
-    debug!("End of program: {}.", stopped.inner().clock().now());
+    debug!("End of program: {}.", stopped.clock().now());
     sleep(Duration::from_secs(1));
 }
 

--- a/examples/cu_nologging_task/src/main.rs
+++ b/examples/cu_nologging_task/src/main.rs
@@ -73,15 +73,14 @@ fn main() {
     let application = App::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create application.");
-    debug!(
-        "Running... starting clock: {}.",
-        application.inner().clock().now()
-    );
+    debug!("Running... starting clock: {}.", application.clock().now());
     // `run` already starts and stops the tasks; the lifecycle wrapper rejects
     // the extra start_all_tasks/stop_all_tasks calls this example used to make.
-    let stopped = application.run().expect("Failed to run application.");
-    debug!("End of program: {}.", stopped.inner().clock().now());
+    let stopped = application
+        .run_until_shutdown()
+        .expect("Failed to run application.");
+    debug!("End of program: {}.", stopped.clock().now());
     // check if the logger file is at least 1 section in length
 }

--- a/examples/cu_nologging_task/src/main.rs
+++ b/examples/cu_nologging_task/src/main.rs
@@ -73,14 +73,15 @@ fn main() {
     let application = App::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create application.");
-    debug!("Running... starting clock: {}.", application.clock().now());
+    debug!(
+        "Running... starting clock: {}.",
+        application.inner().clock().now()
+    );
     // `run` already starts and stops the tasks; the lifecycle wrapper rejects
     // the extra start_all_tasks/stop_all_tasks calls this example used to make.
-    let stopped = CuStdAppLifecycle::new(application)
-        .run()
-        .expect("Failed to run application.");
+    let stopped = application.run().expect("Failed to run application.");
     debug!("End of program: {}.", stopped.inner().clock().now());
     // check if the logger file is at least 1 section in length
 }

--- a/examples/cu_nologging_task/src/main.rs
+++ b/examples/cu_nologging_task/src/main.rs
@@ -70,19 +70,17 @@ fn main() {
     }
     debug!("Logger created at {}.", path = &logger_path);
     debug!("Creating application... ");
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
     debug!("Running... starting clock: {}.", application.clock().now());
-    application
-        .start_all_tasks()
-        .expect("Failed to start application.");
-    application.run().expect("Failed to run application.");
-    application
-        .stop_all_tasks()
-        .expect("Failed to stop application.");
-    debug!("End of program: {}.", application.clock().now());
+    // `run` already starts and stops the tasks; the lifecycle wrapper rejects
+    // the extra start_all_tasks/stop_all_tasks calls this example used to make.
+    let stopped = CuStdAppLifecycle::new(application)
+        .run()
+        .expect("Failed to run application.");
+    debug!("End of program: {}.", stopped.inner().clock().now());
     // check if the logger file is at least 1 section in length
 }

--- a/examples/cu_parallel_mandelbrot/src/lib.rs
+++ b/examples/cu_parallel_mandelbrot/src/lib.rs
@@ -99,7 +99,7 @@ pub fn run_log_only() -> CuResult<()> {
     let settings = load_benchmark_settings()?;
     let logger_path = benchmark_logger_path("parallel_mandelbrot_log_only.copper")?;
     let logger_path_display = logger_path.display().to_string();
-    let mut app = log_only::App::builder()
+    let app = log_only::App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)?
         .build()
         .map_err(|err| CuError::from(format!("failed to build log_only mission: {err}")))?;
@@ -109,7 +109,7 @@ pub fn run_log_only() -> CuResult<()> {
         logger_path_display
     );
     let started = Instant::now();
-    app.run()?;
+    CuStdAppLifecycle::new(app).run()?;
     log_summary("log_only", &logger_path, settings, started.elapsed());
     Ok(())
 }
@@ -119,7 +119,7 @@ pub fn run_viewer_live() -> CuResult<()> {
     let settings = load_benchmark_settings()?;
     let logger_path = benchmark_logger_path("parallel_mandelbrot_viewer.copper")?;
     let logger_path_display = logger_path.display().to_string();
-    let mut app = viewer_live::App::builder()
+    let app = viewer_live::App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)?
         .build()
         .map_err(|err| CuError::from(format!("failed to build viewer_live mission: {err}")))?;
@@ -129,7 +129,7 @@ pub fn run_viewer_live() -> CuResult<()> {
         logger_path_display
     );
     let started = Instant::now();
-    app.run()?;
+    CuStdAppLifecycle::new(app).run()?;
     log_summary("viewer_live", &logger_path, settings, started.elapsed());
     Ok(())
 }

--- a/examples/cu_parallel_mandelbrot/src/lib.rs
+++ b/examples/cu_parallel_mandelbrot/src/lib.rs
@@ -101,7 +101,7 @@ pub fn run_log_only() -> CuResult<()> {
     let logger_path_display = logger_path.display().to_string();
     let app = log_only::App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)?
-        .build()
+        .build_app()
         .map_err(|err| CuError::from(format!("failed to build log_only mission: {err}")))?;
 
     info!(
@@ -109,7 +109,7 @@ pub fn run_log_only() -> CuResult<()> {
         logger_path_display
     );
     let started = Instant::now();
-    CuStdAppLifecycle::new(app).run()?;
+    app.run()?;
     log_summary("log_only", &logger_path, settings, started.elapsed());
     Ok(())
 }
@@ -121,7 +121,7 @@ pub fn run_viewer_live() -> CuResult<()> {
     let logger_path_display = logger_path.display().to_string();
     let app = viewer_live::App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)?
-        .build()
+        .build_app()
         .map_err(|err| CuError::from(format!("failed to build viewer_live mission: {err}")))?;
 
     info!(
@@ -129,7 +129,7 @@ pub fn run_viewer_live() -> CuResult<()> {
         logger_path_display
     );
     let started = Instant::now();
-    CuStdAppLifecycle::new(app).run()?;
+    app.run()?;
     log_summary("viewer_live", &logger_path, settings, started.elapsed());
     Ok(())
 }

--- a/examples/cu_parallel_mandelbrot/src/lib.rs
+++ b/examples/cu_parallel_mandelbrot/src/lib.rs
@@ -101,7 +101,7 @@ pub fn run_log_only() -> CuResult<()> {
     let logger_path_display = logger_path.display().to_string();
     let app = log_only::App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)?
-        .build_app()
+        .build()
         .map_err(|err| CuError::from(format!("failed to build log_only mission: {err}")))?;
 
     info!(
@@ -109,7 +109,7 @@ pub fn run_log_only() -> CuResult<()> {
         logger_path_display
     );
     let started = Instant::now();
-    app.run()?;
+    app.run_until_shutdown()?;
     log_summary("log_only", &logger_path, settings, started.elapsed());
     Ok(())
 }
@@ -121,7 +121,7 @@ pub fn run_viewer_live() -> CuResult<()> {
     let logger_path_display = logger_path.display().to_string();
     let app = viewer_live::App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)?
-        .build_app()
+        .build()
         .map_err(|err| CuError::from(format!("failed to build viewer_live mission: {err}")))?;
 
     info!(
@@ -129,7 +129,7 @@ pub fn run_viewer_live() -> CuResult<()> {
         logger_path_display
     );
     let started = Instant::now();
-    app.run()?;
+    app.run_until_shutdown()?;
     log_summary("viewer_live", &logger_path, settings, started.elapsed());
     Ok(())
 }

--- a/examples/cu_peer_triangulation/src/main.rs
+++ b/examples/cu_peer_triangulation/src/main.rs
@@ -151,14 +151,14 @@ fn main() -> CuResult<()> {
         .with_log_path(logger_path, Some(64 * 1024 * 1024))
         .expect("failed to setup logger")
         .with_sim_callback(&mut callback)
-        .build_app()
+        .build()
         .expect("failed to create runtime");
 
-    let mut running = app.start_all_tasks(&mut callback)?;
+    let mut running = app.start(&mut callback)?;
     for _ in 0..6 {
         running.run_one_iteration(&mut callback)?;
     }
-    running.stop_all_tasks(&mut callback)?;
+    running.stop(&mut callback)?;
 
     Ok(())
 }

--- a/examples/cu_peer_triangulation/src/main.rs
+++ b/examples/cu_peer_triangulation/src/main.rs
@@ -146,19 +146,19 @@ fn main() -> CuResult<()> {
     }
 
     let (robot_clock, _) = RobotClock::mock();
-    let mut app = App::builder()
+    let app = App::builder()
         .with_clock(robot_clock)
         .with_log_path(logger_path, Some(64 * 1024 * 1024))
         .expect("failed to setup logger")
         .with_sim_callback(&mut callback)
-        .build()
+        .build_app()
         .expect("failed to create runtime");
 
-    app.start_all_tasks(&mut callback)?;
+    let mut running = app.start_all_tasks(&mut callback)?;
     for _ in 0..6 {
-        app.run_one_iteration(&mut callback)?;
+        running.run_one_iteration(&mut callback)?;
     }
-    app.stop_all_tasks(&mut callback)?;
+    running.stop_all_tasks(&mut callback)?;
 
     Ok(())
 }

--- a/examples/cu_pointclouds/src/main.rs
+++ b/examples/cu_pointclouds/src/main.rs
@@ -57,12 +57,12 @@ fn main() {
     const PACKET_SIZE: usize = size_of::<Packet>();
     let tmp_dir = tempfile::TempDir::new().expect("could not create a tmp dir");
     let logger_path = tmp_dir.path().join("ptclouds.copper");
-    let mut application = PtCloudsApplication::builder()
+    let application = PtCloudsApplication::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup copper.")
         .build()
         .expect("Failed to create application");
-    application
+    let mut application = CuStdAppLifecycle::new(application)
         .start_all_tasks()
         .expect("Failed to start all tasks.");
 

--- a/examples/cu_pointclouds/src/main.rs
+++ b/examples/cu_pointclouds/src/main.rs
@@ -60,9 +60,9 @@ fn main() {
     let application = PtCloudsApplication::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup copper.")
-        .build()
+        .build_app()
         .expect("Failed to create application");
-    let mut application = CuStdAppLifecycle::new(application)
+    let mut application = application
         .start_all_tasks()
         .expect("Failed to start all tasks.");
 

--- a/examples/cu_pointclouds/src/main.rs
+++ b/examples/cu_pointclouds/src/main.rs
@@ -60,11 +60,9 @@ fn main() {
     let application = PtCloudsApplication::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup copper.")
-        .build_app()
+        .build()
         .expect("Failed to create application");
-    let mut application = application
-        .start_all_tasks()
-        .expect("Failed to start all tasks.");
+    let mut application = application.start().expect("Failed to start all tasks.");
 
     loop {
         let mut streamer = PcapStreamer::new(

--- a/examples/cu_python_task_demo/src/lib.rs
+++ b/examples/cu_python_task_demo/src/lib.rs
@@ -255,17 +255,17 @@ pub fn config_for_mode(mode: PyTaskMode) -> CuConfig {
 pub fn run_demo(mode: PyTaskMode, iterations: usize) -> CuResult<()> {
     let temp_dir = tempfile::TempDir::new().map_err(|e| CuError::new_with_cause("temp dir", e))?;
     let log_path = temp_dir.path().join("python_task_demo.copper");
-    let mut app = PythonTaskDemoApp::builder()
+    let app = PythonTaskDemoApp::builder()
         .with_log_path(&log_path, Some(32 * 1024 * 1024))?
         .with_config(config_for_mode(mode))
         .build()?;
 
     reset_sinks();
-    app.start_all_tasks()?;
+    let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
     for _ in 0..iterations {
-        app.run_one_iteration()?;
+        running.run_one_iteration()?;
     }
-    app.stop_all_tasks()?;
+    running.stop_all_tasks()?;
     Ok(())
 }
 

--- a/examples/cu_python_task_demo/src/lib.rs
+++ b/examples/cu_python_task_demo/src/lib.rs
@@ -258,14 +258,14 @@ pub fn run_demo(mode: PyTaskMode, iterations: usize) -> CuResult<()> {
     let app = PythonTaskDemoApp::builder()
         .with_log_path(&log_path, Some(32 * 1024 * 1024))?
         .with_config(config_for_mode(mode))
-        .build_app()?;
+        .build()?;
 
     reset_sinks();
-    let mut running = app.start_all_tasks()?;
+    let mut running = app.start()?;
     for _ in 0..iterations {
         running.run_one_iteration()?;
     }
-    running.stop_all_tasks()?;
+    running.stop()?;
     Ok(())
 }
 

--- a/examples/cu_python_task_demo/src/lib.rs
+++ b/examples/cu_python_task_demo/src/lib.rs
@@ -258,10 +258,10 @@ pub fn run_demo(mode: PyTaskMode, iterations: usize) -> CuResult<()> {
     let app = PythonTaskDemoApp::builder()
         .with_log_path(&log_path, Some(32 * 1024 * 1024))?
         .with_config(config_for_mode(mode))
-        .build()?;
+        .build_app()?;
 
     reset_sinks();
-    let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
+    let mut running = app.start_all_tasks()?;
     for _ in 0..iterations {
         running.run_one_iteration()?;
     }

--- a/examples/cu_rate_target/src/lib.rs
+++ b/examples/cu_rate_target/src/lib.rs
@@ -251,15 +251,14 @@ pub fn run_example(log_filename: &str) {
     let application = App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create application.");
-    info!(
-        "Running... starting clock: {}.",
-        application.inner().clock().now()
-    );
+    info!("Running... starting clock: {}.", application.clock().now());
     // `run` drives the full start/iterate/stop cycle; the typestate wrapper
     // makes the previous extra start_all_tasks/stop_all_tasks calls around it
     // a compile error instead of a double start/stop at runtime.
-    let stopped = application.run().expect("Failed to run application.");
-    info!("End of program: {}.", stopped.inner().clock().now());
+    let stopped = application
+        .run_until_shutdown()
+        .expect("Failed to run application.");
+    info!("End of program: {}.", stopped.clock().now());
 }

--- a/examples/cu_rate_target/src/lib.rs
+++ b/examples/cu_rate_target/src/lib.rs
@@ -251,14 +251,15 @@ pub fn run_example(log_filename: &str) {
     let application = App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create application.");
-    info!("Running... starting clock: {}.", application.clock().now());
+    info!(
+        "Running... starting clock: {}.",
+        application.inner().clock().now()
+    );
     // `run` drives the full start/iterate/stop cycle; the typestate wrapper
     // makes the previous extra start_all_tasks/stop_all_tasks calls around it
     // a compile error instead of a double start/stop at runtime.
-    let stopped = CuStdAppLifecycle::new(application)
-        .run()
-        .expect("Failed to run application.");
+    let stopped = application.run().expect("Failed to run application.");
     info!("End of program: {}.", stopped.inner().clock().now());
 }

--- a/examples/cu_rate_target/src/lib.rs
+++ b/examples/cu_rate_target/src/lib.rs
@@ -248,18 +248,17 @@ pub fn run_example(log_filename: &str) {
         logger_path.to_string_lossy().into_owned()
     );
     info!("Creating application...");
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
     info!("Running... starting clock: {}.", application.clock().now());
-    application
-        .start_all_tasks()
-        .expect("Failed to start application.");
-    application.run().expect("Failed to run application.");
-    application
-        .stop_all_tasks()
-        .expect("Failed to stop application.");
-    info!("End of program: {}.", application.clock().now());
+    // `run` drives the full start/iterate/stop cycle; the typestate wrapper
+    // makes the previous extra start_all_tasks/stop_all_tasks calls around it
+    // a compile error instead of a double start/stop at runtime.
+    let stopped = CuStdAppLifecycle::new(application)
+        .run()
+        .expect("Failed to run application.");
+    info!("End of program: {}.", stopped.inner().clock().now());
 }

--- a/examples/cu_reflect_demo/src/main.rs
+++ b/examples/cu_reflect_demo/src/main.rs
@@ -137,14 +137,14 @@ fn record_log() -> CuResult<()> {
         .with_clock(clock.clone())
         .with_log_path(Path::new(LOG_PATH), LOG_SLAB_SIZE)?
         .with_sim_callback(&mut sim_cb)
-        .build_app()?;
+        .build()?;
 
-    let mut running = app.start_all_tasks(&mut sim_cb)?;
+    let mut running = app.start(&mut sim_cb)?;
     for _ in 0..8 {
         clock_mock.increment(CuDuration::from_millis(10));
         running.run_one_iteration(&mut sim_cb)?;
     }
-    running.stop_all_tasks(&mut sim_cb)?;
+    running.stop(&mut sim_cb)?;
     Ok(())
 }
 
@@ -157,7 +157,7 @@ fn run_reflect_debug_demo() -> CuResult<()> {
         .with_clock(clock.clone())
         .with_log_path(Path::new(REPLAY_LOG_PATH), LOG_SLAB_SIZE)?
         .with_sim_callback(&mut sim_cb)
-        .build_app()?
+        .build()?
         .into_inner();
 
     fn time_of(cl: &CopperList<default::CuStampedDataSet>) -> Option<CuTime> {

--- a/examples/cu_reflect_demo/src/main.rs
+++ b/examples/cu_reflect_demo/src/main.rs
@@ -133,18 +133,18 @@ fn record_log() -> CuResult<()> {
     let (clock, clock_mock) = RobotClock::mock();
 
     let mut sim_cb = |_step: default::SimStep| SimOverride::ExecuteByRuntime;
-    let mut app = ReflectDemo::builder()
+    let app = ReflectDemo::builder()
         .with_clock(clock.clone())
         .with_log_path(Path::new(LOG_PATH), LOG_SLAB_SIZE)?
         .with_sim_callback(&mut sim_cb)
-        .build()?;
+        .build_app()?;
 
-    app.start_all_tasks(&mut sim_cb)?;
+    let mut running = app.start_all_tasks(&mut sim_cb)?;
     for _ in 0..8 {
         clock_mock.increment(CuDuration::from_millis(10));
-        app.run_one_iteration(&mut sim_cb)?;
+        running.run_one_iteration(&mut sim_cb)?;
     }
-    app.stop_all_tasks(&mut sim_cb)?;
+    running.stop_all_tasks(&mut sim_cb)?;
     Ok(())
 }
 
@@ -152,11 +152,13 @@ fn run_reflect_debug_demo() -> CuResult<()> {
     let (clock, clock_mock) = RobotClock::mock();
 
     let mut sim_cb = |_step: default::SimStep| SimOverride::ExecuteByRuntime;
+    // The debug session engine drives the raw lifecycle itself.
     let app = ReflectDemo::builder()
         .with_clock(clock.clone())
         .with_log_path(Path::new(REPLAY_LOG_PATH), LOG_SLAB_SIZE)?
         .with_sim_callback(&mut sim_cb)
-        .build()?;
+        .build_app()?
+        .into_inner();
 
     fn time_of(cl: &CopperList<default::CuStampedDataSet>) -> Option<CuTime> {
         Option::<CuTime>::from(cl.msgs.get_src_output().metadata.process_time.start)

--- a/examples/cu_remote_debug_session/src/main.rs
+++ b/examples/cu_remote_debug_session/src/main.rs
@@ -159,14 +159,14 @@ fn record_log() -> CuResult<()> {
     let mut sim_cb = |_step: default::SimStep| SimOverride::ExecuteByRuntime;
 
     println!("[record] Building debug app");
-    let mut app = DebugApp::builder()
+    let app = DebugApp::builder()
         .with_clock(clock.clone())
         .with_log_path(Path::new(LOG_PATH), LOG_SLAB_SIZE)?
         .with_sim_callback(&mut sim_cb)
-        .build()?;
+        .build_app()?;
 
     println!("[record] Starting tasks");
-    app.start_all_tasks(&mut sim_cb)?;
+    let mut app = app.start_all_tasks(&mut sim_cb)?;
     for i in 0..128u32 {
         clock_mock.increment(CuDuration::from_millis(10));
         app.run_one_iteration(&mut sim_cb)?;
@@ -208,9 +208,10 @@ fn app_factory(_params: &SessionOpenParams) -> CuResult<(DebugApp, RobotClock, R
         .with_clock(clock.clone())
         .with_log_path(Path::new(REPLAY_LOG_PATH), REPLAY_LOG_SLAB_SIZE)?
         .with_sim_callback(&mut sim_cb)
-        .build()?;
+        .build_app()?;
 
-    Ok((app, clock, clock_mock))
+    // The replay session engine drives the raw lifecycle itself.
+    Ok((app.into_inner(), clock, clock_mock))
 }
 
 fn call_ok(

--- a/examples/cu_remote_debug_session/src/main.rs
+++ b/examples/cu_remote_debug_session/src/main.rs
@@ -163,10 +163,10 @@ fn record_log() -> CuResult<()> {
         .with_clock(clock.clone())
         .with_log_path(Path::new(LOG_PATH), LOG_SLAB_SIZE)?
         .with_sim_callback(&mut sim_cb)
-        .build_app()?;
+        .build()?;
 
     println!("[record] Starting tasks");
-    let mut app = app.start_all_tasks(&mut sim_cb)?;
+    let mut app = app.start(&mut sim_cb)?;
     for i in 0..128u32 {
         clock_mock.increment(CuDuration::from_millis(10));
         app.run_one_iteration(&mut sim_cb)?;
@@ -175,7 +175,7 @@ fn record_log() -> CuResult<()> {
         }
     }
     println!("[record] Stopping tasks");
-    app.stop_all_tasks(&mut sim_cb)?;
+    app.stop(&mut sim_cb)?;
     println!("[record] Log recording complete");
     Ok(())
 }
@@ -208,7 +208,7 @@ fn app_factory(_params: &SessionOpenParams) -> CuResult<(DebugApp, RobotClock, R
         .with_clock(clock.clone())
         .with_log_path(Path::new(REPLAY_LOG_PATH), REPLAY_LOG_SLAB_SIZE)?
         .with_sim_callback(&mut sim_cb)
-        .build_app()?;
+        .build()?;
 
     // The replay session engine drives the raw lifecycle itself.
     Ok((app.into_inner(), clock, clock_mock))

--- a/examples/cu_resources_test/src/main.rs
+++ b/examples/cu_resources_test/src/main.rs
@@ -31,14 +31,14 @@ enum MissionArg {
 
 const SLAB_SIZE: Option<usize> = None;
 
-fn run_once<App>(app: App) -> CuResult<()>
+fn run_once<App>(app: CuAppLifecycle<MmapSectionStorage, UnifiedLoggerWrite, App>) -> CuResult<()>
 where
     App: CuApplication<MmapSectionStorage, UnifiedLoggerWrite>,
 {
-    // `run` drives the full start/iterate/stop cycle; the typestate wrapper
-    // makes the previous extra start_all_tasks/stop_all_tasks calls around it
-    // a compile error instead of a double start/stop at runtime.
-    CuAppLifecycle::new(app).run()?;
+    // `run` drives the full start/iterate/stop cycle; the typestate rejects
+    // the extra start_all_tasks/stop_all_tasks calls this example used to
+    // make around it (a double start/stop at runtime).
+    app.run()?;
     Ok(())
 }
 
@@ -66,13 +66,13 @@ fn drive() -> CuResult<()> {
         MissionArg::A => {
             let app = MissionAApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
-                .build()?;
+                .build_app()?;
             run_once(app)?;
         }
         MissionArg::B => {
             let app = MissionBApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
-                .build()?;
+                .build_app()?;
             run_once(app)?;
         }
     }

--- a/examples/cu_resources_test/src/main.rs
+++ b/examples/cu_resources_test/src/main.rs
@@ -31,13 +31,14 @@ enum MissionArg {
 
 const SLAB_SIZE: Option<usize> = None;
 
-fn run_once<App>(app: &mut App) -> CuResult<()>
+fn run_once<App>(app: App) -> CuResult<()>
 where
     App: CuApplication<MmapSectionStorage, UnifiedLoggerWrite>,
 {
-    app.start_all_tasks()?;
-    app.run()?;
-    app.stop_all_tasks()?;
+    // `run` drives the full start/iterate/stop cycle; the typestate wrapper
+    // makes the previous extra start_all_tasks/stop_all_tasks calls around it
+    // a compile error instead of a double start/stop at runtime.
+    CuAppLifecycle::new(app).run()?;
     Ok(())
 }
 
@@ -63,16 +64,16 @@ fn drive() -> CuResult<()> {
 
     match args.mission {
         MissionArg::A => {
-            let mut app = MissionAApp::builder()
+            let app = MissionAApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
                 .build()?;
-            run_once(&mut app)?;
+            run_once(app)?;
         }
         MissionArg::B => {
-            let mut app = MissionBApp::builder()
+            let app = MissionBApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
                 .build()?;
-            run_once(&mut app)?;
+            run_once(app)?;
         }
     }
 

--- a/examples/cu_resources_test/src/main.rs
+++ b/examples/cu_resources_test/src/main.rs
@@ -38,7 +38,7 @@ where
     // `run` drives the full start/iterate/stop cycle; the typestate rejects
     // the extra start_all_tasks/stop_all_tasks calls this example used to
     // make around it (a double start/stop at runtime).
-    app.run()?;
+    app.run_until_shutdown()?;
     Ok(())
 }
 
@@ -66,13 +66,13 @@ fn drive() -> CuResult<()> {
         MissionArg::A => {
             let app = MissionAApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
-                .build_app()?;
+                .build()?;
             run_once(app)?;
         }
         MissionArg::B => {
             let app = MissionBApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
-                .build_app()?;
+                .build()?;
             run_once(app)?;
         }
     }

--- a/examples/cu_ros2_bridge_demo/src/main.rs
+++ b/examples/cu_ros2_bridge_demo/src/main.rs
@@ -103,8 +103,10 @@ fn drive() -> CuResult<()> {
 
     let tmp_dir = tempfile::TempDir::new().expect("could not create a tmp dir");
     let logger_path = tmp_dir.path().join("ros2_bridge.copper");
-    let app = App::builder().with_log_path(&logger_path, None)?.build()?;
-    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
+    let app = App::builder()
+        .with_log_path(&logger_path, None)?
+        .build_app()?;
+    let mut app = app.start_all_tasks()?;
 
     for _ in 0..ITERATIONS {
         app.run_one_iteration()?;

--- a/examples/cu_ros2_bridge_demo/src/main.rs
+++ b/examples/cu_ros2_bridge_demo/src/main.rs
@@ -103,8 +103,8 @@ fn drive() -> CuResult<()> {
 
     let tmp_dir = tempfile::TempDir::new().expect("could not create a tmp dir");
     let logger_path = tmp_dir.path().join("ros2_bridge.copper");
-    let mut app = App::builder().with_log_path(&logger_path, None)?.build()?;
-    app.start_all_tasks()?;
+    let app = App::builder().with_log_path(&logger_path, None)?.build()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     for _ in 0..ITERATIONS {
         app.run_one_iteration()?;

--- a/examples/cu_ros2_bridge_demo/src/main.rs
+++ b/examples/cu_ros2_bridge_demo/src/main.rs
@@ -103,10 +103,8 @@ fn drive() -> CuResult<()> {
 
     let tmp_dir = tempfile::TempDir::new().expect("could not create a tmp dir");
     let logger_path = tmp_dir.path().join("ros2_bridge.copper");
-    let app = App::builder()
-        .with_log_path(&logger_path, None)?
-        .build_app()?;
-    let mut app = app.start_all_tasks()?;
+    let app = App::builder().with_log_path(&logger_path, None)?.build()?;
+    let mut app = app.start()?;
 
     for _ in 0..ITERATIONS {
         app.run_one_iteration()?;

--- a/examples/cu_rp2350_skeleton/src/firmware.rs
+++ b/examples/cu_rp2350_skeleton/src/firmware.rs
@@ -210,11 +210,11 @@ fn main() -> ! {
     let app = BlinkyApp::builder()
         .with_clock(clock)
         .with_logger::<EMMCSectionStorage<TSPimodoriSdCard>, EMMCLogger<TSPimodoriSdCard>>(writer)
-        .build_app()
+        .build()
         .unwrap();
     info!("Starting Copper...");
 
-    let _ = app.run();
+    let _ = app.run_until_shutdown();
     defmt::error!("Copper crashed.");
     #[allow(clippy::empty_loop)]
     loop {}

--- a/examples/cu_rp2350_skeleton/src/firmware.rs
+++ b/examples/cu_rp2350_skeleton/src/firmware.rs
@@ -207,17 +207,14 @@ fn main() -> ! {
         EMMCLogger::new(sd, blk_id, blk_len).expect("Could not create EMMCLogger"),
     ));
 
-    let mut app = BlinkyApp::builder()
+    let app = BlinkyApp::builder()
         .with_clock(clock)
         .with_logger::<EMMCSectionStorage<TSPimodoriSdCard>, EMMCLogger<TSPimodoriSdCard>>(writer)
-        .build()
+        .build_app()
         .unwrap();
     info!("Starting Copper...");
 
-    let _ = <BlinkyApp as CuApplication<
-        EMMCSectionStorage<TSPimodoriSdCard>,
-        EMMCLogger<TSPimodoriSdCard>,
-    >>::run(&mut app);
+    let _ = app.run();
     defmt::error!("Copper crashed.");
     #[allow(clippy::empty_loop)]
     loop {}

--- a/examples/cu_rp_balancebot/src/main.rs
+++ b/examples/cu_rp_balancebot/src/main.rs
@@ -26,16 +26,12 @@ fn main() {
     let application = BalanceBot::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create runtime.");
 
-    debug!(
-        "Running... starting clock: {}.",
-        application.inner().clock().now()
-    );
-    let stopped = application.run().expect("Failed to run application.");
-    debug!(
-        "End of app: final clock: {}.",
-        stopped.inner().clock().now()
-    );
+    debug!("Running... starting clock: {}.", application.clock().now());
+    let stopped = application
+        .run_until_shutdown()
+        .expect("Failed to run application.");
+    debug!("End of app: final clock: {}.", stopped.clock().now());
 }

--- a/examples/cu_rp_balancebot/src/main.rs
+++ b/examples/cu_rp_balancebot/src/main.rs
@@ -23,13 +23,18 @@ fn main() {
 
     debug!("Creating application... ");
 
-    let mut application = BalanceBot::builder()
+    let application = BalanceBot::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create runtime.");
 
     debug!("Running... starting clock: {}.", application.clock().now());
-    application.run().expect("Failed to run application.");
-    debug!("End of app: final clock: {}.", application.clock().now());
+    let stopped = CuStdAppLifecycle::new(application)
+        .run()
+        .expect("Failed to run application.");
+    debug!(
+        "End of app: final clock: {}.",
+        stopped.inner().clock().now()
+    );
 }

--- a/examples/cu_rp_balancebot/src/main.rs
+++ b/examples/cu_rp_balancebot/src/main.rs
@@ -26,13 +26,14 @@ fn main() {
     let application = BalanceBot::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create runtime.");
 
-    debug!("Running... starting clock: {}.", application.clock().now());
-    let stopped = CuStdAppLifecycle::new(application)
-        .run()
-        .expect("Failed to run application.");
+    debug!(
+        "Running... starting clock: {}.",
+        application.inner().clock().now()
+    );
+    let stopped = application.run().expect("Failed to run application.");
     debug!(
         "End of app: final clock: {}.",
         stopped.inner().clock().now()

--- a/examples/cu_rp_balancebot/src/resim.rs
+++ b/examples/cu_rp_balancebot/src/resim.rs
@@ -1,3 +1,8 @@
+// Replay harness: drives the raw (app-deprecated) lifecycle API on purpose.
+// Replay needs mid-flight runtime access (keyframe locking, forced
+// timestamps) that the lifecycle typestate deliberately does not expose.
+#![allow(deprecated)]
+
 pub mod tasks;
 
 use cu29::prelude::memmap::{MmapSectionStorage, MmapUnifiedLoggerWrite};

--- a/examples/cu_rp_balancebot/src/resim.rs
+++ b/examples/cu_rp_balancebot/src/resim.rs
@@ -158,7 +158,8 @@ fn make_app(log_base: &Path) -> CuResult<(BalanceBotReSim, RobotClock, RobotCloc
         .with_clock(robot_clock.clone())
         .with_log_path(log_base, REPLAY_LOG_SLAB_SIZE)?
         .with_sim_callback(&mut default_callback)
-        .build()?;
+        .build()?
+        .into_inner();
     Ok((copper_app, robot_clock, robot_clock_mock))
 }
 

--- a/examples/cu_rp_balancebot/src/sim_driver.rs
+++ b/examples/cu_rp_balancebot/src/sim_driver.rs
@@ -98,11 +98,11 @@ pub fn setup_native_copper(mut commands: Commands) {
         .with_log_path(PathBuf::from(logger_path), LOG_SLAB_SIZE)
         .expect("Failed to create logger.")
         .with_sim_callback(&mut default_callback)
-        .build_app()
+        .build()
         .expect("Failed to create runtime.");
 
     let copper_app = copper_app
-        .start_all_tasks(&mut default_callback)
+        .start(&mut default_callback)
         .expect("Failed to start all tasks.");
 
     commands.insert_resource(CopperSim {
@@ -126,15 +126,15 @@ pub fn build_bevymon_copper() -> (MonitorModel, CopperSim) {
         .with_clock(clock.clone())
         .with_logger::<BevyMonSectionStorage, BevyMonUnifiedLogger>(unified_logger)
         .with_sim_callback(&mut sim_callback)
-        .build_app()
+        .build()
         .expect("Failed to create runtime.");
 
-    // Pre-start configuration goes through inner_mut(), only available in the
+    // Pre-start mutable access works through DerefMut, only available in the
     // Initialized state.
-    let monitor_model = copper_app.inner_mut().copper_runtime_mut().monitor.model();
+    let monitor_model = copper_app.copper_runtime_mut().monitor.model();
 
     let copper_app = copper_app
-        .start_all_tasks(&mut sim_callback)
+        .start(&mut sim_callback)
         .expect("Failed to start all tasks.");
 
     (
@@ -306,7 +306,7 @@ pub fn stop_copper_on_exit(
         && let Some(copper_app) = copper_ctx.copper_app.take()
     {
         let stopped = copper_app
-            .stop_all_tasks(&mut default_callback)
+            .stop(&mut default_callback)
             .expect("Failed to stop all tasks.");
         let _ = stopped.into_inner().log_shutdown_completed();
     }

--- a/examples/cu_rp_balancebot/src/sim_driver.rs
+++ b/examples/cu_rp_balancebot/src/sim_driver.rs
@@ -19,11 +19,20 @@ use std::path::{Path, PathBuf};
 #[cfg(feature = "bevymon")]
 use std::sync::{Arc, Mutex};
 
+#[cfg(feature = "bevymon")]
+type SimLifecycle<State> =
+    CuSimAppLifecycle<BevyMonSectionStorage, BevyMonUnifiedLogger, crate::BalanceBotSim, State>;
+#[cfg(not(feature = "bevymon"))]
+type SimLifecycle<State> =
+    CuSimAppLifecycle<memmap::MmapSectionStorage, UnifiedLoggerWrite, crate::BalanceBotSim, State>;
+
 #[derive(Resource)]
 pub struct CopperSim {
     clock: RobotClock,
     clock_mock: RobotClockMock,
-    copper_app: crate::BalanceBotSim,
+    /// The running simulation; taken out once on shutdown because stopping
+    /// consumes the lifecycle handle.
+    copper_app: Option<SimLifecycle<Running>>,
 }
 
 #[derive(Resource, Default)]
@@ -84,22 +93,22 @@ pub fn setup_native_copper(mut commands: Commands) {
         path = logger_path
     );
 
-    let mut copper_app = crate::BalanceBotSim::builder()
+    let copper_app = crate::BalanceBotSim::builder()
         .with_clock(robot_clock.clone())
         .with_log_path(PathBuf::from(logger_path), LOG_SLAB_SIZE)
         .expect("Failed to create logger.")
         .with_sim_callback(&mut default_callback)
-        .build()
+        .build_app()
         .expect("Failed to create runtime.");
 
-    copper_app
+    let copper_app = copper_app
         .start_all_tasks(&mut default_callback)
         .expect("Failed to start all tasks.");
 
     commands.insert_resource(CopperSim {
         clock: robot_clock,
         clock_mock: robot_clock_mock,
-        copper_app,
+        copper_app: Some(copper_app),
     });
     commands.insert_resource(LastCopperTick::default());
 }
@@ -117,20 +126,23 @@ pub fn build_bevymon_copper() -> (MonitorModel, CopperSim) {
         .with_clock(clock.clone())
         .with_logger::<BevyMonSectionStorage, BevyMonUnifiedLogger>(unified_logger)
         .with_sim_callback(&mut sim_callback)
-        .build()
+        .build_app()
         .expect("Failed to create runtime.");
 
-    copper_app
+    // Pre-start configuration goes through inner_mut(), only available in the
+    // Initialized state.
+    let monitor_model = copper_app.inner_mut().copper_runtime_mut().monitor.model();
+
+    let copper_app = copper_app
         .start_all_tasks(&mut sim_callback)
         .expect("Failed to start all tasks.");
 
-    let monitor_model = copper_app.copper_runtime_mut().monitor.model();
     (
         monitor_model,
         CopperSim {
             clock,
             clock_mock,
-            copper_app,
+            copper_app: Some(copper_app),
         },
     )
 }
@@ -277,7 +289,10 @@ pub fn run_copper_callback(
             _ => SimOverride::ExecuteByRuntime,
         }
     };
-    if let Err(err) = copper_ctx.copper_app.run_one_iteration(&mut sim_callback) {
+    let Some(copper_app) = copper_ctx.copper_app.as_mut() else {
+        return;
+    };
+    if let Err(err) = copper_app.run_one_iteration(&mut sim_callback) {
         error!("Simulation stopped: {err}");
         exit_writer.write(AppExit::Success);
     }
@@ -287,11 +302,12 @@ pub fn stop_copper_on_exit(
     mut exit_events: MessageReader<AppExit>,
     mut copper_ctx: ResMut<CopperSim>,
 ) {
-    if exit_events.read().next().is_some() {
-        copper_ctx
-            .copper_app
+    if exit_events.read().next().is_some()
+        && let Some(copper_app) = copper_ctx.copper_app.take()
+    {
+        let stopped = copper_app
             .stop_all_tasks(&mut default_callback)
             .expect("Failed to stop all tasks.");
-        let _ = copper_ctx.copper_app.log_shutdown_completed();
+        let _ = stopped.into_inner().log_shutdown_completed();
     }
 }

--- a/examples/cu_run_in_sim/src/main.rs
+++ b/examples/cu_run_in_sim/src/main.rs
@@ -160,19 +160,19 @@ fn main() -> CuResult<()> {
         path = logger_path
     );
 
-    let mut copper_app = App::builder()
+    let copper_app = App::builder()
         .with_clock(robot_clock.clone())
         .with_log_path(logger_path, LOG_SLAB_SIZE)
         .expect("Failed to setup logger.")
         .with_sim_callback(&mut sim_callback)
-        .build()
+        .build_app()
         .expect("Failed to create runtime.");
 
     // Start and run a few iterations, then stop
-    copper_app.start_all_tasks(&mut sim_callback)?;
+    let mut running = copper_app.start_all_tasks(&mut sim_callback)?;
     for _ in 0..5 {
-        copper_app.run_one_iteration(&mut sim_callback)?;
+        running.run_one_iteration(&mut sim_callback)?;
     }
-    copper_app.stop_all_tasks(&mut sim_callback)?;
+    running.stop_all_tasks(&mut sim_callback)?;
     Ok(())
 }

--- a/examples/cu_run_in_sim/src/main.rs
+++ b/examples/cu_run_in_sim/src/main.rs
@@ -165,14 +165,14 @@ fn main() -> CuResult<()> {
         .with_log_path(logger_path, LOG_SLAB_SIZE)
         .expect("Failed to setup logger.")
         .with_sim_callback(&mut sim_callback)
-        .build_app()
+        .build()
         .expect("Failed to create runtime.");
 
     // Start and run a few iterations, then stop
-    let mut running = copper_app.start_all_tasks(&mut sim_callback)?;
+    let mut running = copper_app.start(&mut sim_callback)?;
     for _ in 0..5 {
         running.run_one_iteration(&mut sim_callback)?;
     }
-    running.stop_all_tasks(&mut sim_callback)?;
+    running.stop(&mut sim_callback)?;
     Ok(())
 }

--- a/examples/cu_runtime_matrix/src/lib.rs
+++ b/examples/cu_runtime_matrix/src/lib.rs
@@ -1153,7 +1153,8 @@ fn build_mission_app(
                 .with_log_path(log_path, DEFAULT_LOG_SLAB_SIZE)?
                 .with_instance_id(instance_id)
                 .with_config(config)
-                .build()?,
+                .build()?
+                .into_inner(),
         )),
         MissionArg::OneToManyBackground => Ok(MissionApp::OneToManyBackground(
             OneToManyBackground::RuntimeMatrixApp::builder()
@@ -1161,7 +1162,8 @@ fn build_mission_app(
                 .with_log_path(log_path, DEFAULT_LOG_SLAB_SIZE)?
                 .with_instance_id(instance_id)
                 .with_config(config)
-                .build()?,
+                .build()?
+                .into_inner(),
         )),
         MissionArg::ManyToOne => Ok(MissionApp::ManyToOne(
             ManyToOne::RuntimeMatrixApp::builder()
@@ -1169,7 +1171,8 @@ fn build_mission_app(
                 .with_log_path(log_path, DEFAULT_LOG_SLAB_SIZE)?
                 .with_instance_id(instance_id)
                 .with_config(config)
-                .build()?,
+                .build()?
+                .into_inner(),
         )),
         MissionArg::ManyToOneBackground => Ok(MissionApp::ManyToOneBackground(
             ManyToOneBackground::RuntimeMatrixApp::builder()
@@ -1177,7 +1180,8 @@ fn build_mission_app(
                 .with_log_path(log_path, DEFAULT_LOG_SLAB_SIZE)?
                 .with_instance_id(instance_id)
                 .with_config(config)
-                .build()?,
+                .build()?
+                .into_inner(),
         )),
         MissionArg::ManyToMany => Ok(MissionApp::ManyToMany(
             ManyToMany::RuntimeMatrixApp::builder()
@@ -1185,7 +1189,8 @@ fn build_mission_app(
                 .with_log_path(log_path, DEFAULT_LOG_SLAB_SIZE)?
                 .with_instance_id(instance_id)
                 .with_config(config)
-                .build()?,
+                .build()?
+                .into_inner(),
         )),
         MissionArg::ManyToManyBackground => Ok(MissionApp::ManyToManyBackground(
             ManyToManyBackground::RuntimeMatrixApp::builder()
@@ -1193,7 +1198,8 @@ fn build_mission_app(
                 .with_log_path(log_path, DEFAULT_LOG_SLAB_SIZE)?
                 .with_instance_id(instance_id)
                 .with_config(config)
-                .build()?,
+                .build()?
+                .into_inner(),
         )),
         MissionArg::BridgeFanout => Ok(MissionApp::BridgeFanout(
             BridgeFanout::RuntimeMatrixApp::builder()
@@ -1201,7 +1207,8 @@ fn build_mission_app(
                 .with_log_path(log_path, DEFAULT_LOG_SLAB_SIZE)?
                 .with_instance_id(instance_id)
                 .with_config(config)
-                .build()?,
+                .build()?
+                .into_inner(),
         )),
         MissionArg::BridgeFanoutBackground => Ok(MissionApp::BridgeFanoutBackground(
             BridgeFanoutBackground::RuntimeMatrixApp::builder()
@@ -1209,7 +1216,8 @@ fn build_mission_app(
                 .with_log_path(log_path, DEFAULT_LOG_SLAB_SIZE)?
                 .with_instance_id(instance_id)
                 .with_config(config)
-                .build()?,
+                .build()?
+                .into_inner(),
         )),
     }
 }

--- a/examples/cu_runtime_matrix/src/lib.rs
+++ b/examples/cu_runtime_matrix/src/lib.rs
@@ -1,3 +1,9 @@
+// Benchmark/matrix harness: dispatches over the generated mission apps via a
+// plain enum, driving the raw (app-deprecated) lifecycle API on purpose. The
+// typestate handle would require the enum itself to implement CuApplication;
+// not worth it for a benchmark driver.
+#![allow(deprecated)]
+
 use bincode::{Decode, Encode};
 use clap::{Parser, ValueEnum};
 use cu29::prelude::*;

--- a/examples/cu_ryuw122_probe/src/lib.rs
+++ b/examples/cu_ryuw122_probe/src/lib.rs
@@ -203,7 +203,7 @@ fn run_probe(args: &ProbeArgs) -> CuResult<()> {
     let app = Ryuw122ProbeApp::builder()
         .with_config(config)
         .with_log_path(&log_path, LOG_SLAB_SIZE)?
-        .build()?;
+        .build_app()?;
 
     let running = Arc::new(AtomicBool::new(true));
     let running_for_signal = Arc::clone(&running);
@@ -227,7 +227,7 @@ fn run_probe(args: &ProbeArgs) -> CuResult<()> {
     let started_at = Instant::now();
     let deadline = args.duration_s.map(Duration::from_secs);
 
-    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
+    let mut app = app.start_all_tasks()?;
 
     let mut last_count = 0;
     let mut run_error = None;

--- a/examples/cu_ryuw122_probe/src/lib.rs
+++ b/examples/cu_ryuw122_probe/src/lib.rs
@@ -200,7 +200,7 @@ fn run_probe(args: &ProbeArgs) -> CuResult<()> {
     );
 
     let log_path = prepare_log_path()?;
-    let mut app = Ryuw122ProbeApp::builder()
+    let app = Ryuw122ProbeApp::builder()
         .with_config(config)
         .with_log_path(&log_path, LOG_SLAB_SIZE)?
         .build()?;

--- a/examples/cu_ryuw122_probe/src/lib.rs
+++ b/examples/cu_ryuw122_probe/src/lib.rs
@@ -227,7 +227,7 @@ fn run_probe(args: &ProbeArgs) -> CuResult<()> {
     let started_at = Instant::now();
     let deadline = args.duration_s.map(Duration::from_secs);
 
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     let mut last_count = 0;
     let mut run_error = None;

--- a/examples/cu_ryuw122_probe/src/lib.rs
+++ b/examples/cu_ryuw122_probe/src/lib.rs
@@ -203,7 +203,7 @@ fn run_probe(args: &ProbeArgs) -> CuResult<()> {
     let app = Ryuw122ProbeApp::builder()
         .with_config(config)
         .with_log_path(&log_path, LOG_SLAB_SIZE)?
-        .build_app()?;
+        .build()?;
 
     let running = Arc::new(AtomicBool::new(true));
     let running_for_signal = Arc::clone(&running);
@@ -227,7 +227,7 @@ fn run_probe(args: &ProbeArgs) -> CuResult<()> {
     let started_at = Instant::now();
     let deadline = args.duration_s.map(Duration::from_secs);
 
-    let mut app = app.start_all_tasks()?;
+    let mut app = app.start()?;
 
     let mut last_count = 0;
     let mut run_error = None;
@@ -252,7 +252,7 @@ fn run_probe(args: &ProbeArgs) -> CuResult<()> {
         thread::sleep(Duration::from_millis(5));
     }
 
-    app.stop_all_tasks()?;
+    app.stop()?;
 
     if let Some(err) = run_error {
         return Err(err);

--- a/examples/cu_zenoh/src/main.rs
+++ b/examples/cu_zenoh/src/main.rs
@@ -48,14 +48,11 @@ fn main() {
     let application = App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create application.");
-    debug!(
-        "Running... starting clock: {}.",
-        application.inner().clock().now()
-    );
+    debug!("Running... starting clock: {}.", application.clock().now());
 
-    if let Err(error) = application.run() {
+    if let Err(error) = application.run_until_shutdown() {
         debug!("Application Ended: {}", error.error)
     }
 }

--- a/examples/cu_zenoh/src/main.rs
+++ b/examples/cu_zenoh/src/main.rs
@@ -48,11 +48,14 @@ fn main() {
     let application = App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create application.");
-    debug!("Running... starting clock: {}.", application.clock().now());
+    debug!(
+        "Running... starting clock: {}.",
+        application.inner().clock().now()
+    );
 
-    if let Err(error) = CuStdAppLifecycle::new(application).run() {
+    if let Err(error) = application.run() {
         debug!("Application Ended: {}", error.error)
     }
 }

--- a/examples/cu_zenoh/src/main.rs
+++ b/examples/cu_zenoh/src/main.rs
@@ -45,14 +45,14 @@ fn main() {
     let logger_path = tmp_dir.path().join("zenoh.copper");
     debug!("Logger created at {}.", path = &logger_path);
     debug!("Creating application... ");
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
     debug!("Running... starting clock: {}.", application.clock().now());
 
-    if let Err(error) = application.run() {
-        debug!("Application Ended: {}", error)
+    if let Err(error) = CuStdAppLifecycle::new(application).run() {
+        debug!("Application Ended: {}", error.error)
     }
 }

--- a/examples/cu_zenoh_bridge_demo/src/bin/ping.rs
+++ b/examples/cu_zenoh_bridge_demo/src/bin/ping.rs
@@ -31,15 +31,15 @@ fn drive() -> CuResult<()> {
     let app = PingApp::builder()
         .with_log_path(&options.log_path, SLAB_SIZE)?
         .with_instance_id(options.instance_id)
-        .build_app()?;
-    let mut app = app.start_all_tasks()?;
+        .build()?;
+    let mut app = app.start()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {
             app.run_one_iteration()?;
             std::thread::sleep(Duration::from_millis(200));
         }
-        app.stop_all_tasks()?;
+        app.stop()?;
         Ok(())
     } else {
         loop {

--- a/examples/cu_zenoh_bridge_demo/src/bin/ping.rs
+++ b/examples/cu_zenoh_bridge_demo/src/bin/ping.rs
@@ -28,11 +28,11 @@ fn main() {
 
 fn drive() -> CuResult<()> {
     let options = parse_run_options("zenoh_ping.copper")?;
-    let mut app = PingApp::builder()
+    let app = PingApp::builder()
         .with_log_path(&options.log_path, SLAB_SIZE)?
         .with_instance_id(options.instance_id)
         .build()?;
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {

--- a/examples/cu_zenoh_bridge_demo/src/bin/ping.rs
+++ b/examples/cu_zenoh_bridge_demo/src/bin/ping.rs
@@ -31,8 +31,8 @@ fn drive() -> CuResult<()> {
     let app = PingApp::builder()
         .with_log_path(&options.log_path, SLAB_SIZE)?
         .with_instance_id(options.instance_id)
-        .build()?;
-    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
+        .build_app()?;
+    let mut app = app.start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {

--- a/examples/cu_zenoh_bridge_demo/src/bin/pong.rs
+++ b/examples/cu_zenoh_bridge_demo/src/bin/pong.rs
@@ -31,8 +31,8 @@ fn drive() -> CuResult<()> {
     let app = PongApp::builder()
         .with_log_path(&options.log_path, SLAB_SIZE)?
         .with_instance_id(options.instance_id)
-        .build()?;
-    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
+        .build_app()?;
+    let mut app = app.start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {

--- a/examples/cu_zenoh_bridge_demo/src/bin/pong.rs
+++ b/examples/cu_zenoh_bridge_demo/src/bin/pong.rs
@@ -28,11 +28,11 @@ fn main() {
 
 fn drive() -> CuResult<()> {
     let options = parse_run_options("zenoh_pong.copper")?;
-    let mut app = PongApp::builder()
+    let app = PongApp::builder()
         .with_log_path(&options.log_path, SLAB_SIZE)?
         .with_instance_id(options.instance_id)
         .build()?;
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {

--- a/examples/cu_zenoh_bridge_demo/src/bin/pong.rs
+++ b/examples/cu_zenoh_bridge_demo/src/bin/pong.rs
@@ -31,15 +31,15 @@ fn drive() -> CuResult<()> {
     let app = PongApp::builder()
         .with_log_path(&options.log_path, SLAB_SIZE)?
         .with_instance_id(options.instance_id)
-        .build_app()?;
-    let mut app = app.start_all_tasks()?;
+        .build()?;
+    let mut app = app.start()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {
             app.run_one_iteration()?;
             std::thread::sleep(Duration::from_millis(200));
         }
-        app.stop_all_tasks()?;
+        app.stop()?;
         Ok(())
     } else {
         loop {

--- a/support/cargo_cunew/templates/cu_full/apps/cu_example_app/src/main.rs
+++ b/support/cargo_cunew/templates/cu_full/apps/cu_example_app/src/main.rs
@@ -23,14 +23,17 @@ fn main() {
     }
     debug!("Logger created at {}.", &logger_path);
     debug!("Creating application... ");
-    let mut application = CuExampleAppApplication::builder()
+    let application = CuExampleAppApplication::builder()
         .with_log_path(&logger_path, PREALLOCATED_STORAGE_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create application.");
-    debug!("Running... starting clock: {}.", application.clock().now());
+    debug!(
+        "Running... starting clock: {}.",
+        application.inner().clock().now()
+    );
 
-    application.run().expect("Failed to run application.");
-    debug!("End of program: {}.", application.clock().now());
+    let stopped = application.run().expect("Failed to run application.");
+    debug!("End of program: {}.", stopped.inner().clock().now());
     sleep(Duration::from_secs(1));
 }

--- a/support/cargo_cunew/templates/cu_full/apps/cu_example_app/src/main.rs
+++ b/support/cargo_cunew/templates/cu_full/apps/cu_example_app/src/main.rs
@@ -26,14 +26,14 @@ fn main() {
     let application = CuExampleAppApplication::builder()
         .with_log_path(&logger_path, PREALLOCATED_STORAGE_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create application.");
     debug!(
         "Running... starting clock: {}.",
-        application.inner().clock().now()
+        application.clock().now()
     );
 
-    let stopped = application.run().expect("Failed to run application.");
-    debug!("End of program: {}.", stopped.inner().clock().now());
+    let stopped = application.run_until_shutdown().expect("Failed to run application.");
+    debug!("End of program: {}.", stopped.clock().now());
     sleep(Duration::from_secs(1));
 }

--- a/support/cargo_cunew/templates/cu_full/apps/cu_example_app/src/resim.rs
+++ b/support/cargo_cunew/templates/cu_full/apps/cu_example_app/src/resim.rs
@@ -1,3 +1,8 @@
+// Replay harness: drives the raw (app-deprecated) lifecycle API on purpose.
+// Replay needs mid-flight runtime access (keyframe locking, forced
+// timestamps) that the lifecycle typestate deliberately does not expose.
+#![allow(deprecated)]
+
 mod messages;
 mod tasks;
 

--- a/support/cargo_cunew/templates/cu_full/apps/cu_example_app/src/resim.rs
+++ b/support/cargo_cunew/templates/cu_full/apps/cu_example_app/src/resim.rs
@@ -66,7 +66,7 @@ fn make_app(log_base: &Path) -> CuResult<(CuExampleAppReSim, RobotClock, RobotCl
         .with_clock(clock.clone())
         .with_log_path(log_base, PREALLOCATED_STORAGE_SIZE)?
         .with_sim_callback(&mut default_callback)
-        .build()?;
+        .build()?.into_inner();
     Ok((app, clock, clock_mock))
 }
 

--- a/support/cargo_cunew/templates/cu_project/src/main.rs
+++ b/support/cargo_cunew/templates/cu_project/src/main.rs
@@ -19,14 +19,17 @@ fn main() {
     }
     debug!("Logger created at {}.", logger_path);
     debug!("Creating application... ");
-    let mut application = {{project-name | upper_camel_case}}Application::builder()
+    let application = {{project-name | upper_camel_case}}Application::builder()
         .with_log_path(logger_path, PREALLOCATED_STORAGE_SIZE)
         .expect("Failed to setup logger.")
-        .build()
+        .build_app()
         .expect("Failed to create application.");
-    debug!("Running... starting clock: {}.", application.clock().now());
+    debug!(
+        "Running... starting clock: {}.",
+        application.inner().clock().now()
+    );
 
-    application.run().expect("Failed to run application.");
-    debug!("End of program: {}.", application.clock().now());
+    let stopped = application.run().expect("Failed to run application.");
+    debug!("End of program: {}.", stopped.inner().clock().now());
     sleep(Duration::from_secs(1));
 }

--- a/support/cargo_cunew/templates/cu_project/src/main.rs
+++ b/support/cargo_cunew/templates/cu_project/src/main.rs
@@ -22,14 +22,14 @@ fn main() {
     let application = {{project-name | upper_camel_case}}Application::builder()
         .with_log_path(logger_path, PREALLOCATED_STORAGE_SIZE)
         .expect("Failed to setup logger.")
-        .build_app()
+        .build()
         .expect("Failed to create application.");
     debug!(
         "Running... starting clock: {}.",
-        application.inner().clock().now()
+        application.clock().now()
     );
 
-    let stopped = application.run().expect("Failed to run application.");
-    debug!("End of program: {}.", stopped.inner().clock().now());
+    let stopped = application.run_until_shutdown().expect("Failed to run application.");
+    debug!("End of program: {}.", stopped.clock().now());
     sleep(Duration::from_secs(1));
 }

--- a/support/cargo_cunew/templates/cu_project/src/resim.rs
+++ b/support/cargo_cunew/templates/cu_project/src/resim.rs
@@ -71,7 +71,7 @@ fn make_app(
         .with_clock(clock.clone())
         .with_log_path(replay_log_base, PREALLOCATED_STORAGE_SIZE)?
         .with_sim_callback(&mut default_callback)
-        .build()?;
+        .build()?.into_inner();
     Ok((app, clock, clock_mock))
 }
 

--- a/support/cargo_cunew/templates/cu_project/src/resim.rs
+++ b/support/cargo_cunew/templates/cu_project/src/resim.rs
@@ -1,3 +1,8 @@
+// Replay harness: drives the raw (app-deprecated) lifecycle API on purpose.
+// Replay needs mid-flight runtime access (keyframe locking, forced
+// timestamps) that the lifecycle typestate deliberately does not expose.
+#![allow(deprecated)]
+
 pub mod tasks;
 
 use cu29::prelude::memmap::{MmapSectionStorage, MmapUnifiedLoggerWrite};


### PR DESCRIPTION
## Summary

Adds a compile-time enforced lifecycle for Copper applications, following the typestate design discussed in #1091, and makes it the **default construction path**: the generated builder ends in `build_app()`, which returns the application already wrapped in its lifecycle typestate. Each state is a distinct type that only exposes the transitions that are legal from it, so mistakes like starting an already running application, iterating before start, or reusing a stale handle fail to compile instead of misbehaving at runtime.

## Related issues
- Closes #1091
- Supersedes #1275 (examples port, folded in here)

## Changes
- `CuAppLifecycle<S, L, A, State>` in `cu29_runtime::app` (plus `CuStdAppLifecycle` alias), with states `Initialized`, `Running`, `Stopped`, `Faulted` and sealed `Startable`/`Stoppable` traits carrying `#[diagnostic::on_unimplemented]` hints
- New `CuSimAppLifecycle` counterpart for `CuSimApplication`: same states, each transition threads the `sim_callback`
- The generated application builder gains **`build_app()`** returning the wrapped app; `build()` and the generated inherent lifecycle convenience methods are `#[deprecated]`. The `CuApplication`/`CuSimApplication` traits are unchanged so framework-level harnesses keep working
- Transitions consume the wrapper and return it typed with the new state; a failed transition hands the application back typed `Faulted` inside `LifecycleError`/`SimLifecycleError` for cleanup, and `From<...> for CuError` keeps `?` working. Restarting from `Stopped` is legal (mission chaining)
- `inner_mut()` is exposed only in the `Initialized` state for pre-start configuration; started states are read-only so transitions cannot be bypassed mid-flight
- Whole tree migrated to `build_app()`: examples (sim included — balancebot sim driver and caterpillar determinism are on `CuSimAppLifecycle`), component testers, core tests, and the cargo-cunew templates. Replay harnesses that need mid-flight runtime access (keyframe locking) stay on the raw trait API behind a commented `allow(deprecated)` or `into_inner()`
- api/v1 snapshots regenerated

The migration surfaced real latent misuse now caught at compile time: six examples double-started/stopped tasks around `run()`, and five hardware testers iterated without ever starting their tasks.

Verification:
- Unit tests in `cu29_runtime::app` for both wrappers: full cycle, restart, failed start/stop recovery through `Faulted`, `?` propagation, sim callback threading
- trybuild compile-fail cases (start on a `Running` app, reuse of a consumed handle) and a compile-pass case covering the legal flows
- Clippy `-D warnings` clean across all migrated crates; `no_std` verified on `thumbv7em-none-eabihf`; both embedded example crates build for their targets

## Reminder
- [x] I ran `just` from the repo root
- [x] I have updated docs or examples where needed

## Additional context (Not AI Generated)
- Of the construction-flow options considered, I picked the one with the smallest macro delta: a new terminal on the existing builder rather than a parallel deprecated builder
- A resim-aware typestate for the replay engines is a possible follow-up if wanted
- Task-level lifecycles are untouched: the runtime already sequences those internally
- Local verification notes (macOS): fmt, typos, api-check and the test suites for `cu29-runtime` and `cu29-derive` ran clean; the python/gstreamer/glib-linked targets could not link on this machine, relying on CI for those
- Note this is my first issue so any guidance here is helpful. I'm hoping to contribute to this project more.
