### PR TITLE
feat(examples): port examples to the CuAppLifecycle typestate API

### DIFF
--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -1,5 +1,39 @@
 pub mod cu29_runtime
 pub mod cu29_runtime::app
+pub struct cu29_runtime::app::CuAppLifecycle<S, L, A, State>
+impl<S, L, A, State> cu29_runtime::app::CuAppLifecycle<S, L, A, State> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuApplication<S, L>, State: cu29_runtime::app::Startable
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::run(self) -> cu29_runtime::app::TransitionResult<S, L, A, cu29_runtime::app::Stopped>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::start_all_tasks(self) -> cu29_runtime::app::TransitionResult<S, L, A, cu29_runtime::app::Running>
+impl<S, L, A, State> cu29_runtime::app::CuAppLifecycle<S, L, A, State> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuApplication<S, L>, State: cu29_runtime::app::Stoppable
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::stop_all_tasks(self) -> cu29_runtime::app::TransitionResult<S, L, A, cu29_runtime::app::Stopped>
+impl<S, L, A, State> cu29_runtime::app::CuAppLifecycle<S, L, A, State>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::inner(&self) -> &A
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::into_inner(self) -> A
+impl<S, L, A> cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuApplication<S, L>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Initialized>::new(app: A) -> Self
+impl<S, L, A> cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Running> where S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S> + 'static, A: cu29_runtime::app::CuApplication<S, L>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Running>::run_one_iteration(&mut self) -> cu29_traits::CuResult<()>
+impl<S, L, A, State> core::fmt::Debug for cu29_runtime::app::CuAppLifecycle<S, L, A, State>
+pub fn cu29_runtime::app::CuAppLifecycle<S, L, A, State>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct cu29_runtime::app::Faulted
+impl cu29_runtime::app::Stoppable for cu29_runtime::app::Faulted
+pub struct cu29_runtime::app::Initialized
+impl cu29_runtime::app::Startable for cu29_runtime::app::Initialized
+pub struct cu29_runtime::app::LifecycleError<S, L, A>
+pub cu29_runtime::app::LifecycleError::app: cu29_runtime::app::CuAppLifecycle<S, L, A, cu29_runtime::app::Faulted>
+pub cu29_runtime::app::LifecycleError::error: cu29_traits::CuError
+impl<S, L, A> core::convert::From<cu29_runtime::app::LifecycleError<S, L, A>> for cu29_traits::CuError
+pub fn cu29_traits::CuError::from(value: cu29_runtime::app::LifecycleError<S, L, A>) -> Self
+impl<S, L, A> core::error::Error for cu29_runtime::app::LifecycleError<S, L, A>
+pub fn cu29_runtime::app::LifecycleError<S, L, A>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl<S, L, A> core::fmt::Debug for cu29_runtime::app::LifecycleError<S, L, A>
+pub fn cu29_runtime::app::LifecycleError<S, L, A>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<S, L, A> core::fmt::Display for cu29_runtime::app::LifecycleError<S, L, A>
+pub fn cu29_runtime::app::LifecycleError<S, L, A>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct cu29_runtime::app::Running
+impl cu29_runtime::app::Stoppable for cu29_runtime::app::Running
+pub struct cu29_runtime::app::Stopped
+impl cu29_runtime::app::Startable for cu29_runtime::app::Stopped
 pub struct cu29_runtime::app::Subsystem
 impl cu29_runtime::app::Subsystem
 pub const fn cu29_runtime::app::Subsystem::code(self) -> u16
@@ -33,6 +67,14 @@ pub fn cu29_runtime::app::CuSubsystemMetadata::subsystem() -> cu29_runtime::app:
 pub trait cu29_runtime::app::CurrentRuntimeCopperList<P: cu29_traits::CopperListTuple>
 pub fn cu29_runtime::app::CurrentRuntimeCopperList::current_runtime_copperlist_bytes(&self) -> core::option::Option<&[u8]>
 pub fn cu29_runtime::app::CurrentRuntimeCopperList::set_current_runtime_copperlist_bytes(&mut self, snapshot: core::option::Option<alloc::vec::Vec<u8>>)
+pub trait cu29_runtime::app::Startable: cu29_runtime::app::sealed::Sealed
+impl cu29_runtime::app::Startable for cu29_runtime::app::Initialized
+impl cu29_runtime::app::Startable for cu29_runtime::app::Stopped
+pub trait cu29_runtime::app::Stoppable: cu29_runtime::app::sealed::Sealed
+impl cu29_runtime::app::Stoppable for cu29_runtime::app::Faulted
+impl cu29_runtime::app::Stoppable for cu29_runtime::app::Running
+pub type cu29_runtime::app::CuStdAppLifecycle<A, State> = cu29_runtime::app::CuAppLifecycle<cu29_unifiedlog::memmap::MmapSectionStorage, cu29_unifiedlog::memmap::MmapUnifiedLoggerWrite, A, State>
+pub type cu29_runtime::app::TransitionResult<S, L, A, Next> = core::result::Result<cu29_runtime::app::CuAppLifecycle<S, L, A, Next>, cu29_runtime::app::LifecycleError<S, L, A>>
 pub mod cu29_runtime::config
 pub use cu29_runtime::config::Incoming
 pub use cu29_runtime::config::Outgoing

--- a/core/cu29_derive/tests/compile_fail/lifecycle/reuse_after_start.rs
+++ b/core/cu29_derive/tests/compile_fail/lifecycle/reuse_after_start.rs
@@ -1,0 +1,11 @@
+//! Lifecycle transitions consume the handle: reusing the pre-start handle
+//! after `start_all_tasks` must fail to compile (use of moved value).
+
+use cu29::prelude::*;
+
+fn reuse_after_start<A: CuStdApplication>(app: CuStdAppLifecycle<A>) {
+    let _running = app.start_all_tasks();
+    let _ = app.start_all_tasks();
+}
+
+fn main() {}

