### PR TITLE
Fix no_std ToString import in runtime

### DIFF
--- a/core/cu29_runtime/src/curuntime.rs
+++ b/core/cu29_runtime/src/curuntime.rs
@@ -52,7 +52,7 @@ use cu29_value::to_value;
 use alloc::alloc::{alloc_zeroed, handle_alloc_error};
 use alloc::boxed::Box;
 use alloc::format;
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use bincode::de::read::Reader;
 use bincode::de::{Decoder, DecoderImpl};


### PR DESCRIPTION
## Summary
- import the alloc ToString trait explicitly in cu29-runtime
- restore bare-metal compilation for keyframe error paths

## Why
The std prelude brings ToString into scope on host builds, but the core prelude used by no_std targets does not. Two recently added to_string calls therefore failed during embedded clippy.

## Verification
- just fmt
- rustup run stable cargo clippy -p cu-bdshot --target thumbv8m.main-none-eabihf -- --deny warnings
- just nostd-ci