### PR TITLE
Make distributed keyframes async-safe

### DIFF
--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -2867,16 +2867,6 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 task_specs.task_types.len()
             ));
         }
-        let task_restore_code: Vec<proc_macro2::TokenStream> = keyframe_task_restore_order
-            .iter()
-            .map(|index| {
-                let task_tuple_index = syn::Index::from(*index);
-                quote! {
-                    tasks.#task_tuple_index.thaw(&mut decoder).map_err(|e| CuError::from("Failed to thaw").add_cause(&e.to_string()))?
-                }
-            })
-            .collect();
-
         // Generate the code to create instances of the nodes
         // It maps the types to their index
         let (
@@ -3487,20 +3477,6 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
         postprocess_calls.extend(bridge_postprocess_calls);
         let parallel_rt_run_supported = std && parallel_rt_enabled && !sim_mode;
 
-        // Bridges are frozen alongside tasks; restore them in the same order.
-        let bridge_restore_code: Vec<proc_macro2::TokenStream> = culist_bridge_specs
-            .iter()
-            .enumerate()
-            .map(|(index, _)| {
-                let bridge_tuple_index = syn::Index::from(index);
-                quote! {
-                    __cu_bridges.#bridge_tuple_index
-                        .thaw(&mut decoder)
-                        .map_err(|e| CuError::from("Failed to thaw bridge").add_cause(&e.to_string()))?
-                }
-            })
-            .collect();
-
         let output_pack_sizes = collect_output_pack_sizes(&culist_plan);
         let runtime_plan_code_and_logging: Vec<(
             proc_macro2::TokenStream,
@@ -3638,6 +3614,101 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
         } else {
             None
         };
+        // A sim runtime does not execute parallel-rt, but it must decode the component
+        // frames in the execution-wave order used by the matching recording runtime.
+        let restore_parallel_placements = (std && parallel_rt_enabled)
+            .then(|| build_parallel_lifecycle_placements(&culist_plan, &culist_exec_entities));
+        let mut keyframe_restore_order = Vec::<ParallelLifecycleKey>::new();
+        if let Some(placements) = restore_parallel_placements.as_ref() {
+            for (step_index, unit) in culist_plan.steps.iter().enumerate() {
+                let CuExecutionUnit::Step(step) = unit else {
+                    panic!("Execution loops are not supported in runtime generation");
+                };
+                match &culist_exec_entities[step.node_id as usize].kind {
+                    ExecutionEntityKind::Task { task_index } => {
+                        if step.phase != CuStepPhase::AnytimeRefine
+                            && !keyframe_restore_order
+                                .contains(&ParallelLifecycleKey::Task(*task_index))
+                        {
+                            keyframe_restore_order.push(ParallelLifecycleKey::Task(*task_index));
+                        }
+                    }
+                    ExecutionEntityKind::BridgeRx { bridge_index, .. }
+                    | ExecutionEntityKind::BridgeTx { bridge_index, .. } => {
+                        if placements[step_index].postprocess {
+                            keyframe_restore_order
+                                .push(ParallelLifecycleKey::Bridge(*bridge_index));
+                        }
+                    }
+                }
+            }
+        } else {
+            keyframe_restore_order.extend(
+                keyframe_task_restore_order
+                    .iter()
+                    .copied()
+                    .map(ParallelLifecycleKey::Task),
+            );
+            keyframe_restore_order
+                .extend((0..culist_bridge_specs.len()).map(ParallelLifecycleKey::Bridge));
+        }
+        let keyframe_restore_code: Vec<proc_macro2::TokenStream> = keyframe_restore_order
+            .iter()
+            .map(|component| match component {
+                ParallelLifecycleKey::Task(index) => {
+                    let task_tuple_index = syn::Index::from(*index);
+                    let skip_substituted = sim_mode
+                        && task_specs.cutypes[*index] != CuTaskType::Regular
+                        && !task_specs.run_in_sim_flags[*index];
+                    if skip_substituted {
+                        quote! {
+                            let _ = frames.next_frame()?;
+                        }
+                    } else {
+                        quote! {
+                            let frame = frames.next_frame()?;
+                            cu29::curuntime::thaw_keyframe_component(
+                                &mut tasks.#task_tuple_index,
+                                frame,
+                            )?;
+                        }
+                    }
+                }
+                ParallelLifecycleKey::Bridge(index) => {
+                    let bridge_tuple_index = syn::Index::from(*index);
+                    if sim_mode && !culist_bridge_specs[*index].run_in_sim {
+                        quote! {
+                            let _ = frames.next_frame()?;
+                        }
+                    } else {
+                        quote! {
+                            let frame = frames.next_frame()?;
+                            cu29::curuntime::thaw_keyframe_component(
+                                &mut __cu_bridges.#bridge_tuple_index,
+                                frame,
+                            )?;
+                        }
+                    }
+                }
+            })
+            .collect();
+        let keyframe_preallocation_code: Vec<proc_macro2::TokenStream> = keyframe_restore_order
+            .iter()
+            .map(|component| match component {
+                ParallelLifecycleKey::Task(index) => {
+                    let task_tuple_index = syn::Index::from(*index);
+                    quote! {
+                        kf_manager.include_capture_capacity(&tasks.#task_tuple_index)?;
+                    }
+                }
+                ParallelLifecycleKey::Bridge(index) => {
+                    let bridge_tuple_index = syn::Index::from(*index);
+                    quote! {
+                        kf_manager.include_capture_capacity(&__cu_bridges.#bridge_tuple_index)?;
+                    }
+                }
+            })
+            .collect();
         let runtime_plan_parallel_code_and_logging: Option<
             Vec<(proc_macro2::TokenStream, proc_macro2::TokenStream)>,
         > = if parallel_rt_run_supported {
@@ -4979,8 +5050,12 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 #(#preprocess_logging_calls)*
 
                 cl_manager.end_of_processing(clid)?;
-                kf_manager.end_of_processing(clid)?;
                 monitor_result?;
+
+                // Postprocess calls keep their component-local freeze points. Finish the
+                // framed keyframe only after those late bridge frames have been appended.
+                #(#postprocess_calls)*
+                kf_manager.end_of_processing(clid)?;
                 let stats = cu29::monitoring::CopperListIoStats {
                     raw_culist_bytes: core::mem::size_of::<CuList>() as u64 + cl_manager.last_handle_bytes,
                     handle_bytes: cl_manager.last_handle_bytes,
@@ -4990,9 +5065,6 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                     culistid: clid,
                 };
                 monitor.observe_copperlist_io(stats);
-
-                // Postprocess calls can happen at any time, just packed them up at the end.
-                #(#postprocess_calls)*
                 Ok(())
             }
 
@@ -5002,11 +5074,9 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 let clock = &clock_handle;
                 let tasks = &mut runtime.tasks;
                 let __cu_bridges = &mut runtime.bridges;
-                let config = cu29::bincode::config::standard();
-                let reader = cu29::bincode::de::read::SliceReader::new(&keyframe.serialized_tasks);
-                let mut decoder = DecoderImpl::new(reader, config, ());
-                #(#task_restore_code);*;
-                #(#bridge_restore_code);*;
+                let mut frames = cu29::curuntime::KeyFramePayloadReader::new(keyframe)?;
+                #(#keyframe_restore_code)*
+                frames.finish()?;
                 Ok(())
             }
 
@@ -5023,6 +5093,15 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                     #mission_mod::TASK_IDS,
                 );
                 #(#start_calls)*
+                {
+                    let runtime = &mut self.copper_runtime;
+                    let tasks = &runtime.tasks;
+                    let __cu_bridges = &runtime.bridges;
+                    let kf_manager = &mut runtime.keyframes_manager;
+                    kf_manager.begin_capture_preallocation();
+                    #(#keyframe_preallocation_code)*
+                    kf_manager.finish_capture_preallocation()?;
+                }
                 ctx.clear_current_component();
                 ctx.clear_current_task();
                 self.copper_runtime.monitor.start(&ctx)?;

--- a/core/cu29_runtime/src/context.rs
+++ b/core/cu29_runtime/src/context.rs
@@ -1,7 +1,19 @@
 //! User-facing execution context passed to task and bridge process callbacks.
 
+#[cfg(feature = "std")]
+use bincode::{Decode, Encode};
 use core::ops::Deref;
 use cu29_clock::{RobotClock, RobotClockMock};
+
+#[cfg(feature = "std")]
+#[derive(Clone, Debug, Encode, Decode)]
+pub(crate) struct CuContextSnapshot {
+    cl_id: u64,
+    instance_id: u32,
+    subsystem_code: u16,
+    current_component_index: Option<usize>,
+    current_task_index: Option<usize>,
+}
 
 /// Execution context passed to task and bridge callbacks.
 ///
@@ -156,6 +168,30 @@ impl CuContext {
     pub fn task_id(&self) -> Option<&'static str> {
         self.current_task_index
             .and_then(|idx| self.task_ids.get(idx).copied())
+    }
+
+    #[cfg(feature = "std")]
+    pub(crate) fn snapshot(&self) -> CuContextSnapshot {
+        CuContextSnapshot {
+            cl_id: self.cl_id,
+            instance_id: self.instance_id,
+            subsystem_code: self.subsystem_code,
+            current_component_index: self.current_component_index,
+            current_task_index: self.current_task_index,
+        }
+    }
+
+    #[cfg(feature = "std")]
+    pub(crate) fn restore_snapshot(&self, snapshot: &CuContextSnapshot) -> Self {
+        Self {
+            clock: self.clock.clone(),
+            cl_id: snapshot.cl_id,
+            instance_id: snapshot.instance_id,
+            subsystem_code: snapshot.subsystem_code,
+            task_ids: self.task_ids,
+            current_component_index: snapshot.current_component_index,
+            current_task_index: snapshot.current_task_index,
+        }
     }
 }
 

--- a/core/cu29_runtime/src/context.rs
+++ b/core/cu29_runtime/src/context.rs
@@ -1,19 +1,7 @@
 //! User-facing execution context passed to task and bridge process callbacks.
 
-#[cfg(feature = "std")]
-use bincode::{Decode, Encode};
 use core::ops::Deref;
 use cu29_clock::{RobotClock, RobotClockMock};
-
-#[cfg(feature = "std")]
-#[derive(Clone, Debug, Encode, Decode)]
-pub(crate) struct CuContextSnapshot {
-    cl_id: u64,
-    instance_id: u32,
-    subsystem_code: u16,
-    current_component_index: Option<usize>,
-    current_task_index: Option<usize>,
-}
 
 /// Execution context passed to task and bridge callbacks.
 ///
@@ -171,27 +159,10 @@ impl CuContext {
     }
 
     #[cfg(feature = "std")]
-    pub(crate) fn snapshot(&self) -> CuContextSnapshot {
-        CuContextSnapshot {
-            cl_id: self.cl_id,
-            instance_id: self.instance_id,
-            subsystem_code: self.subsystem_code,
-            current_component_index: self.current_component_index,
-            current_task_index: self.current_task_index,
-        }
-    }
-
-    #[cfg(feature = "std")]
-    pub(crate) fn restore_snapshot(&self, snapshot: &CuContextSnapshot) -> Self {
-        Self {
-            clock: self.clock.clone(),
-            cl_id: snapshot.cl_id,
-            instance_id: snapshot.instance_id,
-            subsystem_code: snapshot.subsystem_code,
-            task_ids: self.task_ids,
-            current_component_index: snapshot.current_component_index,
-            current_task_index: snapshot.current_task_index,
-        }
+    pub(crate) fn with_cl_id(&self, cl_id: u64) -> Self {
+        let mut context = self.clone();
+        context.cl_id = cl_id;
+        context
     }
 }
 

--- a/core/cu29_runtime/src/cuasynctask.rs
+++ b/core/cu29_runtime/src/cuasynctask.rs
@@ -1,146 +1,335 @@
 use crate::config::ComponentConfig;
-use crate::context::CuContext;
-use crate::cutask::{CuMsg, CuMsgPayload, CuSrcTask, CuTask, Freezable};
+use crate::context::{CuContext, CuContextSnapshot};
+use crate::cutask::{BincodeAdapter, CuMsg, CuMsgPayload, CuSrcTask, CuTask, Freezable};
 use crate::reflect::{Reflect, TypePath};
+use bincode::config::standard;
+use bincode::de::read::Reader;
 use bincode::de::{Decode, Decoder};
-use bincode::enc::{Encode, Encoder};
+use bincode::enc::write::Writer;
+use bincode::enc::{Encode, Encoder, EncoderImpl};
 use bincode::error::{DecodeError, EncodeError};
 use cu29_clock::CuTime;
 use cu29_traits::{CuError, CuResult};
 use rayon::ThreadPool;
-use std::sync::{Arc, Mutex};
+use std::any::Any;
+use std::sync::{Arc, Mutex, RwLock};
+
+const ASYNC_SNAPSHOT_MAGIC: u32 = 0x4355_4153;
+const ASYNC_SNAPSHOT_VERSION: u8 = 1;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AsyncPhase {
+    Idle,
+    Running,
+    ReplayPending,
+}
+
+struct PendingDispatch {
+    context: CuContextSnapshot,
+}
 
 struct AsyncState {
-    processing: bool,
+    generation: u64,
+    phase: AsyncPhase,
     ready_at: Option<CuTime>,
     last_error: Option<CuError>,
+    last_error_snapshot: Option<String>,
+    committed_task: Vec<u8>,
+    committed_output: Vec<u8>,
+    task_scratch: Vec<u8>,
+    output_scratch: Vec<u8>,
+    pending: Option<PendingDispatch>,
 }
 
-fn encode_async_state<E: Encoder>(state: &AsyncState, encoder: &mut E) -> Result<(), EncodeError> {
-    if state.processing {
-        return Err(EncodeError::OtherString(
-            "cannot freeze async task while background work is in progress".to_string(),
-        ));
+impl AsyncState {
+    fn new() -> Self {
+        Self {
+            generation: 0,
+            phase: AsyncPhase::Idle,
+            ready_at: None,
+            last_error: None,
+            last_error_snapshot: None,
+            committed_task: Vec::new(),
+            committed_output: Vec::new(),
+            task_scratch: Vec::new(),
+            output_scratch: Vec::new(),
+            pending: None,
+        }
+    }
+}
+
+struct BufferWriter<'a>(&'a mut Vec<u8>);
+
+impl Writer for BufferWriter<'_> {
+    fn write(&mut self, bytes: &[u8]) -> Result<(), EncodeError> {
+        self.0.extend_from_slice(bytes);
+        Ok(())
+    }
+}
+
+fn encode_value_into(value: &impl Encode, buffer: &mut Vec<u8>) -> Result<(), EncodeError> {
+    buffer.clear();
+    let mut encoder = EncoderImpl::new(BufferWriter(buffer), standard());
+    value.encode(&mut encoder)
+}
+
+fn freeze_into(task: &impl Freezable, buffer: &mut Vec<u8>) -> Result<(), EncodeError> {
+    encode_value_into(&BincodeAdapter(task), buffer)
+}
+
+fn thaw_from(task: &mut impl Freezable, buffer: &[u8]) -> Result<(), DecodeError> {
+    let reader = bincode::de::read::SliceReader::new(buffer);
+    let mut decoder = bincode::de::DecoderImpl::new(reader, standard(), ());
+    task.thaw(&mut decoder)
+}
+
+fn decode_value<T: Decode<()>>(buffer: &[u8], label: &str) -> Result<T, DecodeError> {
+    let (value, bytes_read) = bincode::decode_from_slice(buffer, standard())?;
+    if bytes_read != buffer.len() {
+        return Err(DecodeError::OtherString(format!(
+            "async {label} snapshot had trailing bytes"
+        )));
+    }
+    Ok(value)
+}
+
+struct DynWriter<'a>(&'a mut dyn Writer);
+
+impl Writer for DynWriter<'_> {
+    fn write(&mut self, bytes: &[u8]) -> Result<(), EncodeError> {
+        self.0.write(bytes)
+    }
+}
+
+struct DynReader<'a>(&'a mut dyn Reader);
+
+impl Reader for DynReader<'_> {
+    fn read(&mut self, bytes: &mut [u8]) -> Result<(), DecodeError> {
+        self.0.read(bytes)
     }
 
-    Encode::encode(&state.ready_at, encoder)?;
-    let last_error = state.last_error.as_ref().map(ToString::to_string);
-    Encode::encode(&last_error, encoder)?;
-    Ok(())
+    fn peek_read(&mut self, length: usize) -> Option<&[u8]> {
+        self.0.peek_read(length)
+    }
+
+    fn consume(&mut self, length: usize) {
+        self.0.consume(length);
+    }
 }
 
-fn decode_async_state<D: Decoder>(
-    state: &mut AsyncState,
-    decoder: &mut D,
-) -> Result<(), DecodeError> {
-    state.processing = false;
-    state.ready_at = Decode::decode(decoder)?;
-    let last_error: Option<String> = Decode::decode(decoder)?;
-    state.last_error = last_error.map(CuError::from);
-    Ok(())
+trait ErasedDispatch: Any + Send + Sync {
+    fn as_any(&self) -> &dyn Any;
+    fn encode_input(&self, writer: &mut dyn Writer) -> Result<(), EncodeError>;
+    fn decode_input(&self, reader: &mut dyn Reader) -> Result<(), DecodeError>;
 }
 
-fn encode_buffered_output<O, E>(output: &CuMsg<O>, encoder: &mut E) -> Result<(), EncodeError>
+struct DispatchSlot<I: CuMsgPayload> {
+    input: Arc<RwLock<Option<CuMsg<I>>>>,
+}
+
+impl<I> DispatchSlot<I>
 where
-    O: CuMsgPayload + Send + 'static,
+    I: CuMsgPayload + Send + Sync + 'static,
+{
+    fn new() -> Self {
+        Self {
+            input: Arc::new(RwLock::new(None)),
+        }
+    }
+}
+
+impl<I> ErasedDispatch for DispatchSlot<I>
+where
+    I: CuMsgPayload + Send + Sync + 'static,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn encode_input(&self, writer: &mut dyn Writer) -> Result<(), EncodeError> {
+        let input = self.input.read().map_err(|_| {
+            EncodeError::OtherString("async task dispatch slot poisoned".to_string())
+        })?;
+        let mut encoder = EncoderImpl::new(DynWriter(writer), standard());
+        input.is_some().encode(&mut encoder)?;
+        if let Some(input) = input.as_ref() {
+            input.encode(&mut encoder)?;
+        }
+        Ok(())
+    }
+
+    fn decode_input(&self, reader: &mut dyn Reader) -> Result<(), DecodeError> {
+        let mut decoder = bincode::de::DecoderImpl::new(DynReader(reader), standard(), ());
+        let input = if bool::decode(&mut decoder)? {
+            Some(CuMsg::<I>::decode(&mut decoder)?)
+        } else {
+            None
+        };
+        *self.input.write().map_err(|_| {
+            DecodeError::OtherString("async task dispatch slot poisoned".to_string())
+        })? = input;
+        Ok(())
+    }
+}
+
+fn phase_tag(phase: AsyncPhase) -> u8 {
+    match phase {
+        AsyncPhase::Idle => 0,
+        AsyncPhase::Running => 1,
+        AsyncPhase::ReplayPending => 2,
+    }
+}
+
+fn encode_async_state<E>(
+    state: &AsyncState,
+    dispatch: Option<&dyn ErasedDispatch>,
+    encoder: &mut E,
+) -> Result<(), EncodeError>
+where
     E: Encoder,
 {
-    let bytes = bincode::encode_to_vec(output, bincode::config::standard())?;
-    Encode::encode(&bytes, encoder)
+    ASYNC_SNAPSHOT_MAGIC.encode(encoder)?;
+    ASYNC_SNAPSHOT_VERSION.encode(encoder)?;
+    phase_tag(state.phase).encode(encoder)?;
+
+    Encode::encode(&state.ready_at, encoder)?;
+    Encode::encode(&state.last_error_snapshot, encoder)?;
+    Encode::encode(&state.committed_task, encoder)?;
+    Encode::encode(&state.committed_output, encoder)?;
+
+    if let Some(pending) = state.pending.as_ref() {
+        true.encode(encoder)?;
+        pending.context.encode(encoder)?;
+        if let Some(dispatch) = dispatch {
+            dispatch.encode_input(encoder.writer())?;
+        } else {
+            false.encode(encoder)?;
+        }
+    } else {
+        false.encode(encoder)?;
+    }
+    Ok(())
 }
 
-fn decode_buffered_output<O, D>(decoder: &mut D) -> Result<CuMsg<O>, DecodeError>
+fn decode_async_state<D>(
+    decoder: &mut D,
+    dispatch: Option<&dyn ErasedDispatch>,
+) -> Result<AsyncState, DecodeError>
 where