--- a/core/cu29_derive/tests/compile_fail/lifecycle/reuse_after_start.stderr
+++ b/core/cu29_derive/tests/compile_fail/lifecycle/reuse_after_start.stderr
@@ -1,0 +1,15 @@
+error[E0382]: use of moved value: `app`
+ --> tests/compile_fail/lifecycle/reuse_after_start.rs:8:13
+  |
+6 | fn reuse_after_start<A: CuStdApplication>(app: CuStdAppLifecycle<A>) {
+  |                                           --- move occurs because `app` has type `CuAppLifecycle<MmapSectionStorage, MmapUnifiedLoggerWrite, A>`, which does not implement the `Copy` trait
+7 |     let _running = app.start_all_tasks();
+  |                        ----------------- `app` moved due to this method call
+8 |     let _ = app.start_all_tasks();
+  |             ^^^ value used here after move
+  |
+note: `CuAppLifecycle::<S, L, A, State>::start_all_tasks` takes ownership of the receiver `self`, which moves `app`
+ --> $WORKSPACE/core/cu29_runtime/src/app.rs
+  |
+  |     pub fn start_all_tasks(mut self) -> TransitionResult<S, L, A, Running> {
+  |                                ^^^^

--- a/core/cu29_derive/tests/compile_fail/lifecycle/start_running_app.rs
+++ b/core/cu29_derive/tests/compile_fail/lifecycle/start_running_app.rs
@@ -1,0 +1,11 @@
+//! Starting an application that is already `Running` must fail to compile:
+//! `start_all_tasks` is only available from the `Initialized` and `Stopped`
+//! typestates (see the `Startable` on_unimplemented note naming the fix).
+
+use cu29::prelude::*;
+
+fn double_start<A: CuStdApplication>(app: CuStdAppLifecycle<A, Running>) {
+    let _ = app.start_all_tasks();
+}
+
+fn main() {}

--- a/core/cu29_derive/tests/compile_fail/lifecycle/start_running_app.stderr
+++ b/core/cu29_derive/tests/compile_fail/lifecycle/start_running_app.stderr
@@ -1,0 +1,13 @@
+error[E0599]: the method `start_all_tasks` exists for struct `CuAppLifecycle<MmapSectionStorage, MmapUnifiedLoggerWrite, A, cu29::prelude::Running>`, but its trait bounds were not satisfied
+ --> tests/compile_fail/lifecycle/start_running_app.rs:8:17
+  |
+8 |     let _ = app.start_all_tasks();
+  |                 ^^^^^^^^^^^^^^^
+  |
+ ::: $WORKSPACE/core/cu29_runtime/src/app.rs
+  |
+  | pub struct Running;
+  | ------------------ doesn't satisfy `cu29::prelude::Running: Startable`
+  |
+  = note: the following trait bounds were not satisfied:
+          `cu29::prelude::Running: Startable`

--- a/core/cu29_derive/tests/compile_pass/lifecycle/full_lifecycle.rs
+++ b/core/cu29_derive/tests/compile_pass/lifecycle/full_lifecycle.rs
@@ -1,0 +1,30 @@
+//! The legal lifecycle flows must compile: start/iterate/stop, restart from
+//! `Stopped` (mission chaining), full `run`, and cleanup from `Faulted`.
+
+use cu29::prelude::*;
+
+fn start_iterate_stop_restart<A: CuStdApplication>(app: CuStdAppLifecycle<A>) -> CuResult<()> {
+    let mut running = app.start_all_tasks()?;
+    running.run_one_iteration()?;
+    let stopped = running.stop_all_tasks()?;
+
+    // Restarting a stopped application is legal.
+    let running = stopped.start_all_tasks()?;
+    running.stop_all_tasks()?;
+    Ok(())
+}
+
+fn run_full_lifecycle<A: CuStdApplication>(app: CuStdAppLifecycle<A>) -> CuResult<()> {
+    let stopped = app.run()?;
+    // A stopped application can run again.
+    stopped.run()?;
+    Ok(())
+}
+
+fn cleanup_after_failed_start<A: CuStdApplication>(app: CuStdAppLifecycle<A>) {
+    if let Err(failed) = app.start_all_tasks() {
+        // The error hands the application back, typed Faulted: cleanup is
+        // still possible and nothing is lost.
+        let _ = failed.app.stop_all_tasks();
+    }
+}

--- a/core/cu29_runtime/src/app.rs
+++ b/core/cu29_runtime/src/app.rs
@@ -1,6 +1,8 @@
 use crate::curuntime::KeyFrame;
+use core::fmt;
+use core::marker::PhantomData;
 use cu29_traits::CopperListTuple;
-use cu29_traits::CuResult;
+use cu29_traits::{CuError, CuResult};
 use cu29_unifiedlog::{SectionStorage, UnifiedLogWrite};
 
 #[cfg(feature = "std")]
@@ -265,4 +267,369 @@ pub trait CuDistributedReplayApplication<S: SectionStorage, L: UnifiedLogWrite<S
     ) -> CuResult<Self>
     where
         Self: Sized;
+}
+
+/// Typestate marker: the application is built but its tasks have not been started yet.
+pub struct Initialized;
+
+/// Typestate marker: tasks are started and iterations can be executed.
+pub struct Running;
+
+/// Typestate marker: tasks are stopped. The application can be started again,
+/// which is useful to chain missions within the same process.
+pub struct Stopped;
+
+/// Typestate marker: a lifecycle transition failed and the application may be
+/// partially started or partially stopped. The only way forward is a
+/// best-effort cleanup through `stop_all_tasks`.
+pub struct Faulted;
+
+mod sealed {
+    /// Seals the lifecycle state traits so external code cannot add new states
+    /// and bypass the transitions enforced by [`CuAppLifecycle`](super::CuAppLifecycle).
+    pub trait Sealed {}
+    impl Sealed for super::Initialized {}
+    impl Sealed for super::Running {}
+    impl Sealed for super::Stopped {}
+    impl Sealed for super::Faulted {}
+}
+
+/// Lifecycle states from which the application tasks can be started (`Initialized`, `Stopped`).
+#[diagnostic::on_unimplemented(
+    message = "the application cannot be started from the `{Self}` lifecycle state",
+    label = "`start_all_tasks` and `run` require an `Initialized` or `Stopped` application",
+    note = "a `Running` application is already started and a `Faulted` application must first be cleaned up with `stop_all_tasks`"
+)]
+pub trait Startable: sealed::Sealed {}
+impl Startable for Initialized {}
+impl Startable for Stopped {}
+
+/// Lifecycle states from which the application tasks can be stopped (`Running`, `Faulted`).
+#[diagnostic::on_unimplemented(
+    message = "the application cannot be stopped from the `{Self}` lifecycle state",
+    label = "`stop_all_tasks` requires a `Running` or `Faulted` application",
+    note = "start the application first with `start_all_tasks`"
+)]
+pub trait Stoppable: sealed::Sealed {}
+impl Stoppable for Running {}
+impl Stoppable for Faulted {}
+
+/// Compile-time enforced lifecycle for a [`CuApplication`].
+///
+/// Wrapping an application moves lifecycle mistakes (double start, iterating
+/// before start, mixing `start_all_tasks` with `run`...) from runtime surprises
+/// to compile errors: each state is a distinct type exposing only the
+/// transitions that are legal from it.
+///
+/// ```text
+///                 start_all_tasks
+///   Initialized ------------------> Running <---+
+///        |                            |  |      | run_one_iteration
+///        | run                        |  +------+
+///        |                            | stop_all_tasks
+///        +--------> Stopped <---------+
+///                    |   ^
+///                    |   | stop_all_tasks (cleanup)
+///        (restart)   |  Faulted <--- any failed transition
+///                    +---> start_all_tasks / run again
+/// ```
+///
+/// Transitions consume the wrapper and return it typed with the new state, so
+/// a stale pre-transition handle cannot be reused. When a transition fails,
+/// the application is handed back inside [`LifecycleError`], typed [`Faulted`],
+/// so cleanup is still possible and nothing is lost.
+///
+/// This wrapper is opt-in: the underlying [`CuApplication`] methods remain
+/// available on the unwrapped application for existing code.
+pub struct CuAppLifecycle<S, L, A, State = Initialized> {
+    app: A,
+    _lifecycle: PhantomData<(S, L, State)>,
+}
+
+impl<S, L, A, State> fmt::Debug for CuAppLifecycle<S, L, A, State> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CuAppLifecycle")
+            .field("state", &core::any::type_name::<State>())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Convenience alias for applications using the default std unified logger,
+/// mirroring [`CuStdApplication`].
+#[cfg(feature = "std")]
+pub type CuStdAppLifecycle<A, State = Initialized> =
+    CuAppLifecycle<MmapSectionStorage, cu29_unifiedlog::UnifiedLoggerWrite, A, State>;
+
+/// Result of a lifecycle transition: on success the application typed with its
+/// new state, on failure [`LifecycleError`] carrying the application typed [`Faulted`].
+pub type TransitionResult<S, L, A, Next> =
+    Result<CuAppLifecycle<S, L, A, Next>, LifecycleError<S, L, A>>;
+
+/// A failed lifecycle transition.
+///
+/// Because transitions consume the application by value, the failure path hands
+/// it back typed as [`Faulted`]: `app` only exposes `stop_all_tasks` for
+/// best-effort cleanup.
+pub struct LifecycleError<S, L, A> {
+    /// The error reported by the underlying application.
+    pub error: CuError,
+    /// The application, in the `Faulted` state. Call `stop_all_tasks` on it to clean up.
+    pub app: CuAppLifecycle<S, L, A, Faulted>,
+}
+
+impl<S, L, A> fmt::Debug for LifecycleError<S, L, A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LifecycleError")
+            .field("error", &self.error)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<S, L, A> fmt::Display for LifecycleError<S, L, A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "lifecycle transition failed: {}", self.error)
+    }
+}
+
+impl<S, L, A> core::error::Error for LifecycleError<S, L, A> {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
+/// Allows `?` in functions returning `CuResult` when the faulted application
+/// does not need to be recovered.
+impl<S, L, A> From<LifecycleError<S, L, A>> for CuError {
+    fn from(value: LifecycleError<S, L, A>) -> Self {
+        value.error
+    }
+}
+
+impl<S, L, A, State> CuAppLifecycle<S, L, A, State> {
+    /// Rewraps the application under a new typestate. Private: state changes
+    /// only happen through the lifecycle transitions.
+    fn into_state<Next>(self) -> CuAppLifecycle<S, L, A, Next> {
+        CuAppLifecycle {
+            app: self.app,
+            _lifecycle: PhantomData,
+        }
+    }
+
+    /// Read-only access to the wrapped application.
+    pub fn inner(&self) -> &A {
+        &self.app
+    }
+
+    /// Consumes the wrapper and returns the application, dropping the
+    /// compile-time lifecycle tracking.
+    pub fn into_inner(self) -> A {
+        self.app
+    }
+}
+
+impl<S, L, A> CuAppLifecycle<S, L, A, Initialized>
+where
+    S: SectionStorage,
+    L: UnifiedLogWrite<S> + 'static,
+    A: CuApplication<S, L>,
+{
+    /// Wraps a freshly built application in the `Initialized` state.
+    pub fn new(app: A) -> Self {
+        CuAppLifecycle {
+            app,
+            _lifecycle: PhantomData,
+        }
+    }
+}
+
+impl<S, L, A, State> CuAppLifecycle<S, L, A, State>
+where
+    S: SectionStorage,
+    L: UnifiedLogWrite<S> + 'static,
+    A: CuApplication<S, L>,
+    State: Startable,
+{
+    /// Starts all tasks, transitioning to `Running`.
+    ///
+    /// On failure the application may be partially started; it is returned
+    /// typed `Faulted` inside the error so it can be cleaned up.
+    pub fn start_all_tasks(mut self) -> TransitionResult<S, L, A, Running> {
+        match self.app.start_all_tasks() {
+            Ok(()) => Ok(self.into_state()),
+            Err(error) => Err(LifecycleError {
+                error,
+                app: self.into_state(),
+            }),
+        }
+    }
+
+    /// Runs the full lifecycle (start, iterate until shutdown, stop),
+    /// transitioning to `Stopped` on success.
+    pub fn run(mut self) -> TransitionResult<S, L, A, Stopped> {
+        match self.app.run() {
+            Ok(()) => Ok(self.into_state()),
+            Err(error) => Err(LifecycleError {
+                error,
+                app: self.into_state(),
+            }),
+        }
+    }
+}
+
+impl<S, L, A> CuAppLifecycle<S, L, A, Running>
+where
+    S: SectionStorage,
+    L: UnifiedLogWrite<S> + 'static,
+    A: CuApplication<S, L>,
+{
+    /// Executes one iteration of the runtime. An iteration error does not
+    /// change the lifecycle state: the caller decides whether to keep
+    /// iterating or stop.
+    pub fn run_one_iteration(&mut self) -> CuResult<()> {
+        self.app.run_one_iteration()
+    }
+}
+
+impl<S, L, A, State> CuAppLifecycle<S, L, A, State>
+where
+    S: SectionStorage,
+    L: UnifiedLogWrite<S> + 'static,
+    A: CuApplication<S, L>,
+    State: Stoppable,
+{
+    /// Stops all tasks, transitioning to `Stopped`. From `Faulted` this is a
+    /// best-effort cleanup. On failure the application is handed back typed
+    /// `Faulted` again.
+    pub fn stop_all_tasks(mut self) -> TransitionResult<S, L, A, Stopped> {
+        match self.app.stop_all_tasks() {
+            Ok(()) => Ok(self.into_state()),
+            Err(error) => Err(LifecycleError {
+                error,
+                app: self.into_state(),
+            }),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod lifecycle_tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct MockApp {
+        started: u32,
+        stopped: u32,
+        iterations: u32,
+        runs: u32,
+        fail_start: bool,
+        fail_stop: bool,
+    }
+
+    impl<S: SectionStorage, L: UnifiedLogWrite<S> + 'static> CuApplication<S, L> for MockApp {
+        fn get_original_config() -> String {
+            String::new()
+        }
+
+        fn start_all_tasks(&mut self) -> CuResult<()> {
+            if self.fail_start {
+                return Err("mock start failure".into());
+            }
+            self.started += 1;
+            Ok(())
+        }
+
+        fn run_one_iteration(&mut self) -> CuResult<()> {
+            self.iterations += 1;
+            Ok(())
+        }
+
+        fn run(&mut self) -> CuResult<()> {
+            if self.fail_start {
+                return Err("mock run failure".into());
+            }
+            self.runs += 1;
+            Ok(())
+        }
+
+        fn stop_all_tasks(&mut self) -> CuResult<()> {
+            if self.fail_stop {
+                return Err("mock stop failure".into());
+            }
+            self.stopped += 1;
+            Ok(())
+        }
+
+        fn restore_keyframe(&mut self, _freezer: &KeyFrame) -> CuResult<()> {
+            Ok(())
+        }
+    }
+
+    type Lifecycle = CuStdAppLifecycle<MockApp>;
+
+    #[test]
+    fn full_cycle_with_restart() {
+        let app = Lifecycle::new(MockApp::default());
+        let mut running = app.start_all_tasks().unwrap();
+        running.run_one_iteration().unwrap();
+        running.run_one_iteration().unwrap();
+        let stopped = running.stop_all_tasks().unwrap();
+
+        // Restarting a stopped application is legal (mission chaining).
+        let running = stopped.start_all_tasks().unwrap();
+        let stopped = running.stop_all_tasks().unwrap();
+
+        let mock = stopped.into_inner();
+        assert_eq!(mock.started, 2);
+        assert_eq!(mock.iterations, 2);
+        assert_eq!(mock.stopped, 2);
+    }
+
+    #[test]
+    fn run_transitions_to_stopped_and_can_run_again() {
+        let app = Lifecycle::new(MockApp::default());
+        let stopped = app.run().unwrap();
+        let stopped = stopped.run().unwrap();
+        assert_eq!(stopped.inner().runs, 2);
+    }
+
+    #[test]
+    fn failed_start_hands_back_a_faulted_app_for_cleanup() {
+        let app = Lifecycle::new(MockApp {
+            fail_start: true,
+            ..Default::default()
+        });
+        let err = app.start_all_tasks().unwrap_err();
+        assert!(err.error.to_string().contains("mock start failure"));
+
+        // The only legal transition from Faulted is the cleanup.
+        let stopped = err.app.stop_all_tasks().unwrap();
+        let mock = stopped.into_inner();
+        assert_eq!(mock.started, 0);
+        assert_eq!(mock.stopped, 1);
+    }
+
+    #[test]
+    fn failed_stop_hands_back_a_faulted_app() {
+        let app = Lifecycle::new(MockApp {
+            fail_stop: true,
+            ..Default::default()
+        });
+        let running = app.start_all_tasks().unwrap();
+        let err = running.stop_all_tasks().unwrap_err();
+        assert!(err.error.to_string().contains("mock stop failure"));
+    }
+
+    #[test]
+    fn lifecycle_error_propagates_with_question_mark() {
+        fn drive() -> CuResult<()> {
+            let app = Lifecycle::new(MockApp {
+                fail_start: true,
+                ..Default::default()
+            });
+            let _running = app.start_all_tasks()?;
+            Ok(())
+        }
+        let error = drive().unwrap_err();
+        assert!(error.to_string().contains("mock start failure"));
+    }
 }

--- a/examples/cu_anytime_rrt_star/src/main.rs
+++ b/examples/cu_anytime_rrt_star/src/main.rs
@@ -36,16 +36,15 @@ fn main() {
         fs::create_dir_all(parent).expect("Failed to create logs directory");
     }
 
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
-    application
-        .start_all_tasks()
-        .expect("Failed to start application.");
+    // `run` starts the tasks itself; the typestate wrapper rejects the manual
+    // start_all_tasks call this example used to make before it.
     // Paced by `runtime.rate_target_hz` in the RON; stops on Ctrl-C.
-    if let Err(error) = application.run() {
-        eprintln!("Error while running: {error}");
+    if let Err(error) = CuStdAppLifecycle::new(application).run() {
+        eprintln!("Error while running: {}", error.error);
     }
 }

--- a/examples/cu_anytime_task/src/main.rs
+++ b/examples/cu_anytime_task/src/main.rs
@@ -201,18 +201,18 @@ fn main() {
     {
         fs::create_dir_all(parent).expect("Failed to create logs directory");
     }
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
-    application
+    let mut running = CuStdAppLifecycle::new(application)
         .start_all_tasks()
         .expect("Failed to start application.");
     // Three copperlists for the foreground chain; keep polling until the
     // backgrounded node's first job comes back from its worker thread.
     for iteration in 0..100 {
-        application
+        running
             .run_one_iteration()
             .expect("Failed to run application.");
         let landed = !tasks::BACKGROUND_RECORDED
@@ -223,7 +223,7 @@ fn main() {
             break;
         }
     }
-    application
+    running
         .stop_all_tasks()
         .expect("Failed to stop application.");
 

--- a/examples/cu_background_task/src/main.rs
+++ b/examples/cu_background_task/src/main.rs
@@ -89,19 +89,18 @@ fn main() {
     }
     debug!("Logger created at {}.", path = &logger_path);
     debug!("Creating application... ");
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
     debug!("Running... starting clock: {}.", application.clock().now());
-    application
-        .start_all_tasks()
-        .expect("Failed to start application.");
-    application.run().expect("Failed to run application.");
-    application
-        .stop_all_tasks()
-        .expect("Failed to stop application.");
-    debug!("End of program: {}.", application.clock().now());
+    // `run` drives the full start/iterate/stop cycle; the typestate wrapper
+    // makes the previous extra start_all_tasks/stop_all_tasks calls around it
+    // a compile error instead of a double start/stop at runtime.
+    let stopped = CuStdAppLifecycle::new(application)
+        .run()
+        .expect("Failed to run application.");
+    debug!("End of program: {}.", stopped.inner().clock().now());
     // check if the logger file is at least 1 section in length
 }

--- a/examples/cu_baremetal_safety/src/lib.rs
+++ b/examples/cu_baremetal_safety/src/lib.rs
@@ -458,12 +458,12 @@ pub mod harness {
         ) -> CuResult<(Vec<String>, Vec<String>)> {
             super::events::reset();
 
-            let mut app = App::builder().with_log_path(logger_path, None)?.build()?;
+            let app = App::builder().with_log_path(logger_path, None)?.build()?;
             let build_events = super::events::snapshot();
 
-            app.start_all_tasks()?;
-            app.run_one_iteration()?;
-            app.stop_all_tasks()?;
+            let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
+            running.run_one_iteration()?;
+            running.stop_all_tasks()?;
 
             let runtime_events = super::slice_from(&super::events::snapshot(), build_events.len());
             Ok((build_events, runtime_events))
@@ -482,16 +482,16 @@ pub mod harness {
         ) -> CuResult<(Vec<String>, Vec<String>, Vec<String>, Vec<String>)> {
             super::events::reset();
 
-            let mut app = App::builder().with_log_path(logger_path, None)?.build()?;
+            let app = App::builder().with_log_path(logger_path, None)?.build()?;
             let build_events = super::events::snapshot();
 
-            app.start_all_tasks()?;
+            let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
             let after_start = super::events::snapshot();
 
-            app.run_one_iteration()?;
+            running.run_one_iteration()?;
             let after_run = super::events::snapshot();
 
-            app.stop_all_tasks()?;
+            running.stop_all_tasks()?;
             let after_stop = super::events::snapshot();
 
             Ok((

--- a/examples/cu_bevymon_demo/src/main.rs
+++ b/examples/cu_bevymon_demo/src/main.rs
@@ -10,7 +10,7 @@ use bevy::render::render_resource::{TextureDimension, TextureFormat, TextureUsag
 use bevy::ui::Node as UiNode;
 use cu_bevymon::{
     CuBevyMonFocus, CuBevyMonPlugin, CuBevyMonSplitLayoutConfig, CuBevyMonSplitStyle,
-    CuBevyMonSurface, CuBevyMonTexture, MonitorUiOptions, spawn_split_layout,
+    CuBevyMonSurface, CuBevyMonTexture, MonitorModel, MonitorUiOptions, spawn_split_layout,
 };
 use cu29::prelude::*;
 use cu29::prelude::{debug, error, info};
@@ -64,11 +64,22 @@ struct LayoutSpawned(bool);
 #[derive(Resource)]
 struct SplitUiCamera(Entity);
 
+type DemoLifecycle<State> =
+    CuAppLifecycle<DemoSectionStorage, DemoUnifiedLogger, BevyMonDemoApp, State>;
+
+/// The Copper lifecycle spread across Bevy systems: transitions consume the
+/// wrapper, so the driver holds the current state and swaps it on transition.
+/// This replaces the old `started: bool` flag.
+enum CopperState {
+    Initialized(DemoLifecycle<Initialized>),
+    Running(DemoLifecycle<Running>),
+    Stopped,
+}
+
 #[derive(Resource)]
 struct CopperDriver {
-    copper_app: BevyMonDemoApp,
+    state: CopperState,
     iteration_timer: Timer,
-    started: bool,
 }
 
 #[derive(Resource)]
@@ -89,8 +100,7 @@ impl Default for DemoCameraRig {
 }
 
 fn main() {
-    let mut copper = build_copper_driver();
-    let monitor_model = copper.copper_app.copper_runtime_mut().monitor.model();
+    let (copper, monitor_model) = build_copper_driver();
 
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(WindowPlugin {
@@ -131,7 +141,7 @@ fn main() {
     app.run();
 }
 
-fn build_copper_driver() -> CopperDriver {
+fn build_copper_driver() -> (CopperDriver, MonitorModel) {
     let unified_logger = build_unified_logger().expect("Failed to create demo logger.");
 
     #[cfg(target_arch = "wasm32")]
@@ -141,24 +151,31 @@ fn build_copper_driver() -> CopperDriver {
 
     debug!("Creating Copper BevyMon demo application.");
 
-    let copper_app = BevyMonDemoApp::builder()
+    let mut copper_app = BevyMonDemoApp::builder()
         .with_logger::<DemoSectionStorage, DemoUnifiedLogger>(unified_logger)
         .build()
         .expect("Failed to create Copper runtime.");
 
-    CopperDriver {
-        copper_app,
+    // The lifecycle wrapper only hands out shared access to the wrapped app,
+    // so grab the monitor model before wrapping.
+    let monitor_model = copper_app.copper_runtime_mut().monitor.model();
+
+    let driver = CopperDriver {
+        state: CopperState::Initialized(CuAppLifecycle::new(copper_app)),
         iteration_timer: Timer::from_seconds(1.0 / COPPER_TICK_HZ, TimerMode::Repeating),
-        started: false,
-    }
+    };
+    (driver, monitor_model)
 }
 
 fn start_copper_runtime(mut copper: ResMut<CopperDriver>) {
-    <BevyMonDemoApp as CuApplication<DemoSectionStorage, DemoUnifiedLogger>>::start_all_tasks(
-        &mut copper.copper_app,
-    )
-    .expect("Failed to start Copper demo tasks.");
-    copper.started = true;
+    let CopperState::Initialized(app) = std::mem::replace(&mut copper.state, CopperState::Stopped)
+    else {
+        return;
+    };
+    let running = app
+        .start_all_tasks()
+        .expect("Failed to start Copper demo tasks.");
+    copper.state = CopperState::Running(running);
     info!("Copper BevyMon demo runtime started.");
 }
 
@@ -504,40 +521,40 @@ fn run_copper_iteration(
     mut copper: ResMut<CopperDriver>,
     mut exit_writer: MessageWriter<AppExit>,
 ) {
-    if !copper.started {
+    let CopperDriver {
+        state,
+        iteration_timer,
+    } = &mut *copper;
+    let CopperState::Running(app) = state else {
+        return;
+    };
+
+    if !iteration_timer.tick(time.delta()).just_finished() {
         return;
     }
 
-    if !copper.iteration_timer.tick(time.delta()).just_finished() {
-        return;
-    }
-
-    if let Err(err) =
-        <BevyMonDemoApp as CuApplication<DemoSectionStorage, DemoUnifiedLogger>>::run_one_iteration(
-            &mut copper.copper_app,
-        )
-    {
+    if let Err(err) = app.run_one_iteration() {
         error!(
             "Copper demo stopped after runtime error: {}",
             err.to_string()
         );
+        // An iteration error leaves the app Running; request an exit and let
+        // stop_copper_on_exit shut the tasks down cleanly.
         exit_writer.write(AppExit::Success);
-        copper.started = false;
     }
 }
 
 fn stop_copper_on_exit(mut exit_events: MessageReader<AppExit>, mut copper: ResMut<CopperDriver>) {
     if exit_events.read().next().is_some() {
-        if !copper.started {
+        let CopperState::Running(app) = std::mem::replace(&mut copper.state, CopperState::Stopped)
+        else {
             return;
-        }
+        };
 
         info!("Stopping Copper BevyMon demo runtime.");
-        <BevyMonDemoApp as CuApplication<DemoSectionStorage, DemoUnifiedLogger>>::stop_all_tasks(
-            &mut copper.copper_app,
-        )
-        .expect("Failed to stop Copper demo tasks.");
-        let _ = copper.copper_app.log_shutdown_completed();
-        copper.started = false;
+        let stopped = app
+            .stop_all_tasks()
+            .expect("Failed to stop Copper demo tasks.");
+        let _ = stopped.into_inner().log_shutdown_completed();
     }
 }

--- a/examples/cu_bridge_test/src/lib.rs
+++ b/examples/cu_bridge_test/src/lib.rs
@@ -375,13 +375,14 @@ mod tests {
         let clock = RobotClock::default();
 
         events::reset();
-        let mut app = builder(&log_path, clock).expect("build app");
-        <App as CuApplication<MmapSectionStorage, UnifiedLoggerWrite>>::start_all_tasks(&mut app)
+        let app = builder(&log_path, clock).expect("build app");
+        // The lifecycle wrapper pins S/L, so the UFCS disambiguation the raw
+        // trait calls needed is no longer necessary.
+        let mut running = CuAppLifecycle::<MmapSectionStorage, UnifiedLoggerWrite, App>::new(app)
+            .start_all_tasks()
             .expect("start");
-        <App as CuApplication<MmapSectionStorage, UnifiedLoggerWrite>>::run_one_iteration(&mut app)
-            .expect("run");
-        <App as CuApplication<MmapSectionStorage, UnifiedLoggerWrite>>::stop_all_tasks(&mut app)
-            .expect("stop");
+        running.run_one_iteration().expect("run");
+        running.stop_all_tasks().expect("stop");
         events::take()
     }
 
@@ -485,15 +486,17 @@ mod tests {
         let clock = RobotClock::default();
 
         {
-            let mut app = super::BridgeTaskSameApp::builder()
+            let app = super::BridgeTaskSameApp::builder()
                 .with_clock(clock.clone())
                 .with_log_path(&log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
                 .build()
                 .expect("build app");
-            app.start_all_tasks().expect("start");
-            app.run_one_iteration().expect("run");
-            app.stop_all_tasks().expect("stop");
+            let mut running = CuStdAppLifecycle::new(app)
+                .start_all_tasks()
+                .expect("start");
+            running.run_one_iteration().expect("run");
+            running.stop_all_tasks().expect("stop");
         }
 
         let UnifiedLogger::Read(read_logger) = UnifiedLoggerBuilder::new()
@@ -539,29 +542,29 @@ mod tests {
 
         events::reset();
         {
-            let mut app = super::BridgeOnlyABApp::builder()
+            let app = super::BridgeOnlyABApp::builder()
                 .with_clock(clock.clone())
                 .with_log_path(&log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
                 .build()
                 .unwrap();
-            app.start_all_tasks().unwrap();
-            app.run_one_iteration().unwrap();
-            app.stop_all_tasks().unwrap();
+            let mut running = CuStdAppLifecycle::new(app).start_all_tasks().unwrap();
+            running.run_one_iteration().unwrap();
+            running.stop_all_tasks().unwrap();
         }
         let first = events::take();
         assert_eq!(first, vec!["alpha.rx.ingress", "beta.tx.egress"]);
 
         {
-            let mut app = super::BridgeLoopbackApp::builder()
+            let app = super::BridgeLoopbackApp::builder()
                 .with_clock(clock)
                 .with_log_path(&log_path, Some(32 * 1024 * 1024))
                 .expect("logger")
                 .build()
                 .unwrap();
-            app.start_all_tasks().unwrap();
-            app.run_one_iteration().unwrap();
-            app.stop_all_tasks().unwrap();
+            let mut running = CuStdAppLifecycle::new(app).start_all_tasks().unwrap();
+            running.run_one_iteration().unwrap();
+            running.stop_all_tasks().unwrap();
         }
         let second = events::take();
         assert_eq!(second, vec!["alpha.rx.loop", "alpha.tx.loop"]);

--- a/examples/cu_bridge_test/src/main.rs
+++ b/examples/cu_bridge_test/src/main.rs
@@ -18,13 +18,14 @@ struct Cli {
     mission: MissionArg,
 }
 
-fn run_once<App>(app: &mut App) -> CuResult<()>
+fn run_once<App>(app: App) -> CuResult<()>
 where
     App: CuApplication<MmapSectionStorage, UnifiedLoggerWrite>,
 {
-    app.start_all_tasks()?;
-    app.run()?;
-    app.stop_all_tasks()?;
+    // `run` drives the full start/iterate/stop cycle; the typestate wrapper
+    // makes the previous extra start_all_tasks/stop_all_tasks calls around it
+    // a compile error instead of a double start/stop at runtime.
+    CuAppLifecycle::new(app).run()?;
     Ok(())
 }
 
@@ -50,40 +51,40 @@ fn drive() -> CuResult<()> {
 
     match args.mission {
         MissionArg::BridgeOnlyAb => {
-            let mut app = BridgeOnlyABApp::builder()
+            let app = BridgeOnlyABApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
                 .build()?;
-            run_once(&mut app)?;
+            run_once(app)?;
         }
         MissionArg::BridgeLoopback => {
-            let mut app = BridgeLoopbackApp::builder()
+            let app = BridgeLoopbackApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
                 .build()?;
-            run_once(&mut app)?;
+            run_once(app)?;
         }
         MissionArg::SourceToBridge => {
-            let mut app = SourceToBridgeApp::builder()
+            let app = SourceToBridgeApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
                 .build()?;
-            run_once(&mut app)?;
+            run_once(app)?;
         }
         MissionArg::BridgeToSink => {
-            let mut app = BridgeToSinkApp::builder()
+            let app = BridgeToSinkApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
                 .build()?;
-            run_once(&mut app)?;
+            run_once(app)?;
         }
         MissionArg::BridgeTaskSame => {
-            let mut app = BridgeTaskSameApp::builder()
+            let app = BridgeTaskSameApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
                 .build()?;
-            run_once(&mut app)?;
+            run_once(app)?;
         }
         MissionArg::BridgeFanout => {
-            let mut app = BridgeFanoutApp::builder()
+            let app = BridgeFanoutApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
                 .build()?;
-            run_once(&mut app)?;
+            run_once(app)?;
         }
     }
 

--- a/examples/cu_caterpillar/src/main.rs
+++ b/examples/cu_caterpillar/src/main.rs
@@ -17,13 +17,13 @@ fn main() {
         fs::create_dir_all(parent).expect("Failed to create logs directory");
     }
 
-    let mut application = CaterpillarApplication::builder()
+    let application = CaterpillarApplication::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
 
-    if let Err(error) = application.run() {
-        debug!("Application Ended: {}", error)
+    if let Err(error) = CuStdAppLifecycle::new(application).run() {
+        debug!("Application Ended: {}", error.error)
     }
 }

--- a/examples/cu_config_variation/src/main.rs
+++ b/examples/cu_config_variation/src/main.rs
@@ -4,10 +4,10 @@ use std::path::{Path, PathBuf};
 #[copper_runtime(config = "copperconfig.ron")]
 struct MyApp {}
 
-fn run_once(app: &mut MyApp) -> CuResult<()> {
-    app.start_all_tasks()?;
-    app.run_one_iteration()?;
-    app.stop_all_tasks()?;
+fn run_once(app: MyApp) -> CuResult<()> {
+    let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
+    running.run_one_iteration()?;
+    running.stop_all_tasks()?;
     Ok(())
 }
 
@@ -24,14 +24,14 @@ fn main() {
 
     // First run with the base configuration
     {
-        let mut application = MyApp::builder()
+        let application = MyApp::builder()
             .with_clock(clock.clone())
             .with_log_path(&logger_path, None)
             .expect("Failed to setup logger.")
             .with_config(copperconfig.clone())
             .build()
             .expect("Failed to create application.");
-        run_once(&mut application).expect("Failed to run application.");
+        run_once(application).expect("Failed to run application.");
 
         // everything will be teared down here
     }
@@ -44,13 +44,13 @@ fn main() {
             node.set_param("pin", 42);
         }
 
-        let mut application = MyApp::builder()
+        let application = MyApp::builder()
             .with_clock(clock.clone())
             .with_log_path(&logger_path, None)
             .expect("Failed to setup logger.")
             .with_config(copperconfig.clone())
             .build()
             .expect("Failed to create application.");
-        run_once(&mut application).expect("Failed to run application.");
+        run_once(application).expect("Failed to run application.");
     }
 }

--- a/examples/cu_distributed_resim_demo/src/bin/control.rs
+++ b/examples/cu_distributed_resim_demo/src/bin/control.rs
@@ -27,11 +27,11 @@ fn main() {
 
 fn drive() -> CuResult<()> {
     let options = parse_run_options("control.copper", DEFAULT_CONTROL_PERIOD_MS)?;
-    let mut app = ControlApp::builder()
+    let app = ControlApp::builder()
         .with_log_path(&options.log_path, LOG_SLAB_SIZE)?
         .with_instance_id(options.instance_id)
         .build()?;
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {

--- a/examples/cu_distributed_resim_demo/src/bin/plan.rs
+++ b/examples/cu_distributed_resim_demo/src/bin/plan.rs
@@ -27,11 +27,11 @@ fn main() {
 
 fn drive() -> CuResult<()> {
     let options = parse_run_options("plan.copper", DEFAULT_PLAN_PERIOD_MS)?;
-    let mut app = PlanApp::builder()
+    let app = PlanApp::builder()
         .with_log_path(&options.log_path, LOG_SLAB_SIZE)?
         .with_instance_id(options.instance_id)
         .build()?;
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {

--- a/examples/cu_distributed_resim_demo/src/bin/scout.rs
+++ b/examples/cu_distributed_resim_demo/src/bin/scout.rs
@@ -27,11 +27,11 @@ fn main() {
 
 fn drive() -> CuResult<()> {
     let options = parse_run_options("scout.copper", DEFAULT_SCOUT_PERIOD_MS)?;
-    let mut app = ScoutApp::builder()
+    let app = ScoutApp::builder()
         .with_log_path(&options.log_path, LOG_SLAB_SIZE)?
         .with_instance_id(options.instance_id)
         .build()?;
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {

--- a/examples/cu_feature_gated_camera/src/main.rs
+++ b/examples/cu_feature_gated_camera/src/main.rs
@@ -30,12 +30,13 @@ mod app {
                 .map_err(|error| CuError::new_with_cause("creating log directory", error))?;
         }
 
-        let mut app = CameraApp::builder()
+        let app = CameraApp::builder()
             .with_log_path(&log_path, Some(16 * 1024 * 1024))?
             .build()?;
-        app.start_all_tasks()?;
-        app.run_one_iteration()?;
-        app.stop_all_tasks()
+        let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
+        running.run_one_iteration()?;
+        running.stop_all_tasks()?;
+        Ok(())
     }
 }
 

--- a/examples/cu_feetech_demo/src/main.rs
+++ b/examples/cu_feetech_demo/src/main.rs
@@ -19,11 +19,12 @@ use leader_follower::FeetechDemoApp as LeaderFollowerApp;
 
 const SLAB_SIZE: Option<usize> = Some(64 * 1024 * 1024);
 
-fn run_mission<App>(app: &mut App) -> CuResult<()>
+fn run_mission<App>(app: App) -> CuResult<()>
 where
     App: CuApplication<memmap::MmapSectionStorage, UnifiedLoggerWrite>,
 {
-    app.run()
+    CuAppLifecycle::new(app).run()?;
+    Ok(())
 }
 
 fn main() {
@@ -44,7 +45,7 @@ fn main() {
     match mission.as_str() {
         "arm_publisher" => {
             debug!("Starting ARM_PUBLISHER mission – reading positions.");
-            let mut app = ArmPublisherApp::builder()
+            let app = ArmPublisherApp::builder()
                 .with_log_path(logger_path, SLAB_SIZE)
                 .expect("Failed to setup logger.")
                 .build()
@@ -52,13 +53,13 @@ fn main() {
                     print_setup_help(&e);
                     std::process::exit(1);
                 });
-            if let Err(e) = run_mission(&mut app) {
+            if let Err(e) = run_mission(app) {
                 debug!("Arm publisher ended: {}", e);
             }
         }
         "leader_follower" => {
             debug!("Starting LEADER_FOLLOWER mission – leader drives follower.");
-            let mut app = LeaderFollowerApp::builder()
+            let app = LeaderFollowerApp::builder()
                 .with_log_path(logger_path, SLAB_SIZE)
                 .expect("Failed to setup logger.")
                 .build()
@@ -66,7 +67,7 @@ fn main() {
                     print_setup_help(&e);
                     std::process::exit(1);
                 });
-            if let Err(e) = run_mission(&mut app) {
+            if let Err(e) = run_mission(app) {
                 debug!("Leader-follower ended: {}", e);
             }
         }

--- a/examples/cu_flight_controller/src/compute.rs
+++ b/examples/cu_flight_controller/src/compute.rs
@@ -21,8 +21,9 @@ fn main() {
 }
 
 fn drive() -> CuResult<()> {
-    let mut app = ComputeApp::builder()
+    let app = ComputeApp::builder()
         .with_log_path("logs/compute.copper", LOG_SLAB_SIZE)?
         .build()?;
-    app.run()
+    CuStdAppLifecycle::new(app).run()?;
+    Ok(())
 }

--- a/examples/cu_gnss_ublox_demo/src/main.rs
+++ b/examples/cu_gnss_ublox_demo/src/main.rs
@@ -23,11 +23,11 @@ fn run() -> CuResult<()> {
         .map_err(|e| CuError::new_with_cause("failed to create temporary log directory", e))?;
     let log_path = log_dir.path().join("cu_gnss_ublox_demo.copper");
 
-    let mut app = CuGnssUbloxDemo::builder()
+    let app = CuGnssUbloxDemo::builder()
         .with_log_path(&log_path, Some(16 * 1024 * 1024))?
         .build()?;
     let clock = app.clock();
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     let running = Arc::new(AtomicBool::new(true));
     let running_for_signal = Arc::clone(&running);

--- a/examples/cu_human_pose/src/main.rs
+++ b/examples/cu_human_pose/src/main.rs
@@ -44,18 +44,15 @@ fn main() {
     }
 
     // Build the application from RON config
-    let mut application = YoloPoseDemoApplication::builder()
+    let application = YoloPoseDemoApplication::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to set up Copper logging")
         .build()
         .expect("Failed to build application");
 
-    // Start all tasks
-    application
-        .start_all_tasks()
-        .expect("Failed to start tasks");
-
-    if let Err(e) = application.run() {
-        error!("Error during iteration: {}", e.to_string());
+    // `run` starts the tasks itself; the typestate wrapper rejects the manual
+    // start_all_tasks call this example used to make before it.
+    if let Err(e) = CuStdAppLifecycle::new(application).run() {
+        error!("Error during iteration: {}", e.error.to_string());
     }
 }

--- a/examples/cu_iceoryx2_bridge_demo/src/bin/ping.rs
+++ b/examples/cu_iceoryx2_bridge_demo/src/bin/ping.rs
@@ -30,10 +30,10 @@ fn drive() -> CuResult<()> {
     let tmp_dir = tempfile::TempDir::new().expect("could not create temp dir");
     let logger_path = tmp_dir.path().join("iceoryx2_ping.copper");
 
-    let mut app = PingApp::builder()
+    let app = PingApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)?
         .build()?;
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     loop {
         app.run_one_iteration()?;

--- a/examples/cu_iceoryx2_bridge_demo/src/bin/pong.rs
+++ b/examples/cu_iceoryx2_bridge_demo/src/bin/pong.rs
@@ -30,10 +30,10 @@ fn drive() -> CuResult<()> {
     let tmp_dir = tempfile::TempDir::new().expect("could not create temp dir");
     let logger_path = tmp_dir.path().join("iceoryx2_pong.copper");
 
-    let mut app = PongApp::builder()
+    let app = PongApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)?
         .build()?;
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     loop {
         app.run_one_iteration()?;

--- a/examples/cu_image_aligner/src/main.rs
+++ b/examples/cu_image_aligner/src/main.rs
@@ -14,20 +14,20 @@ fn main() {
     debug!("Logger created at {}.", path = &logger_path);
     debug!("Creating application...");
 
-    let mut application = ImageAlignerApp::builder()
+    let application = ImageAlignerApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create runtime.");
     debug!("Running... starting clock: {}.", application.clock().now());
 
-    application
+    let mut running = CuStdAppLifecycle::new(application)
         .start_all_tasks()
         .expect("Failed to start tasks.");
     for _ in 0..ITERATIONS {
-        application
+        running
             .run_one_iteration()
             .expect("Failed to run iteration.");
     }
-    debug!("End of program: {}.", application.clock().now());
+    debug!("End of program: {}.", running.inner().clock().now());
 }

--- a/examples/cu_image_codec_demo/src/consolemon.rs
+++ b/examples/cu_image_codec_demo/src/consolemon.rs
@@ -24,14 +24,15 @@ pub fn main() {
         std::fs::create_dir_all(parent).expect("Failed to create log directory");
     }
 
-    let mut application = ImageCodecDemoConsolemonApp::builder()
+    let application = ImageCodecDemoConsolemonApp::builder()
         .with_log_path(&log_path, Some(64 * 1024 * 1024))
         .expect("Failed to setup Copper log")
         .build()
         .expect("Failed to create application");
 
-    if let Err(err) = application.run() {
-        if err.message() != "Exiting..." {
+    if let Err(err) = CuStdAppLifecycle::new(application).run() {
+        if err.error.message() != "Exiting..." {
+            let err = err.error;
             error!("{err:?}");
         }
     }

--- a/examples/cu_image_codec_demo/src/main.rs
+++ b/examples/cu_image_codec_demo/src/main.rs
@@ -20,17 +20,17 @@ mod real {
             std::fs::create_dir_all(parent).expect("Failed to create log directory");
         }
 
-        let mut application = ImageCodecDemoApp::builder()
+        let application = ImageCodecDemoApp::builder()
             .with_log_path(&log_path, Some(64 * 1024 * 1024))
             .expect("Failed to setup Copper log")
             .build()
             .expect("Failed to create application");
-        application
+        let mut running = CuStdAppLifecycle::new(application)
             .start_all_tasks()
             .expect("Failed to start tasks");
 
         for _ in 0..180 {
-            application
+            running
                 .run_one_iteration()
                 .expect("Failed to run iteration");
         }

--- a/examples/cu_instance_overrides_demo/src/main.rs
+++ b/examples/cu_instance_overrides_demo/src/main.rs
@@ -130,12 +130,12 @@ fn drive() -> CuResult<()> {
             .map_err(|err| CuError::new_with_cause("failed to create log directory", err))?;
     }
 
-    let mut app = App::builder()
+    let app = App::builder()
         .with_log_path(&logger_path, None)?
         .with_instance_id(instance_id)
         .build()?;
-    app.start_all_tasks()?;
-    app.run_one_iteration()?;
-    app.stop_all_tasks()?;
+    let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
+    running.run_one_iteration()?;
+    running.stop_all_tasks()?;
     Ok(())
 }

--- a/examples/cu_logging_size/src/main.rs
+++ b/examples/cu_logging_size/src/main.rs
@@ -77,21 +77,21 @@ fn main() {
     let unified_logger = Arc::new(Mutex::new(logger));
     debug!("Logger created at {}.", path = &logger_path);
     debug!("Creating application... ");
-    let mut application = App::builder()
+    let application = App::builder()
         .with_logger::<memmap::MmapSectionStorage, UnifiedLoggerWrite>(unified_logger.clone())
         .build()
         .expect("Failed to create application.");
     debug!("Running... starting clock: {}.", application.clock().now());
-    application
+    let mut running = CuStdAppLifecycle::new(application)
         .start_all_tasks()
         .expect("Failed to start application.");
-    application
+    running
         .run_one_iteration()
         .expect("Failed to run application.");
-    application
+    let stopped = running
         .stop_all_tasks()
         .expect("Failed to stop application.");
-    debug!("End of program: {}.", application.clock().now());
+    debug!("End of program: {}.", stopped.inner().clock().now());
     // check if the logger file is at least 1 section in length
 
     // change the end of the logger_path from copper to _0.copper

--- a/examples/cu_min_baremetal/src/main.rs
+++ b/examples/cu_min_baremetal/src/main.rs
@@ -93,12 +93,14 @@ pub extern "C" fn main() {
         },
     );
     let writer = Arc::new(Mutex::new(NoopLogger::new()));
-    let mut app = MinimalNoStdApp::builder()
+    let app = MinimalNoStdApp::builder()
         .with_clock(clock)
         .with_logger::<NoopSectionStorage, NoopLogger>(writer)
         .build()
         .unwrap();
-    let _ = <MinimalNoStdApp as CuApplication<NoopSectionStorage, NoopLogger>>::run(&mut app);
+    // CuAppLifecycle is no_std-compatible; naming S/L on the wrapper replaces
+    // the UFCS disambiguation the raw trait call needed.
+    let _ = CuAppLifecycle::<NoopSectionStorage, NoopLogger, _>::new(app).run();
 }
 
 #[cfg(feature = "std")]
@@ -116,13 +118,13 @@ fn main() {
         }
     }
 
-    let mut application = MinimalNoStdApp::builder()
+    let application = MinimalNoStdApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
 
-    if let Err(error) = application.run() {
-        debug!("Application Ended: {}", error)
+    if let Err(error) = CuStdAppLifecycle::new(application).run() {
+        debug!("Application Ended: {}", error.error)
     }
 }

--- a/examples/cu_missions/src/main.rs
+++ b/examples/cu_missions/src/main.rs
@@ -11,13 +11,13 @@ use B::App as MissionBApp;
 
 const SLAB_SIZE: Option<usize> = Some(10 * 1024 * 1024);
 
-fn run_once<App>(app: &mut App) -> CuResult<()>
+fn run_once<App>(app: App) -> CuResult<()>
 where
     App: CuApplication<memmap::MmapSectionStorage, UnifiedLoggerWrite>,
 {
-    app.start_all_tasks()?;
-    app.run_one_iteration()?;
-    app.stop_all_tasks()?;
+    let mut running = CuAppLifecycle::new(app).start_all_tasks()?;
+    running.run_one_iteration()?;
+    running.stop_all_tasks()?;
     Ok(())
 }
 
@@ -31,25 +31,25 @@ fn main() {
     debug!("Running... starting clock: {}.", clock.now());
     debug!("Starting Mission A.");
     {
-        let mut application_a = MissionAApp::builder()
+        let application_a = MissionAApp::builder()
             .with_clock(clock.clone())
             .with_log_path(&logger_path, SLAB_SIZE)
             .expect("Failed to setup logger.")
             .build()
             .expect("Failed to create runtime");
-        run_once(&mut application_a).expect("Failed to run mission A.");
+        run_once(application_a).expect("Failed to run mission A.");
     }
 
     debug!("Starting Mission B.");
     // Note if you don't end the tasks, you'll be up for a bad time because tasks can hog some resources.
     {
-        let mut application_b = MissionBApp::builder()
+        let application_b = MissionBApp::builder()
             .with_clock(clock.clone())
             .with_log_path(&logger_path, SLAB_SIZE)
             .expect("Failed to setup logger.")
             .build()
             .expect("Failed to create runtime");
-        run_once(&mut application_b).expect("Failed to run mission B.");
+        run_once(application_b).expect("Failed to run mission B.");
     }
 
     debug!("End of program: {}.", clock.now());

--- a/examples/cu_monitoring/src/main.rs
+++ b/examples/cu_monitoring/src/main.rs
@@ -115,18 +115,17 @@ fn main() {
 
     debug!("Logger created at {}.", path = &logger_path);
     debug!("Creating application... ");
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create runtime");
     debug!("Running... starting clock: {}.", application.clock().now());
-    application
-        .start_all_tasks()
-        .expect("Failed to start application.");
-    application.run().expect("Failed to run application.");
-    application
-        .stop_all_tasks()
-        .expect("Failed to stop application.");
-    debug!("End of program: {}.", application.clock().now());
+    // `run` drives the full start/iterate/stop cycle; the typestate wrapper
+    // makes the previous extra start_all_tasks/stop_all_tasks calls around it
+    // a compile error instead of a double start/stop at runtime.
+    let stopped = CuStdAppLifecycle::new(application)
+        .run()
+        .expect("Failed to run application.");
+    debug!("End of program: {}.", stopped.inner().clock().now());
 }

--- a/examples/cu_msp_bridge_loopback/src/main.rs
+++ b/examples/cu_msp_bridge_loopback/src/main.rs
@@ -47,21 +47,21 @@ fn drive() -> CuResult<()> {
     emulator.configure_bridge(&mut config)?;
     install_ctrlc_cleanup(emulator.symlink_path.clone())?;
 
-    let mut app = CuMspBridgeLoopbackApp::builder()
+    let app = CuMspBridgeLoopbackApp::builder()
         .with_log_path(&logger_path, Some(16 * 1024 * 1024))?
         .with_config(config)
         .build()?;
 
-    app.start_all_tasks()?;
+    let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
     for i in 0..3 {
         debug!("Running iteration {}", i);
-        app.run_one_iteration()?;
+        running.run_one_iteration()?;
         if tasks::state::was_validated() {
             break;
         }
         thread::sleep(Duration::from_millis(10));
     }
-    app.stop_all_tasks()?;
+    running.stop_all_tasks()?;
 
     if !tasks::state::was_validated() {
         return Err(CuError::from(

--- a/examples/cu_multi_output/src/main.rs
+++ b/examples/cu_multi_output/src/main.rs
@@ -171,18 +171,18 @@ fn main() {
     let tmp_dir = tempfile::TempDir::new().expect("Could not create temporary directory");
     let logger_path = tmp_dir.path().join("logger.copper");
 
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(&logger_path, None)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
-    application
+    let mut running = CuStdAppLifecycle::new(application)
         .start_all_tasks()
         .expect("Failed to start application.");
-    application
+    running
         .run_one_iteration()
         .expect("Failed to run application.");
-    application
+    running
         .stop_all_tasks()
         .expect("Failed to stop application.");
 

--- a/examples/cu_multisources/src/main.rs
+++ b/examples/cu_multisources/src/main.rs
@@ -14,12 +14,14 @@ fn main() {
     let logger_path = tmp_dir.path().join("caterpillar.copper");
     debug!("Logger created at {}.", path = &logger_path);
     debug!("Creating application... ");
-    let mut application = MultiSourceApp::builder()
+    let application = MultiSourceApp::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create runtime.");
 
-    application.run().expect("Failed to run application.");
+    CuStdAppLifecycle::new(application)
+        .run()
+        .expect("Failed to run application.");
     sleep(Duration::from_secs(1));
 }

--- a/examples/cu_nologging_task/src/main.rs
+++ b/examples/cu_nologging_task/src/main.rs
@@ -70,19 +70,17 @@ fn main() {
     }
     debug!("Logger created at {}.", path = &logger_path);
     debug!("Creating application... ");
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
     debug!("Running... starting clock: {}.", application.clock().now());
-    application
-        .start_all_tasks()
-        .expect("Failed to start application.");
-    application.run().expect("Failed to run application.");
-    application
-        .stop_all_tasks()
-        .expect("Failed to stop application.");
-    debug!("End of program: {}.", application.clock().now());
+    // `run` already starts and stops the tasks; the lifecycle wrapper rejects
+    // the extra start_all_tasks/stop_all_tasks calls this example used to make.
+    let stopped = CuStdAppLifecycle::new(application)
+        .run()
+        .expect("Failed to run application.");
+    debug!("End of program: {}.", stopped.inner().clock().now());
     // check if the logger file is at least 1 section in length
 }

--- a/examples/cu_parallel_mandelbrot/src/lib.rs
+++ b/examples/cu_parallel_mandelbrot/src/lib.rs
@@ -99,7 +99,7 @@ pub fn run_log_only() -> CuResult<()> {
     let settings = load_benchmark_settings()?;
     let logger_path = benchmark_logger_path("parallel_mandelbrot_log_only.copper")?;
     let logger_path_display = logger_path.display().to_string();
-    let mut app = log_only::App::builder()
+    let app = log_only::App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)?
         .build()
         .map_err(|err| CuError::from(format!("failed to build log_only mission: {err}")))?;
@@ -109,7 +109,7 @@ pub fn run_log_only() -> CuResult<()> {
         logger_path_display
     );
     let started = Instant::now();
-    app.run()?;
+    CuStdAppLifecycle::new(app).run()?;
     log_summary("log_only", &logger_path, settings, started.elapsed());
     Ok(())
 }
@@ -119,7 +119,7 @@ pub fn run_viewer_live() -> CuResult<()> {
     let settings = load_benchmark_settings()?;
     let logger_path = benchmark_logger_path("parallel_mandelbrot_viewer.copper")?;
     let logger_path_display = logger_path.display().to_string();
-    let mut app = viewer_live::App::builder()
+    let app = viewer_live::App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)?
         .build()
         .map_err(|err| CuError::from(format!("failed to build viewer_live mission: {err}")))?;
@@ -129,7 +129,7 @@ pub fn run_viewer_live() -> CuResult<()> {
         logger_path_display
     );
     let started = Instant::now();
-    app.run()?;
+    CuStdAppLifecycle::new(app).run()?;
     log_summary("viewer_live", &logger_path, settings, started.elapsed());
     Ok(())
 }

--- a/examples/cu_pointclouds/src/main.rs
+++ b/examples/cu_pointclouds/src/main.rs
@@ -57,12 +57,12 @@ fn main() {
     const PACKET_SIZE: usize = size_of::<Packet>();
     let tmp_dir = tempfile::TempDir::new().expect("could not create a tmp dir");
     let logger_path = tmp_dir.path().join("ptclouds.copper");
-    let mut application = PtCloudsApplication::builder()
+    let application = PtCloudsApplication::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup copper.")
         .build()
         .expect("Failed to create application");
-    application
+    let mut application = CuStdAppLifecycle::new(application)
         .start_all_tasks()
         .expect("Failed to start all tasks.");
 

--- a/examples/cu_python_task_demo/src/lib.rs
+++ b/examples/cu_python_task_demo/src/lib.rs
@@ -255,17 +255,17 @@ pub fn config_for_mode(mode: PyTaskMode) -> CuConfig {
 pub fn run_demo(mode: PyTaskMode, iterations: usize) -> CuResult<()> {
     let temp_dir = tempfile::TempDir::new().map_err(|e| CuError::new_with_cause("temp dir", e))?;
     let log_path = temp_dir.path().join("python_task_demo.copper");
-    let mut app = PythonTaskDemoApp::builder()
+    let app = PythonTaskDemoApp::builder()
         .with_log_path(&log_path, Some(32 * 1024 * 1024))?
         .with_config(config_for_mode(mode))
         .build()?;
 
     reset_sinks();
-    app.start_all_tasks()?;
+    let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
     for _ in 0..iterations {
-        app.run_one_iteration()?;
+        running.run_one_iteration()?;
     }
-    app.stop_all_tasks()?;
+    running.stop_all_tasks()?;
     Ok(())
 }
 

--- a/examples/cu_rate_target/src/lib.rs
+++ b/examples/cu_rate_target/src/lib.rs
@@ -248,18 +248,17 @@ pub fn run_example(log_filename: &str) {
         logger_path.to_string_lossy().into_owned()
     );
     info!("Creating application...");
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
     info!("Running... starting clock: {}.", application.clock().now());
-    application
-        .start_all_tasks()
-        .expect("Failed to start application.");
-    application.run().expect("Failed to run application.");
-    application
-        .stop_all_tasks()
-        .expect("Failed to stop application.");
-    info!("End of program: {}.", application.clock().now());
+    // `run` drives the full start/iterate/stop cycle; the typestate wrapper
+    // makes the previous extra start_all_tasks/stop_all_tasks calls around it
+    // a compile error instead of a double start/stop at runtime.
+    let stopped = CuStdAppLifecycle::new(application)
+        .run()
+        .expect("Failed to run application.");
+    info!("End of program: {}.", stopped.inner().clock().now());
 }

--- a/examples/cu_resources_test/src/main.rs
+++ b/examples/cu_resources_test/src/main.rs
@@ -31,13 +31,14 @@ enum MissionArg {
 
 const SLAB_SIZE: Option<usize> = None;
 
-fn run_once<App>(app: &mut App) -> CuResult<()>
+fn run_once<App>(app: App) -> CuResult<()>
 where
     App: CuApplication<MmapSectionStorage, UnifiedLoggerWrite>,
 {
-    app.start_all_tasks()?;
-    app.run()?;
-    app.stop_all_tasks()?;
+    // `run` drives the full start/iterate/stop cycle; the typestate wrapper
+    // makes the previous extra start_all_tasks/stop_all_tasks calls around it
+    // a compile error instead of a double start/stop at runtime.
+    CuAppLifecycle::new(app).run()?;
     Ok(())
 }
 
@@ -63,16 +64,16 @@ fn drive() -> CuResult<()> {
 
     match args.mission {
         MissionArg::A => {
-            let mut app = MissionAApp::builder()
+            let app = MissionAApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
                 .build()?;
-            run_once(&mut app)?;
+            run_once(app)?;
         }
         MissionArg::B => {
-            let mut app = MissionBApp::builder()
+            let app = MissionBApp::builder()
                 .with_log_path(&logger_path, SLAB_SIZE)?
                 .build()?;
-            run_once(&mut app)?;
+            run_once(app)?;
         }
     }
 

--- a/examples/cu_ros2_bridge_demo/src/main.rs
+++ b/examples/cu_ros2_bridge_demo/src/main.rs
@@ -103,8 +103,8 @@ fn drive() -> CuResult<()> {
 
     let tmp_dir = tempfile::TempDir::new().expect("could not create a tmp dir");
     let logger_path = tmp_dir.path().join("ros2_bridge.copper");
-    let mut app = App::builder().with_log_path(&logger_path, None)?.build()?;
-    app.start_all_tasks()?;
+    let app = App::builder().with_log_path(&logger_path, None)?.build()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     for _ in 0..ITERATIONS {
         app.run_one_iteration()?;

--- a/examples/cu_rp_balancebot/src/main.rs
+++ b/examples/cu_rp_balancebot/src/main.rs
@@ -23,13 +23,18 @@ fn main() {
 
     debug!("Creating application... ");
 
-    let mut application = BalanceBot::builder()
+    let application = BalanceBot::builder()
         .with_log_path(logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create runtime.");
 
     debug!("Running... starting clock: {}.", application.clock().now());
-    application.run().expect("Failed to run application.");
-    debug!("End of app: final clock: {}.", application.clock().now());
+    let stopped = CuStdAppLifecycle::new(application)
+        .run()
+        .expect("Failed to run application.");
+    debug!(
+        "End of app: final clock: {}.",
+        stopped.inner().clock().now()
+    );
 }

--- a/examples/cu_ryuw122_probe/src/lib.rs
+++ b/examples/cu_ryuw122_probe/src/lib.rs
@@ -200,7 +200,7 @@ fn run_probe(args: &ProbeArgs) -> CuResult<()> {
     );
 
     let log_path = prepare_log_path()?;
-    let mut app = Ryuw122ProbeApp::builder()
+    let app = Ryuw122ProbeApp::builder()
         .with_config(config)
         .with_log_path(&log_path, LOG_SLAB_SIZE)?
         .build()?;

--- a/examples/cu_ryuw122_probe/src/lib.rs
+++ b/examples/cu_ryuw122_probe/src/lib.rs
@@ -227,7 +227,7 @@ fn run_probe(args: &ProbeArgs) -> CuResult<()> {
     let started_at = Instant::now();
     let deadline = args.duration_s.map(Duration::from_secs);
 
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     let mut last_count = 0;
     let mut run_error = None;

--- a/examples/cu_zenoh/src/main.rs
+++ b/examples/cu_zenoh/src/main.rs
@@ -45,14 +45,14 @@ fn main() {
     let logger_path = tmp_dir.path().join("zenoh.copper");
     debug!("Logger created at {}.", path = &logger_path);
     debug!("Creating application... ");
-    let mut application = App::builder()
+    let application = App::builder()
         .with_log_path(&logger_path, SLAB_SIZE)
         .expect("Failed to setup logger.")
         .build()
         .expect("Failed to create application.");
     debug!("Running... starting clock: {}.", application.clock().now());
 
-    if let Err(error) = application.run() {
-        debug!("Application Ended: {}", error)
+    if let Err(error) = CuStdAppLifecycle::new(application).run() {
+        debug!("Application Ended: {}", error.error)
     }
 }

--- a/examples/cu_zenoh_bridge_demo/src/bin/ping.rs
+++ b/examples/cu_zenoh_bridge_demo/src/bin/ping.rs
@@ -28,11 +28,11 @@ fn main() {
 
 fn drive() -> CuResult<()> {
     let options = parse_run_options("zenoh_ping.copper")?;
-    let mut app = PingApp::builder()
+    let app = PingApp::builder()
         .with_log_path(&options.log_path, SLAB_SIZE)?
         .with_instance_id(options.instance_id)
         .build()?;
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {

--- a/examples/cu_zenoh_bridge_demo/src/bin/pong.rs
+++ b/examples/cu_zenoh_bridge_demo/src/bin/pong.rs
@@ -28,11 +28,11 @@ fn main() {
 
 fn drive() -> CuResult<()> {
     let options = parse_run_options("zenoh_pong.copper")?;
-    let mut app = PongApp::builder()
+    let app = PongApp::builder()
         .with_log_path(&options.log_path, SLAB_SIZE)?
         .with_instance_id(options.instance_id)
         .build()?;
-    app.start_all_tasks()?;
+    let mut app = CuStdAppLifecycle::new(app).start_all_tasks()?;
 
     if let Some(iterations) = options.iterations {
         for _ in 0..iterations {


### PR DESCRIPTION
Follow-up to #1272, as requested there: ports the examples to the new `CuAppLifecycle` typestate API so the user-side ergonomics are visible.

> **Stacked on #1272.** The base branch lives on my fork, so this PR targets `master` and includes the parent commit — only the last commit (`feat(examples): port examples to the CuAppLifecycle typestate API`, 42 files) is new here. Happy to rebase once #1272 lands.

## What the port looks like

The one-shot case shrinks to a single expression:

```rust
CuStdAppLifecycle::new(application).run()?;
```

The iterate-manually case reads as a state progression, and `?` still works because `LifecycleError` converts into `CuError`:

```rust
let mut running = CuStdAppLifecycle::new(app).start_all_tasks()?;
for _ in 0..ITERATIONS {
    running.run_one_iteration()?;
}
running.stop_all_tasks()?;
```

## Findings from dogfooding/Running the demos. 

**The typestate caught real bugs already in the tree.** Six examples (`cu_monitoring`, `cu_background_task`, `cu_nologging_task`, `cu_rate_target`, `cu_bridge_test`, `cu_resources_test`) called `start_all_tasks()` / `stop_all_tasks()` *around* `run()` — which starts and stops tasks itself, so tasks were double-started and double-stopped at runtime. Under the wrapper that sequence no longer compiles; those examples now use a single `run()` transition.

**UFCS noise disappears.** Call sites that needed `<App as CuApplication<S, L>>::start_all_tasks(&mut app)` to disambiguate (cu_bevymon_demo, cu_bridge_test tests, cu_min_baremetal no_std) become plain method calls because the wrapper pins `S`/`L` once.

**It works in an ECS resource** (`cu_bevymon_demo`): consuming transitions map onto Bevy's `&mut` resources via a small state enum + `mem::replace` swap. The old `started: bool` flag disappears — the state enum *is* the flag. As a bonus the error path now shuts tasks down cleanly instead of leaking them (the old code just flipped `started = false`).

**no_std works** (`cu_min_baremetal`): `CuAppLifecycle::<NoopSectionStorage, NoopLogger, _>::new(app).run()` — verified on `thumbv7em-none-eabihf`.

**Friction worth discussing:**
- The wrapper exposes only `inner()` (shared). That's deliberate — `inner_mut()` would let callers bypass the typestate by calling `start_all_tasks` on the raw app — but it means pre-start mutable setup (e.g. `copper_runtime_mut().monitor.model()` in cu_bevymon_demo) must happen before wrapping. Maybe worth a doc note, or a constrained accessor later.
- On failure paths that only log, the payload is reached through `err.error` (e.g. `debug!("Ended: {}", error.error)`), which reads a little indirect. A `.into_cu_error()` or `Deref` could smooth this if it bothers people.

## Not ported (out of the wrapper's scope)  - Let me know if you want any of this pulled in ( Not AI generated) 

- **sim/resim examples** (`cu_caterpillar` resim/determinism, `cu_rp_balancebot` sim/resim, `cu_run_in_sim`, `cu_debug_session`, `cu_remote_debug_session`, `cu_reflect_demo`, `cu_peer_triangulation`, `cu_flight_controller` sim/resim, `cu_bridge_test/resim`): `CuSimApplication` threads a `sim_callback` through every lifecycle call, which the wrapper doesn't model. A sim-side equivalent could be a follow-up if this API lands.
- **`cu_runtime_matrix`**: its `MissionApp` is a dispatch enum with *inherent* lifecycle methods, not a `CuApplication` implementor.

## Verification

- `cargo check --all-targets` on every ported crate (plus `--features safety-ids` for cu_baremetal_safety and `--no-default-features --target thumbv7em-none-eabihf` for cu_min_baremetal), clippy on a sample, `cargo fmt --check` clean.
- `cargo test --lib`: cu-bridge-test 7/7, cu-baremetal-safety 5/5.
- Locally unverifiable (missing system libs on this machine, unrelated to the change): cu-human-pose (glib), cu-image-codec-demo `ffv1` paths (ffmpeg), cu-python-task-demo link step (python3.9). CI covers these.

