### PR TITLE
feat(cu_flight_controller): add autonomous demo profile

### DIFF
--- a/examples/cu_flight_controller/Cargo.toml
+++ b/examples/cu_flight_controller/Cargo.toml
@@ -177,6 +177,7 @@ bevy = { workspace = true, default-features = false, features = [
 default = ["sim", "forest-world"]
 forest-world = []
 urban-world = []
+autonomous-demo = []
 sim_core = [
   "dep:cu29",
   "cu29/std",

--- a/examples/cu_flight_controller/README.md
+++ b/examples/cu_flight_controller/README.md
@@ -212,6 +212,9 @@ just rc
 # Run the normal full-window simulator with MCU + compute Copper runtimes
 just
 
+# Run the autonomous demo, then exit cleanly after 45 simulated seconds
+just demo
+
 # Run the split BevyMon simulator
 just bevy
 
@@ -221,6 +224,10 @@ just web
 # Build a deployable browser bundle into dist/flight-controller with hashed asset filenames
 just web-dist
 ```
+
+The browser bundle enables the compile-time `autonomous-demo` profile: it arms in Angle mode and
+engages AUTO after four simulated seconds, then keeps running. The native `just demo` profile uses
+the same autonomous start and exits cleanly after 45 simulated seconds to finalize its logs.
 
 The split BevyMon path reuses the same `cu_bevymon::spawn_split_layout(...)` shell as
 `cu_rp_balancebot` and `cu_bevymon_demo`, but the left panel still runs the real flight-controller

--- a/examples/cu_flight_controller/index.html
+++ b/examples/cu_flight_controller/index.html
@@ -11,7 +11,7 @@
       data-trunk
       rel="rust"
       data-bin="quad-bevymon"
-      data-cargo-features="bevymon,forest-world"
+      data-cargo-features="bevymon,forest-world,autonomous-demo"
       data-cargo-no-default-features
     />
     <link data-trunk rel="copy-dir" href="assets" />

--- a/examples/cu_flight_controller/justfile
+++ b/examples/cu_flight_controller/justfile
@@ -68,6 +68,13 @@ sim:
   cd "{{ROOT}}"
   cargo --config examples/cu_flight_controller/.cargo/config.toml run -r -p cu-flight-controller --no-default-features --features sim,forest-world --bin quad-sim
 
+# Run a self-starting autonomous demo and exit cleanly so logs are finalized.
+demo:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cd "{{ROOT}}"
+  cargo --config examples/cu_flight_controller/.cargo/config.toml run -r -p cu-flight-controller --no-default-features --features sim,forest-world,autonomous-demo --bin quad-sim
+
 # Run the Bevy + Copper simulation loop in the urban world.
 sim-urban:
   #!/usr/bin/env bash

--- a/examples/cu_flight_controller/src/sim.rs
+++ b/examples/cu_flight_controller/src/sim.rs
@@ -572,6 +572,28 @@ struct SimRcInput {
     auto: bool,
 }
 
+#[derive(Resource)]
+struct SimRunOptions {
+    autostart_s: Option<f32>,
+    exit_after_s: Option<f32>,
+}
+
+impl Default for SimRunOptions {
+    fn default() -> Self {
+        const AUTOSTART_S: f32 = 4.0;
+        const EXIT_AFTER_S: f32 = 45.0;
+
+        Self {
+            autostart_s: cfg!(feature = "autonomous-demo").then_some(AUTOSTART_S),
+            exit_after_s: cfg!(all(
+                feature = "autonomous-demo",
+                not(target_arch = "wasm32")
+            ))
+            .then_some(EXIT_AFTER_S),
+        }
+    }
+}
+
 impl Default for SimRcInput {
     fn default() -> Self {
         Self {
@@ -2325,8 +2347,19 @@ fn update_rc_input_keyboard(
     keyboard: Res<ButtonInput<KeyCode>>,
     rc_source: Res<RcInputSource>,
     _layout: Res<WorldLayout>,
+    run_options: Res<SimRunOptions>,
+    time: Res<Time>,
     #[cfg(feature = "bevymon")] focus: Option<Res<CuBevyMonFocus>>,
 ) {
+    if let Some(after) = run_options.autostart_s
+        && !rc_input.armed
+        && time.elapsed_secs() >= after
+    {
+        rc_input.armed = true;
+        rc_input.mode = messages::FlightMode::Angle;
+        rc_input.auto = true;
+        info!("sim rc: autostart reached; armed in Angle mode with auto=true");
+    }
     #[cfg(feature = "bevymon")]
     if _layout.split_monitor && !focus.is_some_and(|focus| focus.0 == CuBevyMonSurface::Sim) {
         return;
@@ -2517,21 +2550,34 @@ fn sync_vehicle_state(
     };
 }
 
+#[derive(SystemParam)]
+struct SimRunInputs<'w> {
+    rc_input: Res<'w, SimRcInput>,
+    options: Res<'w, SimRunOptions>,
+}
+
 fn run_copper(
     mut copper: ResMut<CopperState>,
     physics_time: Res<Time<Physics>>,
     sim_state: Res<SimState>,
-    rc_input: Res<SimRcInput>,
+    run: SimRunInputs,
     mut motor_commands: ResMut<SimMotorCommands>,
     mut osd_overlay: ResMut<SimOsdOverlay>,
     mut exit_writer: MessageWriter<AppExit>,
 ) {
     let elapsed_ns = physics_time.elapsed().as_nanos() as u64;
+    if let Some(after) = run.options.exit_after_s
+        && physics_time.elapsed().as_secs_f32() >= after
+    {
+        info!("sim: exit deadline reached; exiting");
+        exit_writer.write(AppExit::Success);
+        return;
+    }
     if let Err(err) = run_copper_iteration(
         &mut copper,
         elapsed_ns,
         sim_state.vehicle.clone(),
-        rc_input.clone(),
+        run.rc_input.clone(),
         &mut motor_commands,
         &mut osd_overlay,
     ) {
@@ -3215,6 +3261,7 @@ fn build_world_with_assets(
     app.insert_resource(SimState::default())
         .insert_resource(SimMotorCommands::default())
         .insert_resource(SimRcInput::default())
+        .insert_resource(SimRunOptions::default())
         .insert_resource(SimKinematics::default())
         .insert_resource(SimResetInterlock::default())
         .insert_resource(RcInputSource::default())


### PR DESCRIPTION
## Summary

Extracted from #1290 as a focused change for running the flight-controller autonomous demo without keyboard input.

This uses a compile-time `autonomous-demo` feature as the only activation mechanism:

- The checked-in browser/WASM bundle explicitly enables `autonomous-demo`, so the hosted demo arms in Angle mode and engages AUTO after four simulated seconds.
- Ordinary local `just sim` and `just bevy` builds do not enable the feature and remain interactive; they never autostart.
- `just demo` is the explicit native opt-in and builds the simulator with `autonomous-demo` enabled. It uses the same four-second autonomous start and exits cleanly after 45 simulated seconds to finalize unified logs.
- The WASM demo keeps running instead of applying the native log-finalization deadline.

A compile-time feature is intentional here. Copper spans native, embedded, and WASM targets, where process environment variables and command-line parameters are unavailable or inconsistent. Keeping demo mode in the feature set gives every target the same static, inspectable configuration model and avoids hidden runtime inputs.

The timing values are fixed, visible source constants rather than user-facing tuning knobs. No environment variables, CLI timing options, or URL parameters are introduced.

The original implementation and commit authorship are credited to @arunvenkatadri.

## Verification

- `just fmt`
- `cargo clippy -p cu-flight-controller --no-default-features --features sim,forest-world,autonomous-demo --bin quad-sim -- -D warnings`
- `cargo check -p cu-flight-controller --no-default-features --features bevymon,forest-world,autonomous-demo --bin quad-bevymon`

A direct `wasm32-unknown-unknown` check currently stops in the pre-existing `ctrlc 3.5.2` dependency with missing WASM platform symbols, before compiling this example.