-    O: CuMsgPayload + Send + 'static,
     D: Decoder,
 {
-    let bytes: Vec<u8> = Decode::decode(decoder)?;
-    let (output, bytes_read): (CuMsg<O>, usize) =
-        bincode::decode_from_slice(&bytes, bincode::config::standard())?;
-    if bytes_read != bytes.len() {
+    let magic = u32::decode(decoder).map_err(|_| {
+        DecodeError::OtherString(
+            "unsupported legacy async keyframe payload; expected version 1".to_string(),
+        )
+    })?;
+    let version = u8::decode(decoder)?;
+    if magic != ASYNC_SNAPSHOT_MAGIC || version != ASYNC_SNAPSHOT_VERSION {
+        return Err(DecodeError::OtherString(format!(
+            "unsupported async keyframe payload version {version}; expected version {ASYNC_SNAPSHOT_VERSION}"
+        )));
+    }
+    let recorded_phase = match u8::decode(decoder)? {
+        0 => AsyncPhase::Idle,
+        1 | 2 => AsyncPhase::ReplayPending,
+        phase => {
+            return Err(DecodeError::OtherString(format!(
+                "invalid async keyframe phase {phase}"
+            )));
+        }
+    };
+    let ready_at = Decode::decode(decoder)?;
+    let last_error_snapshot: Option<String> = Decode::decode(decoder)?;
+    let committed_task = Decode::decode(decoder)?;
+    let committed_output = Decode::decode(decoder)?;
+    let pending = if bool::decode(decoder)? {
+        let context = CuContextSnapshot::decode(decoder)?;
+        if let Some(dispatch) = dispatch {
+            dispatch.decode_input(decoder.reader())?;
+        } else if bool::decode(decoder)? {
+            return Err(DecodeError::OtherString(
+                "async task snapshot contains input but no dispatch slot is initialized"
+                    .to_string(),
+            ));
+        }
+        Some(PendingDispatch { context })
+    } else {
+        None
+    };
+    if recorded_phase == AsyncPhase::ReplayPending && pending.is_none() {
         return Err(DecodeError::OtherString(
-            "async task buffered output snapshot had trailing bytes".to_string(),
+            "async keyframe recorded pending work without a dispatch".to_string(),
         ));
     }
-    Ok(output)
+    Ok(AsyncState {
+        generation: 0,
+        phase: recorded_phase,
+        ready_at,
+        last_error: last_error_snapshot
+            .as_ref()
+            .map(|error| CuError::from(error.as_str())),
+        last_error_snapshot,
+        committed_task,
+        committed_output,
+        task_scratch: Vec::new(),
+        output_scratch: Vec::new(),
+        pending,
+    })
 }
 
-fn record_async_error(state: &Mutex<AsyncState>, error: CuError) {
+type ErasedDispatchSlot = Arc<dyn ErasedDispatch>;
+
+fn dispatch_slot<I>(slot: &Option<ErasedDispatchSlot>) -> CuResult<Arc<RwLock<Option<CuMsg<I>>>>>
+where
+    I: CuMsgPayload + Send + Sync + 'static,
+{
+    let slot = slot
+        .as_ref()
+        .ok_or_else(|| CuError::from("Async task dispatch slot was not initialized"))?;
+    slot.as_any()
+        .downcast_ref::<DispatchSlot<I>>()
+        .map(|slot| Arc::clone(&slot.input))
+        .ok_or_else(|| CuError::from("Async task dispatch slot type did not match its input"))
+}
+
+fn record_async_task_error<I>(
+    state: &Mutex<AsyncState>,
+    dispatch: &RwLock<Option<CuMsg<I>>>,
+    generation: u64,
+    error: CuError,
+) where
+    I: CuMsgPayload + Send + Sync + 'static,
+{
     let mut guard = match state.lock() {
         Ok(guard) => guard,
         Err(poison) => poison.into_inner(),
     };
-    guard.processing = false;
+    if guard.generation != generation {
+        return;
+    }
+    if let Ok(mut input) = dispatch.write() {
+        *input = None;
+    }
+    guard.phase = AsyncPhase::Idle;
     guard.ready_at = None;
+    guard.last_error_snapshot = Some(error.to_string());
     guard.last_error = Some(error);
+    guard.pending = None;
 }
 
-fn begin_background_poll<O>(
-    ctx: &CuContext,
-    state: &Mutex<AsyncState>,
-    buffered_output: &Mutex<CuMsg<O>>,
-    real_output: &mut CuMsg<O>,
-) -> CuResult<bool>
-where
-    O: CuMsgPayload + Send + 'static,
-{
-    {
-        let mut state = state.lock().map_err(|_| {
-            CuError::from("Async task state mutex poisoned while scheduling background work")
-        })?;
-        if let Some(error) = state.last_error.take() {
-            return Err(error);
-        }
-        if state.processing {
-            *real_output = CuMsg::default();
-            return Ok(false);
-        }
-
-        if let Some(ready_at) = state.ready_at
-            && ctx.now() < ready_at
-        {
-            *real_output = CuMsg::default();
-            return Ok(false);
-        }
-
-        state.processing = true;
-        state.ready_at = None;
+fn record_async_error(state: &Mutex<AsyncState>, generation: u64, error: CuError) {
+    let mut guard = match state.lock() {
+        Ok(guard) => guard,
+        Err(poison) => poison.into_inner(),
+    };
+    if guard.generation != generation {
+        return;
     }
-
-    let buffered_output = buffered_output.lock().map_err(|_| {
-        let error = CuError::from("Async task output mutex poisoned");
-        record_async_error(state, error.clone());
-        error
-    })?;
-    *real_output = buffered_output.clone();
-    Ok(true)
-}
-
-fn finalize_background_run<O>(
-    state: &Mutex<AsyncState>,
-    output_ref: &mut CuMsg<O>,
-    fallback_end: CuTime,
-    task_result: CuResult<()>,
-) where
-    O: CuMsgPayload + Send + 'static,
-{
-    let mut guard = state.lock().unwrap_or_else(|poison| poison.into_inner());
-    guard.processing = false;
-
-    match task_result {
-        Ok(()) => {
-            let end_from_metadata: Option<CuTime> = output_ref.metadata.process_time.end.into();
-            let end_time = end_from_metadata.unwrap_or_else(|| {
-                output_ref.metadata.process_time.end = fallback_end.into();
-                fallback_end
-            });
-            guard.ready_at = Some(end_time);
-        }
-        Err(error) => {
-            guard.ready_at = None;
-            guard.last_error = Some(error);
-        }
-    }
+    guard.phase = AsyncPhase::Idle;
+    guard.ready_at = None;
+    guard.last_error_snapshot = Some(error.to_string());
+    guard.last_error = Some(error);
+    guard.pending = None;
 }
 
 #[derive(Reflect)]
@@ -156,6 +345,8 @@ where
     output: Arc<Mutex<CuMsg<O>>>,
     #[reflect(ignore)]
     state: Arc<Mutex<AsyncState>>,
+    #[reflect(ignore)]
+    dispatch: Option<ErasedDispatchSlot>,
     #[reflect(ignore)]
     tp: Arc<ThreadPool>,
 }
@@ -208,13 +399,22 @@ where
         Ok(Self {
             task,
             output,
-            state: Arc::new(Mutex::new(AsyncState {
-                processing: false,
-                ready_at: None,
-                last_error: None,
-            })),
+            state: Arc::new(Mutex::new(AsyncState::new())),
+            dispatch: None,
             tp,
         })
+    }
+
+    fn initialize_dispatch<I>(&mut self) -> CuResult<()>
+    where
+        I: CuMsgPayload + Send + Sync + 'static,
+    {
+        if self.dispatch.is_some() {
+            let _ = dispatch_slot::<I>(&self.dispatch)?;
+        } else {
+            self.dispatch = Some(Arc::new(DispatchSlot::<I>::new()));
+        }
+        Ok(())
     }
 }
 
@@ -228,38 +428,30 @@ where
             .state
             .lock()
             .map_err(|_| EncodeError::OtherString("async task state mutex poisoned".to_string()))?;
-        encode_async_state(&state, encoder)?;
-
-        let task = self
-            .task
-            .lock()
-            .map_err(|_| EncodeError::OtherString("async task mutex poisoned".to_string()))?;
-        task.freeze(encoder)?;
-
-        let output = self.output.lock().map_err(|_| {
-            EncodeError::OtherString("async task output mutex poisoned".to_string())
-        })?;
-        encode_buffered_output(&output, encoder)?;
-        Ok(())
+        encode_async_state(&state, self.dispatch.as_deref(), encoder)
     }
 
     fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
-        let mut state = self
-            .state
-            .lock()
-            .map_err(|_| DecodeError::OtherString("async task state mutex poisoned".to_string()))?;
-        decode_async_state(&mut state, decoder)?;
+        let mut restored_state = decode_async_state(decoder, self.dispatch.as_deref())?;
+        let restored_output: CuMsg<O> =
+            decode_value(&restored_state.committed_output, "task output")?;
 
         let mut task = self
             .task
             .lock()
             .map_err(|_| DecodeError::OtherString("async task mutex poisoned".to_string()))?;
-        task.thaw(decoder)?;
+        thaw_from(&mut *task, &restored_state.committed_task)?;
 
         let mut output = self.output.lock().map_err(|_| {
             DecodeError::OtherString("async task output mutex poisoned".to_string())
         })?;
-        *output = decode_buffered_output(decoder)?;
+        *output = restored_output;
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| DecodeError::OtherString("async task state mutex poisoned".to_string()))?;
+        restored_state.generation = state.generation.wrapping_add(1);
+        *state = restored_state;
         Ok(())
     }
 }
