### PR TITLE
feat: Autoware reference system benchmark example (cu_autoware)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ members = [
   "benchmarks/cu_zenoh_bridge_bench",
   "examples/cu_anytime_rrt_star",
   "examples/cu_anytime_task",
+  "examples/cu_autoware",
   "examples/cu_background_task",
   "examples/cu_baremetal_safety",
   "examples/cu_bridge_test",

--- a/examples/cu_autoware/.gitignore
+++ b/examples/cu_autoware/.gitignore
@@ -2,3 +2,4 @@ logs/
 analysis/data/
 analysis/figs/
 copper-crash-*.txt
+plan.svg

--- a/examples/cu_autoware/.gitignore
+++ b/examples/cu_autoware/.gitignore
@@ -1,0 +1,4 @@
+logs/
+analysis/data/
+analysis/figs/
+copper-crash-*.txt

--- a/examples/cu_autoware/Cargo.toml
+++ b/examples/cu_autoware/Cargo.toml
@@ -17,6 +17,7 @@ publish = false
 [dependencies]
 cu29 = { workspace = true }
 cu29-export = { workspace = true, features = ["mcap"] }
+cu-consolemon = { path = "../../components/monitors/cu_consolemon", version = "1.2.0-dev" }
 bincode = { workspace = true, features = ["derive"] }
 chrono = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/examples/cu_autoware/Cargo.toml
+++ b/examples/cu_autoware/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "cu-autoware"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Port of the Autoware reference system benchmark to Copper"
+default-run = "cu-autoware"
+
+publish = false
+
+[dependencies]
+cu29 = { workspace = true }
+cu29-export = { workspace = true, features = ["mcap"] }
+bincode = { workspace = true, features = ["derive"] }
+chrono = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_bytes = { workspace = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_autoware/analysis/plots.py
+++ b/examples/cu_autoware/analysis/plots.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Figures from the CSVs `kpi` writes. Usage: plots.py [data dir] [figs dir]."""
+
+import csv
+import os
+import sys
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DATA = sys.argv[1] if len(sys.argv) > 1 else os.path.join(HERE, "data")
+FIGS = sys.argv[2] if len(sys.argv) > 2 else os.path.join(HERE, "figs")
+
+
+def column(name, *fields):
+    """Columns of a CSV, or None when the run did not produce it."""
+    path = os.path.join(DATA, name)
+    if not os.path.exists(path):
+        print(f"skipping {name}: not found")
+        return None
+    with open(path) as handle:
+        rows = [r for r in csv.DictReader(handle) if all(r.get(f) for f in fields)]
+    parsed = []
+    for row in rows:
+        try:
+            parsed.append([float(row[field]) for field in fields])
+        except ValueError:
+            continue
+    if not parsed:
+        print(f"skipping {name}: empty")
+        return None
+    return [list(col) for col in zip(*parsed)]
+
+
+def figure(name, plot, xlabel, ylabel, title):
+    fig, axes = plt.subplots(figsize=(6, 3.2))
+    plot(axes)
+    axes.set_xlabel(xlabel)
+    axes.set_ylabel(ylabel)
+    axes.set_title(title)
+    axes.grid(True, linewidth=0.3, alpha=0.5)
+    fig.tight_layout()
+    path = os.path.join(FIGS, name)
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+    print(f"wrote {path}")
+
+
+def chain_box():
+    chains = [
+        ("hot path", column("hotpath.csv", "latency_ms")),
+        ("RT1", column("rt1.csv", "latency_ms")),
+        ("RT2", column("rt2.csv", "latency_ms")),
+    ]
+    chains = [(label, series[0]) for label, series in chains if series]
+    if not chains:
+        return
+    figure(
+        "latency_box.png",
+        lambda axes: axes.boxplot(
+            [values for _, values in chains],
+            labels=[label for label, _ in chains],
+            showfliers=True,
+        ),
+        "",
+        "latency (ms)",
+        "Chain latency",
+    )
+
+
+def hotpath_series():
+    series = column("hotpath.csv", "t_ms", "latency_ms")
+    if not series:
+        return
+    t, latency = series
+    figure(
+        "hotpath_series.png",
+        lambda axes: axes.plot([x / 1000 for x in t], latency, linewidth=0.8),
+        "time (s)",
+        "latency (ms)",
+        "Hot-path latency",
+    )
+
+
+def planner_period():
+    series = column("bp_period.csv", "t_ms", "period_ms")
+    if not series:
+        return
+    t, period = series
+
+    def plot(axes):
+        axes.plot([x / 1000 for x in t], period, linewidth=0.8)
+        axes.axhline(100.0, color="black", linewidth=0.8, linestyle="--")
+
+    figure(
+        "planner_period.png",
+        plot,
+        "time (s)",
+        "period (ms)",
+        "behavior_planner period vs 100ms",
+    )
+
+
+def proc_series():
+    series = column("proc.csv", "t_s", "cpu_pct", "rss_mb")
+    if not series:
+        return
+    t, cpu, rss = series
+    # proc.csv comes from the sampler, the rest from kpi: catch a mixed pair of runs.
+    hotpath = column("hotpath.csv", "t_ms")
+    if hotpath and hotpath[0]:
+        kpi_span = hotpath[0][-1] / 1000
+        # The kpi span legitimately trails the process span by startup plus up to one
+        # 200ms sensor period, so short runs need an absolute floor on the tolerance.
+        tolerance = max(0.05 * max(t[-1], kpi_span), 0.5)
+        if kpi_span and abs(t[-1] - kpi_span) > tolerance:
+            print(
+                f"warning: proc.csv spans {t[-1]:.1f}s but hotpath.csv spans "
+                f"{kpi_span:.1f}s - CSVs look like different runs"
+            )
+    figure(
+        "cpu.png",
+        lambda axes: axes.plot(t, cpu, linewidth=0.8),
+        "time (s)",
+        "CPU (%)",
+        "Process CPU",
+    )
+    figure(
+        "rss.png",
+        lambda axes: axes.plot(t, rss, linewidth=0.8),
+        "time (s)",
+        "RSS (MB)",
+        "Process memory",
+    )
+
+
+if __name__ == "__main__":
+    os.makedirs(FIGS, exist_ok=True)
+    chain_box()
+    hotpath_series()
+    planner_period()
+    proc_series()

--- a/examples/cu_autoware/analysis/sample_proc.sh
+++ b/examples/cu_autoware/analysis/sample_proc.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# CPU and RSS of one process at ~10Hz, as t_s,cpu_pct,rss_mb. psrecord without the dependency.
+#
+#   sample_proc.sh data/proc.csv 12345
+#   sample_proc.sh data/proc.csv -- ../../../target/release/cu-autoware 400
+set -euo pipefail
+export LC_ALL=C
+
+if [ $# -lt 2 ]; then
+    echo "usage: sample_proc.sh OUT.csv PID | sample_proc.sh OUT.csv -- COMMAND [ARGS...]" >&2
+    exit 2
+fi
+out=$1
+shift
+mkdir -p "$(dirname "$out")"
+if [ "$1" = "--" ]; then
+    shift
+    "$@" &
+    pid=$!
+    owned=1
+    # We own this child: don't orphan it when the sampler is killed or errors out.
+    trap 'kill "$pid" 2>/dev/null || true' EXIT INT TERM
+else
+    pid=$1
+    owned=0
+fi
+
+# `comm` can hold spaces, so drop everything through it: the rest starts at stat field 3.
+sample() {
+    while [ -r "/proc/$pid/stat" ]; do
+        line=$(< "/proc/$pid/stat") || break
+        printf '%s %s\n' "$EPOCHREALTIME" "${line#*') '}"
+        sleep 0.1
+    done
+}
+
+# $13,$14 are utime,stime in clock ticks; $23 is the resident set in pages.
+sample | awk -v hz="$(getconf CLK_TCK)" -v page="$(getconf PAGESIZE)" '
+BEGIN { print "t_s,cpu_pct,rss_mb" }
+{ cpu = ($13 + $14) / hz }
+NR == 1 { t0 = $1 }
+NR > 1 && $1 > t {
+    printf "%.2f,%.1f,%.1f\n", $1 - t0, 100 * (cpu - c) / ($1 - t), $23 * page / 1048576
+}
+{ t = $1; c = cpu }
+' > "$out"
+
+# Propagate the child's exit status; an attached PID is not ours to wait on.
+status=0
+if [ "$owned" = 1 ]; then
+    wait "$pid" || status=$?
+    trap - EXIT
+fi
+echo "wrote $out" >&2
+exit "$status"

--- a/examples/cu_autoware/build.rs
+++ b/examples/cu_autoware/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    cu29_build::setup();
+}

--- a/examples/cu_autoware/copperconfig.ron
+++ b/examples/cu_autoware/copperconfig.ron
@@ -1,7 +1,6 @@
 // The 24 nodes of the Autoware reference system (LAME fork, Fig. 4 of the RTNS'25 paper).
 // `E` in the comments is the execution time each node must reproduce; the crunch limits
-// below are host-calibrated with the `calibrate` binary and validated against the app's
-// logged `process_time` (see PLAN.md for the procedure). behavior_planner's 0.001ms
+// below are host-calibrated with the `calibrate` binary. behavior_planner's 0.001ms
 // input callback is below timing resolution, so its cache_crunch_limit is not
 // calibrated and stays at 100.
 // 200Hz is the GCD grid of the 200/120/100/60/25ms sensor periods.

--- a/examples/cu_autoware/copperconfig.ron
+++ b/examples/cu_autoware/copperconfig.ron
@@ -1,0 +1,353 @@
+// Calibrated on Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz, 2026-08-18.
+// Limits are host-measured: rerun `cargo run --release --bin calibrate -- --apply`.
+// The 24 nodes of the Autoware reference system (LAME fork, Fig. 4 of the RTNS'25 paper).
+// `E` in the comments is the execution time each node must reproduce; the crunch limits
+// below are what costs that much on the host named in the header line, measured by the
+// `calibrate` binary. behavior_planner's 0.001ms input callback is below timing
+// resolution, so its cache_crunch_limit is not calibrated and stays at 100.
+// 200Hz is the GCD grid of the 200/120/100/60/25ms sensor periods.
+(
+    runtime: (rate_target_hz: 200),
+    tasks: [
+        // Sensors, E 0.1ms each. The two lidars run at Fig. 4's 200ms; the fork's
+        // default.hpp says 100ms, and the paper wins here.
+        (
+            id: "front_lidar",
+            type: "crate::tasks::RefSensor",
+            config: {
+                "period_ms": 200,
+                "crunch_limit": 3374,
+            },
+        ),
+        (
+            id: "rear_lidar",
+            type: "crate::tasks::RefSensor",
+            config: {
+                "period_ms": 200,
+                "crunch_limit": 3374,
+            },
+        ),
+        (
+            id: "point_cloud_map",
+            type: "crate::tasks::RefSensor",
+            config: {
+                "period_ms": 120,
+                "crunch_limit": 3374,
+            },
+        ),
+        (
+            id: "visualizer",
+            type: "crate::tasks::RefSensor",
+            config: {
+                "period_ms": 60,
+                "crunch_limit": 3374,
+            },
+        ),
+        (
+            id: "lanelet2_map",
+            type: "crate::tasks::RefSensor",
+            config: {
+                "period_ms": 100,
+                "crunch_limit": 3374,
+            },
+        ),
+        (
+            id: "euclidean_cluster_settings",
+            type: "crate::tasks::RefSensor",
+            config: {
+                "period_ms": 25,
+                "crunch_limit": 3374,
+            },
+        ),
+        // Transforms, E 10.1ms each.
+        (
+            id: "points_transformer_front",
+            type: "crate::tasks::RefTransform",
+            config: {
+                "crunch_limit": 109495,
+            },
+        ),
+        (
+            id: "points_transformer_rear",
+            type: "crate::tasks::RefTransform",
+            config: {
+                "crunch_limit": 109495,
+            },
+        ),
+        (
+            id: "voxel_grid_downsampler",
+            type: "crate::tasks::RefTransform",
+            config: {
+                "crunch_limit": 109495,
+            },
+        ),
+        (
+            id: "point_cloud_map_loader",
+            type: "crate::tasks::RefTransform",
+            config: {
+                "crunch_limit": 109495,
+            },
+        ),
+        (
+            id: "ray_ground_filter",
+            type: "crate::tasks::RefTransform",
+            config: {
+                "crunch_limit": 109495,
+            },
+        ),
+        (
+            id: "object_collision_estimator",
+            type: "crate::tasks::RefTransform",
+            config: {
+                "crunch_limit": 109495,
+            },
+        ),
+        (
+            id: "mpc_controller",
+            type: "crate::tasks::RefTransform",
+            config: {
+                "crunch_limit": 109495,
+            },
+        ),
+        (
+            id: "parking_planner",
+            type: "crate::tasks::RefTransform",
+            config: {
+                "crunch_limit": 109495,
+            },
+        ),
+        (
+            id: "lane_planner",
+            type: "crate::tasks::RefTransform",
+            config: {
+                "crunch_limit": 109495,
+            },
+        ),
+        // Fusions: `crunch_limit` is the trigger callback, `cache_crunch_limit` the
+        // 2.1ms callback that caches input 1.
+        (
+            id: "point_cloud_fusion", // E 10.005ms
+            type: "crate::tasks::RefFusion",
+            config: {
+                "crunch_limit": 108734,
+                "cache_crunch_limit": 33926,
+            },
+        ),
+        // ndt_localizer's inputs follow the fork's `// modified` swap, so its trigger is
+        // reversed against upstream ros-realtime. Not a typo.
+        (
+            id: "ndt_localizer", // E 10.1ms
+            type: "crate::tasks::RefFusion",
+            config: {
+                "crunch_limit": 109495,
+                "cache_crunch_limit": 33926,
+            },
+        ),
+        (
+            id: "lanelet2_global_planner", // E 10.2ms
+            type: "crate::tasks::RefFusion",
+            config: {
+                "crunch_limit": 110181,
+                "cache_crunch_limit": 33926,
+            },
+        ),
+        (
+            id: "lanelet2_map_loader", // E 10.2ms
+            type: "crate::tasks::RefFusion",
+            config: {
+                "crunch_limit": 110181,
+                "cache_crunch_limit": 33926,
+            },
+        ),
+        (
+            id: "vehicle_interface", // E 10.1ms
+            type: "crate::tasks::RefFusion",
+            config: {
+                "crunch_limit": 109495,
+                "cache_crunch_limit": 33926,
+            },
+        ),
+        // Cyclic: its timer callback is E 10.1ms, its six input callbacks 0.001ms each.
+        (
+            id: "behavior_planner",
+            type: "crate::tasks::RefCyclic",
+            config: {
+                "period_ms": 100,
+                "crunch_limit": 109495,
+                "cache_crunch_limit": 100,
+            },
+        ),
+        // Intersection: lane 0 is E 10.1ms, lane 1 E 10.2ms.
+        (
+            id: "euclidean_cluster_detector",
+            type: "crate::tasks::RefIntersection",
+            config: {
+                "crunch_limit0": 109495,
+                "crunch_limit1": 110181,
+            },
+        ),
+        // Commands, E 1.0ms each.
+        (
+            id: "vehicle_dbw",
+            type: "crate::tasks::RefCommand<crate::payload::RefSample>",
+            config: {
+                "crunch_limit": 19320,
+            },
+        ),
+        (
+            id: "intersection_output",
+            type: "crate::tasks::RefCommand<crate::payload::RefLaneSample>",
+            config: {
+                "crunch_limit": 19320,
+            },
+        ),
+    ],
+    // Connection order is input order, so every multi-input node lists its input 0 first.
+    cnx: [
+        (
+            src: "front_lidar",
+            dst: "points_transformer_front",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "rear_lidar",
+            dst: "points_transformer_rear",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "points_transformer_front",
+            dst: "point_cloud_fusion",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "points_transformer_rear",
+            dst: "point_cloud_fusion",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "point_cloud_fusion",
+            dst: "voxel_grid_downsampler",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "point_cloud_fusion",
+            dst: "ray_ground_filter",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "point_cloud_map",
+            dst: "point_cloud_map_loader",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "point_cloud_map_loader",
+            dst: "ndt_localizer",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "voxel_grid_downsampler",
+            dst: "ndt_localizer",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "visualizer",
+            dst: "lanelet2_global_planner",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "ndt_localizer",
+            dst: "lanelet2_global_planner",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "lanelet2_map",
+            dst: "lanelet2_map_loader",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "lanelet2_global_planner",
+            dst: "lanelet2_map_loader",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "lanelet2_map_loader",
+            dst: "parking_planner",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "lanelet2_map_loader",
+            dst: "lane_planner",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "ray_ground_filter",
+            dst: "euclidean_cluster_detector",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "euclidean_cluster_settings",
+            dst: "euclidean_cluster_detector",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "euclidean_cluster_detector",
+            dst: "object_collision_estimator",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "euclidean_cluster_detector",
+            dst: "intersection_output",
+            msg: "crate::payload::RefLaneSample",
+        ),
+        (
+            src: "object_collision_estimator",
+            dst: "behavior_planner",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "ndt_localizer",
+            dst: "behavior_planner",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "lanelet2_global_planner",
+            dst: "behavior_planner",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "lanelet2_map_loader",
+            dst: "behavior_planner",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "parking_planner",
+            dst: "behavior_planner",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "lane_planner",
+            dst: "behavior_planner",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "behavior_planner",
+            dst: "mpc_controller",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "mpc_controller",
+            dst: "vehicle_interface",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "behavior_planner",
+            dst: "vehicle_interface",
+            msg: "crate::payload::RefSample",
+        ),
+        (
+            src: "vehicle_interface",
+            dst: "vehicle_dbw",
+            msg: "crate::payload::RefSample",
+        ),
+    ],
+)

--- a/examples/cu_autoware/copperconfig.ron
+++ b/examples/cu_autoware/copperconfig.ron
@@ -1,10 +1,9 @@
-// Calibrated on Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz, 2026-08-18.
-// Limits are host-measured: rerun `cargo run --release --bin calibrate -- --apply`.
 // The 24 nodes of the Autoware reference system (LAME fork, Fig. 4 of the RTNS'25 paper).
 // `E` in the comments is the execution time each node must reproduce; the crunch limits
-// below are what costs that much on the host named in the header line, measured by the
-// `calibrate` binary. behavior_planner's 0.001ms input callback is below timing
-// resolution, so its cache_crunch_limit is not calibrated and stays at 100.
+// below are host-calibrated with the `calibrate` binary and validated against the app's
+// logged `process_time` (see PLAN.md for the procedure). behavior_planner's 0.001ms
+// input callback is below timing resolution, so its cache_crunch_limit is not
+// calibrated and stays at 100.
 // 200Hz is the GCD grid of the 200/120/100/60/25ms sensor periods.
 (
     runtime: (rate_target_hz: 200),

--- a/examples/cu_autoware/copperconfig.ron
+++ b/examples/cu_autoware/copperconfig.ron
@@ -349,4 +349,7 @@
             msg: "crate::payload::RefSample",
         ),
     ],
+    monitor: (
+        type: "cu_consolemon::CuConsoleMon",
+    ),
 )

--- a/examples/cu_autoware/justfile
+++ b/examples/cu_autoware/justfile
@@ -1,0 +1,30 @@
+import "../../justfile"
+
+# Record a bounded release run, e.g. `just run 400`.
+run iters="400":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cargo run --release -p cu-autoware --bin cu-autoware -- {{iters}}
+
+# Record a run with the CPU/RSS sampler attached.
+sampled iters="400":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cargo build --release -p cu-autoware --bin cu-autoware
+  analysis/sample_proc.sh analysis/data/proc.csv -- ../../target/release/cu-autoware {{iters}}
+
+# Compute the KPIs from the recorded log.
+kpi log="":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cargo run --release -p cu-autoware --bin kpi -- {{log}}
+
+# Draw the figures from the KPI CSVs.
+plots:
+  python3 analysis/plots.py
+
+# fsck the recorded log through the standard export CLI.
+fsck:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cargo run --release -p cu-autoware --bin cu-autoware-logreader -- logs/autoware.copper fsck

--- a/examples/cu_autoware/justfile
+++ b/examples/cu_autoware/justfile
@@ -1,10 +1,10 @@
 import "../../justfile"
 
-# Record a bounded release run, e.g. `just run 400`.
-run iters="400":
+# Record a bounded release run, e.g. `just run 400 logs/variant-a.copper`.
+run iters="400" log="":
   #!/usr/bin/env bash
   set -euo pipefail
-  cargo run --release -p cu-autoware --bin cu-autoware -- {{iters}}
+  cargo run --release -p cu-autoware --bin cu-autoware -- {{iters}} {{log}}
 
 # Record a run with the CPU/RSS sampler attached.
 sampled iters="400":
@@ -13,11 +13,11 @@ sampled iters="400":
   cargo build --release -p cu-autoware --bin cu-autoware
   analysis/sample_proc.sh analysis/data/proc.csv -- ../../target/release/cu-autoware {{iters}}
 
-# Compute the KPIs from the recorded log.
-kpi log="":
+# Compute the KPIs from the recorded log, e.g. `just kpi logs/variant-a.copper data/a`.
+kpi log="" out="":
   #!/usr/bin/env bash
   set -euo pipefail
-  cargo run --release -p cu-autoware --bin kpi -- {{log}}
+  cargo run --release -p cu-autoware --bin kpi -- {{log}} {{out}}
 
 # Draw the figures from the KPI CSVs.
 plots:

--- a/examples/cu_autoware/src/bin/calibrate.rs
+++ b/examples/cu_autoware/src/bin/calibrate.rs
@@ -56,8 +56,11 @@ const TARGETS: &[(&str, &str, u64)] = &[
 
 /// Timed runs per candidate limit; the median is what the search steers on.
 const RUNS: usize = 15;
-/// The search aims at 1%; `--apply` refuses to write anything worse than the 5% bar.
-const TOLERANCE: f64 = 0.01;
+/// The search aims at 0.3%; `--apply` refuses to write anything worse than the 5% bar.
+/// 1% used to be the bar, which is the whole gap between the 10.1ms and 10.2ms classes:
+/// the search could stop early on either side of it and hand the wider class the smaller
+/// limit. It is only an early exit, so a tighter bar costs probes, not convergence.
+const TOLERANCE: f64 = 0.003;
 const APPLY_BAR: f64 = 5.0;
 const PROBE_LIMIT: u64 = 20_000;
 const WARMUP: Duration = Duration::from_millis(500);

--- a/examples/cu_autoware/src/bin/calibrate.rs
+++ b/examples/cu_autoware/src/bin/calibrate.rs
@@ -1,0 +1,343 @@
+//! Turns the reference system's per-node execution times into `crunch_limit` values for
+//! this host, and with `--apply` writes them into `copperconfig.ron`.
+//!
+//! Run it in release: the crunch is the workload under measurement, and a debug build
+//! calibrates a different one. `crunch` is `#[inline(never)]` so this binary and the app
+//! execute the same codegen of it; the authoritative per-node check is step 4's logged
+//! `process_time`, which measured every load-carrying class within about 1% of target.
+//!
+//! The search also steers on the median while the KPIs pay the mean, which puts calibrate
+//! on the optimistic side of whatever the app ends up charging.
+
+use chrono::Local;
+use cu_autoware::tasks::crunch;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+/// (node id, config key, target execution time in µs). Fig. 4 of the RTNS'25 paper; the
+/// single authority for `--apply`. Nodes sharing a target share one measured limit.
+///
+/// `behavior_planner`'s `cache_crunch_limit` is deliberately absent: its 0.001ms input
+/// callback is a pointer assignment, below what a timed search can resolve, so the config
+/// keeps a fixed small limit there.
+const TARGETS: &[(&str, &str, u64)] = &[
+    ("front_lidar", "crunch_limit", 100),
+    ("rear_lidar", "crunch_limit", 100),
+    ("point_cloud_map", "crunch_limit", 100),
+    ("visualizer", "crunch_limit", 100),
+    ("lanelet2_map", "crunch_limit", 100),
+    ("euclidean_cluster_settings", "crunch_limit", 100),
+    ("vehicle_dbw", "crunch_limit", 1000),
+    ("intersection_output", "crunch_limit", 1000),
+    ("point_cloud_fusion", "cache_crunch_limit", 2100),
+    ("ndt_localizer", "cache_crunch_limit", 2100),
+    ("lanelet2_global_planner", "cache_crunch_limit", 2100),
+    ("lanelet2_map_loader", "cache_crunch_limit", 2100),
+    ("vehicle_interface", "cache_crunch_limit", 2100),
+    ("point_cloud_fusion", "crunch_limit", 10005),
+    ("points_transformer_front", "crunch_limit", 10100),
+    ("points_transformer_rear", "crunch_limit", 10100),
+    ("voxel_grid_downsampler", "crunch_limit", 10100),
+    ("point_cloud_map_loader", "crunch_limit", 10100),
+    ("ray_ground_filter", "crunch_limit", 10100),
+    ("object_collision_estimator", "crunch_limit", 10100),
+    ("mpc_controller", "crunch_limit", 10100),
+    ("parking_planner", "crunch_limit", 10100),
+    ("lane_planner", "crunch_limit", 10100),
+    ("ndt_localizer", "crunch_limit", 10100),
+    ("vehicle_interface", "crunch_limit", 10100),
+    ("behavior_planner", "crunch_limit", 10100),
+    ("euclidean_cluster_detector", "crunch_limit0", 10100),
+    ("lanelet2_global_planner", "crunch_limit", 10200),
+    ("lanelet2_map_loader", "crunch_limit", 10200),
+    ("euclidean_cluster_detector", "crunch_limit1", 10200),
+];
+
+/// Timed runs per candidate limit; the median is what the search steers on.
+const RUNS: usize = 15;
+/// The search aims at 1%; `--apply` refuses to write anything worse than the 5% bar.
+const TOLERANCE: f64 = 0.01;
+const APPLY_BAR: f64 = 5.0;
+const PROBE_LIMIT: u64 = 20_000;
+const WARMUP: Duration = Duration::from_millis(500);
+const HEADER_MARK: &str = "// Calibrated on ";
+const HEADER_NOTE: &str =
+    "// Limits are host-measured: rerun `cargo run --release --bin calibrate -- --apply`.";
+
+/// Median and spread (max-min over median, in %) of `RUNS` timed crunches, in µs.
+fn measure(limit: u64) -> (f64, f64) {
+    let mut samples: Vec<f64> = (0..RUNS)
+        .map(|_| {
+            let start = Instant::now();
+            crunch(limit);
+            start.elapsed().as_secs_f64() * 1e6
+        })
+        .collect();
+    samples.sort_by(f64::total_cmp);
+    let median = samples[RUNS / 2];
+    (median, (samples[RUNS - 1] - samples[0]) / median * 100.0)
+}
+
+/// Binary search for the limit costing `target_us`. `cost` only has to be monotonic.
+fn search(target_us: f64, mut cost: impl FnMut(u64) -> f64) -> u64 {
+    // The cruncher is O(n*sqrt(n)), so one probe places the first guess within a factor.
+    let probe = cost(PROBE_LIMIT);
+    let guess = (PROBE_LIMIT as f64 * (target_us / probe).powf(2.0 / 3.0)).max(1.0) as u64;
+    let (mut lo, mut hi) = (guess / 2 + 1, guess * 2 + 1);
+    while lo > 1 && cost(lo) > target_us {
+        lo /= 2;
+    }
+    while cost(hi) < target_us {
+        hi *= 2;
+    }
+    while lo + 1 < hi {
+        let mid = lo + (hi - lo) / 2;
+        let measured = cost(mid);
+        if (measured - target_us).abs() / target_us <= TOLERANCE {
+            return mid;
+        }
+        if measured < target_us {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    hi
+}
+
+fn cpu_model() -> String {
+    fs::read_to_string("/proc/cpuinfo")
+        .ok()
+        .and_then(|info| {
+            info.lines()
+                .find(|line| line.starts_with("model name"))
+                .and_then(|line| line.split_once(':'))
+                .map(|(_, model)| model.trim().to_string())
+        })
+        .unwrap_or_else(|| "unknown CPU".to_string())
+}
+
+/// Drops a header this binary generated, and only that: a hand-written comment survives
+/// even if the generated block was edited down to one line.
+fn strip_header(text: &str) -> &str {
+    let mut rest = text;
+    loop {
+        let line = rest.lines().next().unwrap_or("");
+        if !line.starts_with(HEADER_MARK) && line != HEADER_NOTE {
+            return rest;
+        }
+        rest = rest[line.len()..].strip_prefix('\n').unwrap_or("");
+    }
+}
+
+fn limit_of(
+    targets: &[(&str, &str, u64)],
+    limits: &[(u64, u64)],
+    node: &str,
+    key: &str,
+) -> Option<u64> {
+    let (_, _, target) = targets.iter().find(|(n, k, _)| *n == node && *k == key)?;
+    limits
+        .iter()
+        .find(|(class, _)| class == target)
+        .map(|(_, limit)| *limit)
+}
+
+/// `        "crunch_limit": 123, // note` with the value swapped, anything else untouched.
+fn rewrite_line(line: &str, limit_of: impl Fn(&str) -> Option<u64>) -> Option<String> {
+    let (head, tail) = line.split_once("\": ")?;
+    let limit = limit_of(head.trim_start().strip_prefix('"')?)?;
+    let digits = tail.len() - tail.trim_start_matches(|c: char| c.is_ascii_digit()).len();
+    (digits > 0).then(|| format!("{head}\": {limit}{}", &tail[digits..]))
+}
+
+/// The rewritten config and the number of values replaced. Node scope comes from the
+/// preceding `id:` line, which is what makes the two `RefIntersection` lanes separable.
+fn rewrite(body: &str, targets: &[(&str, &str, u64)], limits: &[(u64, u64)]) -> (String, usize) {
+    let mut node = "";
+    let mut rewrites = 0;
+    let mut out = String::new();
+    for line in body.lines() {
+        if let Some(rest) = line.trim_start().strip_prefix("id: \"") {
+            node = rest.split('"').next().unwrap_or("");
+        }
+        match rewrite_line(line, |key| limit_of(targets, limits, node, key)) {
+            Some(rewritten) => {
+                out.push_str(&rewritten);
+                rewrites += 1;
+            }
+            None => out.push_str(line),
+        }
+        out.push('\n');
+    }
+    (out, rewrites)
+}
+
+fn apply(limits: &[(u64, u64)]) {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("copperconfig.ron");
+    let text = fs::read_to_string(&path).expect("copperconfig.ron must be readable");
+    let (body, rewrites) = rewrite(strip_header(&text), TARGETS, limits);
+    if rewrites != TARGETS.len() {
+        eprintln!(
+            "copperconfig.ron: rewrote {rewrites} of {} calibrated values, so the config and \
+             TARGETS disagree on node ids or keys. Nothing written.",
+            TARGETS.len()
+        );
+        std::process::exit(1);
+    }
+    let out = format!(
+        "{HEADER_MARK}{}, {}.\n{HEADER_NOTE}\n{body}",
+        cpu_model(),
+        Local::now().format("%Y-%m-%d")
+    );
+    // fmtron's canonical form has no trailing newline.
+    fs::write(&path, out.trim_end()).expect("copperconfig.ron must be writable");
+    println!("applied {rewrites} limits to {}", path.display());
+}
+
+fn main() {
+    if cfg!(debug_assertions) {
+        eprintln!("calibrate measures the release workload: cargo run --release --bin calibrate");
+        std::process::exit(1);
+    }
+    let mut apply_to_config = false;
+    for arg in std::env::args().skip(1) {
+        if arg != "--apply" {
+            eprintln!("unknown argument '{arg}'. usage: calibrate [--apply]");
+            std::process::exit(2);
+        }
+        apply_to_config = true;
+    }
+
+    // The app runs the crunch back to back, so calibrate against a warm core: a cold one
+    // reads several percent slow here, which is the whole error budget.
+    let warmup = Instant::now();
+    while warmup.elapsed() < WARMUP {
+        crunch(PROBE_LIMIT);
+    }
+
+    let mut classes: Vec<u64> = TARGETS.iter().map(|(_, _, target)| *target).collect();
+    classes.sort_unstable();
+    classes.dedup();
+
+    println!("class_ms     limit  median_ms    err%  spread%");
+    let mut limits = Vec::new();
+    let mut worst = 0.0f64;
+    for target in classes {
+        let limit = search(target as f64, |limit| measure(limit).0);
+        let (median, spread) = measure(limit);
+        let err = (median - target as f64) / target as f64 * 100.0;
+        println!(
+            "{:8.3}  {limit:8}  {:9.3}  {err:+6.2}  {spread:7.2}",
+            target as f64 / 1000.0,
+            median / 1000.0
+        );
+        limits.push((target, limit));
+        worst = worst.max(err.abs());
+    }
+
+    if apply_to_config {
+        if worst > APPLY_BAR {
+            eprintln!(
+                "worst class is {worst:.2}% off target, over the {APPLY_BAR}% bar. Nothing written."
+            );
+            std::process::exit(1);
+        }
+        apply(&limits);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_TARGETS: &[(&str, &str, u64)] = &[
+        ("front_lidar", "crunch_limit", 100),
+        ("euclidean_cluster_detector", "crunch_limit0", 10100),
+        ("euclidean_cluster_detector", "crunch_limit1", 10200),
+    ];
+    const TEST_LIMITS: &[(u64, u64)] = &[(100, 11), (10100, 22), (10200, 33)];
+
+    const BODY: &str = "\
+(
+    tasks: [
+        (
+            id: \"front_lidar\",
+            config: {
+                \"period_ms\": 200,
+                \"crunch_limit\": 1, // stale
+            },
+        ),
+        (
+            id: \"euclidean_cluster_detector\",
+            config: {
+                \"crunch_limit0\": 2,
+                \"crunch_limit1\": 3,
+            },
+        ),
+    ],
+)";
+
+    /// Pins the search against a synthetic O(n^1.5) cost, so it never depends on the clock.
+    #[test]
+    fn test_search_converges_on_a_synthetic_cost() {
+        let cost = |limit: u64| (limit as f64).powf(1.5) / 1000.0;
+        for target in [100.0, 2100.0, 10_200.0] {
+            let limit = search(target, cost);
+            let err = (cost(limit) - target).abs() / target;
+            assert!(err <= TOLERANCE, "limit {limit} for {target}us: err {err}");
+        }
+    }
+
+    /// A staircase cost whose treads are 1000us apart: nothing lands within TOLERANCE of a
+    /// target between two of them, so the search has to exhaust the bisection and return
+    /// the cheapest limit that still meets the target.
+    #[test]
+    fn test_search_falls_back_to_the_first_limit_meeting_a_plateau_target() {
+        let cost = |limit: u64| (limit / 1000 * 1000) as f64;
+        let target = 10_500.0;
+        let limit = search(target, cost);
+        assert!(
+            cost(limit) >= target,
+            "limit {limit} undershoots the target"
+        );
+        assert!(
+            cost(limit - 1) < target,
+            "limit {limit} is not the cheapest one meeting it"
+        );
+    }
+
+    #[test]
+    fn test_rewrite_replaces_mapped_values_only() {
+        let (out, rewrites) = rewrite(BODY, TEST_TARGETS, TEST_LIMITS);
+        assert_eq!(rewrites, TEST_TARGETS.len());
+        assert!(out.contains("                \"crunch_limit\": 11, // stale\n"));
+        assert!(
+            out.contains("\"period_ms\": 200,"),
+            "unmapped key rewritten"
+        );
+        assert!(out.contains("\"crunch_limit0\": 22,") && out.contains("\"crunch_limit1\": 33,"));
+    }
+
+    /// A renamed node or a stale TARGETS entry has to show up as a short count, which is
+    /// what `apply` refuses to write on.
+    #[test]
+    fn test_rewrite_counts_short_when_a_key_is_missing() {
+        let body = BODY.replace("                \"crunch_limit1\": 3,\n", "");
+        let (_, rewrites) = rewrite(&body, TEST_TARGETS, TEST_LIMITS);
+        assert_eq!(rewrites, TEST_TARGETS.len() - 1);
+    }
+
+    #[test]
+    fn test_strip_header_only_drops_generated_lines() {
+        let hand_written = "// hand written\n(\n)";
+        assert_eq!(strip_header(hand_written), hand_written);
+        let generated =
+            format!("{HEADER_MARK}some cpu, 2026-01-01.\n{HEADER_NOTE}\n{hand_written}");
+        assert_eq!(strip_header(&generated), hand_written);
+        // Half the block edited away must still not eat the comment under it.
+        let half = format!("{HEADER_MARK}some cpu, 2026-01-01.\n{hand_written}");
+        assert_eq!(strip_header(&half), hand_written);
+    }
+}

--- a/examples/cu_autoware/src/bin/cu-autoware-logreader.rs
+++ b/examples/cu_autoware/src/bin/cu-autoware-logreader.rs
@@ -1,0 +1,41 @@
+//! Standard export CLI over this app's `.copper` logs: fsck, extract-copperlists,
+//! extract-text-log, export-mcap.
+
+use cu_autoware::payload;
+use cu29::prelude::*;
+use cu29_export::run_cli;
+use cu29_export::serde_to_jsonschema::trace_type_to_jsonschema;
+
+gen_cumsgs!("copperconfig.ron");
+
+impl PayloadSchemas for cumsgs::CuStampedDataSet {
+    fn get_payload_schemas() -> Vec<(&'static str, String)> {
+        let ids = <cumsgs::CuStampedDataSet as MatchingTasks>::get_all_task_ids();
+        let sample = trace_type_to_jsonschema::<payload::RefSample>();
+        let lane = trace_type_to_jsonschema::<payload::RefLaneSample>();
+        let unit = trace_type_to_jsonschema::<()>();
+        // Slots repeat the id for a second port: the detector's second slot is the lane.
+        let mut detector_slots = 0;
+        ids.iter()
+            .map(|&id| {
+                let schema = match id {
+                    "vehicle_dbw" | "intersection_output" => unit.clone(),
+                    "euclidean_cluster_detector" => {
+                        detector_slots += 1;
+                        if detector_slots > 1 {
+                            lane.clone()
+                        } else {
+                            sample.clone()
+                        }
+                    }
+                    _ => sample.clone(),
+                };
+                (id, schema)
+            })
+            .collect()
+    }
+}
+
+fn main() {
+    run_cli::<CuMsgs>().expect("Failed to run the export CLI");
+}

--- a/examples/cu_autoware/src/bin/kpi.rs
+++ b/examples/cu_autoware/src/bin/kpi.rs
@@ -1,8 +1,9 @@
 //! Benchmark KPIs from one recorded run.
 //!
-//! `kpi [log base]`, default `<crate>/logs/autoware.copper`. One typed walk over the
-//! copperlists yields every KPI; `CuDurationStatistics` does the aggregation and
-//! `cu29_export`'s `compute_logstats` writes the per-edge view next to the CSVs.
+//! `kpi [log base] [out dir]`, defaults `<crate>/logs/autoware.copper` and
+//! `<crate>/analysis/data`; `KPI_EXPECT=<n>` also asserts the copperlist count. One typed
+//! walk over the copperlists yields every KPI; `CuDurationStatistics` does the aggregation
+//! and `cu29_export`'s `compute_logstats` writes the per-edge view next to the CSVs.
 //!
 //! Timings come from the recorded `process_time` and `tov`. A copperlist is one full
 //! pass over the graph, so a sample and everything it triggers share one list and the
@@ -10,8 +11,8 @@
 
 use cu_autoware::payload;
 use cu29::prelude::*;
-use cu29_export::copperlists_reader;
 use cu29_export::logstats::{compute_logstats, write_logstats};
+use cu29_export::{copperlists_reader, runtime_lifecycle_reader};
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::fmt::Write as _;
@@ -30,6 +31,11 @@ const PLANNER_PERIOD_MS: u64 = 100;
 /// under std), so every series gets a ceiling on the order of its own values rather than
 /// one global ceiling that would quantize the small series away.
 const CEILING_FACTOR: u64 = 4;
+/// The RT1/RT2 chains run in tens of ms, so sizing their buckets off their 200/100ms
+/// deadlines would collapse the whole distribution into one bucket. Overshoot lands in
+/// the top bucket and `max()` stays exact.
+const RT1_CEILING_MS: u64 = 64;
+const RT2_CEILING_MS: u64 = 128;
 
 /// Fig. 4 cost model, in µs. Each entry is a callback the node can charge in one pass,
 /// gated by the copperlist slot whose payload says the callback ran: a node's own slot
@@ -203,17 +209,22 @@ fn alignment(samples: &[u64], updates: &HashMap<u64, u32>) -> (usize, usize, u32
     )
 }
 
-/// One latency series: the samples for the CSV and the statistics for the report.
+/// One latency series: the samples for the CSV, the statistics for the report, and the
+/// deadline the series is judged against.
 struct Series {
     rows: String,
     stats: CuDurationStatistics,
+    deadline_ns: u64,
+    late: u64,
 }
 
 impl Series {
-    fn new(header: &str, deadline_ms: u64) -> Self {
+    fn new(header: &str, ceiling_ms: u64, deadline_ms: u64) -> Self {
         Self {
             rows: format!("{header}\n"),
-            stats: CuDurationStatistics::new(CuDuration::from_millis(deadline_ms * CEILING_FACTOR)),
+            stats: CuDurationStatistics::new(CuDuration::from_millis(ceiling_ms)),
+            deadline_ns: deadline_ms * 1_000_000,
+            late: 0,
         }
     }
 
@@ -226,6 +237,9 @@ impl Series {
             value_ns as f64 / 1e6
         );
         self.stats.record(CuDuration(value_ns));
+        if value_ns > self.deadline_ns {
+            self.late += 1;
+        }
     }
 
     fn report(&self, name: &str) {
@@ -254,7 +268,6 @@ struct Kpis {
     measured: Vec<CuDurationStatistics>,
     modelled_us: Vec<f64>,
     culists: u64,
-    late: u64,
     /// Firings whose `tov` or `process_time` was not usable: a timing gap, not a miss.
     timing_gaps: u64,
     planner_ticks: u64,
@@ -273,17 +286,24 @@ impl Kpis {
                 .map(|(index, name)| (name, index))
                 .collect(),
             rt1_cache_ns: charge_ns("point_cloud_fusion", "points_transformer_rear"),
-            hot_path: Series::new("seq,t_ms,latency_ms", RT0_DEADLINE_MS),
-            rt1: Series::new("seq,t_ms,latency_ms", RT1_DEADLINE_MS),
-            rt2: Series::new("seq,t_ms,latency_ms", RT2_DEADLINE_MS),
-            planner_period: Series::new("seq,t_ms,period_ms", PLANNER_PERIOD_MS),
+            hot_path: Series::new(
+                "seq,t_ms,latency_ms",
+                RT0_DEADLINE_MS * CEILING_FACTOR,
+                RT0_DEADLINE_MS,
+            ),
+            rt1: Series::new("seq,t_ms,latency_ms", RT1_CEILING_MS, RT1_DEADLINE_MS),
+            rt2: Series::new("seq,t_ms,latency_ms", RT2_CEILING_MS, RT2_DEADLINE_MS),
+            planner_period: Series::new(
+                "seq,t_ms,period_ms",
+                PLANNER_PERIOD_MS * CEILING_FACTOR,
+                PLANNER_PERIOD_MS,
+            ),
             measured: NODES
                 .iter()
                 .map(|(_, charges)| CuDurationStatistics::new(ceiling(charges)))
                 .collect(),
             modelled_us: vec![0.0; NODES.len()],
             culists: 0,
-            late: 0,
             timing_gaps: 0,
             planner_ticks: 0,
             front_seqs: Vec::new(),
@@ -312,11 +332,7 @@ impl Kpis {
             *self.estimator_updates.entry(sample.seq).or_default() += 1;
             match (tov_ns(estimator.tov), span(estimator.metadata.process_time)) {
                 (Some(at), Some((_, end))) => {
-                    let latency = end.saturating_sub(at);
-                    self.hot_path.record(sample.seq, at, latency);
-                    if latency > RT0_DEADLINE_MS * 1_000_000 {
-                        self.late += 1;
-                    }
+                    self.hot_path.record(sample.seq, at, end.saturating_sub(at));
                 }
                 _ => self.timing_gaps += 1,
             }
@@ -398,10 +414,12 @@ impl Kpis {
             .collect()
     }
 
-    fn report(&self, log_base: &Path) {
+    fn report(&self, log_base: &Path, ids: (u64, u64)) {
         println!(
-            "cu_autoware KPIs — {} copperlists over {:.1}s ({})",
+            "cu_autoware KPIs — {} copperlists (ids {}..={}) over {:.1}s ({})",
             self.culists,
+            ids.0,
+            ids.1,
             self.span_ns as f64 / 1e9,
             log_base.display()
         );
@@ -426,9 +444,13 @@ impl Kpis {
             self.timing_gaps
         );
         println!(
-            "late       {} of {} hot-path samples over {RT0_DEADLINE_MS}ms",
-            self.late,
-            self.hot_path.stats.len()
+            "late       RT0 {}/{} over {RT0_DEADLINE_MS}ms, RT1 {}/{} over {RT1_DEADLINE_MS}ms, RT2 {}/{} over {RT2_DEADLINE_MS}ms",
+            self.hot_path.late,
+            self.hot_path.stats.len(),
+            self.rt1.late,
+            self.rt1.stats.len(),
+            self.rt2.late,
+            self.rt2.stats.len()
         );
 
         let period = &self.planner_period.stats;
@@ -472,7 +494,7 @@ fn fail(message: impl Display) -> ! {
     std::process::exit(1);
 }
 
-fn reader(log_base: &Path) -> CuResult<UnifiedLoggerIOReader> {
+fn reader(log_base: &Path, section: UnifiedLogType) -> CuResult<UnifiedLoggerIOReader> {
     let logger = UnifiedLoggerBuilder::new()
         .file_base_name(log_base)
         .build()
@@ -483,10 +505,46 @@ fn reader(log_base: &Path) -> CuResult<UnifiedLoggerIOReader> {
             log_base.display()
         )));
     };
-    Ok(UnifiedLoggerIOReader::new(
-        logger,
-        UnifiedLogType::CopperList,
-    ))
+    Ok(UnifiedLoggerIOReader::new(logger, section))
+}
+
+/// The run's own witnesses that the log is whole and belongs to this config: the RON the
+/// app was built from, and the shutdown record `cu_autoware::run` writes last. Without
+/// them a truncated log reports on its prefix and a stale one reports on the wrong graph.
+fn provenance(log_base: &Path) -> CuResult<(String, bool)> {
+    let source = reader(log_base, UnifiedLogType::RuntimeLifecycle)?;
+    let (mut config, mut complete) = (None, false);
+    for record in runtime_lifecycle_reader(source) {
+        match record.event {
+            RuntimeLifecycleEvent::Instantiated {
+                effective_config_ron,
+                ..
+            } => config = Some(effective_config_ron),
+            RuntimeLifecycleEvent::ShutdownCompleted => complete = true,
+            _ => {}
+        }
+    }
+    config
+        .map(|config| (config, complete))
+        .ok_or_else(|| CuError::from("no Instantiated record in the runtime lifecycle section"))
+}
+
+/// What decides which node lands in which copperlist slot. The recorded RON cannot be
+/// compared verbatim — `ComponentConfig` is a `HashMap`, so the two processes serialize
+/// its keys in different orders — and per-node values do not move slots anyway.
+fn layout_witness(config: &CuConfig) -> String {
+    let tasks: Vec<String> = config
+        .graphs
+        .get_default_mission_graph()
+        .map(|graph| {
+            graph
+                .get_all_nodes()
+                .into_iter()
+                .map(|(_, node)| node.get_id())
+                .collect()
+        })
+        .unwrap_or_else(|e| fail(e));
+    format!("{tasks:?}")
 }
 
 fn write(dir: &Path, name: &str, content: &str) {
@@ -499,23 +557,78 @@ fn write(dir: &Path, name: &str, content: &str) {
 
 fn main() {
     let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let log_base = std::env::args().nth(1).map_or_else(
+    let mut args = std::env::args().skip(1);
+    let log_base = args.next().map_or_else(
         || crate_dir.join("logs").join("autoware.copper"),
         PathBuf::from,
     );
+    let out_dir = args
+        .next()
+        .map_or_else(|| crate_dir.join("analysis").join("data"), PathBuf::from);
+
+    let config_path = crate_dir.join("copperconfig.ron");
+    let config = config_path
+        .to_str()
+        .ok_or_else(|| CuError::from("crate path is not UTF-8"))
+        .and_then(read_configuration)
+        .unwrap_or_else(|e| fail(e));
 
     let mut kpis = Kpis::new();
-    let source = reader(&log_base).unwrap_or_else(|e| fail(e));
+    let source = reader(&log_base, UnifiedLogType::CopperList).unwrap_or_else(|e| fail(e));
+    let (mut first, mut last, mut gaps) = (None, 0u64, 0u64);
     for culist in copperlists_reader::<CuMsgs>(source) {
+        match first {
+            None => first = Some(culist.id),
+            Some(_) if culist.id != last + 1 => gaps += 1,
+            _ => {}
+        }
+        last = culist.id;
         kpis.record_pass(&culist.msgs);
     }
-    if kpis.culists == 0 {
+
+    // `cu29_export`'s reader turns any decode failure into a silent end of iteration, so
+    // nothing below this point may run on a log that was not read whole: the report would
+    // be plausible and wrong. Three witnesses, cheapest first.
+    let Some(first) = first else {
         fail(format!("{}: no copperlists recorded", log_base.display()));
+    };
+    if first != 0 || gaps > 0 || kpis.culists != last + 1 {
+        fail(format!(
+            "{}: non-contiguous copperlists — {} of them, ids {first}..={last}, {gaps} gap(s)",
+            log_base.display(),
+            kpis.culists
+        ));
+    }
+    let (logged_ron, complete) = provenance(&log_base).unwrap_or_else(|e| fail(e));
+    if !complete {
+        fail(format!(
+            "{}: no shutdown record — the log is truncated or the run did not finish",
+            log_base.display()
+        ));
+    }
+    let logged = read_configuration_str(logged_ron, None).unwrap_or_else(|e| fail(e));
+    if layout_witness(&logged) != layout_witness(&config) {
+        fail(format!(
+            "{}: recorded under a different graph or plan order than {}",
+            log_base.display(),
+            config_path.display()
+        ));
+    }
+    if let Ok(expected) = std::env::var("KPI_EXPECT") {
+        let expected: u64 = expected
+            .parse()
+            .unwrap_or_else(|e| fail(format!("KPI_EXPECT: {e}")));
+        if kpis.culists != expected {
+            fail(format!(
+                "{}: {} copperlists, KPI_EXPECT says {expected}",
+                log_base.display(),
+                kpis.culists
+            ));
+        }
     }
 
-    kpis.report(&log_base);
+    kpis.report(&log_base, (first, last));
 
-    let out_dir = crate_dir.join("analysis").join("data");
     if let Err(e) = fs::create_dir_all(&out_dir) {
         fail(format!("{}: {e}", out_dir.display()));
     }
@@ -527,13 +640,7 @@ fn main() {
     write(&out_dir, "nodes.csv", &kpis.nodes_csv());
 
     // The per-edge / all-passes view is already a core feature; don't reimplement it.
-    let config_path = crate_dir.join("copperconfig.ron");
-    let config = config_path
-        .to_str()
-        .ok_or_else(|| CuError::from("crate path is not UTF-8"))
-        .and_then(read_configuration)
-        .unwrap_or_else(|e| fail(e));
-    let logstats = reader(&log_base)
+    let logstats = reader(&log_base, UnifiedLogType::CopperList)
         .and_then(|source| compute_logstats::<CuMsgs>(source, &config, None))
         .unwrap_or_else(|e| fail(e));
     let logstats_path = out_dir.join("logstats.json");
@@ -550,28 +657,119 @@ mod tests {
 
     const MS: u64 = 1_000_000;
 
-    fn sample(seq: u64) -> RefSample {
-        RefSample {
-            seq,
-            ..Default::default()
-        }
-    }
-
     fn t(ns: u64) -> CuTime {
         CuDuration(ns).into()
     }
 
-    /// A fired message: payload, time of validity, and the producer's process span.
-    fn fired<P: CuMsgPayload>(msg: &mut CuMsg<P>, payload: P, tov: u64, start: u64, end: u64) {
-        msg.set_payload(payload);
-        msg.tov = Tov::Time(t(tov));
-        timed(msg, start, end);
+    /// The payload a fixture synthesizes for a slot, whatever type that slot carries.
+    trait FixturePayload: CuMsgPayload {
+        fn of_seq(seq: u64) -> Self;
     }
 
-    /// A pass a node ran but produced nothing: the runtime still stamps the span.
-    fn timed<P: CuMsgPayload>(msg: &mut CuMsg<P>, start: u64, end: u64) {
-        msg.metadata.process_time.start = t(start).into();
-        msg.metadata.process_time.end = t(end).into();
+    impl FixturePayload for RefSample {
+        fn of_seq(seq: u64) -> Self {
+            RefSample {
+                seq,
+                ..Default::default()
+            }
+        }
+    }
+
+    impl FixturePayload for RefLaneSample {
+        fn of_seq(seq: u64) -> Self {
+            RefLaneSample(RefSample::of_seq(seq))
+        }
+    }
+
+    impl FixturePayload for () {
+        fn of_seq(_: u64) -> Self {}
+    }
+
+    /// One copperlist slot, written without naming its payload type: slot numbering follows
+    /// the execution plan, so a pinned `runtime.plan.order` moves types between slots.
+    trait Slot {
+        /// Payload, time of validity and process span. `tov: None` is a firing the log
+        /// could not time.
+        fn fire(&mut self, port: usize, seq: u64, tov: Option<u64>, start: u64, end: u64);
+        /// A pass the node ran without producing anything: the runtime still stamps the span.
+        fn timed(&mut self, port: usize, start: u64, end: u64);
+    }
+
+    impl<P: FixturePayload> Slot for CuMsg<P> {
+        fn fire(&mut self, port: usize, seq: u64, tov: Option<u64>, start: u64, end: u64) {
+            self.set_payload(P::of_seq(seq));
+            self.tov = tov.map_or(Tov::None, |ns| Tov::Time(t(ns)));
+            self.timed(port, start, end);
+        }
+
+        fn timed(&mut self, port: usize, start: u64, end: u64) {
+            assert_eq!(port, 0, "single-port slot");
+            self.metadata.process_time.start = t(start).into();
+            self.metadata.process_time.end = t(end).into();
+        }
+    }
+
+    impl<A: Slot, B: Slot> Slot for (A, B) {
+        fn fire(&mut self, port: usize, seq: u64, tov: Option<u64>, start: u64, end: u64) {
+            match port {
+                0 => self.0.fire(0, seq, tov, start, end),
+                1 => self.1.fire(0, seq, tov, start, end),
+                _ => panic!("no port {port}"),
+            }
+        }
+
+        fn timed(&mut self, port: usize, start: u64, end: u64) {
+            match port {
+                0 => self.0.timed(0, start, end),
+                1 => self.1.timed(0, start, end),
+                _ => panic!("no port {port}"),
+            }
+        }
+    }
+
+    /// `&mut msgs.0.N` for a runtime N. The tuple is heterogeneous, so the index has to be
+    /// a literal somewhere; this is the one place it is, and every arm coerces to `Slot`
+    /// whatever type the plan put there.
+    macro_rules! tuple_slots {
+        ($($index:tt)*) => {
+            fn tuple_slot(msgs: &mut CuMsgs, index: usize) -> &mut dyn Slot {
+                match index {
+                    $($index => &mut msgs.0.$index,)*
+                    _ => panic!("copperlist has no slot {index}"),
+                }
+            }
+        };
+    }
+    tuple_slots!(0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23);
+
+    /// (tuple index, port) of the flat slot named `name`, e.g. `euclidean_cluster_detector#1`.
+    fn slot_of(name: &str) -> (usize, usize) {
+        let ids = CuMsgs::get_all_task_ids();
+        let (mut index, mut port) = (0, 0);
+        for (flat, slot) in slot_names().iter().enumerate() {
+            if flat > 0 {
+                if ids[flat] == ids[flat - 1] {
+                    port += 1;
+                } else {
+                    index += 1;
+                    port = 0;
+                }
+            }
+            if slot == name {
+                return (index, port);
+            }
+        }
+        panic!("no copperlist slot named '{name}'");
+    }
+
+    fn fire(msgs: &mut CuMsgs, slot: &str, seq: u64, tov: Option<u64>, start: u64, end: u64) {
+        let (index, port) = slot_of(slot);
+        tuple_slot(msgs, index).fire(port, seq, tov, start, end);
+    }
+
+    fn timed(msgs: &mut CuMsgs, slot: &str, start: u64, end: u64) {
+        let (index, port) = slot_of(slot);
+        tuple_slot(msgs, index).timed(port, start, end);
     }
 
     fn node_index(id: &str) -> usize {
@@ -581,39 +779,83 @@ mod tests {
             .unwrap_or_else(|| panic!("{id} is not in the cost table"))
     }
 
-    /// The pass where the lidar chain is fresh, times in ms. Tuple-field access needs
-    /// literal indices; `test_culist_slot_layout` pins the ones used here. Tuple index n
-    /// is flat slot n below the two-port node (17.0/17.1 = slots 17/18) and slot n+1 above.
+    /// The pass where the lidar chain is fresh, times in ms.
     fn fresh_pass() -> CuMsgs {
         let mut msgs = CuMsgs::default();
-        fired(
-            &mut msgs.0.0,
-            sample(7),
-            1000 * MS,
+        let m = &mut msgs;
+        fire(
+            m,
+            "front_lidar",
+            7,
+            Some(1000 * MS),
             1000 * MS,
             1000 * MS + 100_000,
         );
-        fired(&mut msgs.0.1, sample(7), 1000 * MS, 1000 * MS, 1010 * MS);
-        fired(
-            &mut msgs.0.2,
-            sample(5),
-            1002 * MS,
+        fire(
+            m,
+            "points_transformer_front",
+            7,
+            Some(1000 * MS),
+            1000 * MS,
+            1010 * MS,
+        );
+        fire(
+            m,
+            "rear_lidar",
+            5,
+            Some(1002 * MS),
             1002 * MS,
             1002 * MS + 100_000,
         );
-        fired(&mut msgs.0.3, sample(5), 1002 * MS, 1002 * MS, 1012 * MS);
-        fired(&mut msgs.0.4, sample(7), 1000 * MS, 1012 * MS, 1024 * MS);
-        fired(&mut msgs.0.17.0, sample(7), 1000 * MS, 1030 * MS, 1050 * MS);
-        fired(
-            &mut msgs.0.17.1,
-            RefLaneSample(sample(7)),
-            1000 * MS,
+        fire(
+            m,
+            "points_transformer_rear",
+            5,
+            Some(1002 * MS),
+            1002 * MS,
+            1012 * MS,
+        );
+        fire(
+            m,
+            "point_cloud_fusion",
+            7,
+            Some(1000 * MS),
+            1012 * MS,
+            1024 * MS,
+        );
+        fire(
+            m,
+            "euclidean_cluster_detector",
+            7,
+            Some(1000 * MS),
             1030 * MS,
             1050 * MS,
         );
-        fired(&mut msgs.0.19, sample(7), 1000 * MS, 1140 * MS, 1150 * MS);
-        fired(&mut msgs.0.20, sample(3), 1160 * MS, 1160 * MS, 1170 * MS);
-        timed(&mut msgs.0.23, 1190 * MS, 1191 * MS);
+        fire(
+            m,
+            "euclidean_cluster_detector#1",
+            7,
+            Some(1000 * MS),
+            1030 * MS,
+            1050 * MS,
+        );
+        fire(
+            m,
+            "object_collision_estimator",
+            7,
+            Some(1000 * MS),
+            1140 * MS,
+            1150 * MS,
+        );
+        fire(
+            m,
+            "behavior_planner",
+            3,
+            Some(1160 * MS),
+            1160 * MS,
+            1170 * MS,
+        );
+        timed(m, "vehicle_dbw", 1190 * MS, 1191 * MS);
         msgs
     }
 
@@ -621,51 +863,69 @@ mod tests {
     /// fire, and the gated nodes still carry a span.
     fn gated_pass() -> CuMsgs {
         let mut msgs = CuMsgs::default();
-        timed(&mut msgs.0.0, 1200 * MS, 1200 * MS);
-        timed(&mut msgs.0.1, 1200 * MS, 1200 * MS);
-        timed(&mut msgs.0.3, 1200 * MS, 1200 * MS);
-        timed(&mut msgs.0.4, 1200 * MS, 1200 * MS);
-        timed(&mut msgs.0.19, 1200 * MS, 1200 * MS);
-        fired(
-            &mut msgs.0.16,
-            sample(40),
-            1205 * MS,
+        let m = &mut msgs;
+        for node in [
+            "front_lidar",
+            "points_transformer_front",
+            "points_transformer_rear",
+            "point_cloud_fusion",
+            "object_collision_estimator",
+        ] {
+            timed(m, node, 1200 * MS, 1200 * MS);
+        }
+        fire(
+            m,
+            "euclidean_cluster_settings",
+            40,
+            Some(1205 * MS),
             1205 * MS,
             1205 * MS + 100_000,
         );
-        timed(&mut msgs.0.17.0, 1210 * MS, 1220 * MS);
-        fired(
-            &mut msgs.0.17.1,
-            RefLaneSample(sample(40)),
-            1205 * MS,
+        timed(m, "euclidean_cluster_detector", 1210 * MS, 1220 * MS);
+        fire(
+            m,
+            "euclidean_cluster_detector#1",
+            40,
+            Some(1205 * MS),
             1210 * MS,
             1220 * MS,
         );
-        fired(&mut msgs.0.20, sample(4), 1330 * MS, 1330 * MS, 1340 * MS);
-        timed(&mut msgs.0.23, 1360 * MS, 1361 * MS);
+        fire(
+            m,
+            "behavior_planner",
+            4,
+            Some(1330 * MS),
+            1330 * MS,
+            1340 * MS,
+        );
+        timed(m, "vehicle_dbw", 1360 * MS, 1361 * MS);
         msgs
     }
 
-    /// The fixtures above address the copperlist by literal tuple index; if the graph
-    /// ever renumbers its slots this is what catches it.
+    /// Slot numbering follows the execution plan, so nothing here may depend on a
+    /// particular one. What must hold under any legal order: one uniquely named flat slot
+    /// per task output, every one of them reachable through `tuple_slot`, and the
+    /// detector's two ports adjacent in the same tuple slot.
     #[test]
     fn test_culist_slot_layout() {
-        let slots = slot_names();
-        for (index, name) in [
-            (0, "front_lidar"),
-            (1, "points_transformer_front"),
-            (2, "rear_lidar"),
-            (3, "points_transformer_rear"),
-            (4, "point_cloud_fusion"),
-            (16, "euclidean_cluster_settings"),
-            (17, "euclidean_cluster_detector"),
-            (18, "euclidean_cluster_detector#1"),
-            (20, "object_collision_estimator"),
-            (21, "behavior_planner"),
-            (24, "vehicle_dbw"),
-        ] {
-            assert_eq!(slots[index], name, "slot {index}");
+        let names = slot_names();
+        let mut unique = names.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(unique.len(), names.len(), "duplicate slot name");
+
+        let mut msgs = CuMsgs::default();
+        let mut tuples = 0;
+        for name in &names {
+            let (index, port) = slot_of(name);
+            tuple_slot(&mut msgs, index).timed(port, 0, 0);
+            tuples = tuples.max(index + 1);
         }
+        assert_eq!(tuples, NODES.len(), "tuple_slots! must list every slot");
+
+        let (index, port) = slot_of("euclidean_cluster_detector#1");
+        assert_eq!(port, 1);
+        assert_eq!(slot_of("euclidean_cluster_detector"), (index, 0));
     }
 
     /// The cost model has to name real copperlist slots and cover every node, or a config
@@ -717,7 +977,7 @@ mod tests {
             kpis.planner_period.stats.is_empty(),
             "no period on one tick"
         );
-        assert_eq!(kpis.late, 0);
+        assert_eq!(kpis.hot_path.late, 0);
         assert_eq!(kpis.timing_gaps, 0);
         assert_eq!(
             alignment(&kpis.front_seqs, &kpis.estimator_updates),
@@ -765,7 +1025,14 @@ mod tests {
     #[test]
     fn test_untimed_firing_counts_as_a_gap_not_a_miss() {
         let mut msgs = fresh_pass();
-        msgs.0.19.tov = Tov::None;
+        fire(
+            &mut msgs,
+            "object_collision_estimator",
+            7,
+            None,
+            1140 * MS,
+            1150 * MS,
+        );
         let mut kpis = Kpis::new();
         kpis.record_pass(&msgs);
 

--- a/examples/cu_autoware/src/bin/kpi.rs
+++ b/examples/cu_autoware/src/bin/kpi.rs
@@ -1,0 +1,787 @@
+//! Benchmark KPIs from one recorded run.
+//!
+//! `kpi [log base]`, default `<crate>/logs/autoware.copper`. One typed walk over the
+//! copperlists yields every KPI; `CuDurationStatistics` does the aggregation and
+//! `cu29_export`'s `compute_logstats` writes the per-edge view next to the CSVs.
+//!
+//! Timings come from the recorded `process_time` and `tov`. A copperlist is one full
+//! pass over the graph, so a sample and everything it triggers share one list and the
+//! chain KPIs need no cross-list matching.
+
+use cu_autoware::payload;
+use cu29::prelude::*;
+use cu29_export::copperlists_reader;
+use cu29_export::logstats::{compute_logstats, write_logstats};
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+gen_cumsgs!("copperconfig.ron");
+
+/// Reference-system deadlines. Copper never drops, so overload lands in these instead.
+const RT0_DEADLINE_MS: u64 = 200;
+const RT1_DEADLINE_MS: u64 = 200;
+const RT2_DEADLINE_MS: u64 = 100;
+/// behavior_planner's configured period.
+const PLANNER_PERIOD_MS: u64 = 100;
+/// `CuDurationStatistics` spreads its buckets linearly over one ceiling (1024 of them
+/// under std), so every series gets a ceiling on the order of its own values rather than
+/// one global ceiling that would quantize the small series away.
+const CEILING_FACTOR: u64 = 4;
+
+/// Fig. 4 cost model, in µs. Each entry is a callback the node can charge in one pass,
+/// gated by the copperlist slot whose payload says the callback ran: a node's own slot
+/// for its main callback, an input's slot for a cache callback. `id#1` is a second
+/// output port. Summed over a pass, this is what the node's `process_time` should cost.
+const NODES: &[(&str, &[(&str, f64)])] = &[
+    ("front_lidar", &[("front_lidar", 100.0)]),
+    ("rear_lidar", &[("rear_lidar", 100.0)]),
+    ("point_cloud_map", &[("point_cloud_map", 100.0)]),
+    ("visualizer", &[("visualizer", 100.0)]),
+    ("lanelet2_map", &[("lanelet2_map", 100.0)]),
+    (
+        "euclidean_cluster_settings",
+        &[("euclidean_cluster_settings", 100.0)],
+    ),
+    (
+        "points_transformer_front",
+        &[("points_transformer_front", 10100.0)],
+    ),
+    (
+        "points_transformer_rear",
+        &[("points_transformer_rear", 10100.0)],
+    ),
+    (
+        "point_cloud_fusion",
+        &[
+            ("points_transformer_rear", 2100.0),
+            ("point_cloud_fusion", 10005.0),
+        ],
+    ),
+    (
+        "voxel_grid_downsampler",
+        &[("voxel_grid_downsampler", 10100.0)],
+    ),
+    ("ray_ground_filter", &[("ray_ground_filter", 10100.0)]),
+    (
+        "euclidean_cluster_detector",
+        &[
+            ("euclidean_cluster_detector", 10100.0),
+            ("euclidean_cluster_detector#1", 10200.0),
+        ],
+    ),
+    (
+        "object_collision_estimator",
+        &[("object_collision_estimator", 10100.0)],
+    ),
+    (
+        "point_cloud_map_loader",
+        &[("point_cloud_map_loader", 10100.0)],
+    ),
+    (
+        "ndt_localizer",
+        &[
+            ("voxel_grid_downsampler", 2100.0),
+            ("ndt_localizer", 10100.0),
+        ],
+    ),
+    (
+        "lanelet2_global_planner",
+        &[
+            ("ndt_localizer", 2100.0),
+            ("lanelet2_global_planner", 10200.0),
+        ],
+    ),
+    (
+        "lanelet2_map_loader",
+        &[
+            ("lanelet2_global_planner", 2100.0),
+            ("lanelet2_map_loader", 10200.0),
+        ],
+    ),
+    ("parking_planner", &[("parking_planner", 10100.0)]),
+    ("lane_planner", &[("lane_planner", 10100.0)]),
+    (
+        "behavior_planner",
+        &[
+            ("object_collision_estimator", 1.0),
+            ("ndt_localizer", 1.0),
+            ("lanelet2_global_planner", 1.0),
+            ("lanelet2_map_loader", 1.0),
+            ("parking_planner", 1.0),
+            ("lane_planner", 1.0),
+            ("behavior_planner", 10100.0),
+        ],
+    ),
+    ("mpc_controller", &[("mpc_controller", 10100.0)]),
+    (
+        "vehicle_interface",
+        &[("behavior_planner", 2100.0), ("vehicle_interface", 10100.0)],
+    ),
+    ("vehicle_dbw", &[("vehicle_interface", 1000.0)]),
+    (
+        "intersection_output",
+        &[("euclidean_cluster_detector#1", 1000.0)],
+    ),
+];
+
+/// Flat copperlist slot names, `id` then `id#1`... for the ports of a multi-port node.
+fn slot_names() -> Vec<String> {
+    let mut seen: HashMap<&str, usize> = HashMap::new();
+    CuMsgs::get_all_task_ids()
+        .iter()
+        .map(|id| {
+            let port = seen.entry(id).or_insert(0);
+            let name = if *port == 0 {
+                (*id).to_string()
+            } else {
+                format!("{id}#{port}")
+            };
+            *port += 1;
+            name
+        })
+        .collect()
+}
+
+/// The modelled cost of one callback, in ns. The table is the single source of truth for
+/// the RT1 composition as well as for the err% column.
+fn charge_ns(node: &str, gate: &str) -> u64 {
+    NODES
+        .iter()
+        .find(|(id, _)| *id == node)
+        .and_then(|(_, charges)| charges.iter().find(|(slot, _)| *slot == gate))
+        .map(|(_, us)| (us * 1e3) as u64)
+        .unwrap_or_else(|| panic!("no modelled charge for {node} gated on {gate}"))
+}
+
+fn ceiling(charges: &[(&str, f64)]) -> CuDuration {
+    let total: f64 = charges.iter().map(|(_, us)| us).sum();
+    CuDuration((CEILING_FACTOR as f64 * total * 1e3) as u64)
+}
+
+fn tov_ns(tov: Tov) -> Option<u64> {
+    match tov {
+        Tov::Time(t) => Some(t.as_nanos()),
+        _ => None,
+    }
+}
+
+fn span(process_time: PartialCuTimeRange) -> Option<(u64, u64)> {
+    let start: Option<CuTime> = process_time.start.into();
+    let end: Option<CuTime> = process_time.end.into();
+    match (start, end) {
+        (Some(start), Some(end)) if end >= start => Some((start.as_nanos(), end.as_nanos())),
+        _ => None,
+    }
+}
+
+fn ms(d: CuDuration) -> f64 {
+    d.as_nanos() as f64 / 1e6
+}
+
+/// `CuDurationStatistics` interpolates inside linear buckets, so a percentile can land
+/// just past the largest sample of a tight distribution. A reported one never should.
+fn pct(s: &CuDurationStatistics, percentile: f64) -> f64 {
+    ms(s.percentile(percentile)).min(ms(s.max()))
+}
+
+/// Execution alignment: (matched, missing, duplicate, unmatched) for sensor samples
+/// against the updates each should have produced exactly once.
+fn alignment(samples: &[u64], updates: &HashMap<u64, u32>) -> (usize, usize, u32, usize) {
+    let matched = samples
+        .iter()
+        .filter(|seq| updates.contains_key(seq))
+        .count();
+    let duplicate = updates.values().map(|count| count - 1).sum();
+    (
+        matched,
+        samples.len() - matched,
+        duplicate,
+        updates.len().saturating_sub(matched),
+    )
+}
+
+/// One latency series: the samples for the CSV and the statistics for the report.
+struct Series {
+    rows: String,
+    stats: CuDurationStatistics,
+}
+
+impl Series {
+    fn new(header: &str, deadline_ms: u64) -> Self {
+        Self {
+            rows: format!("{header}\n"),
+            stats: CuDurationStatistics::new(CuDuration::from_millis(deadline_ms * CEILING_FACTOR)),
+        }
+    }
+
+    /// `at_ns` is the sample's own time of validity, already relative to app start.
+    fn record(&mut self, seq: u64, at_ns: u64, value_ns: u64) {
+        let _ = writeln!(
+            self.rows,
+            "{seq},{:.3},{:.3}",
+            at_ns as f64 / 1e6,
+            value_ns as f64 / 1e6
+        );
+        self.stats.record(CuDuration(value_ns));
+    }
+
+    fn report(&self, name: &str) {
+        let s = &self.stats;
+        println!(
+            "{name:<26}{:>6}{:>10.2}{:>10.2}{:>10.2}{:>10.2}",
+            s.len(),
+            ms(s.mean()),
+            pct(s, 0.5),
+            pct(s, 0.99),
+            ms(s.max())
+        );
+    }
+}
+
+/// Everything one walk of the log accumulates.
+struct Kpis {
+    slot_of: HashMap<String, usize>,
+    /// RT1 ends inside point_cloud_fusion's cache callback, whose end is not separately
+    /// observable, so its modelled cost completes the chain.
+    rt1_cache_ns: u64,
+    hot_path: Series,
+    rt1: Series,
+    rt2: Series,
+    planner_period: Series,
+    measured: Vec<CuDurationStatistics>,
+    modelled_us: Vec<f64>,
+    culists: u64,
+    late: u64,
+    /// Firings whose `tov` or `process_time` was not usable: a timing gap, not a miss.
+    timing_gaps: u64,
+    planner_ticks: u64,
+    front_seqs: Vec<u64>,
+    estimator_updates: HashMap<u64, u32>,
+    last_planner_tov: Option<u64>,
+    span_ns: u64,
+}
+
+impl Kpis {
+    fn new() -> Self {
+        Self {
+            slot_of: slot_names()
+                .into_iter()
+                .enumerate()
+                .map(|(index, name)| (name, index))
+                .collect(),
+            rt1_cache_ns: charge_ns("point_cloud_fusion", "points_transformer_rear"),
+            hot_path: Series::new("seq,t_ms,latency_ms", RT0_DEADLINE_MS),
+            rt1: Series::new("seq,t_ms,latency_ms", RT1_DEADLINE_MS),
+            rt2: Series::new("seq,t_ms,latency_ms", RT2_DEADLINE_MS),
+            planner_period: Series::new("seq,t_ms,period_ms", PLANNER_PERIOD_MS),
+            measured: NODES
+                .iter()
+                .map(|(_, charges)| CuDurationStatistics::new(ceiling(charges)))
+                .collect(),
+            modelled_us: vec![0.0; NODES.len()],
+            culists: 0,
+            late: 0,
+            timing_gaps: 0,
+            planner_ticks: 0,
+            front_seqs: Vec::new(),
+            estimator_updates: HashMap::new(),
+            last_planner_tov: None,
+            span_ns: 0,
+        }
+    }
+
+    fn record_pass(&mut self, msgs: &CuMsgs) {
+        let flat = msgs.cumsgs();
+        let present: Vec<bool> = flat.iter().map(|msg| msg.payload().is_some()).collect();
+        self.culists += 1;
+        self.span_ns = self.span_ns.max(
+            flat.iter()
+                .filter_map(|msg| span(msg.metadata().process_time()))
+                .map(|(_, end)| end)
+                .max()
+                .unwrap_or(0),
+        );
+
+        // (a) and (b): the update is a firing whether or not it is timeable, and the
+        // estimator's output carries the front_lidar tov it came from.
+        let estimator = msgs.get_object_collision_estimator_output();
+        if let Some(sample) = estimator.payload() {
+            *self.estimator_updates.entry(sample.seq).or_default() += 1;
+            match (tov_ns(estimator.tov), span(estimator.metadata.process_time)) {
+                (Some(at), Some((_, end))) => {
+                    let latency = end.saturating_sub(at);
+                    self.hot_path.record(sample.seq, at, latency);
+                    if latency > RT0_DEADLINE_MS * 1_000_000 {
+                        self.late += 1;
+                    }
+                }
+                _ => self.timing_gaps += 1,
+            }
+        }
+        if let Some(sample) = msgs.get_front_lidar_output().payload() {
+            self.front_seqs.push(sample.seq);
+        }
+
+        // (d) RT1 ends at point_cloud_fusion's cache callback, which runs first in that
+        // node's process span: the observable part runs to the span start and the
+        // modelled cache cost completes it.
+        let rear = msgs.get_points_transformer_rear_output();
+        let fusion = msgs.get_point_cloud_fusion_output();
+        if let (Some(sample), Some(at), Some((start, _))) = (
+            rear.payload(),
+            tov_ns(rear.tov),
+            span(fusion.metadata.process_time),
+        ) {
+            self.rt1
+                .record(sample.seq, at, start.saturating_sub(at) + self.rt1_cache_ns);
+        }
+
+        // (e) RT2 runs from the planner tick to the command sink, which does get a
+        // copperlist slot and therefore a recorded process_time.
+        let planner = msgs.get_behavior_planner_output();
+        if let (Some(sample), Some(at)) = (planner.payload(), tov_ns(planner.tov)) {
+            self.planner_ticks += 1;
+            if let Some((_, end)) = span(msgs.get_vehicle_dbw_output().metadata.process_time) {
+                self.rt2.record(sample.seq, at, end.saturating_sub(at));
+            }
+            if let Some(previous) = self.last_planner_tov {
+                self.planner_period
+                    .record(sample.seq, at, at.saturating_sub(previous));
+            }
+            self.last_planner_tov = Some(at);
+        }
+
+        // (f) per node, measured against the cost the model says this pass charged.
+        for (index, (node, charges)) in NODES.iter().enumerate() {
+            let cost: f64 = charges
+                .iter()
+                .filter(|(gate, _)| present[self.slot_of[*gate]])
+                .map(|(_, us)| us)
+                .sum();
+            if cost == 0.0 {
+                continue;
+            }
+            let Some((start, end)) = span(flat[self.slot_of[*node]].metadata().process_time())
+            else {
+                continue;
+            };
+            self.measured[index].record(CuDuration(end - start));
+            self.modelled_us[index] += cost;
+        }
+    }
+
+    /// (node, n, mean, p50, p99, target, err%) in ms, for the nodes that charged something.
+    fn node_rows(&self) -> Vec<(&'static str, u64, f64, f64, f64, f64, f64)> {
+        NODES
+            .iter()
+            .enumerate()
+            .filter_map(|(index, (node, _))| {
+                let s = &self.measured[index];
+                if s.is_empty() {
+                    return None;
+                }
+                let target = self.modelled_us[index] / s.len() as f64 / 1e3;
+                let mean = ms(s.mean());
+                Some((
+                    *node,
+                    s.len(),
+                    mean,
+                    pct(s, 0.5),
+                    pct(s, 0.99),
+                    target,
+                    (mean - target) / target * 100.0,
+                ))
+            })
+            .collect()
+    }
+
+    fn report(&self, log_base: &Path) {
+        println!(
+            "cu_autoware KPIs — {} copperlists over {:.1}s ({})",
+            self.culists,
+            self.span_ns as f64 / 1e9,
+            log_base.display()
+        );
+        println!(
+            "\nchain                          n      mean       p50       p99       max   (ms)"
+        );
+        self.hot_path.report("hot path RT0");
+        self.rt1.report("RT1 rear -> fusion*");
+        self.rt2.report("RT2 planner -> dbw");
+        println!(
+            "* RT1 is the rear edge tov to point_cloud_fusion's process start plus its \
+             {:.1}ms cache cost, modelled from the cost table: the cache and the trigger \
+             share one process span.",
+            self.rt1_cache_ns as f64 / 1e6
+        );
+
+        let (matched, missing, duplicate, unmatched) =
+            alignment(&self.front_seqs, &self.estimator_updates);
+        println!(
+            "\nalignment  front_lidar {} -> estimator updates {matched}, missing {missing}, duplicate {duplicate}, unmatched {unmatched}, timing gaps {}",
+            self.front_seqs.len(),
+            self.timing_gaps
+        );
+        println!(
+            "late       {} of {} hot-path samples over {RT0_DEADLINE_MS}ms",
+            self.late,
+            self.hot_path.stats.len()
+        );
+
+        let period = &self.planner_period.stats;
+        if period.is_empty() {
+            println!(
+                "planner    {} ticks, no period to measure",
+                self.planner_ticks
+            );
+        } else {
+            println!(
+                "planner    {} ticks, period mean {:.2}ms vs {PLANNER_PERIOD_MS}ms, jitter mean {:.2}ms max {:.2}ms, drift {:+.1}ms",
+                self.planner_ticks,
+                ms(period.mean()),
+                ms(period.jitter_mean()),
+                ms(period.jitter_max()),
+                (ms(period.mean()) - PLANNER_PERIOD_MS as f64) * period.len() as f64
+            );
+        }
+
+        println!("\nnode                           n      mean       p99    target      err%");
+        println!("(target is the per-pass mean of the gated cost model; err% compares means)");
+        for (node, n, mean, _, p99, target, err) in self.node_rows() {
+            println!("{node:<26}{n:>6}{mean:>10.3}{p99:>10.3}{target:>10.3}{err:>+10.1}");
+        }
+    }
+
+    fn nodes_csv(&self) -> String {
+        let mut csv = String::from("node,n,mean_ms,p50_ms,p99_ms,target_ms,err_pct\n");
+        for (node, n, mean, p50, p99, target, err) in self.node_rows() {
+            let _ = writeln!(
+                csv,
+                "{node},{n},{mean:.4},{p50:.4},{p99:.4},{target:.4},{err:.2}"
+            );
+        }
+        csv
+    }
+}
+
+fn fail(message: impl Display) -> ! {
+    eprintln!("kpi: {message}");
+    std::process::exit(1);
+}
+
+fn reader(log_base: &Path) -> CuResult<UnifiedLoggerIOReader> {
+    let logger = UnifiedLoggerBuilder::new()
+        .file_base_name(log_base)
+        .build()
+        .map_err(|e| CuError::new_with_cause(&format!("{}", log_base.display()), e))?;
+    let UnifiedLogger::Read(logger) = logger else {
+        return Err(CuError::from(format!(
+            "{}: opened for writing",
+            log_base.display()
+        )));
+    };
+    Ok(UnifiedLoggerIOReader::new(
+        logger,
+        UnifiedLogType::CopperList,
+    ))
+}
+
+fn write(dir: &Path, name: &str, content: &str) {
+    let path = dir.join(name);
+    if let Err(e) = fs::write(&path, content) {
+        fail(format!("{}: {e}", path.display()));
+    }
+    println!("  {}", path.display());
+}
+
+fn main() {
+    let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let log_base = std::env::args().nth(1).map_or_else(
+        || crate_dir.join("logs").join("autoware.copper"),
+        PathBuf::from,
+    );
+
+    let mut kpis = Kpis::new();
+    let source = reader(&log_base).unwrap_or_else(|e| fail(e));
+    for culist in copperlists_reader::<CuMsgs>(source) {
+        kpis.record_pass(&culist.msgs);
+    }
+    if kpis.culists == 0 {
+        fail(format!("{}: no copperlists recorded", log_base.display()));
+    }
+
+    kpis.report(&log_base);
+
+    let out_dir = crate_dir.join("analysis").join("data");
+    if let Err(e) = fs::create_dir_all(&out_dir) {
+        fail(format!("{}: {e}", out_dir.display()));
+    }
+    println!("\nwrote");
+    write(&out_dir, "hotpath.csv", &kpis.hot_path.rows);
+    write(&out_dir, "rt1.csv", &kpis.rt1.rows);
+    write(&out_dir, "rt2.csv", &kpis.rt2.rows);
+    write(&out_dir, "bp_period.csv", &kpis.planner_period.rows);
+    write(&out_dir, "nodes.csv", &kpis.nodes_csv());
+
+    // The per-edge / all-passes view is already a core feature; don't reimplement it.
+    let config_path = crate_dir.join("copperconfig.ron");
+    let config = config_path
+        .to_str()
+        .ok_or_else(|| CuError::from("crate path is not UTF-8"))
+        .and_then(read_configuration)
+        .unwrap_or_else(|e| fail(e));
+    let logstats = reader(&log_base)
+        .and_then(|source| compute_logstats::<CuMsgs>(source, &config, None))
+        .unwrap_or_else(|e| fail(e));
+    let logstats_path = out_dir.join("logstats.json");
+    if let Err(e) = write_logstats(&logstats, &logstats_path) {
+        fail(e);
+    }
+    println!("  {}", logstats_path.display());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use payload::{RefLaneSample, RefSample};
+
+    const MS: u64 = 1_000_000;
+
+    fn sample(seq: u64) -> RefSample {
+        RefSample {
+            seq,
+            ..Default::default()
+        }
+    }
+
+    fn t(ns: u64) -> CuTime {
+        CuDuration(ns).into()
+    }
+
+    /// A fired message: payload, time of validity, and the producer's process span.
+    fn fired<P: CuMsgPayload>(msg: &mut CuMsg<P>, payload: P, tov: u64, start: u64, end: u64) {
+        msg.set_payload(payload);
+        msg.tov = Tov::Time(t(tov));
+        timed(msg, start, end);
+    }
+
+    /// A pass a node ran but produced nothing: the runtime still stamps the span.
+    fn timed<P: CuMsgPayload>(msg: &mut CuMsg<P>, start: u64, end: u64) {
+        msg.metadata.process_time.start = t(start).into();
+        msg.metadata.process_time.end = t(end).into();
+    }
+
+    fn node_index(id: &str) -> usize {
+        NODES
+            .iter()
+            .position(|(node, _)| *node == id)
+            .unwrap_or_else(|| panic!("{id} is not in the cost table"))
+    }
+
+    /// The pass where the lidar chain is fresh, times in ms. Tuple-field access needs
+    /// literal indices; `test_culist_slot_layout` pins the ones used here. Tuple index n
+    /// is flat slot n below the two-port node (17.0/17.1 = slots 17/18) and slot n+1 above.
+    fn fresh_pass() -> CuMsgs {
+        let mut msgs = CuMsgs::default();
+        fired(
+            &mut msgs.0.0,
+            sample(7),
+            1000 * MS,
+            1000 * MS,
+            1000 * MS + 100_000,
+        );
+        fired(&mut msgs.0.1, sample(7), 1000 * MS, 1000 * MS, 1010 * MS);
+        fired(
+            &mut msgs.0.2,
+            sample(5),
+            1002 * MS,
+            1002 * MS,
+            1002 * MS + 100_000,
+        );
+        fired(&mut msgs.0.3, sample(5), 1002 * MS, 1002 * MS, 1012 * MS);
+        fired(&mut msgs.0.4, sample(7), 1000 * MS, 1012 * MS, 1024 * MS);
+        fired(&mut msgs.0.17.0, sample(7), 1000 * MS, 1030 * MS, 1050 * MS);
+        fired(
+            &mut msgs.0.17.1,
+            RefLaneSample(sample(7)),
+            1000 * MS,
+            1030 * MS,
+            1050 * MS,
+        );
+        fired(&mut msgs.0.19, sample(7), 1000 * MS, 1140 * MS, 1150 * MS);
+        fired(&mut msgs.0.20, sample(3), 1160 * MS, 1160 * MS, 1170 * MS);
+        timed(&mut msgs.0.23, 1190 * MS, 1191 * MS);
+        msgs
+    }
+
+    /// The pass where both lidars are gated off: only the settings lane and the planner
+    /// fire, and the gated nodes still carry a span.
+    fn gated_pass() -> CuMsgs {
+        let mut msgs = CuMsgs::default();
+        timed(&mut msgs.0.0, 1200 * MS, 1200 * MS);
+        timed(&mut msgs.0.1, 1200 * MS, 1200 * MS);
+        timed(&mut msgs.0.3, 1200 * MS, 1200 * MS);
+        timed(&mut msgs.0.4, 1200 * MS, 1200 * MS);
+        timed(&mut msgs.0.19, 1200 * MS, 1200 * MS);
+        fired(
+            &mut msgs.0.16,
+            sample(40),
+            1205 * MS,
+            1205 * MS,
+            1205 * MS + 100_000,
+        );
+        timed(&mut msgs.0.17.0, 1210 * MS, 1220 * MS);
+        fired(
+            &mut msgs.0.17.1,
+            RefLaneSample(sample(40)),
+            1205 * MS,
+            1210 * MS,
+            1220 * MS,
+        );
+        fired(&mut msgs.0.20, sample(4), 1330 * MS, 1330 * MS, 1340 * MS);
+        timed(&mut msgs.0.23, 1360 * MS, 1361 * MS);
+        msgs
+    }
+
+    /// The fixtures above address the copperlist by literal tuple index; if the graph
+    /// ever renumbers its slots this is what catches it.
+    #[test]
+    fn test_culist_slot_layout() {
+        let slots = slot_names();
+        for (index, name) in [
+            (0, "front_lidar"),
+            (1, "points_transformer_front"),
+            (2, "rear_lidar"),
+            (3, "points_transformer_rear"),
+            (4, "point_cloud_fusion"),
+            (16, "euclidean_cluster_settings"),
+            (17, "euclidean_cluster_detector"),
+            (18, "euclidean_cluster_detector#1"),
+            (20, "object_collision_estimator"),
+            (21, "behavior_planner"),
+            (24, "vehicle_dbw"),
+        ] {
+            assert_eq!(slots[index], name, "slot {index}");
+        }
+    }
+
+    /// The cost model has to name real copperlist slots and cover every node, or a config
+    /// edit silently moves the err% column off its subject.
+    #[test]
+    fn test_cost_model_matches_the_graph() {
+        let slots = slot_names();
+        for (node, charges) in NODES {
+            assert!(slots.iter().any(|slot| slot == node), "no slot '{node}'");
+            for (gate, _) in *charges {
+                assert!(
+                    slots.iter().any(|slot| slot == gate),
+                    "{node}: unknown gate '{gate}'"
+                );
+            }
+        }
+        let mut covered: Vec<&str> = NODES.iter().map(|(node, _)| *node).collect();
+        covered.sort_unstable();
+        let mut ids = CuMsgs::get_all_task_ids().to_vec();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(covered, ids);
+    }
+
+    /// Every callback of Fig. 4, once: the 185.0ms pass PLAN.md quotes.
+    #[test]
+    fn test_cost_model_totals_the_fig4_pass() {
+        let total: f64 = NODES
+            .iter()
+            .flat_map(|(_, charges)| charges.iter())
+            .map(|(_, us)| us)
+            .sum();
+        assert!((total - 185_011.0).abs() < 1e-6, "{total}us");
+    }
+
+    #[test]
+    fn test_fresh_pass_yields_every_chain() {
+        let mut kpis = Kpis::new();
+        kpis.record_pass(&fresh_pass());
+
+        // estimator end 1150 - front_lidar tov 1000.
+        assert_eq!(kpis.hot_path.stats.max(), CuDuration(150 * MS));
+        // fusion process start 1012 - rear edge tov 1002, plus the 2.1ms cache cost.
+        assert_eq!(kpis.rt1.stats.max(), CuDuration(10 * MS + 2_100_000));
+        // dbw end 1191 - planner tov 1160.
+        assert_eq!(kpis.rt2.stats.max(), CuDuration(31 * MS));
+        assert_eq!(kpis.planner_ticks, 1);
+        assert!(
+            kpis.planner_period.stats.is_empty(),
+            "no period on one tick"
+        );
+        assert_eq!(kpis.late, 0);
+        assert_eq!(kpis.timing_gaps, 0);
+        assert_eq!(
+            alignment(&kpis.front_seqs, &kpis.estimator_updates),
+            (1, 0, 0, 0)
+        );
+    }
+
+    #[test]
+    fn test_gated_pass_advances_only_what_fired() {
+        let mut kpis = Kpis::new();
+        kpis.record_pass(&fresh_pass());
+        kpis.record_pass(&gated_pass());
+
+        for node in [
+            "front_lidar",
+            "points_transformer_front",
+            "points_transformer_rear",
+            "point_cloud_fusion",
+            "object_collision_estimator",
+        ] {
+            assert_eq!(
+                kpis.measured[node_index(node)].len(),
+                1,
+                "{node} charged a gated pass"
+            );
+        }
+        // Lane 1 of the intersection ran on both passes, lane 0 only on the fresh one.
+        let detector = node_index("euclidean_cluster_detector");
+        assert_eq!(kpis.measured[detector].len(), 2);
+        assert!((kpis.modelled_us[detector] - (20_300.0 + 10_200.0)).abs() < 1e-6);
+
+        assert_eq!(kpis.hot_path.stats.len(), 1);
+        assert_eq!(kpis.rt1.stats.len(), 1);
+        assert_eq!(kpis.rt2.stats.len(), 2);
+        assert_eq!(kpis.planner_ticks, 2);
+        // Planner tov 1160 then 1330.
+        assert_eq!(kpis.planner_period.stats.max(), CuDuration(170 * MS));
+        assert_eq!(
+            alignment(&kpis.front_seqs, &kpis.estimator_updates),
+            (1, 0, 0, 0)
+        );
+    }
+
+    /// A firing with no usable timestamp is a timing gap, never a missing firing.
+    #[test]
+    fn test_untimed_firing_counts_as_a_gap_not_a_miss() {
+        let mut msgs = fresh_pass();
+        msgs.0.19.tov = Tov::None;
+        let mut kpis = Kpis::new();
+        kpis.record_pass(&msgs);
+
+        assert_eq!(kpis.timing_gaps, 1);
+        assert!(kpis.hot_path.stats.is_empty());
+        assert_eq!(
+            alignment(&kpis.front_seqs, &kpis.estimator_updates),
+            (1, 0, 0, 0)
+        );
+    }
+
+    #[test]
+    fn test_alignment_counts_duplicates_and_strays() {
+        let updates = HashMap::from([(1, 1), (2, 2), (9, 1)]);
+        // Sample 3 never reached the estimator; 2 arrived twice; 9 has no sample.
+        assert_eq!(alignment(&[1, 2, 3], &updates), (2, 1, 1, 1));
+        assert_eq!(alignment(&[], &HashMap::new()), (0, 0, 0, 0));
+    }
+}

--- a/examples/cu_autoware/src/bin/kpi.rs
+++ b/examples/cu_autoware/src/bin/kpi.rs
@@ -950,7 +950,7 @@ mod tests {
         assert_eq!(covered, ids);
     }
 
-    /// Every callback of Fig. 4, once: the 185.0ms pass PLAN.md quotes.
+    /// Every callback of Fig. 4, once: the full 185.0ms pass.
     #[test]
     fn test_cost_model_totals_the_fig4_pass() {
         let total: f64 = NODES

--- a/examples/cu_autoware/src/lib.rs
+++ b/examples/cu_autoware/src/lib.rs
@@ -1,0 +1,58 @@
+//! The Autoware reference system as a Copper application.
+//!
+//! The graph lives here rather than in `main.rs` so the `calibrate` binary links the same
+//! `tasks::crunch` the application runs.
+
+pub mod payload;
+pub mod tasks;
+
+use cu29::curuntime::LoopRateLimiter;
+use cu29::prelude::*;
+use std::fs;
+use std::path::PathBuf;
+
+#[copper_runtime(config = "copperconfig.ron")]
+struct App {}
+
+const SLAB_SIZE: Option<usize> = Some(64 * 1024 * 1024);
+/// Bounded so the example exits on its own. At the calibrated crunch limits one pass over
+/// the graph costs far more than the 5ms grid, so wall time per iteration is what the run
+/// measures rather than something to predict.
+pub const ITERATIONS: usize = 200;
+
+pub fn run(iterations: usize) {
+    // Anchored to the crate, not the cwd: step 4's logreader needs a stable location.
+    let logger_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("logs")
+        .join("autoware.copper");
+    if let Some(parent) = logger_path.parent()
+        && !parent.exists()
+    {
+        fs::create_dir_all(parent).expect("Failed to create logs directory");
+    }
+    let mut application = App::builder()
+        .with_log_path(&logger_path, SLAB_SIZE)
+        .expect("Failed to setup logger.")
+        .build()
+        .expect("Failed to create application.");
+    let rate_target_hz = application
+        .copper_runtime_mut()
+        .runtime_config
+        .rate_target_hz
+        .expect("copperconfig.ron must set runtime.rate_target_hz.");
+    let mut rate_limiter =
+        LoopRateLimiter::from_rate_target_hz(rate_target_hz, &application.clock())
+            .expect("Failed to create the rate limiter.");
+    application
+        .start_all_tasks()
+        .expect("Failed to start application.");
+    for _ in 0..iterations {
+        application
+            .run_one_iteration()
+            .expect("Failed to run application.");
+        rate_limiter.limit(&application.clock());
+    }
+    application
+        .stop_all_tasks()
+        .expect("Failed to stop application.");
+}

--- a/examples/cu_autoware/src/lib.rs
+++ b/examples/cu_autoware/src/lib.rs
@@ -18,13 +18,17 @@ const SLAB_SIZE: Option<usize> = Some(64 * 1024 * 1024);
 /// Bounded so the example exits on its own. At the calibrated crunch limits one pass over
 /// the graph costs far more than the 5ms grid, so wall time per iteration is what the run
 /// measures rather than something to predict.
-pub const ITERATIONS: usize = 200;
+pub const ITERATIONS: usize = 400;
 
-pub fn run(iterations: usize) {
+/// `log_base` defaults to `<crate>/logs/autoware.copper`; give it a distinct base per
+/// variant so parallel or successive runs do not clobber each other's log.
+pub fn run(iterations: usize, log_base: Option<PathBuf>) {
     // Anchored to the crate, not the cwd: step 4's logreader needs a stable location.
-    let logger_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("logs")
-        .join("autoware.copper");
+    let logger_path = log_base.unwrap_or_else(|| {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("logs")
+            .join("autoware.copper")
+    });
     if let Some(parent) = logger_path.parent()
         && !parent.exists()
     {
@@ -55,4 +59,9 @@ pub fn run(iterations: usize) {
     application
         .stop_all_tasks()
         .expect("Failed to stop application.");
+    // The generated `run()` writes this; a manual loop has to. `kpi` refuses to report on
+    // a log that does not end with it, which is how a truncated log is caught.
+    application
+        .log_shutdown_completed()
+        .expect("Failed to record shutdown.");
 }

--- a/examples/cu_autoware/src/main.rs
+++ b/examples/cu_autoware/src/main.rs
@@ -1,0 +1,8 @@
+/// Override the iteration count with the first argument.
+fn main() {
+    let iterations = std::env::args()
+        .nth(1)
+        .map(|arg| arg.parse().expect("iteration count must be a number"))
+        .unwrap_or(cu_autoware::ITERATIONS);
+    cu_autoware::run(iterations);
+}

--- a/examples/cu_autoware/src/main.rs
+++ b/examples/cu_autoware/src/main.rs
@@ -1,8 +1,11 @@
-/// Override the iteration count with the first argument.
+use std::path::PathBuf;
+
+/// `cu-autoware [iterations] [log base]`.
 fn main() {
-    let iterations = std::env::args()
-        .nth(1)
+    let mut args = std::env::args().skip(1);
+    let iterations = args
+        .next()
         .map(|arg| arg.parse().expect("iteration count must be a number"))
         .unwrap_or(cu_autoware::ITERATIONS);
-    cu_autoware::run(iterations);
+    cu_autoware::run(iterations, args.next().map(PathBuf::from));
 }

--- a/examples/cu_autoware/src/payload.rs
+++ b/examples/cu_autoware/src/payload.rs
@@ -1,0 +1,53 @@
+//! The single message type of the reference system.
+
+use bincode::{Decode, Encode};
+use cu29::prelude::*;
+use serde::{Deserialize, Serialize};
+
+/// Message size used by every node of the Autoware reference system.
+pub const DATA_LEN: usize = 4096;
+
+/// The 4kB block. Serde has no derive support for arrays this large, so it rides as bytes.
+#[derive(Debug, Clone, Encode, Decode, Serialize, Deserialize, Reflect)]
+#[reflect(opaque)]
+pub struct DataBlock(#[serde(with = "serde_bytes")] pub [u8; DATA_LEN]);
+
+impl Default for DataBlock {
+    fn default() -> Self {
+        Self([0u8; DATA_LEN])
+    }
+}
+
+#[derive(Default, Debug, Clone, Encode, Decode, Serialize, Deserialize, Reflect)]
+pub struct RefSample {
+    pub data: DataBlock,
+    /// Sequence number stamped by the originating sensor. Its sample time is the
+    /// envelope `tov`, which every node propagates unchanged.
+    pub seq: u64,
+}
+
+/// The same block under a second name.
+///
+/// Copper derives a task's output ports from the *distinct* `msg:` types of its outgoing
+/// connections, so a node cannot drive two ports with one payload type. The intersection
+/// node needs two, so its second lane gets its own type.
+#[derive(Default, Debug, Clone, Encode, Decode, Serialize, Deserialize, Reflect)]
+pub struct RefLaneSample(pub RefSample);
+
+impl From<RefSample> for RefLaneSample {
+    fn from(sample: RefSample) -> Self {
+        Self(sample)
+    }
+}
+
+impl AsRef<RefSample> for RefSample {
+    fn as_ref(&self) -> &RefSample {
+        self
+    }
+}
+
+impl AsRef<RefSample> for RefLaneSample {
+    fn as_ref(&self) -> &RefSample {
+        &self.0
+    }
+}

--- a/examples/cu_autoware/src/tasks.rs
+++ b/examples/cu_autoware/src/tasks.rs
@@ -1,0 +1,762 @@
+//! The six generic node types of the Autoware reference system.
+//!
+//! Every node is parameterized from its RON `config:` block: `crunch_limit` sets the
+//! busy work, `period_ms` the tick of the timed ones. Timing constants are load-bearing
+//! in a benchmark, so a missing or mistyped key is an error rather than a default.
+
+use crate::payload::{RefLaneSample, RefSample};
+use bincode::de::Decoder;
+use bincode::enc::Encoder;
+use bincode::error::{DecodeError, EncodeError};
+use bincode::{Decode, Encode};
+use cu29::prelude::*;
+use std::hint::black_box;
+use std::marker::PhantomData;
+
+fn cfg_u64(config: Option<&ComponentConfig>, task: &str, key: &str) -> CuResult<u64> {
+    config
+        .map(|c| c.get::<u64>(key))
+        .transpose()
+        .map_err(|e| CuError::from(format!("{task}: config key '{key}': {e}")))?
+        .flatten()
+        .ok_or_else(|| CuError::from(format!("{task}: missing required config key '{key}'")))
+}
+
+/// Port of the fork's `number_cruncher`, off-by-one included: the inner loop stops
+/// *below* the truncated square root, so prime squares and a few semiprimes are counted
+/// as prime (32 below 100, not 25). The benchmark calibrates against this cost curve, so
+/// the bug is preserved deliberately.
+fn number_cruncher(limit: u64) -> u64 {
+    let mut primes = 0u64;
+    for i in 3..limit {
+        let bound = (i as f64).sqrt() as u64;
+        let mut is_prime = true;
+        for n in 2..bound {
+            if i.is_multiple_of(n) {
+                is_prime = false;
+                break;
+            }
+        }
+        primes += u64::from(is_prime);
+    }
+    primes
+}
+
+/// The reference system's number crunch. `limit` is calibrated per node to a target
+/// duration.
+///
+/// Never inlined: the app would otherwise get one copy per call site and `calibrate`
+/// another, and the same limit then costs a few percent more in one binary than the other.
+#[inline(never)]
+pub fn crunch(limit: u64) {
+    black_box(number_cruncher(limit));
+}
+
+/// Period gating for the timed nodes. Copper has no per-task period, so the whole
+/// multi-rate mechanism is confined here and stays swappable.
+///
+/// Deliberate choice: clock-based pacing, equivalent to an rclcpp timer. The next
+/// deadline is rescheduled as `due + period`, and resynced to `now + period` once a
+/// whole period has been missed, so a lagging loop never fires a catch-up burst.
+/// Replay is therefore only deterministic at copperlist granularity.
+#[derive(Reflect)]
+pub struct Pacer {
+    period: CuDuration,
+    due: Option<CuTime>,
+}
+
+impl Pacer {
+    pub fn new(config: Option<&ComponentConfig>, task: &str) -> CuResult<Self> {
+        Ok(Self {
+            period: CuDuration::from_millis(cfg_u64(config, task, "period_ms")?),
+            due: None,
+        })
+    }
+
+    /// True on the cycles where the node is due to run.
+    pub fn fire(&mut self, now: CuTime) -> bool {
+        let Some(due) = self.due else {
+            self.due = Some(now + self.period);
+            return true;
+        };
+        if now < due {
+            return false;
+        }
+        let next = due + self.period;
+        self.due = Some(if next > now { next } else { now + self.period });
+        true
+    }
+}
+
+impl Freezable for Pacer {
+    fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        Encode::encode(&self.due, encoder)
+    }
+
+    fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
+        self.due = Decode::decode(decoder)?;
+        Ok(())
+    }
+}
+
+/// The runtime reuses the copperlist slots, so a suppressed output has to drop the
+/// previous cycle's time of validity along with its payload.
+fn suppress<P: CuMsgPayload>(output: &mut CuMsg<P>) {
+    output.clear_payload();
+    output.tov = Tov::default();
+}
+
+/// Timer-driven sensor: emits a fresh sample on its own period.
+#[derive(Reflect)]
+pub struct RefSensor {
+    pacer: Pacer,
+    crunch_limit: u64,
+    seq: u64,
+}
+
+impl Freezable for RefSensor {
+    fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        Encode::encode(&self.seq, encoder)?;
+        self.pacer.freeze(encoder)
+    }
+
+    fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
+        self.seq = Decode::decode(decoder)?;
+        self.pacer.thaw(decoder)
+    }
+}
+
+impl CuSrcTask for RefSensor {
+    type Resources<'r> = ();
+    type Output<'m> = output_msg!(RefSample);
+
+    fn new(config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self> {
+        Ok(Self {
+            pacer: Pacer::new(config, "RefSensor")?,
+            crunch_limit: cfg_u64(config, "RefSensor", "crunch_limit")?,
+            seq: 0,
+        })
+    }
+
+    fn process(&mut self, ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
+        let now = ctx.now();
+        if !self.pacer.fire(now) {
+            suppress(output);
+            return Ok(());
+        }
+        crunch(self.crunch_limit);
+        self.seq += 1;
+        output.tov = Tov::Time(now);
+        output.set_payload(RefSample {
+            seq: self.seq,
+            ..Default::default()
+        });
+        Ok(())
+    }
+}
+
+/// One in, one out: runs only on a fresh input and forwards its provenance.
+#[derive(Reflect)]
+pub struct RefTransform {
+    crunch_limit: u64,
+}
+
+impl Freezable for RefTransform {}
+
+impl CuTask for RefTransform {
+    type Resources<'r> = ();
+    type Input<'m> = input_msg!(RefSample);
+    type Output<'m> = output_msg!(RefSample);
+
+    fn new(config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self> {
+        Ok(Self {
+            crunch_limit: cfg_u64(config, "RefTransform", "crunch_limit")?,
+        })
+    }
+
+    fn process(
+        &mut self,
+        _ctx: &CuContext,
+        input: &Self::Input<'_>,
+        output: &mut Self::Output<'_>,
+    ) -> CuResult<()> {
+        let Some(sample) = input.payload() else {
+            suppress(output);
+            return Ok(());
+        };
+        crunch(self.crunch_limit);
+        output.tov = input.tov;
+        output.set_payload(sample.clone());
+        Ok(())
+    }
+}
+
+/// Two in, one out. Input 0 is the trigger; a fresh input 1 is only charged
+/// `cache_crunch_limit`, the way the reference system's secondary callback is.
+///
+/// The reference node also has a warm-up gate that waits for both inputs before it first
+/// emits. The fork comments out its `.reset()`, so steady state is identical and it is
+/// left out here rather than reimplemented.
+#[derive(Reflect)]
+pub struct RefFusion {
+    crunch_limit: u64,
+    cache_crunch_limit: u64,
+}
+
+impl Freezable for RefFusion {}
+
+impl RefFusion {
+    /// `charge` is `crunch` in production and a recorder in the tests.
+    fn fuse(
+        &self,
+        input: &[&CuMsg<RefSample>; 2],
+        output: &mut CuMsg<RefSample>,
+        mut charge: impl FnMut(u64),
+    ) {
+        if input[1].payload().is_some() {
+            charge(self.cache_crunch_limit);
+        }
+        let Some(trigger) = input[0].payload() else {
+            suppress(output);
+            return;
+        };
+        charge(self.crunch_limit);
+        output.tov = input[0].tov;
+        output.set_payload(trigger.clone());
+    }
+}
+
+impl CuTask for RefFusion {
+    type Resources<'r> = ();
+    type Input<'m> = input_msg!('m, RefSample, RefSample);
+    type Output<'m> = output_msg!(RefSample);
+
+    fn new(config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self> {
+        Ok(Self {
+            crunch_limit: cfg_u64(config, "RefFusion", "crunch_limit")?,
+            cache_crunch_limit: cfg_u64(config, "RefFusion", "cache_crunch_limit")?,
+        })
+    }
+
+    fn process(
+        &mut self,
+        _ctx: &CuContext,
+        input: &Self::Input<'_>,
+        output: &mut Self::Output<'_>,
+    ) -> CuResult<()> {
+        self.fuse(&[input.0, input.1], output, crunch);
+        Ok(())
+    }
+}
+
+/// Six inputs, driven by its own period instead of by its inputs. Each fresh input is
+/// only charged `cache_crunch_limit`.
+#[derive(Reflect)]
+pub struct RefCyclic {
+    pacer: Pacer,
+    crunch_limit: u64,
+    cache_crunch_limit: u64,
+    seq: u64,
+}
+
+impl Freezable for RefCyclic {
+    fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        Encode::encode(&self.seq, encoder)?;
+        self.pacer.freeze(encoder)
+    }
+
+    fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
+        self.seq = Decode::decode(decoder)?;
+        self.pacer.thaw(decoder)
+    }
+}
+
+impl RefCyclic {
+    /// `charge` is `crunch` in production and a recorder in the tests.
+    fn tick(
+        &mut self,
+        now: CuTime,
+        input: &[&CuMsg<RefSample>; 6],
+        output: &mut CuMsg<RefSample>,
+        mut charge: impl FnMut(u64),
+    ) {
+        for msg in input {
+            if msg.payload().is_some() {
+                charge(self.cache_crunch_limit);
+            }
+        }
+        if !self.pacer.fire(now) {
+            suppress(output);
+            return;
+        }
+        charge(self.crunch_limit);
+        self.seq += 1;
+        output.tov = Tov::Time(now);
+        output.set_payload(RefSample {
+            seq: self.seq,
+            ..Default::default()
+        });
+    }
+}
+
+impl CuTask for RefCyclic {
+    type Resources<'r> = ();
+    type Input<'m> =
+        input_msg!('m, RefSample, RefSample, RefSample, RefSample, RefSample, RefSample);
+    type Output<'m> = output_msg!(RefSample);
+
+    fn new(config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self> {
+        Ok(Self {
+            pacer: Pacer::new(config, "RefCyclic")?,
+            crunch_limit: cfg_u64(config, "RefCyclic", "crunch_limit")?,
+            cache_crunch_limit: cfg_u64(config, "RefCyclic", "cache_crunch_limit")?,
+            seq: 0,
+        })
+    }
+
+    fn process(
+        &mut self,
+        ctx: &CuContext,
+        input: &Self::Input<'_>,
+        output: &mut Self::Output<'_>,
+    ) -> CuResult<()> {
+        let input = [input.0, input.1, input.2, input.3, input.4, input.5];
+        self.tick(ctx.now(), &input, output, crunch);
+        Ok(())
+    }
+}
+
+/// Two independent lanes, in0 -> out0 and in1 -> out1, each with its own budget.
+#[derive(Reflect)]
+pub struct RefIntersection {
+    crunch_limit0: u64,
+    crunch_limit1: u64,
+}
+
+impl Freezable for RefIntersection {}
+
+impl CuTask for RefIntersection {
+    type Resources<'r> = ();
+    type Input<'m> = input_msg!('m, RefSample, RefSample);
+    type Output<'m> = output_msg!(RefSample, RefLaneSample);
+
+    fn new(config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self> {
+        Ok(Self {
+            crunch_limit0: cfg_u64(config, "RefIntersection", "crunch_limit0")?,
+            crunch_limit1: cfg_u64(config, "RefIntersection", "crunch_limit1")?,
+        })
+    }
+
+    fn process(
+        &mut self,
+        _ctx: &CuContext,
+        input: &Self::Input<'_>,
+        output: &mut Self::Output<'_>,
+    ) -> CuResult<()> {
+        lane(self.crunch_limit0, input.0, &mut output.0);
+        lane(self.crunch_limit1, input.1, &mut output.1);
+        Ok(())
+    }
+}
+
+fn lane<P: CuMsgPayload + From<RefSample>>(
+    crunch_limit: u64,
+    input: &CuMsg<RefSample>,
+    output: &mut CuMsg<P>,
+) {
+    let Some(sample) = input.payload() else {
+        suppress(output);
+        return;
+    };
+    crunch(crunch_limit);
+    output.tov = input.tov;
+    output.set_payload(sample.clone().into());
+}
+
+/// Terminal command node, over whichever lane type reaches it.
+// No `type_path = false`: the derived per-instantiation TypePath is what
+// `CuSinkTask::debug_state_type_path` needs, and it keeps the two lanes distinguishable.
+#[derive(Reflect)]
+pub struct RefCommand<P: CuMsgPayload + AsRef<RefSample>> {
+    crunch_limit: u64,
+    #[reflect(ignore)]
+    _payload: PhantomData<fn() -> P>,
+}
+
+impl<P: CuMsgPayload + AsRef<RefSample>> Freezable for RefCommand<P> {}
+
+impl<P: CuMsgPayload + AsRef<RefSample>> CuSinkTask for RefCommand<P> {
+    type Resources<'r> = ();
+    type Input<'m> = input_msg!(P);
+
+    fn new(config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self> {
+        Ok(Self {
+            crunch_limit: cfg_u64(config, "RefCommand", "crunch_limit")?,
+            _payload: PhantomData,
+        })
+    }
+
+    fn process(&mut self, ctx: &CuContext, input: &Self::Input<'_>) -> CuResult<()> {
+        let Some(sample) = input.payload() else {
+            return Ok(());
+        };
+        crunch(self.crunch_limit);
+        // A sink has no output message to stamp, so the status goes to the text log
+        // (debug builds only: release compiles debug! out).
+        debug!(ctx, "command seq {}", sample.as_ref().seq);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bincode::config::standard;
+    use bincode::de::DecoderImpl;
+    use bincode::de::read::SliceReader;
+    use bincode::encode_to_vec;
+
+    fn config(entries: &[(&str, u64)]) -> ComponentConfig {
+        let mut config = ComponentConfig::new();
+        for (key, value) in entries {
+            config.set(key, *value);
+        }
+        config
+    }
+
+    fn sample(seq: u64, tov_ms: u64) -> CuMsg<RefSample> {
+        let mut msg = CuMsg::new(Some(RefSample {
+            seq,
+            ..Default::default()
+        }));
+        msg.tov = Tov::Time(CuTime::from_millis(tov_ms));
+        msg
+    }
+
+    fn sensor(period_ms: u64) -> RefSensor {
+        RefSensor::new(
+            Some(&config(&[("period_ms", period_ms), ("crunch_limit", 0)])),
+            (),
+        )
+        .unwrap()
+    }
+
+    fn transform() -> RefTransform {
+        RefTransform::new(Some(&config(&[("crunch_limit", 0)])), ()).unwrap()
+    }
+
+    /// Distinct sentinels so a recorded charge says which callback ran.
+    const CRUNCH: u64 = 7;
+    const CACHE: u64 = 3;
+
+    fn fusion() -> RefFusion {
+        RefFusion::new(
+            Some(&config(&[
+                ("crunch_limit", CRUNCH),
+                ("cache_crunch_limit", CACHE),
+            ])),
+            (),
+        )
+        .unwrap()
+    }
+
+    fn cyclic() -> RefCyclic {
+        RefCyclic::new(
+            Some(&config(&[
+                ("period_ms", 100),
+                ("crunch_limit", CRUNCH),
+                ("cache_crunch_limit", CACHE),
+            ])),
+            (),
+        )
+        .unwrap()
+    }
+
+    fn fusion_charges(task: &RefFusion, input: &[&CuMsg<RefSample>; 2]) -> Vec<u64> {
+        let mut charged = Vec::new();
+        let mut output = CuMsg::new(None);
+        task.fuse(input, &mut output, |limit| charged.push(limit));
+        charged
+    }
+
+    fn thaw_from<T: Freezable>(task: &mut T, frozen: &[u8]) {
+        let mut decoder = DecoderImpl::new(SliceReader::new(frozen), standard(), ());
+        task.thaw(&mut decoder).unwrap();
+    }
+
+    #[test]
+    fn test_crunch_prime_count_is_stable() {
+        // Anchors the shape the step 3 calibration maps milliseconds onto. 32, not 25:
+        // the fork's off-by-one lets 4 and 9 through, and this port keeps it.
+        assert_eq!(number_cruncher(100), 32);
+    }
+
+    #[test]
+    fn test_missing_config_key_is_an_error() {
+        let err = RefTransform::new(Some(&config(&[])), ())
+            .err()
+            .expect("a missing key must fail");
+        assert!(err.to_string().contains("crunch_limit"));
+        // A float where an integer is expected must not silently read as 0 either.
+        let mut float_config = ComponentConfig::new();
+        float_config.set("crunch_limit", 200.0f64);
+        assert!(RefTransform::new(Some(&float_config), ()).is_err());
+    }
+
+    #[test]
+    fn test_pacer_fires_once_per_period() {
+        let mut pacer = Pacer::new(Some(&config(&[("period_ms", 200)])), "t").unwrap();
+        // 5ms loop over one second: fire at t=0 then every 200ms.
+        let fired: Vec<u64> = (0..200)
+            .map(|step| CuTime::from_millis(step * 5))
+            .filter(|now| pacer.fire(*now))
+            .map(|now| now.as_nanos() / 1_000_000)
+            .collect();
+        assert_eq!(fired, [0, 200, 400, 600, 800]);
+    }
+
+    #[test]
+    fn test_pacer_resyncs_after_a_missed_period() {
+        let mut pacer = Pacer::new(Some(&config(&[("period_ms", 200)])), "t").unwrap();
+        assert!(pacer.fire(CuTime::from_millis(0)));
+        // The loop stalls for more than two periods: one fire, no catch-up burst.
+        assert!(pacer.fire(CuTime::from_millis(700)));
+        assert!(!pacer.fire(CuTime::from_millis(800)));
+        assert!(pacer.fire(CuTime::from_millis(900)));
+    }
+
+    #[test]
+    fn test_transform_skips_empty_input() {
+        let (ctx, _mock) = CuContext::new_mock_clock();
+        let mut task = transform();
+        let mut output = CuMsg::new(Some(RefSample::default()));
+        output.tov = Tov::Time(CuTime::from_millis(1));
+
+        task.process(&ctx, &CuMsg::new(None), &mut output).unwrap();
+        assert!(output.payload().is_none());
+        assert_eq!(
+            output.tov,
+            Tov::None,
+            "a suppressed output must drop its tov"
+        );
+
+        task.process(&ctx, &sample(7, 42), &mut output).unwrap();
+        assert_eq!(output.payload().unwrap().seq, 7);
+    }
+
+    #[test]
+    fn test_fusion_triggers_on_input_zero_only() {
+        let (ctx, _mock) = CuContext::new_mock_clock();
+        let mut task = fusion();
+        let mut output = CuMsg::new(None);
+
+        task.process(&ctx, &(&CuMsg::new(None), &sample(1, 10)), &mut output)
+            .unwrap();
+        assert!(output.payload().is_none());
+
+        task.process(&ctx, &(&sample(9, 90), &CuMsg::new(None)), &mut output)
+            .unwrap();
+        assert_eq!(output.payload().unwrap().seq, 9);
+    }
+
+    #[test]
+    fn test_fusion_charge_model() {
+        let task = fusion();
+        let empty = CuMsg::new(None);
+        let fresh = sample(1, 10);
+
+        // The cache callback is charged for a fresh input 1 whether or not anything is emitted.
+        assert_eq!(fusion_charges(&task, &[&empty, &fresh]), [CACHE]);
+        assert_eq!(fusion_charges(&task, &[&fresh, &empty]), [CRUNCH]);
+        assert_eq!(fusion_charges(&task, &[&fresh, &fresh]), [CACHE, CRUNCH]);
+        assert!(fusion_charges(&task, &[&empty, &empty]).is_empty());
+    }
+
+    #[test]
+    fn test_cyclic_charge_model() {
+        let empty = CuMsg::new(None);
+        let fresh = sample(1, 0);
+        for fresh_inputs in 0..=6 {
+            let mut task = cyclic();
+            let input: [&CuMsg<RefSample>; 6] =
+                std::array::from_fn(|i| if i < fresh_inputs { &fresh } else { &empty });
+            let mut output = CuMsg::new(None);
+
+            // The first tick fires the pacer, so the timer callback is charged too.
+            let mut charged = Vec::new();
+            task.tick(CuTime::from_millis(0), &input, &mut output, |limit| {
+                charged.push(limit)
+            });
+            let mut expected = vec![CACHE; fresh_inputs];
+            expected.push(CRUNCH);
+            assert_eq!(charged, expected);
+
+            // The next one does not, but the input callbacks still run.
+            let mut charged = Vec::new();
+            task.tick(CuTime::from_millis(10), &input, &mut output, |limit| {
+                charged.push(limit)
+            });
+            assert_eq!(charged, vec![CACHE; fresh_inputs]);
+        }
+    }
+
+    #[test]
+    fn test_config_pins_the_trigger_lane_of_every_multi_input_node() {
+        let config = read_configuration("copperconfig.ron").unwrap();
+        let graph = config.get_graph(None).unwrap();
+        // Input order is connection order, which only the edge order carries.
+        let inputs = |id: &str| -> Vec<String> {
+            let node_id = graph.get_node_id_by_name(id).unwrap();
+            let mut edges: Vec<&Cnx> = graph
+                .get_dst_edges(node_id)
+                .unwrap()
+                .iter()
+                .map(|edge_id| graph.edge(*edge_id).unwrap())
+                .collect();
+            edges.sort_by_key(|edge| edge.order);
+            edges.iter().map(|edge| edge.src.clone()).collect()
+        };
+
+        assert_eq!(
+            inputs("point_cloud_fusion"),
+            ["points_transformer_front", "points_transformer_rear"]
+        );
+        assert_eq!(
+            inputs("ndt_localizer"),
+            ["point_cloud_map_loader", "voxel_grid_downsampler"]
+        );
+        assert_eq!(
+            inputs("lanelet2_global_planner"),
+            ["visualizer", "ndt_localizer"]
+        );
+        assert_eq!(
+            inputs("lanelet2_map_loader"),
+            ["lanelet2_map", "lanelet2_global_planner"]
+        );
+        assert_eq!(
+            inputs("euclidean_cluster_detector"),
+            ["ray_ground_filter", "euclidean_cluster_settings"]
+        );
+        assert_eq!(
+            inputs("behavior_planner"),
+            [
+                "object_collision_estimator",
+                "ndt_localizer",
+                "lanelet2_global_planner",
+                "lanelet2_map_loader",
+                "parking_planner",
+                "lane_planner",
+            ]
+        );
+        assert_eq!(
+            inputs("vehicle_interface"),
+            ["mpc_controller", "behavior_planner"]
+        );
+    }
+
+    #[test]
+    fn test_intersection_lanes_are_independent() {
+        let (ctx, _mock) = CuContext::new_mock_clock();
+        let mut task = RefIntersection::new(
+            Some(&config(&[("crunch_limit0", 0), ("crunch_limit1", 0)])),
+            (),
+        )
+        .unwrap();
+        let mut output = (CuMsg::new(None), CuMsg::new(None));
+
+        task.process(&ctx, &(&sample(1, 10), &CuMsg::new(None)), &mut output)
+            .unwrap();
+        assert_eq!(output.0.payload().unwrap().seq, 1);
+        assert!(output.1.payload().is_none());
+
+        task.process(&ctx, &(&CuMsg::new(None), &sample(2, 20)), &mut output)
+            .unwrap();
+        assert!(output.0.payload().is_none());
+        assert_eq!(output.1.payload().unwrap().0.seq, 2);
+    }
+
+    #[test]
+    fn test_cyclic_ticks_on_its_own_period() {
+        let (ctx, mock) = CuContext::new_mock_clock();
+        let mut task = cyclic();
+        let empty = CuMsg::new(None);
+        let fresh = sample(1, 0);
+        let mut output = CuMsg::new(None);
+
+        // First cycle ticks, the next one does not even though every input is fresh.
+        let all_fresh = (&fresh, &fresh, &fresh, &fresh, &fresh, &fresh);
+        task.process(&ctx, &all_fresh, &mut output).unwrap();
+        assert_eq!(output.payload().unwrap().seq, 1);
+        mock.increment(CuDuration::from_millis(10));
+        task.process(&ctx, &all_fresh, &mut output).unwrap();
+        assert!(output.payload().is_none());
+
+        // ... and it ticks on its period even with no input at all.
+        mock.increment(CuDuration::from_millis(100));
+        let none = (&empty, &empty, &empty, &empty, &empty, &empty);
+        task.process(&ctx, &none, &mut output).unwrap();
+        assert_eq!(output.payload().unwrap().seq, 2);
+    }
+
+    #[test]
+    fn test_sensor_freeze_thaw_restores_state() {
+        let (ctx, mock) = CuContext::new_mock_clock();
+        let mut task = sensor(200);
+        let mut output = CuMsg::new(None);
+        mock.increment(CuDuration::from_millis(500));
+        task.process(&ctx, &mut output).unwrap();
+
+        let frozen = encode_to_vec(BincodeAdapter(&task), standard()).unwrap();
+        // Drift the state away from what was frozen.
+        mock.increment(CuDuration::from_millis(400));
+        task.process(&ctx, &mut output).unwrap();
+        assert_eq!(output.payload().unwrap().seq, 2);
+
+        thaw_from(&mut task, &frozen);
+        assert_eq!(task.pacer.due, Some(CuTime::from_millis(700)));
+        mock.increment(CuDuration::from_millis(400));
+        task.process(&ctx, &mut output).unwrap();
+        assert_eq!(
+            output.payload().unwrap().seq,
+            2,
+            "seq resumed from the keyframe"
+        );
+    }
+
+    #[test]
+    fn test_cyclic_freeze_thaw_restores_state() {
+        let mut task = cyclic();
+        task.seq = 12;
+        task.pacer.due = Some(CuTime::from_millis(340));
+        let frozen = encode_to_vec(BincodeAdapter(&task), standard()).unwrap();
+
+        task.seq = 99;
+        task.pacer.due = None;
+        thaw_from(&mut task, &frozen);
+        assert_eq!(task.seq, 12);
+        assert_eq!(task.pacer.due, Some(CuTime::from_millis(340)));
+    }
+
+    #[test]
+    fn test_seq_and_tov_propagate_to_fusion() {
+        let (ctx, mock) = CuContext::new_mock_clock();
+        mock.increment(CuDuration::from_millis(300));
+        let mut sensor = sensor(200);
+        let mut transform = transform();
+        let mut fusion = fusion();
+
+        let mut sensed = CuMsg::new(None);
+        let mut transformed = CuMsg::new(None);
+        let mut fused = CuMsg::new(None);
+        sensor.process(&ctx, &mut sensed).unwrap();
+        transform.process(&ctx, &sensed, &mut transformed).unwrap();
+        fusion
+            .process(&ctx, &(&transformed, &CuMsg::new(None)), &mut fused)
+            .unwrap();
+
+        assert_eq!(sensed.payload().unwrap().seq, 1);
+        assert_eq!(sensed.tov, Tov::Time(CuTime::from_millis(300)));
+        assert_eq!(fused.payload().unwrap().seq, 1);
+        assert_eq!(fused.tov, sensed.tov);
+    }
+}


### PR DESCRIPTION
## Summary
Fair port of the Autoware reference system benchmark (rtenlab/reference-system-latency-management, RTNS'25 LaME paper) as a Copper example: `examples/cu_autoware`.

## Related issues
None.

## Changes
- 24-node graph, Fig. 4 periods and execution times; six generic task types (sensor/transform/fusion/cyclic/intersection/command) with a calibrated prime-crunch workload
- `calibrate` binary maps per-class target durations to crunch limits on the host (`--apply` rewrites the config)
- `kpi` binary computes the six reference-system KPIs from the recorded `.copper` log; `analysis/` has a CPU/RSS sampler and the plotting script; standard export CLI included
- `cu_consolemon` wired as the app monitor for a live per-task view (headless when stdout is not a tty)
- core/ untouched; one workspace-member line in the root Cargo.toml

## Reminder
- [x] I ran `just` from the repo root (full gate on the previous head; scoped test/clippy/fmt on the monitor commit)
- [x] I have updated docs or examples where needed


## Notes (PLZ check)
Two things surfaced by the port that may deserve a home outside this example:

1. **Pacer / per-task periods.** Copper has no per-task period, so the multi-rate behavior lives in a small clock-based `Pacer` (rclcpp-timer equivalent) inside the tasks. Open question: per-task periods as a core feature, or `Pacer` as a reusable `components/tasks` crate?
2. **Chain latency.** `cu29_export` aggregates per-task/per-edge only. Chain (multi-hop) response time vs deadline — the benchmark's main KPI — is computed locally in the `kpi` binary from `tov` + `process_time`. A chain-stats API in `cu29_export` would make this reusable.

