### PR TITLE
fix(zenoh): timeout API change with 1.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -387,7 +387,7 @@ simplelog = "0.12"
 socket2 = "0.6"
 stm32h7xx-hal = { version = "0.16.0", default-features = false }
 strfmt = "0.2"
-zenoh = { version = "1.7.0", default-features = false }
+zenoh = { version = "~1.10.0", default-features = false }
 
 [workspace.metadata.cargo-shear]
 ignored = ["cu-consolemon"]

--- a/core/cu29_runtime/src/remote_debug.rs
+++ b/core/cu29_runtime/src/remote_debug.rs
@@ -1416,10 +1416,10 @@ fn initialize_remote_debug_shm_provider(
     loop {
         match session.get_shm_provider() {
             ShmProviderState::Ready(provider) => return Ok(provider),
-            ShmProviderState::Initializing if started.elapsed() < SHM_PROVIDER_INIT_TIMEOUT => {
+            ShmProviderState::Initializing(_) if started.elapsed() < SHM_PROVIDER_INIT_TIMEOUT => {
                 std::thread::sleep(SHM_PROVIDER_INIT_POLL_INTERVAL);
             }
-            ShmProviderState::Initializing => {
+            ShmProviderState::Initializing(_) => {
                 return Err(CuError::from(format!(
                     "RemoteDebug server timed out after {:?} initializing its mandatory \
                      shared-memory provider",


### PR DESCRIPTION
## Summary

## Related issues
- Closes #

## Changes

## Reminder
- [ ] I ran `just` from the repo root
- [ ] I have updated docs or examples where needed

## Additional context
