### PR TITLE
chore: apply current RON formatting

### DIFF
--- a/benchmarks/cu_zenoh_bridge_bench/rx_config.ron
+++ b/benchmarks/cu_zenoh_bridge_bench/rx_config.ron
@@ -1,7 +1,5 @@
 (
-    logging: (
-        enable_task_logging: false,
-    ),
+    logging: (enable_task_logging: false),
     tasks: [
         (
             id: "sink",

--- a/benchmarks/cu_zenoh_bridge_bench/tx_config.ron
+++ b/benchmarks/cu_zenoh_bridge_bench/tx_config.ron
@@ -1,7 +1,5 @@
 (
-    logging: (
-        enable_task_logging: false,
-    ),
+    logging: (enable_task_logging: false),
     runtime: (rate_target_hz: 100),
     tasks: [
         (

--- a/components/monitors/cu_logmon/copperconfig.ron
+++ b/components/monitors/cu_logmon/copperconfig.ron
@@ -22,9 +22,7 @@
             msg: "u32",
         ),
     ],
-    monitor: (
-        type: "cu_logmon::CuLogMon",
-    ),
+    monitor: (type: "cu_logmon::CuLogMon"),
     logging: (
         slab_size_mib: 16,
         section_size_mib: 4,

--- a/components/sources/cu_gstreamer/tests/copperconfig.ron
+++ b/components/sources/cu_gstreamer/tests/copperconfig.ron
@@ -20,7 +20,5 @@
             msg: "cu_gstreamer::CuGstBuffer",
         ),
     ],
-    logging: (
-        enable_task_logging: false,
-    ),
+    logging: (enable_task_logging: false),
 )

--- a/components/sources/cu_sen0682/examples/usb_probe.ron
+++ b/components/sources/cu_sen0682/examples/usb_probe.ron
@@ -21,9 +21,7 @@
             id: "sen0682",
             type: "cu_sen0682::Sen0682SerialSource",
             logging: (enabled: false),
-            resources: {
-                "serial": "linux.serial0",
-            },
+            resources: {"serial": "linux.serial0"},
             config: {
                 "configure_device": true,
                 "row_id": 0,

--- a/components/sources/cu_sen0682/examples/usb_rerun.ron
+++ b/components/sources/cu_sen0682/examples/usb_rerun.ron
@@ -16,9 +16,7 @@
             id: "sen0682",
             type: "cu_sen0682::Sen0682SerialSource",
             logging: (enabled: false),
-            resources: {
-                "serial": "linux.serial0",
-            },
+            resources: {"serial": "linux.serial0"},
             config: {
                 "configure_device": true,
                 "row_id": 0,

--- a/components/tasks/cu_rrt_star/tests/copperconfig.ron
+++ b/components/tasks/cu_rrt_star/tests/copperconfig.ron
@@ -16,9 +16,7 @@
         (
             id: "quick_planner",
             type: "cu_rrt_star::RrtStarPlanner",
-            resources: {
-                "rng": "quick_rng.rng",
-            },
+            resources: {"rng": "quick_rng.rng"},
             anytime: (
                 max_refines: 2,
                 time_budget_ms: 50.0,
@@ -29,9 +27,7 @@
         (
             id: "thorough_planner",
             type: "cu_rrt_star::RrtStarPlanner",
-            resources: {
-                "rng": "thorough_rng.rng",
-            },
+            resources: {"rng": "thorough_rng.rng"},
             anytime: (
                 max_refines: 24,
                 time_budget_ms: 250.0,

--- a/core/cu29_derive/tests/config/anytime_background_task_valid.ron
+++ b/core/cu29_derive/tests/config/anytime_background_task_valid.ron
@@ -1,8 +1,6 @@
 (
     runtime: (
-        thread_pools: [
-            (id: "planner", threads: 1),
-        ],
+        thread_pools: [(id: "planner", threads: 1)],
     ),
     resources: [
         (
@@ -27,13 +25,9 @@
         (
             id: "counter",
             type: "AnytimeCounter",
-            background: (
-                pool: "planner",
-            ),
+            background: (pool: "planner"),
             anytime: (max_refines: 2),
-            resources: {
-                "scratch": "board.scratch",
-            },
+            resources: {"scratch": "board.scratch"},
         ),
         (
             id: "sink",

--- a/core/cu29_derive/tests/config/anytime_task_valid.ron
+++ b/core/cu29_derive/tests/config/anytime_task_valid.ron
@@ -23,9 +23,7 @@
             id: "counter",
             type: "AnytimeCounter",
             anytime: (max_refines: 2),
-            resources: {
-                "scratch": "board.scratch",
-            },
+            resources: {"scratch": "board.scratch"},
         ),
         (
             id: "sink",

--- a/core/cu29_derive/tests/config/background_source_valid.ron
+++ b/core/cu29_derive/tests/config/background_source_valid.ron
@@ -1,11 +1,6 @@
 (
     runtime: (
-        thread_pools: [
-            (
-                id: "background",
-                threads: 1,
-            ),
-        ],
+        thread_pools: [(id: "background", threads: 1)],
     ),
     tasks: [
         (

--- a/core/cu29_derive/tests/config/invalid_config.ron
+++ b/core/cu29_derive/tests/config/invalid_config.ron
@@ -25,7 +25,5 @@
             msg: "i32",
         ),
     ],
-    monitors: [
-        (type: "ExampleMonitor"),
-    ],
+    monitors: [(type: "ExampleMonitor")],
 )

--- a/core/cu29_derive/tests/config/invalid_logging_config.ron
+++ b/core/cu29_derive/tests/config/invalid_logging_config.ron
@@ -25,9 +25,7 @@
             msg: "i32",
         ),
     ],
-    monitors: [
-        (type: "ExampleMonitor"),
-    ],
+    monitors: [(type: "ExampleMonitor")],
     logging: (
         section_size_mib: 2,
         slab_size_mib: 1,

--- a/core/cu29_derive/tests/config/multimission_valid.ron
+++ b/core/cu29_derive/tests/config/multimission_valid.ron
@@ -1,11 +1,6 @@
 (
     missions: [(id: "A"), (id: "B")],
-    tasks: [
-        (
-            id: "src",
-            type: "tasks::Source",
-        ),
-    ],
+    tasks: [(id: "src", type: "tasks::Source")],
     cnx: [
         (
             src: "src",

--- a/core/cu29_derive/tests/config/sim_background_source_placeholder_valid.ron
+++ b/core/cu29_derive/tests/config/sim_background_source_placeholder_valid.ron
@@ -1,11 +1,6 @@
 (
     runtime: (
-        thread_pools: [
-            (
-                id: "background",
-                threads: 1,
-            ),
-        ],
+        thread_pools: [(id: "background", threads: 1)],
     ),
     tasks: [
         (

--- a/core/cu29_runtime/tests/remote_debug_missions_config.ron
+++ b/core/cu29_runtime/tests/remote_debug_missions_config.ron
@@ -1,8 +1,5 @@
 (
-    missions: [
-        (id: "Alpha"),
-        (id: "Beta"),
-    ],
+    missions: [(id: "Alpha"), (id: "Beta")],
     tasks: [
         (
             id: "alpha_src",

--- a/core/cu29_runtime/tests/render_edge_cases.ron
+++ b/core/cu29_runtime/tests/render_edge_cases.ron
@@ -144,9 +144,7 @@
         (
             id: "self_multi",
             type: "bridges::SelfMulti",
-            missions: [
-                "EdgeSelfLoopMulti",
-            ],
+            missions: ["EdgeSelfLoopMulti"],
             config: {
                 "alpha": 1,
                 "beta": 22,
@@ -189,25 +187,19 @@
             src: "self_multi/in1",
             dst: "self_multi/out1",
             msg: "messages::SelfLoop",
-            missions: [
-                "EdgeSelfLoopMulti",
-            ],
+            missions: ["EdgeSelfLoopMulti"],
         ),
         (
             src: "self_multi/in2",
             dst: "self_multi/out2",
             msg: "messages::SelfLoop",
-            missions: [
-                "EdgeSelfLoopMulti",
-            ],
+            missions: ["EdgeSelfLoopMulti"],
         ),
         (
             src: "self_multi/in3",
             dst: "self_multi/out1",
             msg: "messages::SelfLoop",
-            missions: [
-                "EdgeSelfLoopMulti",
-            ],
+            missions: ["EdgeSelfLoopMulti"],
         ),
         (
             src: "back_src",
@@ -284,17 +276,13 @@
             src: "cross_a",
             dst: "cross_c",
             msg: "messages::CrossThree",
-            missions: [
-                "EdgeCrossingMulti",
-            ],
+            missions: ["EdgeCrossingMulti"],
         ),
         (
             src: "cross_b",
             dst: "cross_d",
             msg: "messages::CrossFour",
-            missions: [
-                "EdgeCrossingMulti",
-            ],
+            missions: ["EdgeCrossingMulti"],
         ),
     ],
 )

--- a/core/cu29_runtime/tests/render_resource_tables.ron
+++ b/core/cu29_runtime/tests/render_resource_tables.ron
@@ -1,8 +1,5 @@
 (
-    missions: [
-        (id: "Alpha"),
-        (id: "Beta"),
-    ],
+    missions: [(id: "Alpha"), (id: "Beta")],
     resources: [
         (
             id: "board",
@@ -36,17 +33,13 @@
             id: "control",
             type: "tasks::Control",
             missions: ["Alpha"],
-            resources: {
-                "spi": "board.spi1",
-            },
+            resources: {"spi": "board.spi1"},
         ),
         (
             id: "logger",
             type: "tasks::Logger",
             missions: ["Beta"],
-            resources: {
-                "cfg": "memory.cfg",
-            },
+            resources: {"cfg": "memory.cfg"},
         ),
     ],
     bridges: [
@@ -54,13 +47,8 @@
             id: "telemetry",
             type: "bridges::Telemetry",
             missions: ["Beta"],
-            resources: {
-                "serial": "radio.uart1",
-            },
-            channels: [
-                Tx(id: "tx"),
-                Rx(id: "rx"),
-            ],
+            resources: {"serial": "radio.uart1"},
+            channels: [Tx(id: "tx"), Rx(id: "rx")],
         ),
     ],
     cnx: [

--- a/examples/cu_anytime_rrt_star/copperconfig.ron
+++ b/examples/cu_anytime_rrt_star/copperconfig.ron
@@ -16,9 +16,7 @@
         (
             id: "planner",
             type: "cu_rrt_star::RrtStarPlanner",
-            resources: {
-                "rng": "planner_rng.rng",
-            },
+            resources: {"rng": "planner_rng.rng"},
             anytime: (
                 max_refines: 16,
                 time_budget_ms: 30.0,

--- a/examples/cu_background_task/copperconfig.ron
+++ b/examples/cu_background_task/copperconfig.ron
@@ -17,17 +17,13 @@
             id: "task1",
             type: "tasks::ExampleTask",
             background: true,
-            config: {
-                "sleep_duration_ms": 1000,
-            },
+            config: {"sleep_duration_ms": 1000},
         ),
         (
             id: "task2",
             type: "tasks::ExampleTask",
             background: (pool: "slow"),
-            config: {
-                "sleep_duration_ms": 250,
-            },
+            config: {"sleep_duration_ms": 250},
         ),
     ],
     cnx: [

--- a/examples/cu_baremetal_safety/copperconfig_lifecycle.ron
+++ b/examples/cu_baremetal_safety/copperconfig_lifecycle.ron
@@ -1,7 +1,5 @@
 (
-    logging: (
-        enable_task_logging: false,
-    ),
+    logging: (enable_task_logging: false),
     tasks: [
         (
             id: "source",

--- a/examples/cu_baremetal_safety/copperconfig_resources.ron
+++ b/examples/cu_baremetal_safety/copperconfig_resources.ron
@@ -1,7 +1,5 @@
 (
-    logging: (
-        enable_task_logging: false,
-    ),
+    logging: (enable_task_logging: false),
     resources: [
         (
             id: "board",
@@ -34,9 +32,7 @@
         (
             id: "tap",
             type: "crate::harness::resource_bridges::ResourceBridge",
-            resources: {
-                "tag": "board.tag",
-            },
+            resources: {"tag": "board.tag"},
             channels: [
                 Rx(id: "probe_rx"),
                 Tx(id: "probe_tx"),

--- a/examples/cu_bevymon_demo/copperconfig.ron
+++ b/examples/cu_bevymon_demo/copperconfig.ron
@@ -3,9 +3,7 @@
         (
             id: "clock",
             type: "tasks::ClockSource",
-            config: {
-                "phase_step": 0.17,
-            },
+            config: {"phase_step": 0.17},
         ),
         (
             id: "planner",
@@ -65,7 +63,5 @@
         section_size_mib: 8,
         keyframe_interval: 90,
     ),
-    monitor: (
-        type: "cu_bevymon::CuBevyMon",
-    ),
+    monitor: (type: "cu_bevymon::CuBevyMon"),
 )

--- a/examples/cu_bridge_test/copperconfig.ron
+++ b/examples/cu_bridge_test/copperconfig.ron
@@ -11,16 +11,12 @@
         (
             id: "src_to_bridge",
             type: "tasks::SourceToBridge",
-            missions: [
-                "SourceToBridge",
-            ],
+            missions: ["SourceToBridge"],
         ),
         (
             id: "passthrough",
             type: "tasks::PassthroughChain",
-            missions: [
-                "BridgeTaskSame",
-            ],
+            missions: ["BridgeTaskSame"],
         ),
         (
             id: "sink_from_bridge",
@@ -113,17 +109,13 @@
             src: "alpha/loop_in",
             dst: "alpha/loop_out",
             msg: "messages::LoopbackMsg",
-            missions: [
-                "BridgeLoopback",
-            ],
+            missions: ["BridgeLoopback"],
         ),
         (
             src: "src_to_bridge",
             dst: "beta/from_src",
             msg: "messages::FromSource",
-            missions: [
-                "SourceToBridge",
-            ],
+            missions: ["SourceToBridge"],
         ),
         (
             src: "alpha/to_sink",
@@ -135,17 +127,13 @@
             src: "alpha/chain_in",
             dst: "passthrough",
             msg: "messages::ChainPayload",
-            missions: [
-                "BridgeTaskSame",
-            ],
+            missions: ["BridgeTaskSame"],
         ),
         (
             src: "passthrough",
             dst: "alpha/chain_out",
             msg: "messages::ChainPayload",
-            missions: [
-                "BridgeTaskSame",
-            ],
+            missions: ["BridgeTaskSame"],
         ),
         (
             src: "alpha/ingress",

--- a/examples/cu_config_constants/copperconfig.ron
+++ b/examples/cu_config_constants/copperconfig.ron
@@ -62,7 +62,5 @@
             msg: "()",
         ),
     ],
-    includes: [
-        (path: "constants-extra.ron"),
-    ],
+    includes: [(path: "constants-extra.ron")],
 )

--- a/examples/cu_elrs_bdshot_demo/copperconfig.ron
+++ b/examples/cu_elrs_bdshot_demo/copperconfig.ron
@@ -31,9 +31,7 @@
         (
             id: "crsf",
             type: "cu_crsf::CrsfBridge<SerialResource, SerialPortError>",
-            resources: {
-                "serial": "fc.serial",
-            },
+            resources: {"serial": "fc.serial"},
             channels: [
                 Rx(id: "rc_rx"),
                 Tx(id: "lq_tx"),

--- a/examples/cu_feature_gated_camera/copperconfig.ron
+++ b/examples/cu_feature_gated_camera/copperconfig.ron
@@ -7,9 +7,7 @@
         (
             path: "graph/jetson_mipi.ron",
             params: {},
-            when: Feature(
-                "jetson-mipi",
-            ),
+            when: Feature("jetson-mipi"),
         ),
     ],
     logging: (

--- a/examples/cu_feature_gated_camera/tests/forwarding/main.ron
+++ b/examples/cu_feature_gated_camera/tests/forwarding/main.ron
@@ -3,9 +3,7 @@
         (path: "base.ron"),
         (
             path: "feature.ron",
-            when: Feature(
-                "jetson-mipi",
-            ),
+            when: Feature("jetson-mipi"),
         ),
     ],
 )

--- a/examples/cu_feetech_demo/copperconfig.ron
+++ b/examples/cu_feetech_demo/copperconfig.ron
@@ -29,9 +29,7 @@
             id: "feetech",
             type: "cu_feetech::FeetechBridge",
             missions: ["arm_publisher"],
-            resources: {
-                "serial": "hw.serial0",
-            },
+            resources: {"serial": "hw.serial0"},
             config: {
                 "servo0": 1,
                 "servo1": 2,
@@ -40,19 +38,13 @@
                 "servo4": 5,
                 "servo5": 6,
             },
-            channels: [
-                Rx(id: "positions"),
-            ],
+            channels: [Rx(id: "positions")],
         ),
         (
             id: "leader",
             type: "cu_feetech::FeetechBridge",
-            missions: [
-                "leader_follower",
-            ],
-            resources: {
-                "serial": "hw.serial0",
-            },
+            missions: ["leader_follower"],
+            resources: {"serial": "hw.serial0"},
             config: {
                 "servo0": 1,
                 "servo1": 2,
@@ -63,19 +55,13 @@
                 "units": "normalize",
                 "calibration_file": "calibration_leader.json",
             },
-            channels: [
-                Rx(id: "positions"),
-            ],
+            channels: [Rx(id: "positions")],
         ),
         (
             id: "follower",
             type: "cu_feetech::FeetechBridge",
-            missions: [
-                "leader_follower",
-            ],
-            resources: {
-                "serial": "hw.serial1",
-            },
+            missions: ["leader_follower"],
+            resources: {"serial": "hw.serial1"},
             config: {
                 "servo0": 1,
                 "servo1": 2,
@@ -87,9 +73,7 @@
                 "calibration_file": "calibration_follower.json",
             },
             channels: [
-                Tx(
-                    id: "goal_positions",
-                ),
+                Tx(id: "goal_positions"),
                 Rx(id: "positions"),
             ],
         ),
@@ -105,9 +89,7 @@
             src: "leader/positions",
             dst: "follower/goal_positions",
             msg: "cu_feetech::messages::JointPositions",
-            missions: [
-                "leader_follower",
-            ],
+            missions: ["leader_follower"],
         ),
     ],
     runtime: (rate_target_hz: 30),

--- a/examples/cu_flight_controller/mcu_autonomy.ron
+++ b/examples/cu_flight_controller/mcu_autonomy.ron
@@ -32,9 +32,7 @@
             type: "autonomy_bridge::AutonomyBridge",
             run_in_sim: false,
             logging: (enabled: true),
-            config: {
-                "wire_format": "bincode",
-            },
+            config: {"wire_format": "bincode"},
             channels: [
                 Tx(
                     id: "context",

--- a/examples/cu_flight_controller/mcu_config.ron
+++ b/examples/cu_flight_controller/mcu_config.ron
@@ -8,9 +8,7 @@
             },
             when: Any(
                 [
-                    Feature(
-                        "sim-debug",
-                    ),
+                    Feature("sim-debug"),
                     Not(
                         Any(
                             [
@@ -114,27 +112,21 @@
             type: "tasks::Dps310Source",
             run_in_sim: true,
             logging: (enabled: true),
-            resources: {
-                "i2c": "fc.i2c2_dps310",
-            },
+            resources: {"i2c": "fc.i2c2_dps310"},
         ),
         (
             id: "ist8310",
             type: "tasks::Ist8310Source",
             run_in_sim: true,
             logging: (enabled: true),
-            resources: {
-                "i2c": "fc.i2c2_ist8310",
-            },
+            resources: {"i2c": "fc.i2c2_ist8310"},
         ),
         (
             id: "mag_heading",
             type: "tasks::MagneticTrueHeading",
             run_in_sim: true,
             logging: (enabled: true),
-            config: {
-                "declination_deg": 4.7,
-            },
+            config: {"declination_deg": 4.7},
         ),
         (
             id: "battery_adc",
@@ -238,9 +230,7 @@
             type: "tasks::activity_led::ActivityLed",
             run_in_sim: true,
             logging: (enabled: false),
-            resources: {
-                "led": "fc.green_led",
-            },
+            resources: {"led": "fc.green_led"},
         ),
         (
             id: "vtx_osd",
@@ -272,9 +262,7 @@
             type: "tasks::gnss::GnssSource",
             run_in_sim: true,
             logging: (enabled: true),
-            resources: {
-                "serial": "fc.uart3",
-            },
+            resources: {"serial": "fc.uart3"},
             config: {
                 "poll_nav_pvt_ms": 200,
                 "poll_nav_sat_ms": 1000,
@@ -297,9 +285,7 @@
             type: "cu_crsf::CrsfBridge<cu_micoairh743::Uart6Port, cu_micoairh743::SerialPortError>",
             run_in_sim: false,
             logging: (enabled: true),
-            resources: {
-                "serial": "fc.uart6",
-            },
+            resources: {"serial": "fc.uart6"},
             channels: [
                 Rx(id: "rc_rx"),
                 Tx(id: "lq_tx"),
@@ -310,9 +296,7 @@
             type: "cu_msp_bridge::CuMspBridge<cu_micoairh743::Uart2Port, cu_micoairh743::SerialPortError>",
             run_in_sim: false,
             logging: (enabled: false),
-            resources: {
-                "serial": "fc.uart2",
-            },
+            resources: {"serial": "fc.uart2"},
             channels: [
                 Tx(id: "requests"),
                 Rx(id: "responses"),
@@ -325,9 +309,7 @@
             missions: ["flow"],
             run_in_sim: false,
             logging: (enabled: false),
-            resources: {
-                "serial": "fc.uart4",
-            },
+            resources: {"serial": "fc.uart4"},
             channels: [
                 Tx(id: "requests"),
                 Rx(id: "responses"),

--- a/examples/cu_gnss_ublox_demo/copperconfig.ron
+++ b/examples/cu_gnss_ublox_demo/copperconfig.ron
@@ -14,9 +14,7 @@
         (
             id: "ublox",
             type: "cu_gnss_ublox::UbxSource",
-            resources: {
-                "serial": "linux.serial0",
-            },
+            resources: {"serial": "linux.serial0"},
             config: {
                 "poll_nav_pvt_ms": 200,
                 "poll_nav_sat_ms": 1000,

--- a/examples/cu_human_pose/copperconfig.ron
+++ b/examples/cu_human_pose/copperconfig.ron
@@ -61,7 +61,5 @@
         keyframe_interval: 10000,
         section_size_mib: 32,
     ),
-    monitor: (
-        type: "cu_logmon::CuLogMon",
-    ),
+    monitor: (type: "cu_logmon::CuLogMon"),
 )

--- a/examples/cu_instance_overrides_demo/instances/17/robot.ron
+++ b/examples/cu_instance_overrides_demo/instances/17/robot.ron
@@ -4,11 +4,7 @@
             path: "tasks/reporter/config",
             value: {
                 "label": "robot-17",
-                "gyro_bias": [
-                    0.012,
-                    -0.004,
-                    0.008,
-                ],
+                "gyro_bias": [0.012, -0.004, 0.008],
             },
         ),
     ],

--- a/examples/cu_instance_overrides_demo/instances/42/robot.ron
+++ b/examples/cu_instance_overrides_demo/instances/42/robot.ron
@@ -4,11 +4,7 @@
             path: "tasks/reporter/config",
             value: {
                 "label": "robot-42",
-                "gyro_bias": [
-                    -0.021,
-                    0.005,
-                    0.014,
-                ],
+                "gyro_bias": [-0.021, 0.005, 0.014],
             },
         ),
     ],

--- a/examples/cu_instance_overrides_demo/robot_base.ron
+++ b/examples/cu_instance_overrides_demo/robot_base.ron
@@ -5,11 +5,7 @@
             type: "CalibrationReporter",
             config: {
                 "label": "base-robot",
-                "gyro_bias": [
-                    0.0,
-                    0.0,
-                    0.0,
-                ],
+                "gyro_bias": [0.0, 0.0, 0.0],
             },
         ),
     ],

--- a/examples/cu_missions/copperconfig.ron
+++ b/examples/cu_missions/copperconfig.ron
@@ -8,17 +8,13 @@
         (
             id: "taskA",
             type: "tasks::ExampleTask",
-            config: {
-                "label": "Mission A",
-            },
+            config: {"label": "Mission A"},
             missions: ["A"],
         ),
         (
             id: "taskB",
             type: "tasks::ExampleTask",
-            config: {
-                "label": "Mission B",
-            },
+            config: {"label": "Mission B"},
             missions: ["B"],
         ),
     ],

--- a/examples/cu_msp_bridge_loopback/copperconfig.ron
+++ b/examples/cu_msp_bridge_loopback/copperconfig.ron
@@ -24,9 +24,7 @@
         (
             id: "msp_bridge",
             type: "cu_msp_bridge::CuMspBridgeStd",
-            resources: {
-                "serial": "linux.serial3",
-            },
+            resources: {"serial": "linux.serial3"},
             channels: [
                 Tx(id: "requests"),
                 Rx(id: "responses"),

--- a/examples/cu_multi_output/copperconfig.ron
+++ b/examples/cu_multi_output/copperconfig.ron
@@ -22,10 +22,7 @@
         (
             id: "bool_sink",
             type: "tasks::BoolSink",
-            missions: [
-                "default",
-                "loopback",
-            ],
+            missions: ["default", "loopback"],
         ),
         (
             id: "loopback",

--- a/examples/cu_peer_triangulation/copperconfig.ron
+++ b/examples/cu_peer_triangulation/copperconfig.ron
@@ -10,9 +10,7 @@
             type: "cu_peer_range_accumulator::PeerRangeAccumulatorTask<4>",
             config: {
                 "min_samples": 4,
-                "sample_retention": MaxAgeMs(
-                    50,
-                ),
+                "sample_retention": MaxAgeMs(50),
             },
         ),
         (

--- a/examples/cu_resources_test/copperconfig.ron
+++ b/examples/cu_resources_test/copperconfig.ron
@@ -26,15 +26,11 @@
         (
             id: "extras_b",
             provider: "crate::resources::ExtraBundle",
-            config: {
-                "note": "mission-b-note",
-            },
+            config: {"note": "mission-b-note"},
             missions: ["B"],
         ),
     ],
-    logging: (
-        enable_task_logging: false,
-    ),
+    logging: (enable_task_logging: false),
     tasks: [
         (
             id: "sensor_a",

--- a/examples/cu_rp_balancebot/copperconfig.ron
+++ b/examples/cu_rp_balancebot/copperconfig.ron
@@ -75,7 +75,5 @@
             msg: "cu_rp_sn754410_new::MotorPayload",
         ),
     ],
-    monitor: (
-        type: "tasks::monitor::AppMonitor",
-    ),
+    monitor: (type: "tasks::monitor::AppMonitor"),
 )

--- a/examples/cu_runtime_matrix/copperconfig.ron
+++ b/examples/cu_runtime_matrix/copperconfig.ron
@@ -62,9 +62,7 @@
         (
             id: "otm_left_bg",
             type: "tasks::TransformTask",
-            missions: [
-                "OneToManyBackground",
-            ],
+            missions: ["OneToManyBackground"],
             background: true,
             config: {
                 "stage_id": 11,
@@ -75,9 +73,7 @@
         (
             id: "otm_right_bg",
             type: "tasks::TransformTask",
-            missions: [
-                "OneToManyBackground",
-            ],
+            missions: ["OneToManyBackground"],
             background: true,
             config: {
                 "stage_id": 12,
@@ -133,9 +129,7 @@
         (
             id: "mto_join_bg",
             type: "tasks::JoinTask",
-            missions: [
-                "ManyToOneBackground",
-            ],
+            missions: ["ManyToOneBackground"],
             config: {
                 "stage_id": 21,
                 "logical_delay_ticks": 0,
@@ -145,9 +139,7 @@
         (
             id: "mto_delay_bg",
             type: "tasks::JoinDelayTask",
-            missions: [
-                "ManyToOneBackground",
-            ],
+            missions: ["ManyToOneBackground"],
             background: true,
             config: {
                 "stage_id": 21,
@@ -213,9 +205,7 @@
         (
             id: "mtm_join_left_bg",
             type: "tasks::JoinTask",
-            missions: [
-                "ManyToManyBackground",
-            ],
+            missions: ["ManyToManyBackground"],
             config: {
                 "stage_id": 31,
                 "logical_delay_ticks": 0,
@@ -225,9 +215,7 @@
         (
             id: "mtm_join_right_bg",
             type: "tasks::JoinTask",
-            missions: [
-                "ManyToManyBackground",
-            ],
+            missions: ["ManyToManyBackground"],
             config: {
                 "stage_id": 32,
                 "logical_delay_ticks": 0,
@@ -237,9 +225,7 @@
         (
             id: "mtm_delay_left_bg",
             type: "tasks::JoinDelayTask",
-            missions: [
-                "ManyToManyBackground",
-            ],
+            missions: ["ManyToManyBackground"],
             background: true,
             config: {
                 "stage_id": 31,
@@ -250,9 +236,7 @@
         (
             id: "mtm_delay_right_bg",
             type: "tasks::JoinDelayTask",
-            missions: [
-                "ManyToManyBackground",
-            ],
+            missions: ["ManyToManyBackground"],
             background: true,
             config: {
                 "stage_id": 32,
@@ -292,9 +276,7 @@
         (
             id: "bridge_task_left_bg",
             type: "tasks::BridgeStampTask",
-            missions: [
-                "BridgeFanoutBackground",
-            ],
+            missions: ["BridgeFanoutBackground"],
             background: true,
             config: {
                 "stage_id": 41,
@@ -305,9 +287,7 @@
         (
             id: "bridge_task_right_bg",
             type: "tasks::BridgeStampTask",
-            missions: [
-                "BridgeFanoutBackground",
-            ],
+            missions: ["BridgeFanoutBackground"],
             background: true,
             config: {
                 "stage_id": 42,
@@ -383,33 +363,25 @@
             src: "otm_src",
             dst: "otm_left_bg",
             msg: "SeqPayload",
-            missions: [
-                "OneToManyBackground",
-            ],
+            missions: ["OneToManyBackground"],
         ),
         (
             src: "otm_src",
             dst: "otm_right_bg",
             msg: "SeqPayload",
-            missions: [
-                "OneToManyBackground",
-            ],
+            missions: ["OneToManyBackground"],
         ),
         (
             src: "otm_left_bg",
             dst: "otm_sink",
             msg: "SeqPayload",
-            missions: [
-                "OneToManyBackground",
-            ],
+            missions: ["OneToManyBackground"],
         ),
         (
             src: "otm_right_bg",
             dst: "otm_sink",
             msg: "SeqPayload",
-            missions: [
-                "OneToManyBackground",
-            ],
+            missions: ["OneToManyBackground"],
         ),
         (
             src: "mto_src_a",
@@ -433,33 +405,25 @@
             src: "mto_src_a",
             dst: "mto_join_bg",
             msg: "SeqPayload",
-            missions: [
-                "ManyToOneBackground",
-            ],
+            missions: ["ManyToOneBackground"],
         ),
         (
             src: "mto_src_b",
             dst: "mto_join_bg",
             msg: "SeqPayload",
-            missions: [
-                "ManyToOneBackground",
-            ],
+            missions: ["ManyToOneBackground"],
         ),
         (
             src: "mto_join_bg",
             dst: "mto_delay_bg",
             msg: "JoinPayload",
-            missions: [
-                "ManyToOneBackground",
-            ],
+            missions: ["ManyToOneBackground"],
         ),
         (
             src: "mto_delay_bg",
             dst: "mto_sink",
             msg: "JoinPayload",
-            missions: [
-                "ManyToOneBackground",
-            ],
+            missions: ["ManyToOneBackground"],
         ),
         (
             src: "mtm_src_a",
@@ -501,65 +465,49 @@
             src: "mtm_src_a",
             dst: "mtm_join_left_bg",
             msg: "SeqPayload",
-            missions: [
-                "ManyToManyBackground",
-            ],
+            missions: ["ManyToManyBackground"],
         ),
         (
             src: "mtm_src_b",
             dst: "mtm_join_left_bg",
             msg: "SeqPayload",
-            missions: [
-                "ManyToManyBackground",
-            ],
+            missions: ["ManyToManyBackground"],
         ),
         (
             src: "mtm_src_a",
             dst: "mtm_join_right_bg",
             msg: "SeqPayload",
-            missions: [
-                "ManyToManyBackground",
-            ],
+            missions: ["ManyToManyBackground"],
         ),
         (
             src: "mtm_src_b",
             dst: "mtm_join_right_bg",
             msg: "SeqPayload",
-            missions: [
-                "ManyToManyBackground",
-            ],
+            missions: ["ManyToManyBackground"],
         ),
         (
             src: "mtm_join_left_bg",
             dst: "mtm_delay_left_bg",
             msg: "JoinPayload",
-            missions: [
-                "ManyToManyBackground",
-            ],
+            missions: ["ManyToManyBackground"],
         ),
         (
             src: "mtm_join_right_bg",
             dst: "mtm_delay_right_bg",
             msg: "JoinPayload",
-            missions: [
-                "ManyToManyBackground",
-            ],
+            missions: ["ManyToManyBackground"],
         ),
         (
             src: "mtm_delay_left_bg",
             dst: "mtm_sink",
             msg: "JoinPayload",
-            missions: [
-                "ManyToManyBackground",
-            ],
+            missions: ["ManyToManyBackground"],
         ),
         (
             src: "mtm_delay_right_bg",
             dst: "mtm_sink",
             msg: "JoinPayload",
-            missions: [
-                "ManyToManyBackground",
-            ],
+            missions: ["ManyToManyBackground"],
         ),
         (
             src: "alpha/ingress",
@@ -589,33 +537,25 @@
             src: "alpha/ingress",
             dst: "bridge_task_left_bg",
             msg: "SeqPayload",
-            missions: [
-                "BridgeFanoutBackground",
-            ],
+            missions: ["BridgeFanoutBackground"],
         ),
         (
             src: "alpha/ingress",
             dst: "bridge_task_right_bg",
             msg: "SeqPayload",
-            missions: [
-                "BridgeFanoutBackground",
-            ],
+            missions: ["BridgeFanoutBackground"],
         ),
         (
             src: "bridge_task_left_bg",
             dst: "beta/left",
             msg: "SeqPayload",
-            missions: [
-                "BridgeFanoutBackground",
-            ],
+            missions: ["BridgeFanoutBackground"],
         ),
         (
             src: "bridge_task_right_bg",
             dst: "beta/right",
             msg: "SeqPayload",
-            missions: [
-                "BridgeFanoutBackground",
-            ],
+            missions: ["BridgeFanoutBackground"],
         ),
     ],
 )

--- a/examples/cu_ryuw122_probe/copperconfig.ron
+++ b/examples/cu_ryuw122_probe/copperconfig.ron
@@ -20,13 +20,9 @@
         (
             id: "ranges",
             type: "cu_ryuw122::Ryuw122InitiatorSource",
-            resources: {
-                "serial": "linux.serial0",
-            },
+            resources: {"serial": "linux.serial0"},
             config: {
-                "anchor_ids": [
-                    "ANCH0001",
-                ],
+                "anchor_ids": ["ANCH0001"],
                 "poll_payload": "PING",
                 "response_timeout_ms": 250,
                 "read_buffer_bytes": 512,

--- a/examples/cu_zenoh/copperconfig.ron
+++ b/examples/cu_zenoh/copperconfig.ron
@@ -7,9 +7,7 @@
         (
             id: "task1",
             type: "cu_zenoh::ExampleSink",
-            config: {
-                "topic": "copper/output",
-            },
+            config: {"topic": "copper/output"},
         ),
     ],
     cnx: [

--- a/examples/cu_zenoh_bridge_demo/ping_config.ron
+++ b/examples/cu_zenoh_bridge_demo/ping_config.ron
@@ -8,32 +8,24 @@
         (
             id: "pong_sink_bin",
             type: "tasks::PongSink",
-            config: {
-                "label": "pong-bincode",
-            },
+            config: {"label": "pong-bincode"},
         ),
         (
             id: "pong_sink_json",
             type: "tasks::PongSink",
-            config: {
-                "label": "pong-json",
-            },
+            config: {"label": "pong-json"},
         ),
         (
             id: "pong_sink_cbor",
             type: "tasks::PongSink",
-            config: {
-                "label": "pong-cbor",
-            },
+            config: {"label": "pong-cbor"},
         ),
     ],
     bridges: [
         (
             id: "zenoh",
             type: "bridges::DemoZenohBridge",
-            config: {
-                "wire_format": "bincode",
-            },
+            config: {"wire_format": "bincode"},
             channels: [
                 Tx(
                     id: "ping_bin",

--- a/examples/cu_zenoh_bridge_demo/pong_config.ron
+++ b/examples/cu_zenoh_bridge_demo/pong_config.ron
@@ -3,32 +3,24 @@
         (
             id: "responder_bin",
             type: "tasks::PongResponder",
-            config: {
-                "label": "pong-bincode",
-            },
+            config: {"label": "pong-bincode"},
         ),
         (
             id: "responder_json",
             type: "tasks::PongResponder",
-            config: {
-                "label": "pong-json",
-            },
+            config: {"label": "pong-json"},
         ),
         (
             id: "responder_cbor",
             type: "tasks::PongResponder",
-            config: {
-                "label": "pong-cbor",
-            },
+            config: {"label": "pong-cbor"},
         ),
     ],
     bridges: [
         (
             id: "zenoh",
             type: "bridges::DemoZenohBridge",
-            config: {
-                "wire_format": "bincode",
-            },
+            config: {"wire_format": "bincode"},
             channels: [
                 Rx(
                     id: "ping_bin",


### PR DESCRIPTION
## Summary

- apply the current fmtron output across existing RON configuration files
- isolate formatter-only churn from the async-safe keyframe change that will be stacked on this PR

## Verification

- just fmt