### PR TITLE
fix(cu_autoware): migrate deprecated APIs

### DIFF
--- a/examples/cu_autoware/src/bin/cu-autoware-logreader.rs
+++ b/examples/cu_autoware/src/bin/cu-autoware-logreader.rs
@@ -4,37 +4,8 @@
 use cu_autoware::payload;
 use cu29::prelude::*;
 use cu29_export::run_cli;
-use cu29_export::serde_to_jsonschema::trace_type_to_jsonschema;
 
 gen_cumsgs!("copperconfig.ron");
-
-impl PayloadSchemas for cumsgs::CuStampedDataSet {
-    fn get_payload_schemas() -> Vec<(&'static str, String)> {
-        let ids = <cumsgs::CuStampedDataSet as MatchingTasks>::get_all_task_ids();
-        let sample = trace_type_to_jsonschema::<payload::RefSample>();
-        let lane = trace_type_to_jsonschema::<payload::RefLaneSample>();
-        let unit = trace_type_to_jsonschema::<()>();
-        // Slots repeat the id for a second port: the detector's second slot is the lane.
-        let mut detector_slots = 0;
-        ids.iter()
-            .map(|&id| {
-                let schema = match id {
-                    "vehicle_dbw" | "intersection_output" => unit.clone(),
-                    "euclidean_cluster_detector" => {
-                        detector_slots += 1;
-                        if detector_slots > 1 {
-                            lane.clone()
-                        } else {
-                            sample.clone()
-                        }
-                    }
-                    _ => sample.clone(),
-                };
-                (id, schema)
-            })
-            .collect()
-    }
-}
 
 fn main() {
     run_cli::<CuMsgs>().expect("Failed to run the export CLI");

--- a/examples/cu_autoware/src/lib.rs
+++ b/examples/cu_autoware/src/lib.rs
@@ -47,20 +47,17 @@ pub fn run(iterations: usize, log_base: Option<PathBuf>) {
     let mut rate_limiter =
         LoopRateLimiter::from_rate_target_hz(rate_target_hz, &application.clock())
             .expect("Failed to create the rate limiter.");
-    application
-        .start_all_tasks()
-        .expect("Failed to start application.");
+    let mut running = application.start().expect("Failed to start application.");
     for _ in 0..iterations {
-        application
+        running
             .run_one_iteration()
             .expect("Failed to run application.");
-        rate_limiter.limit(&application.clock());
+        rate_limiter.limit(&running.clock());
     }
-    application
-        .stop_all_tasks()
-        .expect("Failed to stop application.");
+    let stopped = running.stop().expect("Failed to stop application.");
     // The generated `run()` writes this; a manual loop has to. `kpi` refuses to report on
     // a log that does not end with it, which is how a truncated log is caught.
+    let mut application = stopped.into_inner();
     application
         .log_shutdown_completed()
         .expect("Failed to record shutdown.");


### PR DESCRIPTION
## Summary

- migrate the Autoware runner to the typestate lifecycle API
- rely on generated output metadata for logreader payload schemas
- restore strict all-target clippy for `cu-autoware`

## Validation

- `just fmt`
- `cargo +stable clippy -p cu-autoware --all-targets -- --deny warnings`