### PR TITLE
Fix direct unit payloads without reflection

### DIFF
--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -71,7 +71,7 @@ jobs:
 
     env:
       CARGO_TERM_COLOR: always
-      BASE_FEATURES: mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
+      BASE_FEATURES: cu29/reflect,mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
       WORKSPACE_SCOPE: workspace
 
     strategy:
@@ -152,7 +152,7 @@ jobs:
 
     env:
       CARGO_TERM_COLOR: always
-      BASE_FEATURES: mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
+      BASE_FEATURES: cu29/reflect,mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
       WORKSPACE_SCOPE: workspace
 
     strategy:
@@ -310,7 +310,7 @@ jobs:
 
     env:
       CARGO_TERM_COLOR: always
-      BASE_FEATURES: mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
+      BASE_FEATURES: cu29/reflect,mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
       WORKSPACE_SCOPE: workspace
 
     steps:
@@ -361,7 +361,7 @@ jobs:
 
     env:
       CARGO_TERM_COLOR: always
-      BASE_FEATURES: mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
+      BASE_FEATURES: cu29/reflect,mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
       WORKSPACE_SCOPE: ${{ matrix.target_os == 'windows' && 'core' || 'workspace' }}
 
     strategy:
@@ -484,7 +484,7 @@ jobs:
 
     env:
       CARGO_TERM_COLOR: always
-      BASE_FEATURES: mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
+      BASE_FEATURES: cu29/reflect,mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
       WORKSPACE_SCOPE: workspace
 
     steps:
@@ -540,7 +540,7 @@ jobs:
 
     env:
       CARGO_TERM_COLOR: always
-      BASE_FEATURES: mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
+      BASE_FEATURES: cu29/reflect,mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
       WORKSPACE_SCOPE: workspace
 
     steps:
@@ -584,7 +584,7 @@ jobs:
 
     env:
       CARGO_TERM_COLOR: always
-      BASE_FEATURES: mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
+      BASE_FEATURES: cu29/reflect,mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
       WORKSPACE_SCOPE: workspace
 
     steps:
@@ -642,7 +642,7 @@ jobs:
 
     env:
       CARGO_TERM_COLOR: always
-      BASE_FEATURES: mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
+      BASE_FEATURES: cu29/reflect,mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug
       WORKSPACE_SCOPE: ${{ matrix.target_os == 'windows' && 'core' || 'workspace' }}
 
     strategy:

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -1395,7 +1395,7 @@ fn gen_culist_support(
                 cu29::TaskOutputSpec {
                     task_id: #task_id,
                     msg_type: #msg_type,
-                    payload_type_path_fn: <#payload_type as cu29::prelude::TypePath>::type_path,
+                    payload_type_path_fn: cu29::reflect::__payload_type_path::<#payload_type>,
                 }
             }
         })

--- a/core/cu29_derive/tests/compile_pass/copper_runtime/direct_unit_payload.rs
+++ b/core/cu29_derive/tests/compile_pass/copper_runtime/direct_unit_payload.rs
@@ -1,0 +1,28 @@
+use cu29::prelude::*;
+use cu29::units::si::angle::radian;
+use cu29::units::si::f32::Angle;
+use cu29_derive::copper_runtime;
+
+#[derive(Reflect)]
+struct AngleSource;
+
+impl Freezable for AngleSource {}
+
+impl CuSrcTask for AngleSource {
+    type Resources<'r> = ();
+    type Output<'m> = output_msg!(Angle);
+
+    fn new(_config: Option<&ComponentConfig>, _resources: Self::Resources<'_>) -> CuResult<Self> {
+        Ok(Self)
+    }
+
+    fn process(&mut self, _ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
+        output.set_payload(Angle::new::<radian>(0.0));
+        Ok(())
+    }
+}
+
+#[copper_runtime(config = "config/direct_unit_payload_valid.ron")]
+struct App {}
+
+fn main() {}

--- a/core/cu29_derive/tests/config/direct_unit_payload_valid.ron
+++ b/core/cu29_derive/tests/config/direct_unit_payload_valid.ron
@@ -1,0 +1,15 @@
+(
+    tasks: [
+        (
+            id: "angle-src",
+            type: "AngleSource",
+        ),
+    ],
+    cnx: [
+        (
+            src: "angle-src",
+            dst: "__nc__",
+            msg: "cu29::units::si::f32::Angle",
+        ),
+    ],
+)