@@ -282,11 +474,31 @@ where
     }
 
     fn start(&mut self, ctx: &CuContext) -> CuResult<()> {
+        self.initialize_dispatch::<I>()?;
         let mut task = self
             .task
             .lock()
             .map_err(|_| CuError::from("Async task mutex poisoned during start"))?;
-        task.start(ctx)
+        task.start(ctx)?;
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| CuError::from("Async task state mutex poisoned during start"))?;
+        let mut snapshot = core::mem::take(&mut state.task_scratch);
+        freeze_into(&*task, &mut snapshot).map_err(|error| {
+            CuError::from("Failed to snapshot async task after start").with_cause(error)
+        })?;
+        state.task_scratch = core::mem::replace(&mut state.committed_task, snapshot);
+        let output = self
+            .output
+            .lock()
+            .map_err(|_| CuError::from("Async task output mutex poisoned during start"))?;
+        let mut output_snapshot = core::mem::take(&mut state.output_scratch);
+        encode_value_into(&*output, &mut output_snapshot).map_err(|error| {
+            CuError::from("Failed to snapshot async task output after start").with_cause(error)
+        })?;
+        state.output_scratch = core::mem::replace(&mut state.committed_output, output_snapshot);
+        Ok(())
     }
 
     fn process<'i, 'o>(
@@ -295,24 +507,124 @@ where
         input: &Self::Input<'i>,
         real_output: &mut Self::Output<'o>,
     ) -> CuResult<()> {
-        if !begin_background_poll(ctx, &self.state, &self.output, real_output)? {
-            return Ok(());
-        }
+        let dispatch = dispatch_slot::<I>(&self.dispatch)?;
+        let (generation, dispatch_context, mut task_snapshot, mut output_snapshot) = {
+            let mut state = self.state.lock().map_err(|_| {
+                CuError::from("Async task state mutex poisoned while scheduling background work")
+            })?;
+            if let Some(error) = state.last_error.take() {
+                state.last_error_snapshot = None;
+                return Err(error);
+            }
+            if state.phase == AsyncPhase::Running {
+                *real_output = CuMsg::default();
+                return Ok(());
+            }
+            if state.phase == AsyncPhase::Idle
+                && let Some(ready_at) = state.ready_at
+                && ctx.now() < ready_at
+            {
+                *real_output = CuMsg::default();
+                return Ok(());
+            }
 
-        // immediately requeue a task based on the new input
+            let (dispatch_input, dispatch_context) = if state.phase == AsyncPhase::ReplayPending {
+                let pending = state.pending.take().ok_or_else(|| {
+                    CuError::from("Async replay is pending without a retained dispatch")
+                })?;
+                let has_input = dispatch
+                    .read()
+                    .map_err(|_| CuError::from("Async task dispatch slot poisoned"))?
+                    .is_some();
+                if !has_input {
+                    return Err(CuError::from(
+                        "Async task replay dispatch is missing its input",
+                    ));
+                }
+                (None, pending.context)
+            } else {
+                (Some((*input).clone()), ctx.snapshot())
+            };
+            if let Some(dispatch_input) = dispatch_input {
+                *dispatch
+                    .write()
+                    .map_err(|_| CuError::from("Async task dispatch slot poisoned"))? =
+                    Some(dispatch_input);
+            }
+            state.pending = Some(PendingDispatch {
+                context: dispatch_context.clone(),
+            });
+            state.generation = state.generation.wrapping_add(1);
+            state.phase = AsyncPhase::Running;
+            state.ready_at = None;
+            (
+                state.generation,
+                dispatch_context,
+                core::mem::take(&mut state.task_scratch),
+                core::mem::take(&mut state.output_scratch),
+            )
+        };
+
+        let buffered_output = self.output.lock().map_err(|_| {
+            let error = CuError::from("Async task output mutex poisoned");
+            record_async_task_error(&self.state, &dispatch, generation, error.clone());
+            error
+        })?;
+        *real_output = buffered_output.clone();
+        drop(buffered_output);
+
         self.tp.spawn_fifo({
-            let ctx = ctx.clone();
-            let input = (*input).clone();
+            let ctx = ctx.restore_snapshot(&dispatch_context);
             let output = self.output.clone();
             let task = self.task.clone();
             let state = self.state.clone();
+            let dispatch = dispatch.clone();
             move || {
-                let input_ref: &CuMsg<I> = &input;
+                let input_guard = match dispatch.read() {
+                    Ok(guard) => guard,
+                    Err(_) => {
+                        record_async_task_error(
+                            &state,
+                            &dispatch,
+                            generation,
+                            CuError::from("Async task dispatch slot poisoned"),
+                        );
+                        return;
+                    }
+                };
+                let input_ref = if let Some(input_ref) = input_guard.as_ref() {
+                    input_ref
+                } else {
+                    drop(input_guard);
+                    record_async_task_error(
+                        &state,
+                        &dispatch,
+                        generation,
+                        CuError::from("Async task dispatch input disappeared before execution"),
+                    );
+                    return;
+                };
+                let mut task_guard = match task.lock() {
+                    Ok(guard) => guard,
+                    Err(poison) => {
+                        drop(input_guard);
+                        record_async_task_error(
+                            &state,
+                            &dispatch,
+                            generation,
+                            CuError::from(format!("Async task mutex poisoned: {poison}")),
+                        );
+                        return;
+                    }
+                };
                 let mut output_guard = match output.lock() {
                     Ok(guard) => guard,
                     Err(_) => {
-                        record_async_error(
+                        drop(input_guard);
+                        record_async_task_error(
                             &state,
+                            &dispatch,
+                            generation,
                             CuError::from("Async task output mutex poisoned"),
                         );
                         return;
@@ -328,13 +640,55 @@ where
                 if output_ref.metadata.process_time.start.is_none() {
                     output_ref.metadata.process_time.start = ctx.now().into();
                 }
-                let task_result = match task.lock() {
-                    Ok(mut task_guard) => task_guard.process(&ctx, input_ref, output_ref),
-                    Err(poison) => Err(CuError::from(format!(
-                        "Async task mutex poisoned: {poison}"
-                    ))),
-                };
-                finalize_background_run(&state, output_ref, ctx.now(), task_result);
+                let task_result = task_guard.process(&ctx, input_ref, output_ref);
+                let fallback_end = ctx.now();
+                let end_from_metadata: Option<CuTime> = output_ref.metadata.process_time.end.into();
+                let ready_at = end_from_metadata.unwrap_or_else(|| {
+                    output_ref.metadata.process_time.end = fallback_end.into();
+                    fallback_end
+                });
+                let snapshot_result = freeze_into(&*task_guard, &mut task_snapshot)
+                    .and_then(|()| encode_value_into(output_ref, &mut output_snapshot));
+                drop(output_guard);
+                drop(task_guard);
+                drop(input_guard);
+
+                let mut guard = state.lock().unwrap_or_else(|poison| poison.into_inner());
+                if guard.generation != generation {
+                    return;
+                }
+                if let Ok(mut input) = dispatch.write() {
+                    *input = None;
+                }
+                match snapshot_result {
+                    Ok(()) => {
+                        guard.task_scratch =
+                            core::mem::replace(&mut guard.committed_task, task_snapshot);
+                        guard.output_scratch =
+                            core::mem::replace(&mut guard.committed_output, output_snapshot);
+                        guard.phase = AsyncPhase::Idle;
+                        guard.pending = None;
+                        match task_result {
+                            Ok(()) => guard.ready_at = Some(ready_at),
+                            Err(error) => {
+                                guard.ready_at = None;
+                                guard.last_error_snapshot = Some(error.to_string());
+                                guard.last_error = Some(error);
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        guard.task_scratch = task_snapshot;
+                        guard.output_scratch = output_snapshot;
+                        guard.phase = AsyncPhase::Idle;
+                        guard.pending = None;
+                        guard.ready_at = None;
+                        let error = CuError::from("Failed to snapshot completed async task")
+                            .with_cause(error);
+                        guard.last_error_snapshot = Some(error.to_string());
+                        guard.last_error = Some(error);
+                    }
+                }
             }
         });
         Ok(())
@@ -414,11 +768,7 @@ where
         Ok(Self {
             task,
             output,
-            state: Arc::new(Mutex::new(AsyncState {
-                processing: false,
-                ready_at: None,
-                last_error: None,
-            })),
+            state: Arc::new(Mutex::new(AsyncState::new())),
             tp,
         })
     }
@@ -433,37 +783,29 @@ where
         let state = self.state.lock().map_err(|_| {
             EncodeError::OtherString("async source state mutex poisoned".to_string())
         })?;
-        encode_async_state(&state, encoder)?;
-
-        let task = self
-            .task
-            .lock()
-            .map_err(|_| EncodeError::OtherString("async source mutex poisoned".to_string()))?;
-        task.freeze(encoder)?;
-
-        let output = self.output.lock().map_err(|_| {
-            EncodeError::OtherString("async source output mutex poisoned".to_string())
-        })?;
-        encode_buffered_output(&output, encoder)?;
-        Ok(())
+        encode_async_state(&state, None, encoder)
     }
 
     fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
-        let mut state = self.state.lock().map_err(|_| {
-            DecodeError::OtherString("async source state mutex poisoned".to_string())
-        })?;
-        decode_async_state(&mut state, decoder)?;
+        let mut restored_state = decode_async_state(decoder, None)?;
+        let restored_output: CuMsg<O> =
+            decode_value(&restored_state.committed_output, "source output")?;
 
         let mut task = self
             .task
             .lock()
             .map_err(|_| DecodeError::OtherString("async source mutex poisoned".to_string()))?;
-        task.thaw(decoder)?;
+        thaw_from(&mut *task, &restored_state.committed_task)?;
 
         let mut output = self.output.lock().map_err(|_| {
             DecodeError::OtherString("async source output mutex poisoned".to_string())
         })?;
-        *output = decode_buffered_output(decoder)?;
+        *output = restored_output;
+        let mut state = self.state.lock().map_err(|_| {
+            DecodeError::OtherString("async source state mutex poisoned".to_string())
+        })?;
+        restored_state.generation = state.generation.wrapping_add(1);
+        *state = restored_state;
         Ok(())
     }
 }
@@ -488,25 +830,102 @@ where
             .task
             .lock()
             .map_err(|_| CuError::from("Async source mutex poisoned during start"))?;
-        task.start(ctx)
+        task.start(ctx)?;
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| CuError::from("Async source state mutex poisoned during start"))?;
+        let mut snapshot = core::mem::take(&mut state.task_scratch);
+        freeze_into(&*task, &mut snapshot).map_err(|error| {
+            CuError::from("Failed to snapshot async source after start").with_cause(error)
+        })?;
+        state.task_scratch = core::mem::replace(&mut state.committed_task, snapshot);
+        let output = self
+            .output
+            .lock()
+            .map_err(|_| CuError::from("Async source output mutex poisoned during start"))?;
+        let mut output_snapshot = core::mem::take(&mut state.output_scratch);
+        encode_value_into(&*output, &mut output_snapshot).map_err(|error| {
+            CuError::from("Failed to snapshot async source output after start").with_cause(error)
+        })?;
+        state.output_scratch = core::mem::replace(&mut state.committed_output, output_snapshot);
+        Ok(())
     }
 
     fn process<'o>(&mut self, ctx: &CuContext, real_output: &mut Self::Output<'o>) -> CuResult<()> {
-        if !begin_background_poll(ctx, &self.state, &self.output, real_output)? {
-            return Ok(());
-        }
+        let (generation, dispatch_context, mut task_snapshot, mut output_snapshot) = {
+            let mut state = self.state.lock().map_err(|_| {
+                CuError::from("Async source state mutex poisoned while scheduling background work")
+            })?;
+            if let Some(error) = state.last_error.take() {
+                state.last_error_snapshot = None;
+                return Err(error);
+            }
+            if state.phase == AsyncPhase::Running {
+                *real_output = CuMsg::default();
+                return Ok(());
+            }
+            if state.phase == AsyncPhase::Idle
+                && let Some(ready_at) = state.ready_at
+                && ctx.now() < ready_at
+            {
+                *real_output = CuMsg::default();
+                return Ok(());
+            }
+
+            let dispatch_context = if state.phase == AsyncPhase::ReplayPending {
+                let pending = state.pending.take().ok_or_else(|| {
+                    CuError::from("Async source replay is pending without a retained dispatch")
+                })?;
+                pending.context
+            } else {
+                ctx.snapshot()
+            };
+            state.pending = Some(PendingDispatch {
+                context: dispatch_context.clone(),
+            });
+            state.generation = state.generation.wrapping_add(1);
+            state.phase = AsyncPhase::Running;
+            state.ready_at = None;
+            (
+                state.generation,
+                dispatch_context,
+                core::mem::take(&mut state.task_scratch),
+                core::mem::take(&mut state.output_scratch),
+            )
+        };
+
+        let buffered_output = self.output.lock().map_err(|_| {
+            let error = CuError::from("Async source output mutex poisoned");
+            record_async_error(&self.state, generation, error.clone());
+            error
+        })?;
+        *real_output = buffered_output.clone();
+        drop(buffered_output);
 
         self.tp.spawn_fifo({
-            let ctx = ctx.clone();
+            let ctx = ctx.restore_snapshot(&dispatch_context);
             let output = self.output.clone();
             let task = self.task.clone();
             let state = self.state.clone();
             move || {
+                let mut task_guard = match task.lock() {
+                    Ok(guard) => guard,
+                    Err(poison) => {
+                        record_async_error(
+                            &state,
+                            generation,
+                            CuError::from(format!("Async source mutex poisoned: {poison}")),
+                        );
+                        return;
+                    }
+                };
                 let mut output_guard = match output.lock() {
                     Ok(guard) => guard,
                     Err(_) => {
                         record_async_error(
                             &state,
+                            generation,
                             CuError::from("Async task output mutex poisoned"),
                         );
                         return;
@@ -519,13 +938,51 @@ where
                 if output_ref.metadata.process_time.start.is_none() {
                     output_ref.metadata.process_time.start = ctx.now().into();
                 }
-                let task_result = match task.lock() {
-                    Ok(mut task_guard) => task_guard.process(&ctx, output_ref),
-                    Err(poison) => Err(CuError::from(format!(
-                        "Async source mutex poisoned: {poison}"
-                    ))),
-                };
-                finalize_background_run(&state, output_ref, ctx.now(), task_result);
+                let task_result = task_guard.process(&ctx, output_ref);
+                let fallback_end = ctx.now();
+                let end_from_metadata: Option<CuTime> = output_ref.metadata.process_time.end.into();
+                let ready_at = end_from_metadata.unwrap_or_else(|| {
+                    output_ref.metadata.process_time.end = fallback_end.into();
+                    fallback_end
+                });
+                let snapshot_result = freeze_into(&*task_guard, &mut task_snapshot)
+                    .and_then(|()| encode_value_into(output_ref, &mut output_snapshot));
+                drop(output_guard);
+                drop(task_guard);
+
+                let mut guard = state.lock().unwrap_or_else(|poison| poison.into_inner());
+                if guard.generation != generation {
+                    return;
+                }
+                match snapshot_result {
+                    Ok(()) => {
+                        guard.task_scratch =
+                            core::mem::replace(&mut guard.committed_task, task_snapshot);
+                        guard.output_scratch =
+                            core::mem::replace(&mut guard.committed_output, output_snapshot);
+                        guard.phase = AsyncPhase::Idle;
+                        guard.pending = None;
+                        match task_result {
+                            Ok(()) => guard.ready_at = Some(ready_at),
+                            Err(error) => {
+                                guard.ready_at = None;
+                                guard.last_error_snapshot = Some(error.to_string());
+                                guard.last_error = Some(error);
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        guard.task_scratch = task_snapshot;
+                        guard.output_scratch = output_snapshot;
+                        guard.phase = AsyncPhase::Idle;
+                        guard.pending = None;
+                        guard.ready_at = None;
+                        let error = CuError::from("Failed to snapshot completed async source")
+                            .with_cause(error);
+                        guard.last_error_snapshot = Some(error.to_string());
+                        guard.last_error = Some(error);
+                    }
+                }
             }
         });
         Ok(())
@@ -602,6 +1059,7 @@ mod tests {
         let context = CuContext::new_with_clock();
         let mut async_task: CuAsyncTask<TestTask, u32> =
             CuAsyncTask::new(Some(&config), (), tp).unwrap();
+        async_task.start(&context).unwrap();
         let input = CuMsg::new(Some(42u32));
         let mut output = CuMsg::new(None);
 
@@ -668,7 +1126,7 @@ mod tests {
     {
         for _ in 0..100 {
             let state = async_task.state.lock().unwrap();
-            if !state.processing {
+            if state.phase != AsyncPhase::Running {
                 return;
             }
             drop(state);
@@ -684,7 +1142,7 @@ mod tests {
     {
         for _ in 0..100 {
             let state = async_task.state.lock().unwrap();
-            if !state.processing {
+            if state.phase != AsyncPhase::Running {
                 return;
             }
             drop(state);
@@ -847,6 +1305,7 @@ mod tests {
 
         let mut async_task: CuAsyncTask<ActionTask, u32> =
             CuAsyncTask::new(Some(&ComponentConfig::default()), resources, tp).unwrap();
+        async_task.start(&context).unwrap();
         let input = CuMsg::new(Some(1u32));
         let mut output = CuMsg::new(None);
 
@@ -879,6 +1338,7 @@ mod tests {
 
         let mut async_task: CuAsyncTask<ActionTask, u32> =
             CuAsyncTask::new(Some(&ComponentConfig::default()), resources, tp).unwrap();
+        async_task.start(&context).unwrap();
         let some_input = CuMsg::new(Some(1u32));
         let no_input = CuMsg::new(None::<u32>);
         let mut output = CuMsg::new(None);
@@ -1010,6 +1470,7 @@ mod tests {
 
         let mut async_task: CuAsyncTask<ControlledTask, u32> =
             CuAsyncTask::new(Some(&ComponentConfig::default()), (), tp.clone()).unwrap();
+        async_task.start(&context).unwrap();
         let input = CuMsg::new(Some(1u32));
         let mut output = CuMsg::new(None);
 
@@ -1033,7 +1494,7 @@ mod tests {
         let mut ready_at_recorded = None;
         for _ in 0..100 {
             let state = async_task.state.lock().unwrap();
-            if !state.processing {
+            if state.phase != AsyncPhase::Running {
                 ready_at_recorded = state.ready_at;
                 if ready_at_recorded.is_some() {
                     break;
@@ -1125,6 +1586,7 @@ mod tests {
         let context = CuContext::new_with_clock();
         let mut task: CuAsyncTask<CuAnytimeRunner<IncrementalPlanner, ThreeQuantaPolicy>, u32> =
             CuAsyncTask::new(Some(&ComponentConfig::default()), (), tp).unwrap();
+        task.start(&context).unwrap();
 
         let input = CuMsg::new(Some(5u32));
         let mut output = CuMsg::new(None);
@@ -1176,7 +1638,7 @@ mod tests {
         let mut ready_at_recorded = None;
         for _ in 0..100 {
             let state = async_src.state.lock().unwrap();
-            if !state.processing {
+            if state.phase != AsyncPhase::Running {
                 ready_at_recorded = state.ready_at;
                 if ready_at_recorded.is_some() {
                     break;
@@ -1203,5 +1665,418 @@ mod tests {
 
         ready_tx.send(CuTime::from(40u64)).unwrap();
         let _ = done_rx.recv_timeout(Duration::from_secs(1));
+    }
+
+    #[derive(Clone)]
+    struct ReplayTaskResources {
+        release: Arc<Mutex<mpsc::Receiver<()>>>,
+        observed: mpsc::Sender<(u32, u64, u32)>,
+    }
+
+    #[derive(Reflect)]
+    #[reflect(no_field_bounds, from_reflect = false)]
+    struct ReplayTask {
+        counter: u32,
+        #[reflect(ignore)]
+        release: Arc<Mutex<mpsc::Receiver<()>>>,
+        #[reflect(ignore)]
+        observed: mpsc::Sender<(u32, u64, u32)>,
+    }
+
+    impl Freezable for ReplayTask {
+        fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+            self.counter.encode(encoder)
+        }
+
+        fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
+            self.counter = u32::decode(decoder)?;
+            Ok(())
+        }
+    }
+
+    impl CuTask for ReplayTask {
+        type Resources<'r> = ReplayTaskResources;
+        type Input<'m> = input_msg!(u32);
+        type Output<'m> = output_msg!(u32);
+
+        fn new(
+            _config: Option<&ComponentConfig>,
+            resources: Self::Resources<'_>,
+        ) -> CuResult<Self> {
+            Ok(Self {
+                counter: 0,
+                release: resources.release,
+                observed: resources.observed,
+            })
+        }
+
+        fn start(&mut self, _ctx: &CuContext) -> CuResult<()> {
+            self.counter = 10;
+            Ok(())
+        }
+
+        fn process(
+            &mut self,
+            ctx: &CuContext,
+            input: &Self::Input<'_>,
+            output: &mut Self::Output<'_>,
+        ) -> CuResult<()> {
+            self.release
+                .lock()
+                .unwrap()
+                .recv_timeout(Duration::from_secs(1))
+                .expect("timed out waiting to release replay task");
+            let input = input.payload().copied().expect("replay task input");
+            self.observed
+                .send((input, ctx.cl_id(), self.counter))
+                .expect("failed to record replay task dispatch");
+            self.counter += 1;
+            output.set_payload(input + self.counter);
+            Ok(())
+        }
+    }
+
+    fn replay_task_resources() -> (
+        ReplayTaskResources,
+        mpsc::Sender<()>,
+        mpsc::Receiver<(u32, u64, u32)>,
+    ) {
+        let (release_tx, release_rx) = mpsc::channel();
+        let (observed_tx, observed_rx) = mpsc::channel();
+        (
+            ReplayTaskResources {
+                release: Arc::new(Mutex::new(release_rx)),
+                observed: observed_tx,
+            },
+            release_tx,
+            observed_rx,
+        )
+    }
+
+    #[test]
+    fn background_freeze_mid_run_replays_original_dispatch_from_committed_state() {
+        let tp = Arc::new(ThreadPoolBuilder::new().num_threads(1).build().unwrap());
+        let (resources, release_tx, observed_rx) = replay_task_resources();
+        let (base_context, _) = CuContext::new_mock_clock();
+        let mut dispatch_context = CuContext::builder(base_context.clock.clone())
+            .cl_id(7)
+            .instance_id(3)
+            .task_ids(&["replay"])
+            .build();
+        dispatch_context.set_current_task(0);
+        let mut original: CuAsyncTask<ReplayTask, u32> =
+            CuAsyncTask::new(Some(&ComponentConfig::default()), resources, tp).unwrap();
+        original.start(&dispatch_context).unwrap();
+        let original_input = CuMsg::new(Some(41u32));
+        let mut output = CuMsg::default();
+        original
+            .process(&dispatch_context, &original_input, &mut output)
+            .unwrap();
+
+        let frozen = bincode::encode_to_vec(BincodeAdapter(&original), standard())
+            .expect("mid-run async freeze failed");
+        assert_eq!(
+            original.state.lock().unwrap().phase,
+            AsyncPhase::Running,
+            "freezing must not disturb the live worker"
+        );
+        release_tx.send(()).unwrap();
+        assert_eq!(
+            observed_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            (41, 7, 10)
+        );
+
+        let replay_tp = Arc::new(ThreadPoolBuilder::new().num_threads(1).build().unwrap());
+        let (replay_resources, replay_release_tx, replay_observed_rx) = replay_task_resources();
+        let mut restored: CuAsyncTask<ReplayTask, u32> = CuAsyncTask::new(
+            Some(&ComponentConfig::default()),
+            replay_resources,
+            replay_tp,
+        )
+        .unwrap();
+        restored.start(&dispatch_context).unwrap();
+        let reader = bincode::de::read::SliceReader::new(&frozen);
+        let mut decoder = bincode::de::DecoderImpl::new(reader, standard(), ());
+        restored.thaw(&mut decoder).unwrap();
+        assert_eq!(
+            restored.state.lock().unwrap().phase,
+            AsyncPhase::ReplayPending
+        );
+
+        let current_context = CuContext::builder(base_context.clock.clone())
+            .cl_id(99)
+            .instance_id(8)
+            .build();
+        let current_input = CuMsg::new(Some(999u32));
+        restored
+            .process(&current_context, &current_input, &mut output)
+            .unwrap();
+        replay_release_tx.send(()).unwrap();
+        assert_eq!(
+            replay_observed_rx
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap(),
+            (41, 7, 10),
+            "replay must ignore the current CopperList input and context"
+        );
+        wait_until_async_idle(&restored);
+
+        restored
+            .process(&current_context, &current_input, &mut output)
+            .unwrap();
+        assert_eq!(output.payload(), Some(&52));
+        replay_release_tx.send(()).unwrap();
+        let _ = replay_observed_rx.recv_timeout(Duration::from_secs(1));
+    }
+
+    #[cfg(feature = "memory_monitoring")]
+    #[test]
+    fn background_freeze_mid_run_does_not_allocate() {
+        const SNAPSHOT_CAPACITY: usize = 4 * 1024;
+
+        let tp = Arc::new(ThreadPoolBuilder::new().num_threads(1).build().unwrap());
+        let (resources, release_tx, observed_rx) = replay_task_resources();
+        let (context, _) = CuContext::new_mock_clock();
+        let mut async_task: CuAsyncTask<ReplayTask, u32> =
+            CuAsyncTask::new(Some(&ComponentConfig::default()), resources, tp).unwrap();
+        async_task.start(&context).unwrap();
+        let input = CuMsg::new(Some(41u32));
+        let mut output = CuMsg::default();
+        async_task.process(&context, &input, &mut output).unwrap();
+
+        let mut snapshot = [0u8; SNAPSHOT_CAPACITY];
+        let allocations = crate::monitoring::ScopedAllocCounter::new();
+        let writer = bincode::enc::write::SliceWriter::new(&mut snapshot);
+        let mut encoder = EncoderImpl::new(writer, standard());
+        BincodeAdapter(&async_task).encode(&mut encoder).unwrap();
+        assert_eq!(allocations.allocated(), 0);
+
+        release_tx.send(()).unwrap();
+        let _ = observed_rx.recv_timeout(Duration::from_secs(1));
+    }
+
+    #[test]
+    fn background_freeze_thaw_preserves_pending_error() {
+        let tp = Arc::new(ThreadPoolBuilder::new().num_threads(1).build().unwrap());
+        let context = CuContext::new_with_clock();
+        let mut original: CuAsyncTask<TestTask, u32> =
+            CuAsyncTask::new(Some(&ComponentConfig::default()), (), tp).unwrap();
+        original.start(&context).unwrap();
+        {
+            let mut state = original.state.lock().unwrap();
+            let error = CuError::from("expected async failure");
+            state.last_error_snapshot = Some(error.to_string());
+            state.last_error = Some(error);
+        }
+        let frozen = bincode::encode_to_vec(BincodeAdapter(&original), standard()).unwrap();
+
+        let replay_tp = Arc::new(ThreadPoolBuilder::new().num_threads(1).build().unwrap());
+        let mut restored: CuAsyncTask<TestTask, u32> =
+            CuAsyncTask::new(Some(&ComponentConfig::default()), (), replay_tp).unwrap();
+        restored.start(&context).unwrap();
+        let reader = bincode::de::read::SliceReader::new(&frozen);
+        let mut decoder = bincode::de::DecoderImpl::new(reader, standard(), ());
+        restored.thaw(&mut decoder).unwrap();
+
+        let input = CuMsg::new(Some(1u32));
+        let mut output = CuMsg::default();
+        let error = restored.process(&context, &input, &mut output).unwrap_err();
+        assert!(error.to_string().contains("expected async failure"));
+    }
+
+    #[test]
+    fn worker_completion_racing_freeze_is_an_atomic_committed_snapshot() {
+        let tp = Arc::new(ThreadPoolBuilder::new().num_threads(1).build().unwrap());
+        let (resources, release_tx, observed_rx) = replay_task_resources();
+        let (context, _) = CuContext::new_mock_clock();
+        let mut async_task: CuAsyncTask<ReplayTask, u32> =
+            CuAsyncTask::new(Some(&ComponentConfig::default()), resources, tp).unwrap();
+        async_task.start(&context).unwrap();
+        let input = CuMsg::new(Some(41u32));
+        let mut output = CuMsg::default();
+        async_task.process(&context, &input, &mut output).unwrap();
+
+        let mut snapshots = vec![
+            bincode::encode_to_vec(BincodeAdapter(&async_task), standard())
+                .expect("freeze running async task"),
+        ];
+        release_tx.send(()).unwrap();
+        observed_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("worker did not complete");
+        for _ in 0..100 {
+            snapshots.push(
+                bincode::encode_to_vec(BincodeAdapter(&async_task), standard())
+                    .expect("freeze async task racing completion"),
+            );
+            if async_task.state.lock().unwrap().phase == AsyncPhase::Idle {
+                break;
+            }
+            std::thread::yield_now();
+        }
+        wait_until_async_idle(&async_task);
+        snapshots.push(
+            bincode::encode_to_vec(BincodeAdapter(&async_task), standard())
+                .expect("freeze completed async task"),
+        );
+
+        let mut saw_running = false;
+        let mut saw_idle = false;
+        for snapshot in snapshots {
+            let reader = bincode::de::read::SliceReader::new(&snapshot);
+            let mut decoder = bincode::de::DecoderImpl::new(reader, standard(), ());
+            let dispatch = DispatchSlot::<u32>::new();
+            let state =
+                decode_async_state(&mut decoder, Some(&dispatch)).expect("decode raced snapshot");
+            let task_counter: u32 =
+                decode_value(&state.committed_task, "task").expect("decode committed task");
+            let committed_output: CuMsg<u32> =
+                decode_value(&state.committed_output, "output").expect("decode committed output");
+            match state.phase {
+                AsyncPhase::ReplayPending => {
+                    saw_running = true;
+                    assert_eq!(task_counter, 10);
+                    assert!(committed_output.payload().is_none());
+                    assert!(state.pending.is_some());
+                }
+                AsyncPhase::Idle => {
+                    saw_idle = true;
+                    assert_eq!(task_counter, 11);
+                    assert_eq!(committed_output.payload(), Some(&52));
+                    assert!(state.pending.is_none());
+                }
+                AsyncPhase::Running => panic!("decoded keyframe cannot remain actively running"),
+            }
+        }
+        assert!(saw_running, "race did not capture the pre-completion state");
+        assert!(
+            saw_idle,
+            "race did not capture the committed completion state"
+        );
+    }
+
+    #[derive(Clone)]
+    struct ReplaySrcResources {
+        release: Arc<Mutex<mpsc::Receiver<()>>>,
+        observed: mpsc::Sender<(u64, u32)>,
+    }
+
+    #[derive(Reflect)]
+    #[reflect(no_field_bounds, from_reflect = false)]
+    struct ReplaySrc {
+        counter: u32,
+        #[reflect(ignore)]
+        release: Arc<Mutex<mpsc::Receiver<()>>>,
+        #[reflect(ignore)]
+        observed: mpsc::Sender<(u64, u32)>,
+    }
+
+    impl Freezable for ReplaySrc {
+        fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+            self.counter.encode(encoder)
+        }
+
+        fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
+            self.counter = u32::decode(decoder)?;
+            Ok(())
+        }
+    }
+
+    impl CuSrcTask for ReplaySrc {
+        type Resources<'r> = ReplaySrcResources;
+        type Output<'m> = output_msg!(u32);
+
+        fn new(
+            _config: Option<&ComponentConfig>,
+            resources: Self::Resources<'_>,
+        ) -> CuResult<Self> {
+            Ok(Self {
+                counter: 0,
+                release: resources.release,
+                observed: resources.observed,
+            })
+        }
+
+        fn start(&mut self, _ctx: &CuContext) -> CuResult<()> {
+            self.counter = 20;
+            Ok(())
+        }
+
+        fn process(&mut self, ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
+            self.release
+                .lock()
+                .unwrap()
+                .recv_timeout(Duration::from_secs(1))
+                .expect("timed out waiting to release replay source");
+            self.observed
+                .send((ctx.cl_id(), self.counter))
+                .expect("failed to record replay source dispatch");
+            self.counter += 1;
+            output.set_payload(self.counter);
+            Ok(())
+        }
+    }
+
+    fn replay_src_resources() -> (
+        ReplaySrcResources,
+        mpsc::Sender<()>,
+        mpsc::Receiver<(u64, u32)>,
+    ) {
+        let (release_tx, release_rx) = mpsc::channel();
+        let (observed_tx, observed_rx) = mpsc::channel();
+        (
+            ReplaySrcResources {
+                release: Arc::new(Mutex::new(release_rx)),
+                observed: observed_tx,
+            },
+            release_tx,
+            observed_rx,
+        )
+    }
+
+    #[test]
+    fn background_source_freeze_mid_run_replays_original_context() {
+        let tp = Arc::new(ThreadPoolBuilder::new().num_threads(1).build().unwrap());
+        let (resources, release_tx, observed_rx) = replay_src_resources();
+        let (base_context, _) = CuContext::new_mock_clock();
+        let dispatch_context = CuContext::builder(base_context.clock.clone())
+            .cl_id(7)
+            .build();
+        let mut original: CuAsyncSrcTask<ReplaySrc, u32> =
+            CuAsyncSrcTask::new(Some(&ComponentConfig::default()), resources, tp).unwrap();
+        original.start(&dispatch_context).unwrap();
+        let mut output = CuMsg::default();
+        original.process(&dispatch_context, &mut output).unwrap();
+        let frozen = bincode::encode_to_vec(BincodeAdapter(&original), standard())
+            .expect("mid-run async source freeze failed");
+        release_tx.send(()).unwrap();
+        assert_eq!(
+            observed_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            (7, 20)
+        );
+
+        let replay_tp = Arc::new(ThreadPoolBuilder::new().num_threads(1).build().unwrap());
+        let (replay_resources, replay_release_tx, replay_observed_rx) = replay_src_resources();
+        let mut restored: CuAsyncSrcTask<ReplaySrc, u32> = CuAsyncSrcTask::new(
+            Some(&ComponentConfig::default()),
+            replay_resources,
+            replay_tp,
+        )
+        .unwrap();
+        restored.start(&dispatch_context).unwrap();
+        let reader = bincode::de::read::SliceReader::new(&frozen);
+        let mut decoder = bincode::de::DecoderImpl::new(reader, standard(), ());
+        restored.thaw(&mut decoder).unwrap();
+        let current_context = CuContext::builder(base_context.clock.clone())
+            .cl_id(99)
+            .build();
+        restored.process(&current_context, &mut output).unwrap();
+        replay_release_tx.send(()).unwrap();
+        assert_eq!(
+            replay_observed_rx
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap(),
+            (7, 20)
+        );
     }
 }

--- a/core/cu29_runtime/src/cuasynctask.rs
+++ b/core/cu29_runtime/src/cuasynctask.rs
@@ -1,5 +1,5 @@
 use crate::config::ComponentConfig;
-use crate::context::{CuContext, CuContextSnapshot};
+use crate::context::CuContext;
 use crate::cutask::{BincodeAdapter, CuMsg, CuMsgPayload, CuSrcTask, CuTask, Freezable};
 use crate::reflect::{Reflect, TypePath};
 use bincode::config::standard;
@@ -12,50 +12,46 @@ use cu29_clock::CuTime;
 use cu29_traits::{CuError, CuResult};
 use rayon::ThreadPool;
 use std::any::Any;
-use std::sync::{Arc, Mutex, RwLock};
+use std::cell::UnsafeCell;
+use std::sync::{Arc, Mutex};
 
-const ASYNC_SNAPSHOT_MAGIC: u32 = 0x4355_4153;
-const ASYNC_SNAPSHOT_VERSION: u8 = 1;
+const ASYNC_IDLE_TAG: u8 = 0xA0;
+const ASYNC_WAITING_TAG: u8 = 0xA1;
+const ASYNC_FAILED_TAG: u8 = 0xA2;
+const ASYNC_PENDING_TAG: u8 = 0xA3;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum AsyncPhase {
+enum AsyncStatus {
     Idle,
-    Running,
-    ReplayPending,
+    Waiting(CuTime),
+    Failed(String),
+    Running(u64),
+    ReplayPending(u64),
 }
 
-struct PendingDispatch {
-    context: CuContextSnapshot,
-}
-
-struct AsyncState {
-    generation: u64,
-    phase: AsyncPhase,
-    ready_at: Option<CuTime>,
-    last_error: Option<CuError>,
-    last_error_snapshot: Option<String>,
+struct AsyncState<O: CuMsgPayload> {
+    status: AsyncStatus,
     committed_task: Vec<u8>,
-    committed_output: Vec<u8>,
     task_scratch: Vec<u8>,
-    output_scratch: Vec<u8>,
-    pending: Option<PendingDispatch>,
+    committed_output: CuMsg<O>,
 }
 
-impl AsyncState {
+impl<O: CuMsgPayload> AsyncState<O> {
     fn new() -> Self {
         Self {
-            generation: 0,
-            phase: AsyncPhase::Idle,
-            ready_at: None,
-            last_error: None,
-            last_error_snapshot: None,
+            status: AsyncStatus::Idle,
             committed_task: Vec::new(),
-            committed_output: Vec::new(),
             task_scratch: Vec::new(),
-            output_scratch: Vec::new(),
-            pending: None,
+            committed_output: CuMsg::default(),
         }
     }
+}
+
+fn commit_initial_snapshot<O: CuMsgPayload>(state: &mut AsyncState<O>, snapshot: Vec<u8>) {
+    let mut scratch = core::mem::replace(&mut state.committed_task, snapshot);
+    if scratch.capacity() < state.committed_task.len() {
+        scratch.reserve_exact(state.committed_task.len() - scratch.len());
+    }
+    state.task_scratch = scratch;
 }
 
 struct BufferWriter<'a>(&'a mut Vec<u8>);
@@ -81,16 +77,6 @@ fn thaw_from(task: &mut impl Freezable, buffer: &[u8]) -> Result<(), DecodeError
     let reader = bincode::de::read::SliceReader::new(buffer);
     let mut decoder = bincode::de::DecoderImpl::new(reader, standard(), ());
     task.thaw(&mut decoder)
-}
-
-fn decode_value<T: Decode<()>>(buffer: &[u8], label: &str) -> Result<T, DecodeError> {
-    let (value, bytes_read) = bincode::decode_from_slice(buffer, standard())?;
-    if bytes_read != buffer.len() {
-        return Err(DecodeError::OtherString(format!(
-            "async {label} snapshot had trailing bytes"
-        )));
-    }
-    Ok(value)
 }
 
 struct DynWriter<'a>(&'a mut dyn Writer);
@@ -124,8 +110,12 @@ trait ErasedDispatch: Any + Send + Sync {
 }
 
 struct DispatchSlot<I: CuMsgPayload> {
-    input: Arc<RwLock<Option<CuMsg<I>>>>,
+    input: UnsafeCell<CuMsg<I>>,
 }
+
+// SAFETY: the slot is written only before a run is published or while thaw holds the
+// inner-task mutex. While a run is published, workers and keyframes only read it.
+unsafe impl<I: CuMsgPayload + Send + Sync> Sync for DispatchSlot<I> {}
 
 impl<I> DispatchSlot<I>
 where
@@ -133,8 +123,18 @@ where
 {
     fn new() -> Self {
         Self {
-            input: Arc::new(RwLock::new(None)),
+            input: UnsafeCell::new(CuMsg::default()),
         }
+    }
+
+    fn replace(&self, input: CuMsg<I>) -> CuMsg<I> {
+        // SAFETY: callers write only while no worker can hold a reference to the slot.
+        unsafe { core::mem::replace(&mut *self.input.get(), input) }
+    }
+
+    fn get(&self) -> &CuMsg<I> {
+        // SAFETY: published dispatch input remains immutable until the worker finishes.
+        unsafe { &*self.input.get() }
     }
 }
 
@@ -147,189 +147,97 @@ where
     }
 
     fn encode_input(&self, writer: &mut dyn Writer) -> Result<(), EncodeError> {
-        let input = self.input.read().map_err(|_| {
-            EncodeError::OtherString("async task dispatch slot poisoned".to_string())
-        })?;
         let mut encoder = EncoderImpl::new(DynWriter(writer), standard());
-        input.is_some().encode(&mut encoder)?;
-        if let Some(input) = input.as_ref() {
-            input.encode(&mut encoder)?;
-        }
-        Ok(())
+        self.get().encode(&mut encoder)
     }
 
     fn decode_input(&self, reader: &mut dyn Reader) -> Result<(), DecodeError> {
         let mut decoder = bincode::de::DecoderImpl::new(DynReader(reader), standard(), ());
-        let input = if bool::decode(&mut decoder)? {
-            Some(CuMsg::<I>::decode(&mut decoder)?)
-        } else {
-            None
-        };
-        *self.input.write().map_err(|_| {
-            DecodeError::OtherString("async task dispatch slot poisoned".to_string())
-        })? = input;
+        drop(self.replace(CuMsg::<I>::decode(&mut decoder)?));
         Ok(())
     }
 }
 
-fn phase_tag(phase: AsyncPhase) -> u8 {
-    match phase {
-        AsyncPhase::Idle => 0,
-        AsyncPhase::Running => 1,
-        AsyncPhase::ReplayPending => 2,
-    }
+fn failure(error: CuError) -> AsyncStatus {
+    AsyncStatus::Failed(error.to_string())
 }
 
-fn encode_async_state<E>(
-    state: &AsyncState,
-    dispatch: Option<&dyn ErasedDispatch>,
-    encoder: &mut E,
-) -> Result<(), EncodeError>
+fn encode_async_state<O, E>(state: &AsyncState<O>, encoder: &mut E) -> Result<bool, EncodeError>
 where
+    O: CuMsgPayload + Send + 'static,
     E: Encoder,
 {
-    ASYNC_SNAPSHOT_MAGIC.encode(encoder)?;
-    ASYNC_SNAPSHOT_VERSION.encode(encoder)?;
-    phase_tag(state.phase).encode(encoder)?;
-
-    Encode::encode(&state.ready_at, encoder)?;
-    Encode::encode(&state.last_error_snapshot, encoder)?;
     Encode::encode(&state.committed_task, encoder)?;
     Encode::encode(&state.committed_output, encoder)?;
-
-    if let Some(pending) = state.pending.as_ref() {
-        true.encode(encoder)?;
-        pending.context.encode(encoder)?;
-        if let Some(dispatch) = dispatch {
-            dispatch.encode_input(encoder.writer())?;
-        } else {
-            false.encode(encoder)?;
+    match &state.status {
+        AsyncStatus::Idle => {
+            ASYNC_IDLE_TAG.encode(encoder)?;
+            Ok(false)
         }
-    } else {
-        false.encode(encoder)?;
+        AsyncStatus::Waiting(ready_at) => {
+            ASYNC_WAITING_TAG.encode(encoder)?;
+            ready_at.encode(encoder)?;
+            Ok(false)
+        }
+        AsyncStatus::Failed(snapshot) => {
+            ASYNC_FAILED_TAG.encode(encoder)?;
+            snapshot.encode(encoder)?;
+            Ok(false)
+        }
+        AsyncStatus::Running(cl_id) | AsyncStatus::ReplayPending(cl_id) => {
+            ASYNC_PENDING_TAG.encode(encoder)?;
+            cl_id.encode(encoder)?;
+            Ok(true)
+        }
     }
-    Ok(())
 }
 
-fn decode_async_state<D>(
-    decoder: &mut D,
-    dispatch: Option<&dyn ErasedDispatch>,
-) -> Result<AsyncState, DecodeError>
+fn decode_async_state<O, D>(decoder: &mut D) -> Result<AsyncState<O>, DecodeError>
 where
+    O: CuMsgPayload + Send + 'static,
     D: Decoder,
 {
-    let magic = u32::decode(decoder).map_err(|_| {
-        DecodeError::OtherString(
-            "unsupported legacy async keyframe payload; expected version 1".to_string(),
-        )
-    })?;
-    let version = u8::decode(decoder)?;
-    if magic != ASYNC_SNAPSHOT_MAGIC || version != ASYNC_SNAPSHOT_VERSION {
-        return Err(DecodeError::OtherString(format!(
-            "unsupported async keyframe payload version {version}; expected version {ASYNC_SNAPSHOT_VERSION}"
-        )));
-    }
-    let recorded_phase = match u8::decode(decoder)? {
-        0 => AsyncPhase::Idle,
-        1 | 2 => AsyncPhase::ReplayPending,
-        phase => {
+    let committed_task = Decode::decode(decoder)?;
+    let committed_output = CuMsg::<O>::decode(&mut decoder.with_context(()))?;
+    let status = match u8::decode(decoder)? {
+        ASYNC_IDLE_TAG => AsyncStatus::Idle,
+        ASYNC_WAITING_TAG => AsyncStatus::Waiting(Decode::decode(decoder)?),
+        ASYNC_FAILED_TAG => {
+            let snapshot: String = Decode::decode(decoder)?;
+            AsyncStatus::Failed(snapshot)
+        }
+        ASYNC_PENDING_TAG => AsyncStatus::ReplayPending(u64::decode(decoder)?),
+        tag => {
             return Err(DecodeError::OtherString(format!(
-                "invalid async keyframe phase {phase}"
+                "unsupported async keyframe payload tag {tag:#04x}; expected version 1"
             )));
         }
     };
-    let ready_at = Decode::decode(decoder)?;
-    let last_error_snapshot: Option<String> = Decode::decode(decoder)?;
-    let committed_task = Decode::decode(decoder)?;
-    let committed_output = Decode::decode(decoder)?;
-    let pending = if bool::decode(decoder)? {
-        let context = CuContextSnapshot::decode(decoder)?;
-        if let Some(dispatch) = dispatch {
-            dispatch.decode_input(decoder.reader())?;
-        } else if bool::decode(decoder)? {
-            return Err(DecodeError::OtherString(
-                "async task snapshot contains input but no dispatch slot is initialized"
-                    .to_string(),
-            ));
-        }
-        Some(PendingDispatch { context })
-    } else {
-        None
-    };
-    if recorded_phase == AsyncPhase::ReplayPending && pending.is_none() {
-        return Err(DecodeError::OtherString(
-            "async keyframe recorded pending work without a dispatch".to_string(),
-        ));
-    }
     Ok(AsyncState {
-        generation: 0,
-        phase: recorded_phase,
-        ready_at,
-        last_error: last_error_snapshot
-            .as_ref()
-            .map(|error| CuError::from(error.as_str())),
-        last_error_snapshot,
+        status,
         committed_task,
-        committed_output,
         task_scratch: Vec::new(),
-        output_scratch: Vec::new(),
-        pending,
+        committed_output,
     })
 }
 
 type ErasedDispatchSlot = Arc<dyn ErasedDispatch>;
 
-fn dispatch_slot<I>(slot: &Option<ErasedDispatchSlot>) -> CuResult<Arc<RwLock<Option<CuMsg<I>>>>>
+fn dispatch_slot<I>(slot: &ErasedDispatchSlot) -> CuResult<&DispatchSlot<I>>
 where
     I: CuMsgPayload + Send + Sync + 'static,
 {
-    let slot = slot
-        .as_ref()
-        .ok_or_else(|| CuError::from("Async task dispatch slot was not initialized"))?;
     slot.as_any()
         .downcast_ref::<DispatchSlot<I>>()
-        .map(|slot| Arc::clone(&slot.input))
         .ok_or_else(|| CuError::from("Async task dispatch slot type did not match its input"))
 }
 
-fn record_async_task_error<I>(
-    state: &Mutex<AsyncState>,
-    dispatch: &RwLock<Option<CuMsg<I>>>,
-    generation: u64,
-    error: CuError,
-) where
-    I: CuMsgPayload + Send + Sync + 'static,
-{
+fn record_async_error<O: CuMsgPayload>(state: &Mutex<AsyncState<O>>, error: CuError) {
     let mut guard = match state.lock() {
         Ok(guard) => guard,
         Err(poison) => poison.into_inner(),
     };
-    if guard.generation != generation {
-        return;
-    }
-    if let Ok(mut input) = dispatch.write() {
-        *input = None;
-    }
-    guard.phase = AsyncPhase::Idle;
-    guard.ready_at = None;
-    guard.last_error_snapshot = Some(error.to_string());
-    guard.last_error = Some(error);
-    guard.pending = None;
-}
-
-fn record_async_error(state: &Mutex<AsyncState>, generation: u64, error: CuError) {
-    let mut guard = match state.lock() {
-        Ok(guard) => guard,
-        Err(poison) => poison.into_inner(),
-    };
-    if guard.generation != generation {
-        return;
-    }
-    guard.phase = AsyncPhase::Idle;
-    guard.ready_at = None;
-    guard.last_error_snapshot = Some(error.to_string());
-    guard.last_error = Some(error);
-    guard.pending = None;
+    guard.status = failure(error);
 }
 
 #[derive(Reflect)]
@@ -342,9 +250,7 @@ where
     #[reflect(ignore)]
     task: Arc<Mutex<T>>,
     #[reflect(ignore)]
-    output: Arc<Mutex<CuMsg<O>>>,
-    #[reflect(ignore)]
-    state: Arc<Mutex<AsyncState>>,
+    state: Arc<Mutex<AsyncState<O>>>,
     #[reflect(ignore)]
     dispatch: Option<ErasedDispatchSlot>,
     #[reflect(ignore)]
@@ -395,10 +301,8 @@ where
         tp: Arc<ThreadPool>,
     ) -> CuResult<Self> {
         let task = Arc::new(Mutex::new(T::new(config, resources)?));
-        let output = Arc::new(Mutex::new(CuMsg::default()));
         Ok(Self {
             task,
-            output,
             state: Arc::new(Mutex::new(AsyncState::new())),
             dispatch: None,
             tp,
@@ -409,8 +313,8 @@ where
     where
         I: CuMsgPayload + Send + Sync + 'static,
     {
-        if self.dispatch.is_some() {
-            let _ = dispatch_slot::<I>(&self.dispatch)?;
+        if let Some(dispatch) = self.dispatch.as_ref() {
+            let _ = dispatch_slot::<I>(dispatch)?;
         } else {
             self.dispatch = Some(Arc::new(DispatchSlot::<I>::new()));
         }
@@ -428,29 +332,42 @@ where
             .state
             .lock()
             .map_err(|_| EncodeError::OtherString("async task state mutex poisoned".to_string()))?;
-        encode_async_state(&state, self.dispatch.as_deref(), encoder)
+        let pending = encode_async_state(&state, encoder)?;
+        if pending {
+            self.dispatch
+                .as_ref()
+                .ok_or_else(|| {
+                    EncodeError::OtherString(
+                        "async task pending before dispatch initialization".to_string(),
+                    )
+                })?
+                .encode_input(encoder.writer())?;
+        }
+        Ok(())
     }
 
     fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
-        let mut restored_state = decode_async_state(decoder, self.dispatch.as_deref())?;
-        let restored_output: CuMsg<O> =
-            decode_value(&restored_state.committed_output, "task output")?;
-
         let mut task = self
             .task
             .lock()
             .map_err(|_| DecodeError::OtherString("async task mutex poisoned".to_string()))?;
+        let restored_state = decode_async_state(decoder)?;
+        if matches!(restored_state.status, AsyncStatus::ReplayPending(_)) {
+            self.dispatch
+                .as_ref()
+                .ok_or_else(|| {
+                    DecodeError::OtherString(
+                        "async task restored before dispatch initialization".to_string(),
+                    )
+                })?
+                .decode_input(decoder.reader())?;
+        }
         thaw_from(&mut *task, &restored_state.committed_task)?;
 
-        let mut output = self.output.lock().map_err(|_| {
-            DecodeError::OtherString("async task output mutex poisoned".to_string())
-        })?;
-        *output = restored_output;
         let mut state = self
             .state
             .lock()
             .map_err(|_| DecodeError::OtherString("async task state mutex poisoned".to_string()))?;
-        restored_state.generation = state.generation.wrapping_add(1);
         *state = restored_state;
         Ok(())
     }
@@ -488,16 +405,7 @@ where
         freeze_into(&*task, &mut snapshot).map_err(|error| {
             CuError::from("Failed to snapshot async task after start").with_cause(error)
         })?;
-        state.task_scratch = core::mem::replace(&mut state.committed_task, snapshot);
-        let output = self
-            .output
-            .lock()
-            .map_err(|_| CuError::from("Async task output mutex poisoned during start"))?;
-        let mut output_snapshot = core::mem::take(&mut state.output_scratch);
-        encode_value_into(&*output, &mut output_snapshot).map_err(|error| {
-            CuError::from("Failed to snapshot async task output after start").with_cause(error)
-        })?;
-        state.output_scratch = core::mem::replace(&mut state.committed_output, output_snapshot);
+        commit_initial_snapshot(&mut state, snapshot);
         Ok(())
     }
 
@@ -507,188 +415,131 @@ where
         input: &Self::Input<'i>,
         real_output: &mut Self::Output<'o>,
     ) -> CuResult<()> {
-        let dispatch = dispatch_slot::<I>(&self.dispatch)?;
-        let (generation, dispatch_context, mut task_snapshot, mut output_snapshot) = {
+        let (dispatch, dispatch_cl_id, mut task_snapshot, retired_input) = {
             let mut state = self.state.lock().map_err(|_| {
                 CuError::from("Async task state mutex poisoned while scheduling background work")
             })?;
-            if let Some(error) = state.last_error.take() {
-                state.last_error_snapshot = None;
-                return Err(error);
+            if matches!(state.status, AsyncStatus::Failed(_)) {
+                let AsyncStatus::Failed(error) =
+                    core::mem::replace(&mut state.status, AsyncStatus::Idle)
+                else {
+                    unreachable!();
+                };
+                return Err(CuError::from(error));
             }
-            if state.phase == AsyncPhase::Running {
+            if matches!(state.status, AsyncStatus::Running(_)) {
                 *real_output = CuMsg::default();
                 return Ok(());
             }
-            if state.phase == AsyncPhase::Idle
-                && let Some(ready_at) = state.ready_at
+            if let AsyncStatus::Waiting(ready_at) = state.status
                 && ctx.now() < ready_at
             {
                 *real_output = CuMsg::default();
                 return Ok(());
             }
 
-            let (dispatch_input, dispatch_context) = if state.phase == AsyncPhase::ReplayPending {
-                let pending = state.pending.take().ok_or_else(|| {
-                    CuError::from("Async replay is pending without a retained dispatch")
-                })?;
-                let has_input = dispatch
-                    .read()
-                    .map_err(|_| CuError::from("Async task dispatch slot poisoned"))?
-                    .is_some();
-                if !has_input {
-                    return Err(CuError::from(
-                        "Async task replay dispatch is missing its input",
-                    ));
-                }
-                (None, pending.context)
+            let dispatch = self
+                .dispatch
+                .as_ref()
+                .ok_or_else(|| CuError::from("Async task dispatch slot was not initialized"))?;
+            let typed_dispatch = dispatch_slot::<I>(dispatch)?;
+            let (dispatch_cl_id, replay_pending) =
+                if let AsyncStatus::ReplayPending(cl_id) = state.status {
+                    (cl_id, true)
+                } else {
+                    (ctx.cl_id(), false)
+                };
+            let retired_input = if replay_pending {
+                CuMsg::default()
             } else {
-                (Some((*input).clone()), ctx.snapshot())
+                typed_dispatch.replace((*input).clone())
             };
-            if let Some(dispatch_input) = dispatch_input {
-                *dispatch
-                    .write()
-                    .map_err(|_| CuError::from("Async task dispatch slot poisoned"))? =
-                    Some(dispatch_input);
-            }
-            state.pending = Some(PendingDispatch {
-                context: dispatch_context.clone(),
-            });
-            state.generation = state.generation.wrapping_add(1);
-            state.phase = AsyncPhase::Running;
-            state.ready_at = None;
+            *real_output = state.committed_output.clone();
+            state.status = AsyncStatus::Running(dispatch_cl_id);
             (
-                state.generation,
-                dispatch_context,
+                dispatch.clone(),
+                dispatch_cl_id,
                 core::mem::take(&mut state.task_scratch),
-                core::mem::take(&mut state.output_scratch),
+                retired_input,
             )
         };
 
-        let buffered_output = self.output.lock().map_err(|_| {
-            let error = CuError::from("Async task output mutex poisoned");
-            record_async_task_error(&self.state, &dispatch, generation, error.clone());
-            error
-        })?;
-        *real_output = buffered_output.clone();
-        drop(buffered_output);
-
         self.tp.spawn_fifo({
-            let ctx = ctx.restore_snapshot(&dispatch_context);
-            let output = self.output.clone();
+            let ctx = ctx.with_cl_id(dispatch_cl_id);
             let task = self.task.clone();
             let state = self.state.clone();
-            let dispatch = dispatch.clone();
             move || {
-                let input_guard = match dispatch.read() {
-                    Ok(guard) => guard,
-                    Err(_) => {
-                        record_async_task_error(
+                let mut worker_output = CuMsg::default();
+                let typed_dispatch =
+                    if let Some(slot) = dispatch.as_any().downcast_ref::<DispatchSlot<I>>() {
+                        slot
+                    } else {
+                        record_async_error(
                             &state,
-                            &dispatch,
-                            generation,
-                            CuError::from("Async task dispatch slot poisoned"),
+                            CuError::from("Async task dispatch slot type did not match its input"),
                         );
                         return;
-                    }
-                };
-                let input_ref = if let Some(input_ref) = input_guard.as_ref() {
-                    input_ref
-                } else {
-                    drop(input_guard);
-                    record_async_task_error(
-                        &state,
-                        &dispatch,
-                        generation,
-                        CuError::from("Async task dispatch input disappeared before execution"),
-                    );
-                    return;
-                };
+                    };
+                let input_ref = typed_dispatch.get();
                 let mut task_guard = match task.lock() {
                     Ok(guard) => guard,
                     Err(poison) => {
-                        drop(input_guard);
-                        record_async_task_error(
+                        record_async_error(
                             &state,
-                            &dispatch,
-                            generation,
                             CuError::from(format!("Async task mutex poisoned: {poison}")),
                         );
                         return;
                     }
                 };
-                let mut output_guard = match output.lock() {
-                    Ok(guard) => guard,
-                    Err(_) => {
-                        drop(input_guard);
-                        record_async_task_error(
-                            &state,
-                            &dispatch,
-                            generation,
-                            CuError::from("Async task output mutex poisoned"),
-                        );
-                        return;
-                    }
-                };
-                let output_ref: &mut CuMsg<O> = &mut output_guard;
-
                 // Each async run starts from an empty output so a task that
                 // chooses not to publish does not leak the previous payload.
-                *output_ref = CuMsg::default();
-
                 // Track the actual processing interval so replay can honor it.
-                if output_ref.metadata.process_time.start.is_none() {
-                    output_ref.metadata.process_time.start = ctx.now().into();
+                if worker_output.metadata.process_time.start.is_none() {
+                    worker_output.metadata.process_time.start = ctx.now().into();
                 }
-                let task_result = task_guard.process(&ctx, input_ref, output_ref);
+                let task_result = task_guard.process(&ctx, input_ref, &mut worker_output);
                 let fallback_end = ctx.now();
-                let end_from_metadata: Option<CuTime> = output_ref.metadata.process_time.end.into();
+                let end_from_metadata: Option<CuTime> =
+                    worker_output.metadata.process_time.end.into();
                 let ready_at = end_from_metadata.unwrap_or_else(|| {
-                    output_ref.metadata.process_time.end = fallback_end.into();
+                    worker_output.metadata.process_time.end = fallback_end.into();
                     fallback_end
                 });
-                let snapshot_result = freeze_into(&*task_guard, &mut task_snapshot)
-                    .and_then(|()| encode_value_into(output_ref, &mut output_snapshot));
-                drop(output_guard);
-                drop(task_guard);
-                drop(input_guard);
+                let snapshot_result = freeze_into(&*task_guard, &mut task_snapshot);
+                let (commit_snapshot, status) = match snapshot_result {
+                    Ok(()) => (
+                        true,
+                        match task_result {
+                            Ok(()) => AsyncStatus::Waiting(ready_at),
+                            Err(error) => failure(error),
+                        },
+                    ),
+                    Err(error) => (
+                        false,
+                        failure(
+                            CuError::from("Failed to snapshot completed async task")
+                                .with_cause(error),
+                        ),
+                    ),
+                };
 
                 let mut guard = state.lock().unwrap_or_else(|poison| poison.into_inner());
-                if guard.generation != generation {
-                    return;
-                }
-                if let Ok(mut input) = dispatch.write() {
-                    *input = None;
-                }
-                match snapshot_result {
-                    Ok(()) => {
-                        guard.task_scratch =
-                            core::mem::replace(&mut guard.committed_task, task_snapshot);
-                        guard.output_scratch =
-                            core::mem::replace(&mut guard.committed_output, output_snapshot);
-                        guard.phase = AsyncPhase::Idle;
-                        guard.pending = None;
-                        match task_result {
-                            Ok(()) => guard.ready_at = Some(ready_at),
-                            Err(error) => {
-                                guard.ready_at = None;
-                                guard.last_error_snapshot = Some(error.to_string());
-                                guard.last_error = Some(error);
-                            }
-                        }
-                    }
-                    Err(error) => {
-                        guard.task_scratch = task_snapshot;
-                        guard.output_scratch = output_snapshot;
-                        guard.phase = AsyncPhase::Idle;
-                        guard.pending = None;
-                        guard.ready_at = None;
-                        let error = CuError::from("Failed to snapshot completed async task")
-                            .with_cause(error);
-                        guard.last_error_snapshot = Some(error.to_string());
-                        guard.last_error = Some(error);
-                    }
-                }
+                let retired_output = if commit_snapshot {
+                    guard.task_scratch =
+                        core::mem::replace(&mut guard.committed_task, task_snapshot);
+                    Some(core::mem::replace(
+                        &mut guard.committed_output,
+                        worker_output,
+                    ))
+                } else {
+                    guard.task_scratch = task_snapshot;
+                    None
+                };
+                guard.status = status;
+                drop(guard);
+                drop(task_guard);
+                drop(retired_output);
+                drop(retired_input);
             }
         });
         Ok(())
@@ -713,9 +564,7 @@ where
     #[reflect(ignore)]
     task: Arc<Mutex<T>>,
     #[reflect(ignore)]
-    output: Arc<Mutex<CuMsg<O>>>,
-    #[reflect(ignore)]
-    state: Arc<Mutex<AsyncState>>,
+    state: Arc<Mutex<AsyncState<O>>>,
     #[reflect(ignore)]
     tp: Arc<ThreadPool>,
 }
@@ -764,10 +613,8 @@ where
         tp: Arc<ThreadPool>,
     ) -> CuResult<Self> {
         let task = Arc::new(Mutex::new(T::new(config, resources)?));
-        let output = Arc::new(Mutex::new(CuMsg::default()));
         Ok(Self {
             task,
-            output,
             state: Arc::new(Mutex::new(AsyncState::new())),
             tp,
         })
@@ -783,28 +630,21 @@ where
         let state = self.state.lock().map_err(|_| {
             EncodeError::OtherString("async source state mutex poisoned".to_string())
         })?;
-        encode_async_state(&state, None, encoder)
+        let _ = encode_async_state(&state, encoder)?;
+        Ok(())
     }
 
     fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
-        let mut restored_state = decode_async_state(decoder, None)?;
-        let restored_output: CuMsg<O> =
-            decode_value(&restored_state.committed_output, "source output")?;
-
         let mut task = self
             .task
             .lock()
             .map_err(|_| DecodeError::OtherString("async source mutex poisoned".to_string()))?;
+        let restored_state = decode_async_state(decoder)?;
         thaw_from(&mut *task, &restored_state.committed_task)?;
 
-        let mut output = self.output.lock().map_err(|_| {
-            DecodeError::OtherString("async source output mutex poisoned".to_string())
-        })?;
-        *output = restored_output;
         let mut state = self.state.lock().map_err(|_| {
             DecodeError::OtherString("async source state mutex poisoned".to_string())
         })?;
-        restored_state.generation = state.generation.wrapping_add(1);
         *state = restored_state;
         Ok(())
     }
@@ -839,150 +679,105 @@ where
         freeze_into(&*task, &mut snapshot).map_err(|error| {
             CuError::from("Failed to snapshot async source after start").with_cause(error)
         })?;
-        state.task_scratch = core::mem::replace(&mut state.committed_task, snapshot);
-        let output = self
-            .output
-            .lock()
-            .map_err(|_| CuError::from("Async source output mutex poisoned during start"))?;
-        let mut output_snapshot = core::mem::take(&mut state.output_scratch);
-        encode_value_into(&*output, &mut output_snapshot).map_err(|error| {
-            CuError::from("Failed to snapshot async source output after start").with_cause(error)
-        })?;
-        state.output_scratch = core::mem::replace(&mut state.committed_output, output_snapshot);
+        commit_initial_snapshot(&mut state, snapshot);
         Ok(())
     }
 
     fn process<'o>(&mut self, ctx: &CuContext, real_output: &mut Self::Output<'o>) -> CuResult<()> {
-        let (generation, dispatch_context, mut task_snapshot, mut output_snapshot) = {
+        let (dispatch_cl_id, mut task_snapshot) = {
             let mut state = self.state.lock().map_err(|_| {
                 CuError::from("Async source state mutex poisoned while scheduling background work")
             })?;
-            if let Some(error) = state.last_error.take() {
-                state.last_error_snapshot = None;
-                return Err(error);
+            if matches!(state.status, AsyncStatus::Failed(_)) {
+                let AsyncStatus::Failed(error) =
+                    core::mem::replace(&mut state.status, AsyncStatus::Idle)
+                else {
+                    unreachable!();
+                };
+                return Err(CuError::from(error));
             }
-            if state.phase == AsyncPhase::Running {
+            if matches!(state.status, AsyncStatus::Running(_)) {
                 *real_output = CuMsg::default();
                 return Ok(());
             }
-            if state.phase == AsyncPhase::Idle
-                && let Some(ready_at) = state.ready_at
+            if let AsyncStatus::Waiting(ready_at) = state.status
                 && ctx.now() < ready_at
             {
                 *real_output = CuMsg::default();
                 return Ok(());
             }
 
-            let dispatch_context = if state.phase == AsyncPhase::ReplayPending {
-                let pending = state.pending.take().ok_or_else(|| {
-                    CuError::from("Async source replay is pending without a retained dispatch")
-                })?;
-                pending.context
+            let dispatch_cl_id = if let AsyncStatus::ReplayPending(cl_id) = state.status {
+                cl_id
             } else {
-                ctx.snapshot()
+                ctx.cl_id()
             };
-            state.pending = Some(PendingDispatch {
-                context: dispatch_context.clone(),
-            });
-            state.generation = state.generation.wrapping_add(1);
-            state.phase = AsyncPhase::Running;
-            state.ready_at = None;
-            (
-                state.generation,
-                dispatch_context,
-                core::mem::take(&mut state.task_scratch),
-                core::mem::take(&mut state.output_scratch),
-            )
+            *real_output = state.committed_output.clone();
+            state.status = AsyncStatus::Running(dispatch_cl_id);
+            (dispatch_cl_id, core::mem::take(&mut state.task_scratch))
         };
 
-        let buffered_output = self.output.lock().map_err(|_| {
-            let error = CuError::from("Async source output mutex poisoned");
-            record_async_error(&self.state, generation, error.clone());
-            error
-        })?;
-        *real_output = buffered_output.clone();
-        drop(buffered_output);
-
         self.tp.spawn_fifo({
-            let ctx = ctx.restore_snapshot(&dispatch_context);
-            let output = self.output.clone();
+            let ctx = ctx.with_cl_id(dispatch_cl_id);
             let task = self.task.clone();
             let state = self.state.clone();
             move || {
+                let mut worker_output = CuMsg::default();
                 let mut task_guard = match task.lock() {
                     Ok(guard) => guard,
                     Err(poison) => {
                         record_async_error(
                             &state,
-                            generation,
                             CuError::from(format!("Async source mutex poisoned: {poison}")),
                         );
                         return;
                     }
                 };
-                let mut output_guard = match output.lock() {
-                    Ok(guard) => guard,
-                    Err(_) => {
-                        record_async_error(
-                            &state,
-                            generation,
-                            CuError::from("Async task output mutex poisoned"),
-                        );
-                        return;
-                    }
-                };
-                let output_ref: &mut CuMsg<O> = &mut output_guard;
-
-                *output_ref = CuMsg::default();
-
-                if output_ref.metadata.process_time.start.is_none() {
-                    output_ref.metadata.process_time.start = ctx.now().into();
+                if worker_output.metadata.process_time.start.is_none() {
+                    worker_output.metadata.process_time.start = ctx.now().into();
                 }
-                let task_result = task_guard.process(&ctx, output_ref);
+                let task_result = task_guard.process(&ctx, &mut worker_output);
                 let fallback_end = ctx.now();
-                let end_from_metadata: Option<CuTime> = output_ref.metadata.process_time.end.into();
+                let end_from_metadata: Option<CuTime> =
+                    worker_output.metadata.process_time.end.into();
                 let ready_at = end_from_metadata.unwrap_or_else(|| {
-                    output_ref.metadata.process_time.end = fallback_end.into();
+                    worker_output.metadata.process_time.end = fallback_end.into();
                     fallback_end
                 });
-                let snapshot_result = freeze_into(&*task_guard, &mut task_snapshot)
-                    .and_then(|()| encode_value_into(output_ref, &mut output_snapshot));
-                drop(output_guard);
-                drop(task_guard);
+                let snapshot_result = freeze_into(&*task_guard, &mut task_snapshot);
+                let (commit_snapshot, status) = match snapshot_result {
+                    Ok(()) => (
+                        true,
+                        match task_result {
+                            Ok(()) => AsyncStatus::Waiting(ready_at),
+                            Err(error) => failure(error),
+                        },
+                    ),
+                    Err(error) => (
+                        false,
+                        failure(
+                            CuError::from("Failed to snapshot completed async source")
+                                .with_cause(error),
+                        ),
+                    ),
+                };
 
                 let mut guard = state.lock().unwrap_or_else(|poison| poison.into_inner());
-                if guard.generation != generation {
-                    return;
-                }
-                match snapshot_result {
-                    Ok(()) => {
-                        guard.task_scratch =
-                            core::mem::replace(&mut guard.committed_task, task_snapshot);
-                        guard.output_scratch =
-                            core::mem::replace(&mut guard.committed_output, output_snapshot);
-                        guard.phase = AsyncPhase::Idle;
-                        guard.pending = None;
-                        match task_result {
-                            Ok(()) => guard.ready_at = Some(ready_at),
-                            Err(error) => {
-                                guard.ready_at = None;
-                                guard.last_error_snapshot = Some(error.to_string());
-                                guard.last_error = Some(error);
-                            }
-                        }
-                    }
-                    Err(error) => {
-                        guard.task_scratch = task_snapshot;
-                        guard.output_scratch = output_snapshot;
-                        guard.phase = AsyncPhase::Idle;
-                        guard.pending = None;
-                        guard.ready_at = None;
-                        let error = CuError::from("Failed to snapshot completed async source")
-                            .with_cause(error);
-                        guard.last_error_snapshot = Some(error.to_string());
-                        guard.last_error = Some(error);
-                    }
-                }
+                let retired_output = if commit_snapshot {
+                    guard.task_scratch =
+                        core::mem::replace(&mut guard.committed_task, task_snapshot);
+                    Some(core::mem::replace(
+                        &mut guard.committed_output,
+                        worker_output,
+                    ))
+                } else {
+                    guard.task_scratch = task_snapshot;
+                    None
+                };
+                guard.status = status;
+                drop(guard);
+                drop(task_guard);
+                drop(retired_output);
             }
         });
         Ok(())
@@ -1126,7 +921,7 @@ mod tests {
     {
         for _ in 0..100 {
             let state = async_task.state.lock().unwrap();
-            if state.phase != AsyncPhase::Running {
+            if !matches!(state.status, AsyncStatus::Running(_)) {
                 return;
             }
             drop(state);
@@ -1142,7 +937,7 @@ mod tests {
     {
         for _ in 0..100 {
             let state = async_task.state.lock().unwrap();
-            if state.phase != AsyncPhase::Running {
+            if !matches!(state.status, AsyncStatus::Running(_)) {
                 return;
             }
             drop(state);
@@ -1491,20 +1286,18 @@ mod tests {
             .recv_timeout(Duration::from_secs(1))
             .expect("background task never finished");
         // Wait until the async wrapper has cleared its processing flag and captured ready_at.
-        let mut ready_at_recorded = None;
+        let mut ready_at_recorded = false;
         for _ in 0..100 {
             let state = async_task.state.lock().unwrap();
-            if state.phase != AsyncPhase::Running {
-                ready_at_recorded = state.ready_at;
-                if ready_at_recorded.is_some() {
-                    break;
-                }
+            if matches!(state.status, AsyncStatus::Waiting(_)) {
+                ready_at_recorded = true;
+                break;
             }
             drop(state);
             std::thread::sleep(Duration::from_millis(1));
         }
         assert!(
-            ready_at_recorded.is_some(),
+            ready_at_recorded,
             "background task finished without recording ready_at"
         );
 
@@ -1635,20 +1428,18 @@ mod tests {
             .recv_timeout(Duration::from_secs(1))
             .expect("background source never finished");
 
-        let mut ready_at_recorded = None;
+        let mut ready_at_recorded = false;
         for _ in 0..100 {
             let state = async_src.state.lock().unwrap();
-            if state.phase != AsyncPhase::Running {
-                ready_at_recorded = state.ready_at;
-                if ready_at_recorded.is_some() {
-                    break;
-                }
+            if matches!(state.status, AsyncStatus::Waiting(_)) {
+                ready_at_recorded = true;
+                break;
             }
             drop(state);
             std::thread::sleep(Duration::from_millis(1));
         }
         assert!(
-            ready_at_recorded.is_some(),
+            ready_at_recorded,
             "background source finished without recording ready_at"
         );
 
@@ -1667,10 +1458,12 @@ mod tests {
         let _ = done_rx.recv_timeout(Duration::from_secs(1));
     }
 
+    type ReplayTaskObservation = (u32, u64, u32, u32);
+
     #[derive(Clone)]
     struct ReplayTaskResources {
         release: Arc<Mutex<mpsc::Receiver<()>>>,
-        observed: mpsc::Sender<(u32, u64, u32)>,
+        observed: mpsc::Sender<ReplayTaskObservation>,
     }
 
     #[derive(Reflect)]
@@ -1680,7 +1473,7 @@ mod tests {
         #[reflect(ignore)]
         release: Arc<Mutex<mpsc::Receiver<()>>>,
         #[reflect(ignore)]
-        observed: mpsc::Sender<(u32, u64, u32)>,
+        observed: mpsc::Sender<ReplayTaskObservation>,
     }
 
     impl Freezable for ReplayTask {
@@ -1728,7 +1521,7 @@ mod tests {
                 .expect("timed out waiting to release replay task");
             let input = input.payload().copied().expect("replay task input");
             self.observed
-                .send((input, ctx.cl_id(), self.counter))
+                .send((input, ctx.cl_id(), ctx.instance_id(), self.counter))
                 .expect("failed to record replay task dispatch");
             self.counter += 1;
             output.set_payload(input + self.counter);
@@ -1739,7 +1532,7 @@ mod tests {
     fn replay_task_resources() -> (
         ReplayTaskResources,
         mpsc::Sender<()>,
-        mpsc::Receiver<(u32, u64, u32)>,
+        mpsc::Receiver<ReplayTaskObservation>,
     ) {
         let (release_tx, release_rx) = mpsc::channel();
         let (observed_tx, observed_rx) = mpsc::channel();
@@ -1775,15 +1568,33 @@ mod tests {
 
         let frozen = bincode::encode_to_vec(BincodeAdapter(&original), standard())
             .expect("mid-run async freeze failed");
+        let committed_task = bincode::encode_to_vec(10u32, standard()).unwrap();
+        let expected = bincode::encode_to_vec(
+            (
+                committed_task,
+                CuMsg::<u32>::default(),
+                ASYNC_PENDING_TAG,
+                7u64,
+                original_input.clone(),
+            ),
+            standard(),
+        )
+        .unwrap();
         assert_eq!(
-            original.state.lock().unwrap().phase,
-            AsyncPhase::Running,
+            frozen, expected,
+            "pending task frames contain only committed state, CL id, and input"
+        );
+        assert!(
+            matches!(
+                original.state.lock().unwrap().status,
+                AsyncStatus::Running(7)
+            ),
             "freezing must not disturb the live worker"
         );
         release_tx.send(()).unwrap();
         assert_eq!(
             observed_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
-            (41, 7, 10)
+            (41, 7, 3, 10)
         );
 
         let replay_tp = Arc::new(ThreadPoolBuilder::new().num_threads(1).build().unwrap());
@@ -1798,15 +1609,17 @@ mod tests {
         let reader = bincode::de::read::SliceReader::new(&frozen);
         let mut decoder = bincode::de::DecoderImpl::new(reader, standard(), ());
         restored.thaw(&mut decoder).unwrap();
-        assert_eq!(
-            restored.state.lock().unwrap().phase,
-            AsyncPhase::ReplayPending
-        );
+        assert!(matches!(
+            restored.state.lock().unwrap().status,
+            AsyncStatus::ReplayPending(7)
+        ));
 
-        let current_context = CuContext::builder(base_context.clock.clone())
+        let mut current_context = CuContext::builder(base_context.clock.clone())
             .cl_id(99)
             .instance_id(8)
+            .task_ids(&["replay"])
             .build();
+        current_context.set_current_task(0);
         let current_input = CuMsg::new(Some(999u32));
         restored
             .process(&current_context, &current_input, &mut output)
@@ -1816,8 +1629,8 @@ mod tests {
             replay_observed_rx
                 .recv_timeout(Duration::from_secs(1))
                 .unwrap(),
-            (41, 7, 10),
-            "replay must ignore the current CopperList input and context"
+            (41, 7, 8, 10),
+            "replay must retain only the original input and CopperList id"
         );
         wait_until_async_idle(&restored);
 
@@ -1865,8 +1678,7 @@ mod tests {
         {
             let mut state = original.state.lock().unwrap();
             let error = CuError::from("expected async failure");
-            state.last_error_snapshot = Some(error.to_string());
-            state.last_error = Some(error);
+            state.status = failure(error);
         }
         let frozen = bincode::encode_to_vec(BincodeAdapter(&original), standard()).unwrap();
 
@@ -1909,7 +1721,10 @@ mod tests {
                 bincode::encode_to_vec(BincodeAdapter(&async_task), standard())
                     .expect("freeze async task racing completion"),
             );
-            if async_task.state.lock().unwrap().phase == AsyncPhase::Idle {
+            if !matches!(
+                async_task.state.lock().unwrap().status,
+                AsyncStatus::Running(_)
+            ) {
                 break;
             }
             std::thread::yield_now();
@@ -1926,26 +1741,28 @@ mod tests {
             let reader = bincode::de::read::SliceReader::new(&snapshot);
             let mut decoder = bincode::de::DecoderImpl::new(reader, standard(), ());
             let dispatch = DispatchSlot::<u32>::new();
-            let state =
-                decode_async_state(&mut decoder, Some(&dispatch)).expect("decode raced snapshot");
-            let task_counter: u32 =
-                decode_value(&state.committed_task, "task").expect("decode committed task");
-            let committed_output: CuMsg<u32> =
-                decode_value(&state.committed_output, "output").expect("decode committed output");
-            match state.phase {
-                AsyncPhase::ReplayPending => {
+            let state: AsyncState<u32> =
+                decode_async_state(&mut decoder).expect("decode raced snapshot");
+            if matches!(state.status, AsyncStatus::ReplayPending(_)) {
+                dispatch.decode_input(decoder.reader()).unwrap();
+            }
+            let (task_counter, bytes_read): (u32, usize) =
+                bincode::decode_from_slice(&state.committed_task, standard())
+                    .expect("decode committed task");
+            assert_eq!(bytes_read, state.committed_task.len());
+            match state.status {
+                AsyncStatus::ReplayPending(0) => {
                     saw_running = true;
                     assert_eq!(task_counter, 10);
-                    assert!(committed_output.payload().is_none());
-                    assert!(state.pending.is_some());
+                    assert!(state.committed_output.payload().is_none());
+                    assert_eq!(dispatch.get().payload(), Some(&41));
                 }
-                AsyncPhase::Idle => {
+                AsyncStatus::Waiting(_) => {
                     saw_idle = true;
                     assert_eq!(task_counter, 11);
-                    assert_eq!(committed_output.payload(), Some(&52));
-                    assert!(state.pending.is_none());
+                    assert_eq!(state.committed_output.payload(), Some(&52));
                 }
-                AsyncPhase::Running => panic!("decoded keyframe cannot remain actively running"),
+                _ => panic!("decoded keyframe was neither pending nor committed"),
             }
         }
         assert!(saw_running, "race did not capture the pre-completion state");
@@ -2049,6 +1866,21 @@ mod tests {
         original.process(&dispatch_context, &mut output).unwrap();
         let frozen = bincode::encode_to_vec(BincodeAdapter(&original), standard())
             .expect("mid-run async source freeze failed");
+        let committed_task = bincode::encode_to_vec(20u32, standard()).unwrap();
+        let expected = bincode::encode_to_vec(
+            (
+                committed_task,
+                CuMsg::<u32>::default(),
+                ASYNC_PENDING_TAG,
+                7u64,
+            ),
+            standard(),
+        )
+        .unwrap();
+        assert_eq!(
+            frozen, expected,
+            "pending source frames contain no task-only dispatch marker"
+        );
         release_tx.send(()).unwrap();
         assert_eq!(
             observed_rx.recv_timeout(Duration::from_secs(1)).unwrap(),

--- a/core/cu29_runtime/src/curuntime.rs
+++ b/core/cu29_runtime/src/curuntime.rs
@@ -1011,9 +1011,6 @@ pub struct KeyFramesManager {
     /// Bytes written by the last keyframe log
     pub last_encoded_bytes: u64,
 
-    /// Ordinal of the next component snapshot along this execution wave.
-    next_freeze_ordinal: u32,
-
     /// Cold-path sizing accumulator used to reserve the capture buffer before execution.
     capture_size_hint: usize,
 }
@@ -1101,7 +1098,6 @@ impl KeyFramesManager {
             }
             let ts = self.forced_timestamp.take().unwrap_or_else(|| clock.now());
             self.inner.reset(culistid, ts);
-            self.next_freeze_ordinal = 0;
             self.locked = false;
         }
     }
@@ -1124,15 +1120,10 @@ impl KeyFramesManager {
                     culistid, self.inner.culistid
                 )));
             }
-            let ordinal = self.next_freeze_ordinal;
             let encoded = self
                 .inner
-                .add_frozen_task(ordinal, task)
+                .add_frozen_task(task)
                 .map_err(|e| CuError::from(format!("Failed to serialize task: {e}")))?;
-            self.next_freeze_ordinal =
-                self.next_freeze_ordinal.checked_add(1).ok_or_else(|| {
-                    CuError::from("Keyframe contains more component snapshots than u32 can address")
-                })?;
             Ok(encoded)
         } else {
             Ok(0)
@@ -1381,7 +1372,6 @@ where
             last_encoded_bytes: 0,
             forced_timestamp: None,
             locked: false,
-            next_freeze_ordinal: 0,
             capture_size_hint: KEYFRAME_PAYLOAD_HEADER.len(),
         };
         #[cfg(all(feature = "std", feature = "parallel-rt"))]
@@ -1501,7 +1491,6 @@ where
             last_encoded_bytes: 0,
             forced_timestamp: None,
             locked: false,
-            next_freeze_ordinal: 0,
             capture_size_hint: KEYFRAME_PAYLOAD_HEADER.len(),
         };
 
@@ -1557,11 +1546,7 @@ impl KeyFrame {
     }
 
     /// Append one length-framed component snapshot in a single `freeze` pass.
-    fn add_frozen_task(
-        &mut self,
-        ordinal: u32,
-        task: &impl Freezable,
-    ) -> Result<usize, EncodeError> {
+    fn add_frozen_task(&mut self, task: &impl Freezable) -> Result<usize, EncodeError> {
         let cfg = bincode::config::standard();
         let start = self.serialized_tasks.len();
         let payload_offset =
@@ -1575,8 +1560,7 @@ impl KeyFrame {
         }
 
         self.serialized_tasks.resize(payload_offset, 0);
-        self.serialized_tasks[start..start + 4].copy_from_slice(&ordinal.to_le_bytes());
-        let length_offset = start + 4;
+        let length_offset = start;
         self.serialized_tasks[length_offset..payload_offset].fill(0);
 
         let mut encoder =
@@ -1603,13 +1587,12 @@ impl KeyFrame {
 const KEYFRAME_PAYLOAD_MAGIC: &[u8; 4] = b"CUKF";
 const KEYFRAME_PAYLOAD_VERSION: u8 = 1;
 const KEYFRAME_PAYLOAD_HEADER: &[u8; 5] = b"CUKF\x01";
-const KEYFRAME_FRAME_HEADER_LEN: usize = 8;
+const KEYFRAME_FRAME_HEADER_LEN: usize = 4;
 
 /// Reader for the versioned component frames inside a [`KeyFrame`].
 #[doc(hidden)]
 pub struct KeyFramePayloadReader<'a> {
     remaining: &'a [u8],
-    next_ordinal: u32,
 }
 
 impl<'a> KeyFramePayloadReader<'a> {
@@ -1631,31 +1614,16 @@ impl<'a> KeyFramePayloadReader<'a> {
         }
         Ok(Self {
             remaining: &payload[KEYFRAME_PAYLOAD_HEADER.len()..],
-            next_ordinal: 0,
         })
     }
 
-    /// Consume the next frame, validating the distributed-cut ordinal.
+    /// Consume the next component frame in generated execution order.
     pub fn next_frame(&mut self) -> CuResult<&'a [u8]> {
         if self.remaining.len() < KEYFRAME_FRAME_HEADER_LEN {
-            return Err(CuError::from(format!(
-                "Keyframe ended before component frame ordinal {}",
-                self.next_ordinal
-            )));
-        }
-        let ordinal = u32::from_le_bytes(
-            self.remaining[..4]
-                .try_into()
-                .map_err(|_| CuError::from("Invalid keyframe component ordinal"))?,
-        );
-        if ordinal != self.next_ordinal {
-            return Err(CuError::from(format!(
-                "Keyframe component frame out of order: expected ordinal {}, found {}",
-                self.next_ordinal, ordinal
-            )));
+            return Err(CuError::from("Keyframe ended before next component frame"));
         }
         let payload_len = u32::from_le_bytes(
-            self.remaining[4..KEYFRAME_FRAME_HEADER_LEN]
+            self.remaining[..KEYFRAME_FRAME_HEADER_LEN]
                 .try_into()
                 .map_err(|_| CuError::from("Invalid keyframe component frame length"))?,
         ) as usize;
@@ -1663,16 +1631,10 @@ impl<'a> KeyFramePayloadReader<'a> {
             .checked_add(payload_len)
             .ok_or_else(|| CuError::from("Keyframe component frame length overflow"))?;
         if frame_end > self.remaining.len() {
-            return Err(CuError::from(format!(
-                "Keyframe component frame {} is truncated",
-                self.next_ordinal
-            )));
+            return Err(CuError::from("Keyframe component frame is truncated"));
         }
         let payload = &self.remaining[KEYFRAME_FRAME_HEADER_LEN..frame_end];
         self.remaining = &self.remaining[frame_end..];
-        self.next_ordinal = self.next_ordinal.checked_add(1).ok_or_else(|| {
-            CuError::from("Keyframe contains more component frames than u32 can address")
-        })?;
         Ok(payload)
     }
 
@@ -1681,10 +1643,7 @@ impl<'a> KeyFramePayloadReader<'a> {
         if self.remaining.is_empty() {
             Ok(())
         } else {
-            Err(CuError::from(format!(
-                "Keyframe contains trailing data after {} component frames",
-                self.next_ordinal
-            )))
+            Err(CuError::from("Keyframe contains trailing component data"))
         }
     }
 }
@@ -2421,42 +2380,44 @@ mod tests {
             .unwrap();
         keyframe.reset(7, CuTime::from_nanos(70));
         keyframe
-            .add_frozen_task(
-                0,
-                &CountingSnapshot {
-                    calls: &calls,
-                    value: 11,
-                    fail: false,
-                },
-            )
+            .add_frozen_task(&CountingSnapshot {
+                calls: &calls,
+                value: 11,
+                fail: false,
+            })
             .unwrap();
         let committed_len = keyframe.serialized_tasks.len();
 
-        assert!(
-            keyframe
-                .add_frozen_task(
-                    1,
-                    &CountingSnapshot {
-                        calls: &calls,
-                        value: 99,
-                        fail: true,
-                    },
-                )
-                .is_err()
-        );
+        let failing = CountingSnapshot {
+            calls: &calls,
+            value: 99,
+            fail: true,
+        };
+        assert!(keyframe.add_frozen_task(&failing).is_err());
         assert_eq!(keyframe.serialized_tasks.len(), committed_len);
 
         keyframe
-            .add_frozen_task(
-                1,
-                &CountingSnapshot {
-                    calls: &calls,
-                    value: 22,
-                    fail: false,
-                },
-            )
+            .add_frozen_task(&CountingSnapshot {
+                calls: &calls,
+                value: 22,
+                fail: false,
+            })
             .unwrap();
         assert_eq!(calls.get(), 3, "each append must call freeze exactly once");
+        let first_payload_len = bincode::encode_to_vec(11u32, bincode::config::standard())
+            .unwrap()
+            .len();
+        let second_payload_len = bincode::encode_to_vec(22u32, bincode::config::standard())
+            .unwrap()
+            .len();
+        assert_eq!(
+            keyframe.serialized_tasks.len(),
+            KEYFRAME_PAYLOAD_HEADER.len()
+                + 2 * KEYFRAME_FRAME_HEADER_LEN
+                + first_payload_len
+                + second_payload_len,
+            "component frames carry only a length prefix"
+        );
 
         let mut frames = KeyFramePayloadReader::new(&keyframe).unwrap();
         let mut first = SnapshotValue::default();
@@ -2480,14 +2441,11 @@ mod tests {
 
         let allocations = crate::monitoring::ScopedAllocCounter::new();
         keyframe
-            .add_frozen_task(
-                0,
-                &CountingSnapshot {
-                    calls: &calls,
-                    value: 42,
-                    fail: false,
-                },
-            )
+            .add_frozen_task(&CountingSnapshot {
+                calls: &calls,
+                value: 42,
+                fail: false,
+            })
             .unwrap();
 
         assert_eq!(allocations.allocated(), 0);

--- a/core/cu29_runtime/src/curuntime.rs
+++ b/core/cu29_runtime/src/curuntime.rs
@@ -54,9 +54,11 @@ use alloc::collections::{BTreeSet, VecDeque};
 use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
+use bincode::de::read::Reader;
+use bincode::de::{Decoder, DecoderImpl};
 use bincode::enc::EncoderImpl;
-use bincode::enc::write::{SizeWriter, SliceWriter};
-use bincode::error::EncodeError;
+use bincode::enc::write::{SizeWriter, Writer};
+use bincode::error::{DecodeError, EncodeError};
 use bincode::{Decode, Encode};
 #[cfg(all(feature = "std", any(feature = "async-cl-io", feature = "parallel-rt")))]
 use core::alloc::Layout;
@@ -1008,6 +1010,28 @@ pub struct KeyFramesManager {
 
     /// Bytes written by the last keyframe log
     pub last_encoded_bytes: u64,
+
+    /// Ordinal of the next component snapshot along this execution wave.
+    next_freeze_ordinal: u32,
+
+    /// Cold-path sizing accumulator used to reserve the capture buffer before execution.
+    capture_size_hint: usize,
+}
+
+const MIN_KEYFRAME_CAPTURE_CAPACITY: usize = 4 * 1024;
+
+/// A `Vec` writer that is forbidden from growing its backing allocation.
+struct PreallocatedVecWriter<'a>(&'a mut Vec<u8>);
+
+impl Writer for PreallocatedVecWriter<'_> {
+    fn write(&mut self, bytes: &[u8]) -> Result<(), EncodeError> {
+        if bytes.len() > self.0.capacity().saturating_sub(self.0.len()) {
+            return Err(EncodeError::UnexpectedEnd);
+        }
+        // The capacity check above makes this append allocation-free.
+        self.0.extend_from_slice(bytes);
+        Ok(())
+    }
 }
 
 impl KeyFramesManager {
@@ -1020,6 +1044,55 @@ impl KeyFramesManager {
         self.is_keyframe(culistid)
     }
 
+    /// Start a cold-path sizing pass for the next mission's keyframe buffer.
+    #[doc(hidden)]
+    pub fn begin_capture_preallocation(&mut self) {
+        self.capture_size_hint = KEYFRAME_PAYLOAD_HEADER.len();
+    }
+
+    /// Include one component's current frozen size in the cold-path capacity estimate.
+    #[doc(hidden)]
+    pub fn include_capture_capacity(&mut self, item: &impl Freezable) -> CuResult<()> {
+        if self.logger.is_none() {
+            return Ok(());
+        }
+        let mut sizer = EncoderImpl::new(SizeWriter::default(), bincode::config::standard());
+        BincodeAdapter(item)
+            .encode(&mut sizer)
+            .map_err(|_| CuError::from("Failed to size component keyframe state"))?;
+        let payload_bytes = sizer.into_writer().bytes_written as usize;
+        self.capture_size_hint = self
+            .capture_size_hint
+            .checked_add(KEYFRAME_FRAME_HEADER_LEN)
+            .and_then(|size| size.checked_add(payload_bytes))
+            .ok_or_else(|| CuError::from("Keyframe capture capacity overflow"))?;
+        Ok(())
+    }
+
+    /// Reserve the capture buffer before entering the execution loop.
+    #[doc(hidden)]
+    pub fn finish_capture_preallocation(&mut self) -> CuResult<()> {
+        if self.logger.is_none() {
+            return Ok(());
+        }
+        let requested = self
+            .capture_size_hint
+            .max(MIN_KEYFRAME_CAPTURE_CAPACITY)
+            .checked_next_power_of_two()
+            .ok_or_else(|| CuError::from("Keyframe capture capacity overflow"))?;
+        if self.inner.serialized_tasks.capacity() < requested {
+            let additional = requested.saturating_sub(self.inner.serialized_tasks.len());
+            self.inner
+                .serialized_tasks
+                .try_reserve_exact(additional)
+                .map_err(|error| {
+                    CuError::from("Failed to preallocate keyframe capture buffer")
+                        .add_cause(&error.to_string())
+                })?;
+        }
+        Ok(())
+    }
+
     pub fn reset(&mut self, culistid: u64, clock: &RobotClock) {
         if self.is_keyframe(culistid) {
             // If a recorded keyframe was preloaded for this CL, keep it as-is.
@@ -1028,6 +1101,7 @@ impl KeyFramesManager {
             }
             let ts = self.forced_timestamp.take().unwrap_or_else(|| clock.now());
             self.inner.reset(culistid, ts);
+            self.next_freeze_ordinal = 0;
             self.locked = false;
         }
     }
@@ -1050,9 +1124,16 @@ impl KeyFramesManager {
                     culistid, self.inner.culistid
                 )));
             }
-            self.inner
-                .add_frozen_task(task)
-                .map_err(|e| CuError::from(format!("Failed to serialize task: {e}")))
+            let ordinal = self.next_freeze_ordinal;
+            let encoded = self
+                .inner
+                .add_frozen_task(ordinal, task)
+                .map_err(|e| CuError::from(format!("Failed to serialize task: {e}")))?;
+            self.next_freeze_ordinal =
+                self.next_freeze_ordinal.checked_add(1).ok_or_else(|| {
+                    CuError::from("Keyframe contains more component snapshots than u32 can address")
+                })?;
+            Ok(encoded)
         } else {
             Ok(0)
         }
@@ -1300,6 +1381,8 @@ where
             last_encoded_bytes: 0,
             forced_timestamp: None,
             locked: false,
+            next_freeze_ordinal: 0,
+            capture_size_hint: KEYFRAME_PAYLOAD_HEADER.len(),
         };
         #[cfg(all(feature = "std", feature = "parallel-rt"))]
         let parallel_rt = ParallelRt::new(parts.parallel_rt_metadata)?;
@@ -1418,6 +1501,8 @@ where
             last_encoded_bytes: 0,
             forced_timestamp: None,
             locked: false,
+            next_freeze_ordinal: 0,
+            capture_size_hint: KEYFRAME_PAYLOAD_HEADER.len(),
         };
 
         let runtime_config = config.runtime.clone().unwrap_or_default();
@@ -1439,16 +1524,17 @@ where
     }
 }
 
-/// A KeyFrame is recording a snapshot of the tasks state before a given copperlist.
-/// It is a double encapsulation: this one recording the culistid and another even in
-/// bincode in the serialized_tasks.
+/// A keyframe records a distributed snapshot of component state around a copperlist.
+///
+/// `serialized_tasks` contains a versioned sequence of length-framed component
+/// snapshots in their generated execution-wave freeze order.
 #[derive(Clone, Encode, Decode)]
 pub struct KeyFrame {
     // This is the id of the copper list that this keyframe is associated with (recorded before the copperlist).
     pub culistid: u64,
     // This is the timestamp when the keyframe was created, using the robot clock.
     pub timestamp: CuTime,
-    // This is the bincode representation of the tuple of all the tasks.
+    // Versioned, length-framed bincode snapshots of all generated components.
     pub serialized_tasks: Vec<u8>,
 }
 
@@ -1457,7 +1543,7 @@ impl KeyFrame {
         KeyFrame {
             culistid: 0,
             timestamp: CuTime::default(),
-            serialized_tasks: Vec::new(),
+            serialized_tasks: KEYFRAME_PAYLOAD_HEADER.to_vec(),
         }
     }
 
@@ -1466,22 +1552,184 @@ impl KeyFrame {
         self.culistid = culistid;
         self.timestamp = timestamp;
         self.serialized_tasks.clear();
+        self.serialized_tasks
+            .extend_from_slice(KEYFRAME_PAYLOAD_HEADER);
     }
 
-    /// We need to be able to accumulate tasks to the serialization as they are executed after the step.
-    fn add_frozen_task(&mut self, task: &impl Freezable) -> Result<usize, EncodeError> {
+    /// Append one length-framed component snapshot in a single `freeze` pass.
+    fn add_frozen_task(
+        &mut self,
+        ordinal: u32,
+        task: &impl Freezable,
+    ) -> Result<usize, EncodeError> {
         let cfg = bincode::config::standard();
-        let mut sizer = EncoderImpl::<_, _>::new(SizeWriter::default(), cfg);
-        BincodeAdapter(task).encode(&mut sizer)?;
-        let need = sizer.into_writer().bytes_written as usize;
-
         let start = self.serialized_tasks.len();
-        self.serialized_tasks.resize(start + need, 0);
-        let mut enc =
-            EncoderImpl::<_, _>::new(SliceWriter::new(&mut self.serialized_tasks[start..]), cfg);
-        BincodeAdapter(task).encode(&mut enc)?;
-        Ok(need)
+        let payload_offset =
+            start
+                .checked_add(KEYFRAME_FRAME_HEADER_LEN)
+                .ok_or(EncodeError::Other(
+                    "keyframe component frame offset overflow",
+                ))?;
+        if payload_offset > self.serialized_tasks.capacity() {
+            return Err(EncodeError::UnexpectedEnd);
+        }
+
+        self.serialized_tasks.resize(payload_offset, 0);
+        self.serialized_tasks[start..start + 4].copy_from_slice(&ordinal.to_le_bytes());
+        let length_offset = start + 4;
+        self.serialized_tasks[length_offset..payload_offset].fill(0);
+
+        let mut encoder =
+            EncoderImpl::<_, _>::new(PreallocatedVecWriter(&mut self.serialized_tasks), cfg);
+        if let Err(error) = BincodeAdapter(task).encode(&mut encoder) {
+            self.serialized_tasks.truncate(start);
+            return Err(error);
+        }
+        let payload_len = encoder.into_writer().0.len() - payload_offset;
+        let payload_len = u32::try_from(payload_len).map_err(|_| {
+            self.serialized_tasks.truncate(start);
+            EncodeError::OtherString(
+                "keyframe component snapshot exceeds the u32 frame limit".to_string(),
+            )
+        })?;
+        self.serialized_tasks
+            .truncate(payload_offset + payload_len as usize);
+        self.serialized_tasks[length_offset..payload_offset]
+            .copy_from_slice(&payload_len.to_le_bytes());
+        Ok(self.serialized_tasks.len() - start)
     }
+}
+
+const KEYFRAME_PAYLOAD_MAGIC: &[u8; 4] = b"CUKF";
+const KEYFRAME_PAYLOAD_VERSION: u8 = 1;
+const KEYFRAME_PAYLOAD_HEADER: &[u8; 5] = b"CUKF\x01";
+const KEYFRAME_FRAME_HEADER_LEN: usize = 8;
+
+/// Reader for the versioned component frames inside a [`KeyFrame`].
+#[doc(hidden)]
+pub struct KeyFramePayloadReader<'a> {
+    remaining: &'a [u8],
+    next_ordinal: u32,
+}
+
+impl<'a> KeyFramePayloadReader<'a> {
+    /// Validate a keyframe payload and prepare to consume its component frames.
+    pub fn new(keyframe: &'a KeyFrame) -> CuResult<Self> {
+        let payload = keyframe.serialized_tasks.as_slice();
+        if payload.len() < KEYFRAME_PAYLOAD_HEADER.len()
+            || payload[..KEYFRAME_PAYLOAD_MAGIC.len()] != *KEYFRAME_PAYLOAD_MAGIC
+        {
+            return Err(CuError::from(
+                "Unsupported legacy keyframe payload: expected framed format version 1",
+            ));
+        }
+        let version = payload[KEYFRAME_PAYLOAD_MAGIC.len()];
+        if version != KEYFRAME_PAYLOAD_VERSION {
+            return Err(CuError::from(format!(
+                "Unsupported keyframe payload version {version}; expected {KEYFRAME_PAYLOAD_VERSION}"
+            )));
+        }
+        Ok(Self {
+            remaining: &payload[KEYFRAME_PAYLOAD_HEADER.len()..],
+            next_ordinal: 0,
+        })
+    }
+
+    /// Consume the next frame, validating the distributed-cut ordinal.
+    pub fn next_frame(&mut self) -> CuResult<&'a [u8]> {
+        if self.remaining.len() < KEYFRAME_FRAME_HEADER_LEN {
+            return Err(CuError::from(format!(
+                "Keyframe ended before component frame ordinal {}",
+                self.next_ordinal
+            )));
+        }
+        let ordinal = u32::from_le_bytes(
+            self.remaining[..4]
+                .try_into()
+                .map_err(|_| CuError::from("Invalid keyframe component ordinal"))?,
+        );
+        if ordinal != self.next_ordinal {
+            return Err(CuError::from(format!(
+                "Keyframe component frame out of order: expected ordinal {}, found {}",
+                self.next_ordinal, ordinal
+            )));
+        }
+        let payload_len = u32::from_le_bytes(
+            self.remaining[4..KEYFRAME_FRAME_HEADER_LEN]
+                .try_into()
+                .map_err(|_| CuError::from("Invalid keyframe component frame length"))?,
+        ) as usize;
+        let frame_end = KEYFRAME_FRAME_HEADER_LEN
+            .checked_add(payload_len)
+            .ok_or_else(|| CuError::from("Keyframe component frame length overflow"))?;
+        if frame_end > self.remaining.len() {
+            return Err(CuError::from(format!(
+                "Keyframe component frame {} is truncated",
+                self.next_ordinal
+            )));
+        }
+        let payload = &self.remaining[KEYFRAME_FRAME_HEADER_LEN..frame_end];
+        self.remaining = &self.remaining[frame_end..];
+        self.next_ordinal = self.next_ordinal.checked_add(1).ok_or_else(|| {
+            CuError::from("Keyframe contains more component frames than u32 can address")
+        })?;
+        Ok(payload)
+    }
+
+    /// Reject trailing component frames that the generated restore did not consume.
+    pub fn finish(self) -> CuResult<()> {
+        if self.remaining.is_empty() {
+            Ok(())
+        } else {
+            Err(CuError::from(format!(
+                "Keyframe contains trailing data after {} component frames",
+                self.next_ordinal
+            )))
+        }
+    }
+}
+
+struct FrameSliceReader<'a> {
+    remaining: &'a [u8],
+}
+
+impl Reader for FrameSliceReader<'_> {
+    fn read(&mut self, bytes: &mut [u8]) -> Result<(), DecodeError> {
+        if bytes.len() > self.remaining.len() {
+            return Err(DecodeError::UnexpectedEnd {
+                additional: bytes.len() - self.remaining.len(),
+            });
+        }
+        let (read, remaining) = self.remaining.split_at(bytes.len());
+        bytes.copy_from_slice(read);
+        self.remaining = remaining;
+        Ok(())
+    }
+
+    fn peek_read(&mut self, length: usize) -> Option<&[u8]> {
+        self.remaining.get(..length)
+    }
+
+    fn consume(&mut self, length: usize) {
+        self.remaining = self.remaining.get(length..).unwrap_or_default();
+    }
+}
+
+/// Thaw one component from an isolated keyframe frame and require full consumption.
+#[doc(hidden)]
+pub fn thaw_keyframe_component(item: &mut impl Freezable, frame: &[u8]) -> CuResult<()> {
+    let reader = FrameSliceReader { remaining: frame };
+    let mut decoder = DecoderImpl::new(reader, bincode::config::standard(), ());
+    item.thaw(&mut decoder)
+        .map_err(|error| CuError::from(format!("Failed to thaw keyframe component: {error}")))?;
+    let trailing = decoder.reader().remaining.len();
+    if trailing != 0 {
+        return Err(CuError::from(format!(
+            "Keyframe component snapshot has {} trailing bytes",
+            trailing
+        )));
+    }
+    Ok(())
 }
 
 /// Identifies where the effective runtime configuration came from.
@@ -2127,10 +2375,138 @@ mod tests {
     use crate::monitoring::NoMonitor;
     use crate::reflect::Reflect;
     use bincode::Encode;
+    use core::cell::Cell;
     use cu29_traits::{ErasedCuStampedData, ErasedCuStampedDataSet, MatchingTasks};
     use serde_derive::{Deserialize, Serialize};
     #[cfg(feature = "std")]
     use std::sync::{Arc, Mutex};
+
+    struct CountingSnapshot<'a> {
+        calls: &'a Cell<usize>,
+        value: u32,
+        fail: bool,
+    }
+
+    impl Freezable for CountingSnapshot<'_> {
+        fn freeze<E: bincode::enc::Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+            self.calls.set(self.calls.get() + 1);
+            self.value.encode(encoder)?;
+            if self.fail {
+                Err(EncodeError::OtherString(
+                    "intentional freeze failure".to_string(),
+                ))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct SnapshotValue(u32);
+
+    impl Freezable for SnapshotValue {
+        fn thaw<D: bincode::de::Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
+            self.0 = u32::decode(decoder)?;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn keyframe_frames_freeze_once_and_roll_back_only_failed_frame() {
+        let calls = Cell::new(0);
+        let mut keyframe = KeyFrame::new();
+        keyframe
+            .serialized_tasks
+            .try_reserve_exact(MIN_KEYFRAME_CAPTURE_CAPACITY)
+            .unwrap();
+        keyframe.reset(7, CuTime::from_nanos(70));
+        keyframe
+            .add_frozen_task(
+                0,
+                &CountingSnapshot {
+                    calls: &calls,
+                    value: 11,
+                    fail: false,
+                },
+            )
+            .unwrap();
+        let committed_len = keyframe.serialized_tasks.len();
+
+        assert!(
+            keyframe
+                .add_frozen_task(
+                    1,
+                    &CountingSnapshot {
+                        calls: &calls,
+                        value: 99,
+                        fail: true,
+                    },
+                )
+                .is_err()
+        );
+        assert_eq!(keyframe.serialized_tasks.len(), committed_len);
+
+        keyframe
+            .add_frozen_task(
+                1,
+                &CountingSnapshot {
+                    calls: &calls,
+                    value: 22,
+                    fail: false,
+                },
+            )
+            .unwrap();
+        assert_eq!(calls.get(), 3, "each append must call freeze exactly once");
+
+        let mut frames = KeyFramePayloadReader::new(&keyframe).unwrap();
+        let mut first = SnapshotValue::default();
+        thaw_keyframe_component(&mut first, frames.next_frame().unwrap()).unwrap();
+        let mut second = SnapshotValue::default();
+        thaw_keyframe_component(&mut second, frames.next_frame().unwrap()).unwrap();
+        frames.finish().unwrap();
+        assert_eq!((first.0, second.0), (11, 22));
+    }
+
+    #[cfg(all(feature = "std", feature = "memory_monitoring"))]
+    #[test]
+    fn preallocated_keyframe_append_does_not_allocate() {
+        let calls = Cell::new(0);
+        let mut keyframe = KeyFrame::new();
+        keyframe
+            .serialized_tasks
+            .try_reserve_exact(MIN_KEYFRAME_CAPTURE_CAPACITY)
+            .unwrap();
+        keyframe.reset(3, CuTime::from_nanos(30));
+
+        let allocations = crate::monitoring::ScopedAllocCounter::new();
+        keyframe
+            .add_frozen_task(
+                0,
+                &CountingSnapshot {
+                    calls: &calls,
+                    value: 42,
+                    fail: false,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(allocations.allocated(), 0);
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[test]
+    fn keyframe_reader_rejects_legacy_payload_clearly() {
+        let keyframe = KeyFrame {
+            culistid: 0,
+            timestamp: CuTime::default(),
+            serialized_tasks: vec![0, 1, 2],
+        };
+        let error = match KeyFramePayloadReader::new(&keyframe) {
+            Ok(_) => panic!("legacy payload unexpectedly accepted"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("legacy keyframe payload"));
+    }
 
     #[derive(Reflect)]
     pub struct TestSource {}

--- a/core/cu29_runtime/src/debug.rs
+++ b/core/cu29_runtime/src/debug.rs
@@ -1017,19 +1017,10 @@ where
 }
 
 fn nearest_replay_anchor(keyframes: &[KeyFrame], target_culistid: u64) -> Option<KeyFrame> {
-    // Nonzero runtime keyframes are currently frozen task-by-task immediately before each
-    // task process step, so restoring one and replaying from the top of the CL can create a
-    // mixed task-boundary state. The initial keyframe is still a coherent replay anchor.
     keyframes
         .iter()
-        .filter(|kf| kf.culistid == 0 && kf.culistid <= target_culistid)
+        .filter(|kf| kf.culistid <= target_culistid)
         .max_by_key(|kf| kf.culistid)
-        .or_else(|| {
-            keyframes
-                .iter()
-                .filter(|kf| kf.culistid <= target_culistid)
-                .min_by_key(|kf| kf.culistid)
-        })
         .cloned()
 }
 
@@ -1046,21 +1037,21 @@ mod tests {
     }
 
     #[test]
-    fn replay_anchor_prefers_initial_keyframe_over_later_task_boundary_keyframes() {
+    fn replay_anchor_selects_nearest_keyframe_at_or_before_target() {
         let keyframes = [keyframe(0), keyframe(100), keyframe(500)];
 
         let anchor = nearest_replay_anchor(&keyframes, 533).expect("replay anchor");
 
-        assert_eq!(anchor.culistid, 0);
+        assert_eq!(anchor.culistid, 500);
     }
 
     #[test]
-    fn replay_anchor_falls_back_to_earliest_keyframe_without_initial_anchor() {
+    fn replay_anchor_uses_nearest_available_nonzero_keyframe() {
         let keyframes = [keyframe(100), keyframe(500), keyframe(900)];
 
         let anchor = nearest_replay_anchor(&keyframes, 533).expect("replay anchor");
 
-        assert_eq!(anchor.culistid, 100);
+        assert_eq!(anchor.culistid, 500);
         assert!(nearest_replay_anchor(&keyframes, 99).is_none());
     }
 }

--- a/core/cu29_runtime/tests/async_keyframes.rs
+++ b/core/cu29_runtime/tests/async_keyframes.rs
@@ -1,0 +1,189 @@
+#![cfg(all(test, feature = "std"))]
+
+use bincode::{Decode, Encode};
+use cu29::bincode::de::Decoder;
+use cu29::bincode::enc::Encoder;
+use cu29::bincode::error::{DecodeError, EncodeError};
+use cu29::curuntime::KeyFramePayloadReader;
+use cu29::prelude::*;
+use cu29_export::keyframes_reader;
+use cu29_unifiedlog::memmap::{MmapSectionStorage, MmapUnifiedLoggerWrite};
+use cu29_unifiedlog::{UnifiedLogger, UnifiedLoggerBuilder, UnifiedLoggerIOReader};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[derive(Default, Debug, Clone, Encode, Decode, Serialize, Deserialize, Reflect)]
+struct WorkMsg(u32);
+
+#[derive(Reflect)]
+struct SlowSource {
+    next: u32,
+    #[reflect(ignore)]
+    delay: Duration,
+}
+
+impl Freezable for SlowSource {
+    fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        Encode::encode(&self.next, encoder)
+    }
+
+    fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
+        self.next = Decode::decode(decoder)?;
+        Ok(())
+    }
+}
+
+impl CuSrcTask for SlowSource {
+    type Resources<'r> = ();
+    type Output<'m> = output_msg!(WorkMsg);
+
+    fn new(config: Option<&ComponentConfig>, _resources: ()) -> CuResult<Self> {
+        let config = config.ok_or_else(|| CuError::from("SlowSource needs config"))?;
+        let sleep_ms = config
+            .get::<u64>("sleep_ms")?
+            .ok_or_else(|| CuError::from("SlowSource needs sleep_ms"))?;
+        Ok(Self {
+            next: 0,
+            delay: Duration::from_millis(sleep_ms),
+        })
+    }
+
+    fn process(&mut self, _ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
+        std::thread::sleep(self.delay);
+        self.next += 1;
+        output.set_payload(WorkMsg(self.next));
+        Ok(())
+    }
+}
+
+#[derive(Reflect)]
+struct SlowTask {
+    completed: u32,
+    #[reflect(ignore)]
+    delay: Duration,
+}
+
+impl Freezable for SlowTask {
+    fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        Encode::encode(&self.completed, encoder)
+    }
+
+    fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
+        self.completed = Decode::decode(decoder)?;
+        Ok(())
+    }
+}
+
+impl CuTask for SlowTask {
+    type Resources<'r> = ();
+    type Input<'m> = input_msg!(WorkMsg);
+    type Output<'m> = output_msg!(WorkMsg);
+
+    fn new(config: Option<&ComponentConfig>, _resources: ()) -> CuResult<Self> {
+        let config = config.ok_or_else(|| CuError::from("SlowTask needs config"))?;
+        let sleep_ms = config
+            .get::<u64>("sleep_ms")?
+            .ok_or_else(|| CuError::from("SlowTask needs sleep_ms"))?;
+        Ok(Self {
+            completed: 0,
+            delay: Duration::from_millis(sleep_ms),
+        })
+    }
+
+    fn process(
+        &mut self,
+        _ctx: &CuContext,
+        input: &Self::Input<'_>,
+        output: &mut Self::Output<'_>,
+    ) -> CuResult<()> {
+        std::thread::sleep(self.delay);
+        self.completed += 1;
+        output.set_payload(WorkMsg(
+            input.payload().map(|payload| payload.0).unwrap_or_default() + 1,
+        ));
+        Ok(())
+    }
+}
+
+#[derive(Reflect)]
+struct OutputSink;
+
+impl Freezable for OutputSink {}
+
+impl CuSinkTask for OutputSink {
+    type Resources<'r> = ();
+    type Input<'m> = input_msg!(WorkMsg);
+
+    fn new(_config: Option<&ComponentConfig>, _resources: ()) -> CuResult<Self> {
+        Ok(Self)
+    }
+
+    fn process(&mut self, _ctx: &CuContext, _input: &Self::Input<'_>) -> CuResult<()> {
+        Ok(())
+    }
+}
+
+#[copper_runtime(config = "tests/async_keyframes_config.ron")]
+struct AsyncKeyframeApp {}
+
+fn build_logger(path: &Path) -> CuResult<Arc<Mutex<MmapUnifiedLoggerWrite>>> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| CuError::new_with_cause("create log directory failed", error))?;
+    }
+    let UnifiedLogger::Write(writer) = UnifiedLoggerBuilder::new()
+        .write(true)
+        .create(true)
+        .preallocated_size(16 * 1024 * 1024)
+        .file_base_name(path)
+        .build()
+        .map_err(|error| CuError::new_with_cause("logger initialization failed", error))?
+    else {
+        return Err(CuError::from("logger builder did not return a writer"));
+    };
+    Ok(Arc::new(Mutex::new(writer)))
+}
+
+#[test]
+fn continuously_busy_async_workers_produce_complete_keyframes() -> CuResult<()> {
+    const ITERATIONS: usize = 100;
+    const COMPONENTS: usize = 4;
+
+    let temp_dir = tempfile::tempdir()
+        .map_err(|error| CuError::new_with_cause("create temp directory failed", error))?;
+    let log_path = temp_dir.path().join("async_keyframes.copper");
+    let logger = build_logger(&log_path)?;
+    let mut app = AsyncKeyframeApp::builder()
+        .with_logger::<MmapSectionStorage, MmapUnifiedLoggerWrite>(logger)
+        .build()?;
+
+    app.start_all_tasks()?;
+    for _ in 0..ITERATIONS {
+        app.run_one_iteration()?;
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    app.stop_all_tasks()?;
+    drop(app);
+
+    let UnifiedLogger::Read(reader) = UnifiedLoggerBuilder::new()
+        .file_base_name(&log_path)
+        .build()
+        .map_err(|error| CuError::new_with_cause("open keyframe log failed", error))?
+    else {
+        return Err(CuError::from("logger builder did not return a reader"));
+    };
+    let mut reader = UnifiedLoggerIOReader::new(reader, UnifiedLogType::FrozenTasks);
+    let keyframes: Vec<_> = keyframes_reader(&mut reader).collect();
+    assert_eq!(keyframes.len(), ITERATIONS);
+    for keyframe in &keyframes {
+        let mut frames = KeyFramePayloadReader::new(keyframe)?;
+        for _ in 0..COMPONENTS {
+            let _ = frames.next_frame()?;
+        }
+        frames.finish()?;
+    }
+    Ok(())
+}

--- a/core/cu29_runtime/tests/async_keyframes_config.ron
+++ b/core/cu29_runtime/tests/async_keyframes_config.ron
@@ -1,0 +1,70 @@
+(
+    runtime: (
+        thread_pools: [
+            (
+                id: "source_pool",
+                threads: 1,
+            ),
+            (
+                id: "first_pool",
+                threads: 1,
+            ),
+            (
+                id: "second_pool",
+                threads: 1,
+            ),
+        ],
+    ),
+    logging: (
+        enable_task_logging: true,
+        slab_size_mib: 16,
+        keyframe_interval: 1,
+    ),
+    tasks: [
+        (
+            id: "source",
+            type: "SlowSource",
+            background: (
+                pool: "source_pool",
+            ),
+            config: {"sleep_ms": 80},
+        ),
+        (
+            id: "first",
+            type: "SlowTask",
+            background: (
+                pool: "first_pool",
+            ),
+            config: {"sleep_ms": 120},
+        ),
+        (
+            id: "second",
+            type: "SlowTask",
+            background: (
+                pool: "second_pool",
+            ),
+            config: {"sleep_ms": 160},
+        ),
+        (
+            id: "sink",
+            type: "OutputSink",
+        ),
+    ],
+    cnx: [
+        (
+            src: "source",
+            dst: "first",
+            msg: "WorkMsg",
+        ),
+        (
+            src: "first",
+            dst: "second",
+            msg: "WorkMsg",
+        ),
+        (
+            src: "second",
+            dst: "sink",
+            msg: "WorkMsg",
+        ),
+    ],
+)

--- a/core/cu29_runtime/tests/sim_bridge.rs
+++ b/core/cu29_runtime/tests/sim_bridge.rs
@@ -11,9 +11,10 @@ use cu29::reflect::Reflect;
 use cu29::rx_channels;
 use cu29::simulation::{CuTaskCallbackState, SimOverride};
 use cu29::tx_channels;
+use cu29_export::keyframes_reader;
 use cu29_runtime::app::CuSimApplication;
 use cu29_unifiedlog::memmap::{MmapSectionStorage, MmapUnifiedLoggerWrite};
-use cu29_unifiedlog::{UnifiedLogger, UnifiedLoggerBuilder};
+use cu29_unifiedlog::{UnifiedLogger, UnifiedLoggerBuilder, UnifiedLoggerIOReader};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -174,6 +175,93 @@ impl CuSinkTask for MySink {
 #[copper_runtime(config = "tests/sim_bridge_config.ron", sim_mode = true)]
 struct App {}
 
+mod recording {
+    use super::{DummyBridge, MySink, MySrc, Ping, Pong};
+    use cu29::prelude::*;
+    use cu29_unifiedlog::memmap::{MmapSectionStorage, MmapUnifiedLoggerWrite};
+    use std::sync::{Arc, Mutex};
+
+    #[copper_runtime(config = "tests/sim_bridge_config.ron")]
+    struct RealApp {}
+
+    pub(super) fn record(logger: Arc<Mutex<MmapUnifiedLoggerWrite>>) -> CuResult<()> {
+        let mut app = RealApp::builder()
+            .with_logger::<MmapSectionStorage, MmapUnifiedLoggerWrite>(logger)
+            .build()?;
+        app.start_all_tasks()?;
+        app.run_one_iteration()?;
+        app.run_one_iteration()?;
+        app.stop_all_tasks()?;
+        Ok(())
+    }
+}
+
+mod run_in_sim {
+    use super::{DummyBridge, MySink, MySrc, Ping, Pong, build_logger, recording};
+    use cu29::prelude::*;
+    use cu29_export::{copperlists_reader, keyframes_reader};
+    use cu29_runtime::app::CuSimApplication;
+    use cu29_unifiedlog::memmap::{MmapSectionStorage, MmapUnifiedLoggerWrite};
+    use cu29_unifiedlog::{UnifiedLogger, UnifiedLoggerBuilder, UnifiedLoggerIOReader};
+
+    #[copper_runtime(config = "tests/sim_bridge_run_in_sim_config.ron", sim_mode = true)]
+    struct RunInSimApp {}
+
+    #[test]
+    fn nonzero_bridge_keyframe_matches_linear_debug_replay() -> CuResult<()> {
+        let temp_dir = tempfile::tempdir()
+            .map_err(|error| CuError::new_with_cause("create temp log dir failed", error))?;
+        let record_path = temp_dir.path().join("bridge_replay_record.copper");
+        recording::record(build_logger(&record_path)?)?;
+
+        let UnifiedLogger::Read(reader) = UnifiedLoggerBuilder::new()
+            .file_base_name(&record_path)
+            .build()
+            .map_err(|error| CuError::new_with_cause("open keyframe log failed", error))?
+        else {
+            return Err(CuError::from("logger builder did not return a reader"));
+        };
+        let mut reader = UnifiedLoggerIOReader::new(reader, UnifiedLogType::FrozenTasks);
+        let keyframe = keyframes_reader(&mut reader)
+            .find(|keyframe| keyframe.culistid == 1)
+            .ok_or_else(|| CuError::from("recorded log did not contain the CL1 keyframe"))?;
+
+        let UnifiedLogger::Read(reader) = UnifiedLoggerBuilder::new()
+            .file_base_name(&record_path)
+            .build()
+            .map_err(|error| CuError::new_with_cause("open CopperList log failed", error))?
+        else {
+            return Err(CuError::from("logger builder did not return a reader"));
+        };
+        let mut reader = UnifiedLoggerIOReader::new(reader, UnifiedLogType::CopperList);
+        let recorded_cl1 = copperlists_reader::<default::CuStampedDataSet>(&mut reader)
+            .find(|copperlist| copperlist.id == 1)
+            .ok_or_else(|| CuError::from("recorded log did not contain CopperList 1"))?;
+
+        let replay_path = temp_dir.path().join("bridge_replay.copper");
+        let mut callback = |_step: default::SimStep<'_>| SimOverride::ExecuteByRuntime;
+        let mut app = RunInSimApp::builder()
+            .with_logger::<MmapSectionStorage, MmapUnifiedLoggerWrite>(build_logger(&replay_path)?)
+            .with_sim_callback(&mut callback)
+            .build()?;
+        app.start_all_tasks(&mut callback)?;
+        <RunInSimApp as CuSimApplication<
+            MmapSectionStorage,
+            MmapUnifiedLoggerWrite,
+        >>::restore_keyframe(&mut app, &keyframe)?;
+        assert_eq!(app.copper_runtime_mut().bridges.0.tx_called, 2);
+        assert_eq!(app.copper_runtime_mut().bridges.0.rx_called, 2);
+
+        let mut replay_callback =
+            |step: default::SimStep<'_>| default::recorded_debug_replay_step(step, &recorded_cl1);
+        app.run_one_iteration(&mut replay_callback)?;
+        assert_eq!(app.copper_runtime_mut().bridges.0.tx_called, 2);
+        assert_eq!(app.copper_runtime_mut().bridges.0.rx_called, 2);
+        app.stop_all_tasks(&mut callback)?;
+        Ok(())
+    }
+}
+
 fn build_logger(path: &Path) -> CuResult<Arc<Mutex<MmapUnifiedLoggerWrite>>> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
@@ -198,6 +286,44 @@ fn build_test_logger() -> CuResult<(TempDir, PathBuf, Arc<Mutex<MmapUnifiedLogge
         .map_err(|e| cu29::CuError::new_with_cause("create temp log dir failed", e))?;
     let log_path = temp_dir.path().join("sim_bridge.log");
     Ok((temp_dir, log_path.clone(), build_logger(&log_path)?))
+}
+
+fn read_first_keyframe(path: &Path) -> CuResult<KeyFrame> {
+    let UnifiedLogger::Read(reader) = UnifiedLoggerBuilder::new()
+        .file_base_name(path)
+        .build()
+        .map_err(|error| CuError::new_with_cause("open keyframe log failed", error))?
+    else {
+        return Err(CuError::from("logger builder did not return a reader"));
+    };
+    let mut reader = UnifiedLoggerIOReader::new(reader, UnifiedLogType::FrozenTasks);
+    keyframes_reader(&mut reader)
+        .next()
+        .ok_or_else(|| CuError::from("recorded log did not contain a keyframe"))
+}
+
+#[test]
+fn sim_restore_skips_substituted_bridge_frame() -> CuResult<()> {
+    let temp_dir = tempfile::tempdir()
+        .map_err(|error| CuError::new_with_cause("create temp log dir failed", error))?;
+    let record_path = temp_dir.path().join("real_bridge.copper");
+    let logger = build_logger(&record_path)?;
+    recording::record(logger)?;
+    let keyframe = read_first_keyframe(&record_path)?;
+
+    let sim_path = temp_dir.path().join("sim_bridge.copper");
+    let logger = build_logger(&sim_path)?;
+    let mut callback = |_step: default::SimStep<'_>| SimOverride::ExecuteByRuntime;
+    let mut sim = App::builder()
+        .with_logger::<MmapSectionStorage, MmapUnifiedLoggerWrite>(logger)
+        .with_sim_callback(&mut callback)
+        .build()?;
+    sim.start_all_tasks(&mut callback)?;
+    <App as CuSimApplication<MmapSectionStorage, MmapUnifiedLoggerWrite>>::restore_keyframe(
+        &mut sim, &keyframe,
+    )?;
+    sim.stop_all_tasks(&mut callback)?;
+    Ok(())
 }
 
 #[test]

--- a/core/cu29_runtime/tests/sim_bridge_run_in_sim_config.ron
+++ b/core/cu29_runtime/tests/sim_bridge_run_in_sim_config.ron
@@ -16,7 +16,7 @@
         (
             id: "bridge",
             type: "DummyBridge",
-            run_in_sim: false,
+            run_in_sim: true,
             channels: [
                 Tx(
                     id: "tx",

--- a/core/cu29_runtime/tests/sim_substituted_keyframes.rs
+++ b/core/cu29_runtime/tests/sim_substituted_keyframes.rs
@@ -1,0 +1,211 @@
+#![cfg(all(test, feature = "std"))]
+
+use bincode::{Decode, Encode};
+use cu29::bincode::de::Decoder;
+use cu29::bincode::enc::Encoder;
+use cu29::bincode::error::{DecodeError, EncodeError};
+use cu29::prelude::*;
+use cu29_export::{copperlists_reader, keyframes_reader};
+use cu29_runtime::app::CuSimApplication;
+use cu29_unifiedlog::memmap::{MmapSectionStorage, MmapUnifiedLoggerWrite};
+use cu29_unifiedlog::{UnifiedLogger, UnifiedLoggerBuilder, UnifiedLoggerIOReader};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+#[derive(Default, Debug, Clone, Encode, Decode, Serialize, Deserialize, Reflect)]
+struct ValueMsg(u32);
+
+#[derive(Reflect)]
+struct StatefulSrc {
+    next: u32,
+}
+
+impl Freezable for StatefulSrc {
+    fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        Encode::encode(&self.next, encoder)
+    }
+
+    fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
+        self.next = Decode::decode(decoder)?;
+        Ok(())
+    }
+}
+
+impl CuSrcTask for StatefulSrc {
+    type Resources<'r> = ();
+    type Output<'m> = output_msg!(ValueMsg);
+
+    fn new(_config: Option<&ComponentConfig>, _resources: ()) -> CuResult<Self> {
+        Ok(Self { next: 0 })
+    }
+
+    fn process(&mut self, _ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
+        self.next += 1;
+        output.set_payload(ValueMsg(self.next));
+        Ok(())
+    }
+}
+
+#[derive(Reflect)]
+struct StatefulTask {
+    sum: u32,
+}
+
+impl Freezable for StatefulTask {
+    fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        Encode::encode(&self.sum, encoder)
+    }
+
+    fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
+        self.sum = Decode::decode(decoder)?;
+        Ok(())
+    }
+}
+
+impl CuTask for StatefulTask {
+    type Resources<'r> = ();
+    type Input<'m> = input_msg!(ValueMsg);
+    type Output<'m> = output_msg!(ValueMsg);
+
+    fn new(_config: Option<&ComponentConfig>, _resources: ()) -> CuResult<Self> {
+        Ok(Self { sum: 0 })
+    }
+
+    fn process(
+        &mut self,
+        _ctx: &CuContext,
+        input: &Self::Input<'_>,
+        output: &mut Self::Output<'_>,
+    ) -> CuResult<()> {
+        self.sum += input.payload().map(|value| value.0).unwrap_or_default();
+        output.set_payload(ValueMsg(self.sum));
+        Ok(())
+    }
+}
+
+#[derive(Reflect)]
+struct StatefulSink {
+    last: u32,
+}
+
+impl Freezable for StatefulSink {
+    fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        Encode::encode(&self.last, encoder)
+    }
+
+    fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
+        self.last = Decode::decode(decoder)?;
+        Ok(())
+    }
+}
+
+impl CuSinkTask for StatefulSink {
+    type Resources<'r> = ();
+    type Input<'m> = input_msg!(ValueMsg);
+
+    fn new(_config: Option<&ComponentConfig>, _resources: ()) -> CuResult<Self> {
+        Ok(Self { last: 0 })
+    }
+
+    fn process(&mut self, _ctx: &CuContext, input: &Self::Input<'_>) -> CuResult<()> {
+        self.last = input.payload().map(|value| value.0).unwrap_or_default();
+        Ok(())
+    }
+}
+
+#[copper_runtime(config = "tests/sim_substituted_keyframes_config.ron", sim_mode = true)]
+struct SimApp {}
+
+mod recording {
+    use super::{StatefulSink, StatefulSrc, StatefulTask, ValueMsg};
+    use cu29::prelude::*;
+    use cu29_unifiedlog::memmap::{MmapSectionStorage, MmapUnifiedLoggerWrite};
+    use std::sync::{Arc, Mutex};
+
+    #[copper_runtime(config = "tests/sim_substituted_keyframes_config.ron")]
+    struct RealApp {}
+
+    pub(super) fn record(logger: Arc<Mutex<MmapUnifiedLoggerWrite>>) -> CuResult<()> {
+        let mut app = RealApp::builder()
+            .with_logger::<MmapSectionStorage, MmapUnifiedLoggerWrite>(logger)
+            .build()?;
+        app.start_all_tasks()?;
+        app.run_one_iteration()?;
+        app.run_one_iteration()?;
+        app.stop_all_tasks()?;
+        Ok(())
+    }
+}
+
+fn build_logger(path: &Path) -> CuResult<Arc<Mutex<MmapUnifiedLoggerWrite>>> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| CuError::new_with_cause("create log directory failed", error))?;
+    }
+    let UnifiedLogger::Write(writer) = UnifiedLoggerBuilder::new()
+        .write(true)
+        .create(true)
+        .preallocated_size(16 * 1024 * 1024)
+        .file_base_name(path)
+        .build()
+        .map_err(|error| CuError::new_with_cause("logger initialization failed", error))?
+    else {
+        return Err(CuError::from("logger builder did not return a writer"));
+    };
+    Ok(Arc::new(Mutex::new(writer)))
+}
+
+#[test]
+fn sim_restore_skips_substituted_source_and_sink_but_thaws_regular_task() -> CuResult<()> {
+    let temp_dir = tempfile::tempdir()
+        .map_err(|error| CuError::new_with_cause("create temp directory failed", error))?;
+    let record_path = temp_dir.path().join("record.copper");
+    recording::record(build_logger(&record_path)?)?;
+    let UnifiedLogger::Read(reader) = UnifiedLoggerBuilder::new()
+        .file_base_name(&record_path)
+        .build()
+        .map_err(|error| CuError::new_with_cause("open keyframe log failed", error))?
+    else {
+        return Err(CuError::from("logger builder did not return a reader"));
+    };
+    let mut reader = UnifiedLoggerIOReader::new(reader, UnifiedLogType::FrozenTasks);
+    let keyframe = keyframes_reader(&mut reader)
+        .find(|keyframe| keyframe.culistid == 1)
+        .ok_or_else(|| CuError::from("recorded log did not contain the CL1 keyframe"))?;
+
+    let sim_path = temp_dir.path().join("sim.copper");
+    let mut callback = |_step: default::SimStep<'_>| SimOverride::ExecuteByRuntime;
+    let mut app = SimApp::builder()
+        .with_logger::<MmapSectionStorage, MmapUnifiedLoggerWrite>(build_logger(&sim_path)?)
+        .with_sim_callback(&mut callback)
+        .build()?;
+    app.start_all_tasks(&mut callback)?;
+    <SimApp as CuSimApplication<MmapSectionStorage, MmapUnifiedLoggerWrite>>::restore_keyframe(
+        &mut app, &keyframe,
+    )?;
+    assert_eq!(app.copper_runtime_mut().tasks.1.sum, 1);
+
+    let UnifiedLogger::Read(reader) = UnifiedLoggerBuilder::new()
+        .file_base_name(&record_path)
+        .build()
+        .map_err(|error| CuError::new_with_cause("open CopperList log failed", error))?
+    else {
+        return Err(CuError::from("logger builder did not return a reader"));
+    };
+    let mut reader = UnifiedLoggerIOReader::new(reader, UnifiedLogType::CopperList);
+    let recorded_cl1 = copperlists_reader::<default::CuStampedDataSet>(&mut reader)
+        .find(|copperlist| copperlist.id == 1)
+        .ok_or_else(|| CuError::from("recorded log did not contain CopperList 1"))?;
+    let mut replay_callback =
+        |step: default::SimStep<'_>| default::recorded_debug_replay_step(step, &recorded_cl1);
+    app.run_one_iteration(&mut replay_callback)?;
+    assert_eq!(
+        app.copper_runtime_mut().tasks.1.sum,
+        3,
+        "replay from the nonzero CL1 keyframe must match linear task state"
+    );
+    app.stop_all_tasks(&mut callback)?;
+    Ok(())
+}

--- a/core/cu29_runtime/tests/sim_substituted_keyframes_config.ron
+++ b/core/cu29_runtime/tests/sim_substituted_keyframes_config.ron
@@ -1,0 +1,29 @@
+(
+    logging: (keyframe_interval: 1),
+    tasks: [
+        (
+            id: "src",
+            type: "StatefulSrc",
+        ),
+        (
+            id: "task",
+            type: "StatefulTask",
+        ),
+        (
+            id: "sink",
+            type: "StatefulSink",
+        ),
+    ],
+    cnx: [
+        (
+            src: "src",
+            dst: "task",
+            msg: "ValueMsg",
+        ),
+        (
+            src: "task",
+            dst: "sink",
+            msg: "ValueMsg",
+        ),
+    ],
+)

--- a/examples/cu_rp_balancebot/src/resim.rs
+++ b/examples/cu_rp_balancebot/src/resim.rs
@@ -277,8 +277,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cu29::bincode::de::{DecoderImpl, read::SliceReader};
     use cu29::bincode::{config::standard, decode_from_slice, encode_to_vec};
+    use cu29::curuntime::{KeyFramePayloadReader, thaw_keyframe_component};
     use cu29::cutask::BincodeAdapter;
     use cu29::debug::CuDebugSession;
     use std::path::PathBuf;
@@ -490,33 +490,15 @@ mod tests {
         let (mut app, _robot_clock, _robot_clock_mock) = make_app(&debug_log_base)?;
         app.start_all_tasks(&mut default_callback)?;
 
-        let reader = SliceReader::new(&first_keyframe.serialized_tasks);
-        let mut decoder = DecoderImpl::new(reader, standard(), ());
+        let mut frames = KeyFramePayloadReader::new(first_keyframe)?;
         let tasks = &mut app.copper_runtime_mut().tasks;
-        tasks
-            .0
-            .thaw(&mut decoder)
-            .map_err(|err| CuError::new_with_cause("task 0 thaw failed", err))?;
-        tasks
-            .1
-            .thaw(&mut decoder)
-            .map_err(|err| CuError::new_with_cause("task 1 thaw failed", err))?;
-        tasks
-            .2
-            .thaw(&mut decoder)
-            .map_err(|err| CuError::new_with_cause("task 2 thaw failed", err))?;
-        tasks
-            .3
-            .thaw(&mut decoder)
-            .map_err(|err| CuError::new_with_cause("task 3 thaw failed", err))?;
-        tasks
-            .4
-            .thaw(&mut decoder)
-            .map_err(|err| CuError::new_with_cause("task 4 thaw failed", err))?;
-        tasks
-            .5
-            .thaw(&mut decoder)
-            .map_err(|err| CuError::new_with_cause("task 5 thaw failed", err))?;
+        thaw_keyframe_component(&mut tasks.0, frames.next_frame()?)?;
+        thaw_keyframe_component(&mut tasks.1, frames.next_frame()?)?;
+        thaw_keyframe_component(&mut tasks.2, frames.next_frame()?)?;
+        thaw_keyframe_component(&mut tasks.3, frames.next_frame()?)?;
+        thaw_keyframe_component(&mut tasks.4, frames.next_frame()?)?;
+        thaw_keyframe_component(&mut tasks.5, frames.next_frame()?)?;
+        frames.finish()?;
 
         let (mut app_100, _robot_clock_100, _robot_clock_mock_100) =
             make_app(&temp_replay_log_base("fresh_keyframe_decode_runtime_100"))?;
@@ -543,51 +525,21 @@ mod tests {
             .expect("encode task 1 runtime state for CL100");
         let task_2_bytes = encode_to_vec(BincodeAdapter(&runtime_tasks.2), standard())
             .expect("encode task 2 runtime state for CL100");
-        let expected_prefix = [
-            task_0_bytes.as_slice(),
-            task_1_bytes.as_slice(),
-            task_2_bytes.as_slice(),
-        ]
-        .concat();
-        assert!(
-            keyframe_100.serialized_tasks.len() >= expected_prefix.len(),
-            "CL100 keyframe shorter than encoded task prefix: {} < {}",
-            keyframe_100.serialized_tasks.len(),
-            expected_prefix.len()
-        );
-        assert_eq!(
-            &keyframe_100.serialized_tasks[..expected_prefix.len()],
-            expected_prefix.as_slice(),
-            "CL100 keyframe prefix diverged from live task freeze bytes"
-        );
-
-        let reader_100 = SliceReader::new(&keyframe_100.serialized_tasks);
-        let mut decoder_100 = DecoderImpl::new(reader_100, standard(), ());
+        let mut frames_100 = KeyFramePayloadReader::new(keyframe_100)?;
         let tasks_100 = &mut app_100.copper_runtime_mut().tasks;
-        tasks_100
-            .0
-            .thaw(&mut decoder_100)
-            .map_err(|err| CuError::new_with_cause("task 0 thaw failed for CL100", err))?;
-        tasks_100
-            .1
-            .thaw(&mut decoder_100)
-            .map_err(|err| CuError::new_with_cause("task 1 thaw failed for CL100", err))?;
-        tasks_100
-            .2
-            .thaw(&mut decoder_100)
-            .map_err(|err| CuError::new_with_cause("task 2 thaw failed for CL100", err))?;
-        tasks_100
-            .3
-            .thaw(&mut decoder_100)
-            .map_err(|err| CuError::new_with_cause("task 3 thaw failed for CL100", err))?;
-        tasks_100
-            .4
-            .thaw(&mut decoder_100)
-            .map_err(|err| CuError::new_with_cause("task 4 thaw failed for CL100", err))?;
-        tasks_100
-            .5
-            .thaw(&mut decoder_100)
-            .map_err(|err| CuError::new_with_cause("task 5 thaw failed for CL100", err))?;
+        let frame_0 = frames_100.next_frame()?;
+        let frame_1 = frames_100.next_frame()?;
+        let frame_2 = frames_100.next_frame()?;
+        assert_eq!(frame_0, task_0_bytes, "CL100 task 0 freeze bytes diverged");
+        assert_eq!(frame_1, task_1_bytes, "CL100 task 1 freeze bytes diverged");
+        assert_eq!(frame_2, task_2_bytes, "CL100 task 2 freeze bytes diverged");
+        thaw_keyframe_component(&mut tasks_100.0, frame_0)?;
+        thaw_keyframe_component(&mut tasks_100.1, frame_1)?;
+        thaw_keyframe_component(&mut tasks_100.2, frame_2)?;
+        thaw_keyframe_component(&mut tasks_100.3, frames_100.next_frame()?)?;
+        thaw_keyframe_component(&mut tasks_100.4, frames_100.next_frame()?)?;
+        thaw_keyframe_component(&mut tasks_100.5, frames_100.next_frame()?)?;
+        frames_100.finish()?;
 
         for keyframe in &keyframes {
             <BalanceBotReSim as CuSimApplication<MmapSectionStorage, MmapUnifiedLoggerWrite>>::restore_keyframe(

--- a/examples/cu_runtime_matrix/src/lib.rs
+++ b/examples/cu_runtime_matrix/src/lib.rs
@@ -1486,7 +1486,7 @@ mod tests {
     const TEST_COMPUTE_ROUNDS: u32 = 2;
     const MAX_BG_SETTLE_ITERS: u64 = 32;
     const BG_STABLE_PASSES: usize = 4;
-    const TRACE_FIXTURE_KEYFRAME_INTERVAL: u32 = u32::MAX;
+    const TRACE_FIXTURE_KEYFRAME_INTERVAL: u32 = 1;
 
     #[derive(Debug, Clone, PartialEq)]
     struct NormalizedCuMsg {
@@ -1581,9 +1581,8 @@ mod tests {
         let logging = config
             .logging
             .get_or_insert_with(cu29::config::LoggingConfig::default);
-        // These tests validate live traces and CopperLists, not replay keyframes.
-        // Async background tasks may legitimately have work in flight at normal
-        // keyframe boundaries, so keep only the initial idle keyframe.
+        // Capture every distributed execution-wave cut, including cuts taken while
+        // background workers are continuously occupied.
         logging.keyframe_interval = Some(TRACE_FIXTURE_KEYFRAME_INTERVAL);
     }
 


### PR DESCRIPTION
## Summary

- preserve execution-wave keyframe cuts without draining background or parallel workers
- length-frame component snapshots in generated execution order and restore the nearest nonzero keyframe
- replay in-flight async tasks and sources from their committed pre-run state using only the original dispatch input and CopperList ID; current runtime/component identity is reused
- skip framed state for sim-substituted sources, sinks, and bridges while restoring regular and run-in-sim components
- keep capture and mid-run async freeze allocation-free on the real-time path

## Resource model

- no graph-wide lock or pipeline drain
- two reusable task-snapshot buffers, serialized only after `start` and on the background worker after completion
- one short per-wrapper state lock; the existing inner-task lock remains worker/lifecycle-only during normal execution
- no dispatch lock, output lock, generation counter, duplicated error state, output serialization pass, context snapshot, or per-frame ordinal
- each component frame adds only a 4-byte length; one 5-byte version header covers the complete keyframe

## Verification

- `just nostd-ci` (445 tests passed plus embedded clippy/build matrix)
- `cargo test -p cu29-runtime --lib -- --test-threads=1` (214 passed, 1 ignored)
- allocation-counter tests for mid-run async freeze and preallocated keyframe append: 0 bytes allocated
- busy async worker, completion race, replay, bridge, sim substitution, and `parallel-rt` runtime-matrix regressions
- caterpillar record/resim determinism regression
- `cargo clippy -p cu29-runtime --all-targets --features memory_monitoring -- -D warnings`
- `just pr-check`: formatting, std/no_std clippy, and API checks passed; its workspace test phase was blocked locally by the environment missing Python `cbor2` (nine unrelated `cu_python_task` tests)

The only RON changes are configs directly used by these tests; no repository-wide formatter churn is included.

Documentation: copper-project/copper-rs-book#39; the sibling wiki was updated directly.

closes: #1282 
