### PR TITLE
feat(cu_flight_controller): MCAP export for both logreaders and scripted sim runs

### DIFF
--- a/examples/cu_flight_controller/Cargo.toml
+++ b/examples/cu_flight_controller/Cargo.toml
@@ -253,6 +253,7 @@ logreader = [
   "bincode/std",
   "serde/std",
   "dep:cu29-export",
+  "cu29-export/mcap",
   "dep:cu-crsf",
   "dep:cu-msp-bridge",
   "dep:cu-bdshot",

--- a/examples/cu_flight_controller/src/compute_logreader.rs
+++ b/examples/cu_flight_controller/src/compute_logreader.rs
@@ -3,10 +3,47 @@ extern crate cu29 as bevy;
 mod messages;
 
 use cu29::prelude::*;
-use cu29_export::run_cli;
+use cu29_export::{PayloadSchemas, run_cli, trace_type_to_jsonschema};
+use messages::*;
 
 // The simulator and deployed compute runtime use the same auto-flying graph.
 gen_cumsgs!("compute_config.ron");
+
+/// Schema for tasks whose payload type is not traced here (see logreader.rs).
+/// `cu_zed::ZedDepthMap` as serialized: 16-bit samples in `handle`, scaled by
+/// `encoding.units_per_meter`, with `encoding.invalid` marking no-return pixels.
+fn depth_map_schema() -> String {
+    r#"{"$schema":"https://json-schema.org/draft-07/schema#","type":"object","properties":{
+"format":{"type":"object","properties":{"width":{"type":"integer"},"height":{"type":"integer"},"stride":{"type":"integer"}}},
+"encoding":{"type":"object","properties":{"units_per_meter":{"type":"number"},"invalid":{"type":"object","properties":{"unsigned":{"type":"integer"}}}}},
+"handle":{"type":"array","items":{"type":"integer"}}}}"#
+        .to_string()
+}
+
+fn untyped_schema() -> String {
+    r#"{"$schema":"https://json-schema.org/draft-07/schema#","type":"object","properties":{}}"#
+        .to_string()
+}
+
+impl PayloadSchemas for CuStampedDataSet {
+    fn get_payload_schemas() -> Vec<(&'static str, String)> {
+        <CuStampedDataSet as MatchingTasks>::get_all_task_ids()
+            .iter()
+            .map(|&id| {
+                let schema = match id {
+                    // The reflected schema of the depth map stops at `format`;
+                    // spell out the whole payload so exported depth samples are typed.
+                    "vitfly_depth_rate" => depth_map_schema(),
+                    "zed" => untyped_schema(),
+                    "vitfly" => trace_type_to_jsonschema::<cu_vitfly::VitFlyVelocity>(),
+                    "vitfly_command" => trace_type_to_jsonschema::<AutonomyVelocityCommand>(),
+                    _ => untyped_schema(),
+                };
+                (id, schema)
+            })
+            .collect()
+    }
+}
 
 fn main() {
     run_cli::<CuStampedDataSet>().expect("Failed to run the compute export CLI");

--- a/examples/cu_flight_controller/src/logreader.rs
+++ b/examples/cu_flight_controller/src/logreader.rs
@@ -3,11 +3,45 @@ extern crate cu29 as bevy;
 mod messages;
 
 use cu29::prelude::*;
-use cu29_export::run_cli;
+use cu29_export::{PayloadSchemas, run_cli, trace_type_to_jsonschema};
+use messages::*;
 
 // The simulator logs the MCU side of the closed-loop autonomy graph.
 // Keep this schema aligned with `sim.rs` rather than the legacy mission config.
 gen_cumsgs!("mcu_config.ron");
+
+/// Schema for tasks whose payload type is not traced here: an empty object, so
+/// MCAP consumers still see the channel (with Copper's tov/process_time
+/// envelope) without a typed payload.
+fn untyped_schema() -> String {
+    r#"{"$schema":"https://json-schema.org/draft-07/schema#","type":"object","properties":{}}"#
+        .to_string()
+}
+
+impl PayloadSchemas for CuStampedDataSet {
+    fn get_payload_schemas() -> Vec<(&'static str, String)> {
+        <CuStampedDataSet as MatchingTasks>::get_all_task_ids()
+            .iter()
+            .map(|&id| {
+                let schema = match id {
+                    "bmi088" => trace_type_to_jsonschema::<cu_sensor_payloads::ImuPayload>(),
+                    "ahrs" => trace_type_to_jsonschema::<cu_ahrs::AhrsPose>(),
+                    "mapper" | "mode_supervisor" => trace_type_to_jsonschema::<ControlInputs>(),
+                    "mag_heading" => trace_type_to_jsonschema::<GeographicHeading>(),
+                    "navigation" => trace_type_to_jsonschema::<NavigationState>(),
+                    "auto_mission" => trace_type_to_jsonschema::<AutoMissionTarget>(),
+                    "autonomy_context" => trace_type_to_jsonschema::<AutonomyContext>(),
+                    "auto_controller" => trace_type_to_jsonschema::<AutonomyControl>(),
+                    "attitude" => trace_type_to_jsonschema::<BodyRateSetpoint>(),
+                    "rate" => trace_type_to_jsonschema::<BodyCommand>(),
+                    "battery_adc" => trace_type_to_jsonschema::<BatteryVoltage>(),
+                    _ => untyped_schema(),
+                };
+                (id, schema)
+            })
+            .collect()
+    }
+}
 
 fn main() {
     run_cli::<CuStampedDataSet>().expect("Failed to run the export CLI");

--- a/examples/cu_flight_controller/src/sim.rs
+++ b/examples/cu_flight_controller/src/sim.rs
@@ -2320,13 +2320,30 @@ fn apply_joystick_frame(frame: &RcFrame, rc_input: &mut SimRcInput) {
     rc_input.auto = frame.knob_sc.is_some_and(three_pos_is_middle);
 }
 
+/// Seconds parsed from an environment variable, for scripted (headless-ish) runs.
+fn env_seconds(name: &str) -> Option<f32> {
+    std::env::var(name).ok()?.trim().parse::<f32>().ok()
+}
+
 fn update_rc_input_keyboard(
     mut rc_input: ResMut<SimRcInput>,
     keyboard: Res<ButtonInput<KeyCode>>,
     rc_source: Res<RcInputSource>,
     _layout: Res<WorldLayout>,
+    time: Res<Time>,
     #[cfg(feature = "bevymon")] focus: Option<Res<CuBevyMonFocus>>,
 ) {
+    // CU_SIM_AUTOSTART_S=<secs>: arm in Angle mode and engage AUTO once the
+    // sim has been running that long, so scripted runs need no keyboard.
+    if let Some(after) = env_seconds("CU_SIM_AUTOSTART_S")
+        && !rc_input.armed
+        && time.elapsed_secs() >= after
+    {
+        rc_input.armed = true;
+        rc_input.mode = messages::FlightMode::Angle;
+        rc_input.auto = true;
+        info!("sim rc: CU_SIM_AUTOSTART_S reached; armed in Angle mode with auto=true");
+    }
     #[cfg(feature = "bevymon")]
     if _layout.split_monitor && !focus.is_some_and(|focus| focus.0 == CuBevyMonSurface::Sim) {
         return;
@@ -2527,6 +2544,15 @@ fn run_copper(
     mut exit_writer: MessageWriter<AppExit>,
 ) {
     let elapsed_ns = physics_time.elapsed().as_nanos() as u64;
+    // CU_SIM_EXIT_AFTER_S=<secs>: request a clean AppExit (Copper stops and
+    // the unified log is finalized) after that much simulated time.
+    if let Some(after) = env_seconds("CU_SIM_EXIT_AFTER_S")
+        && physics_time.elapsed().as_secs_f32() >= after
+    {
+        info!("sim: CU_SIM_EXIT_AFTER_S reached; exiting");
+        exit_writer.write(AppExit::Success);
+        return;
+    }
     if let Err(err) = run_copper_iteration(
         &mut copper,
         elapsed_ns,


### PR DESCRIPTION
## Summary

`cu_flight_controller` could not export its logs to MCAP, and the simulator needed a keyboard to fly. This PR makes the example usable end to end for log analysis: run the sim scripted, export both subsystem logs to MCAP, query them with any MCAP tool.

Motivation: answering "how close did the drone get to a tree?" from the forest-world sim log with an external analysis tool. After this change the answer is a query away (closest ZED depth return over the flight, joined to `/navigation`).

## Related issues
- None filed; happy to open one for the schema tracing note below.

## Changes

- **MCAP export for both logreaders.** `logreader` feature now enables `cu29-export/mcap`; `quad-logreader` and `quad-compute-logreader` implement `PayloadSchemas`. Task payloads with a known type get a traced schema (`NavigationState`, `AutoMissionTarget`, `AutonomyContext`, `AhrsPose`, `ImuPayload`, `ControlInputs`, …); everything else gets an explicit empty-object schema so the channel still exports with Copper's `tov`/`process_time` envelope instead of the export panicking on an unknown id.
- **Explicit depth-map schema.** `trace_type_to_jsonschema::<ZedDepthMap>()` stops at `format` (the `handle` samples and `encoding` are not reflected), so `vitfly_depth_rate` gets a hand-written schema matching the serialized payload: `format`, `encoding{units_per_meter, invalid}`, `handle: integer[]`.
- **Scripted sim runs.** Two optional env vars, no behavior change when unset:
  - `CU_SIM_AUTOSTART_S=<secs>` — arm in Angle mode and engage AUTO once the sim has run that long (equivalent to Space then `4`).
  - `CU_SIM_EXIT_AFTER_S=<secs>` — request a clean `AppExit` after that much physics time, so Copper stops and the unified log is finalized (SIGINT/SIGKILL leave the slab unfinished).

Example:

```bash
CU_SIM_AUTOSTART_S=4 CU_SIM_EXIT_AFTER_S=45 just sim
cargo run -p cu-flight-controller --no-default-features --features logreader --bin quad-logreader -- \
    examples/cu_flight_controller/logs/flight_controller_sim.copper export-mcap --output fc.mcap
cargo run -p cu-flight-controller --no-default-features --features compute-logreader --bin quad-compute-logreader -- \
    examples/cu_flight_controller/logs/flight_compute_sim.copper export-mcap --output compute.mcap
```

On a 45 s forest run: MCU log → 2,880 CopperLists / 115,200 messages / 40 channels in 0.4 s; compute log → 46,080 messages / 16 channels (the `zed` stereo frames dominate the size).

## Reminder
- [x] `cargo fmt`, clippy (`-D warnings`) for the `sim,forest-world` and `compute-logreader` targets, and the `config_matrix` test
- [x] Example updated; no docs/book changes needed

## Additional context

Two things noticed while doing this, left for maintainers to decide:

1. **Unit newtypes trace as objects but serialize as scalars.** `trace_type_to_jsonschema` emits `{"value": number}` for `Length`, `Velocity`, angle types, etc., while serde writes the bare number. Consumers that trust the schema reject every typed channel (`"Could not convert -0.0 with type float ... to struct"`). Downstream I made the consumer tolerant (wrap scalars into single-field structs), but the exporter is the right place to fix it — either trace serde-transparent newtypes as their inner type, or serialize them as objects.
2. `CuDepthMap`'s reflected schema omits `handle`/`encoding`, hence the hand-written schema here; a `Reflect`-visible representation would let the generic trace work.