--- a/core/cu29_runtime/src/reflect.rs
+++ b/core/cu29_runtime/src/reflect.rs
@@ -58,6 +58,22 @@ pub trait TypePath {
     }
 }
 
+/// Returns the canonical payload type path used by generated output metadata.
+#[doc(hidden)]
+#[inline]
+#[cfg(feature = "reflect")]
+pub fn __payload_type_path<T: TypePath>() -> &'static str {
+    T::type_path()
+}
+
+/// Returns the canonical payload type path used by generated output metadata.
+#[doc(hidden)]
+#[inline]
+#[cfg(not(feature = "reflect"))]
+pub fn __payload_type_path<T>() -> &'static str {
+    core::any::type_name::<T>()
+}
+
 #[cfg(not(feature = "reflect"))]
 macro_rules! impl_type_path_for_primitives {
     ($($ty:ty),* $(,)?) => {
@@ -169,7 +185,9 @@ pub fn dump_type_registry_schema(_registry: &TypeRegistry) -> String {
 
 #[cfg(all(test, not(feature = "reflect")))]
 mod tests {
-    use super::TypePath;
+    use super::{__payload_type_path, TypePath};
+
+    struct PayloadWithoutTypePath;
 
     fn assert_type_path<T: TypePath + ?Sized>() {}
 
@@ -177,5 +195,13 @@ mod tests {
     fn unit_and_primitive_type_paths_exist_without_reflect() {
         assert_type_path::<()>();
         assert_type_path::<i8>();
+    }
+
+    #[test]
+    fn payload_type_path_does_not_require_type_path_without_reflect() {
+        assert_eq!(
+            __payload_type_path::<PayloadWithoutTypePath>(),
+            core::any::type_name::<PayloadWithoutTypePath>()
+        );
     }
 }

--- a/core/cu29_runtime/src/remote_debug.rs
+++ b/core/cu29_runtime/src/remote_debug.rs
@@ -5516,7 +5516,7 @@ mod tests {
             &[TaskOutputSpec {
                 task_id: "alias_task",
                 msg_type: "alias::payload",
-                payload_type_path_fn: <PayloadAlias as TypePath>::type_path,
+                payload_type_path_fn: crate::reflect::__payload_type_path::<PayloadAlias>,
             }]
         }
     }

--- a/justfile
+++ b/justfile
@@ -1,8 +1,9 @@
 # CI-aligned helpers mirroring .github/workflows/general.yml
 import "support/just/plan.just"
 
-BASE_FEATURES := "mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug"
-WINDOWS_BASE_FEATURES := "mock,cu-sensor-payloads/image,kornia,python,gst,faer,nalgebra,glam,debug_pane,bincode"
+# Keep first-party messages checked against the reflect-enabled CuMsgPayload contract.
+BASE_FEATURES := "cu29/reflect,mock,cu-sensor-payloads/image,kornia,gst,faer,nalgebra,glam,debug_pane,bincode,log-level-debug"
+WINDOWS_BASE_FEATURES := "cu29/reflect,mock,cu-sensor-payloads/image,kornia,python,gst,faer,nalgebra,glam,debug_pane,bincode"
 MSRV := "1.95.0"
 PUBLIC_API_VERSION := "0.51.0"
 PUBLIC_API_TOOLCHAIN := "nightly-2026-06-25"


### PR DESCRIPTION
## Summary

- route generated output payload paths through a feature-aware helper
- preserve canonical `TypePath` metadata when reflection is enabled
- fall back to `core::any::type_name` without imposing a `TypePath` bound when reflection is disabled
- add compile-pass coverage for a direct `cu29::units::si::f32::Angle` payload
- enable `cu29/reflect` in first-party host CI feature lanes so every in-scope message is compile-checked for reflection compatibility

The non-reflect and embedded lanes remain in place, so reflection stays optional for downstream/no_std builds.

## Testing

- `just fmt`
- `cargo test -p cu29-derive test_compile_fail -- --nocapture`
- `cargo test -p cu29-derive --features cu29/reflect test_compile_fail -- --nocapture`
- `cargo test -p cu29-runtime --features remote-debug output_schema_resolves_alias_payload_types_via_canonical_type_path`
- `cargo check --workspace --all-targets --features cu29/reflect` (with standard workspace exclusions)
- `just clippy-std`
- `just api-check`
- `just test`
- `just nostd-ci`