### PR TITLE
Report remote debug log indexing progress

### DIFF
--- a/api/v1/cu29-unifiedlog.txt
+++ b/api/v1/cu29-unifiedlog.txt
@@ -34,6 +34,7 @@ impl cu29_unifiedlog::memmap::MmapUnifiedLoggerRead
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::new(base_file_path: &std::path::Path) -> std::io::error::Result<Self>
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::position(&self) -> cu29_unifiedlog::memmap::LogPosition
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::raw_main_header(&self) -> &cu29_unifiedlog::MainHeader
+pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::raw_skip_section(&mut self) -> cu29_traits::CuResult<cu29_unifiedlog::SectionHeader>
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::scan_section_bytes(&mut self, datalogtype: cu29_traits::UnifiedLogType) -> cu29_traits::CuResult<u64>
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::seek(&mut self, pos: cu29_unifiedlog::memmap::LogPosition) -> cu29_traits::CuResult<()>
 impl cu29_unifiedlog::UnifiedLogRead for cu29_unifiedlog::memmap::MmapUnifiedLoggerRead
@@ -174,6 +175,7 @@ impl cu29_unifiedlog::memmap::MmapUnifiedLoggerRead
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::new(base_file_path: &std::path::Path) -> std::io::error::Result<Self>
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::position(&self) -> cu29_unifiedlog::memmap::LogPosition
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::raw_main_header(&self) -> &cu29_unifiedlog::MainHeader
+pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::raw_skip_section(&mut self) -> cu29_traits::CuResult<cu29_unifiedlog::SectionHeader>
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::scan_section_bytes(&mut self, datalogtype: cu29_traits::UnifiedLogType) -> cu29_traits::CuResult<u64>
 pub fn cu29_unifiedlog::memmap::MmapUnifiedLoggerRead::seek(&mut self, pos: cu29_unifiedlog::memmap::LogPosition) -> cu29_traits::CuResult<()>
 impl cu29_unifiedlog::UnifiedLogRead for cu29_unifiedlog::memmap::MmapUnifiedLoggerRead

--- a/core/cu29_runtime/src/debug.rs
+++ b/core/cu29_runtime/src/debug.rs
@@ -67,6 +67,13 @@ pub(crate) struct SectionIndexEntry {
     pub(crate) last_ts: Option<CuTime>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LogIndexProgress {
+    pub(crate) scanned_bytes: u64,
+    pub(crate) total_bytes: u64,
+    pub(crate) indexed_entries: usize,
+}
+
 /// Cached copperlists for one section.
 #[derive(Debug, Clone)]
 struct CachedSection<P: CopperListTuple> {
@@ -131,8 +138,29 @@ where
         build_callback: CB,
         time_of: TF,
     ) -> CuResult<Self> {
+        Self::from_log_with_progress(
+            log_base,
+            app,
+            robot_clock,
+            clock_mock,
+            build_callback,
+            time_of,
+            |_| {},
+        )
+    }
+
+    pub(crate) fn from_log_with_progress(
+        log_base: &Path,
+        app: App,
+        robot_clock: RobotClock,
+        clock_mock: RobotClockMock,
+        build_callback: CB,
+        time_of: TF,
+        mut progress: impl FnMut(LogIndexProgress),
+    ) -> CuResult<Self> {
         let _ = crate::logcodec::seed_effective_config_from_log::<P>(log_base)?;
-        let (sections, keyframes, total_entries) = index_log::<P, _>(log_base, &time_of)?;
+        let (sections, keyframes, total_entries) =
+            index_log_with_progress::<P, _, _>(log_base, &time_of, &mut progress)?;
         let log_reader = build_read_logger(log_base)?;
         Ok(Self::new(
             log_reader,
@@ -157,8 +185,32 @@ where
         time_of: TF,
         cache_cap: usize,
     ) -> CuResult<Self> {
+        Self::from_log_with_cache_cap_and_progress(
+            log_base,
+            app,
+            robot_clock,
+            clock_mock,
+            build_callback,
+            time_of,
+            cache_cap,
+            |_| {},
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_log_with_cache_cap_and_progress(
+        log_base: &Path,
+        app: App,
+        robot_clock: RobotClock,
+        clock_mock: RobotClockMock,
+        build_callback: CB,
+        time_of: TF,
+        cache_cap: usize,
+        mut progress: impl FnMut(LogIndexProgress),
+    ) -> CuResult<Self> {
         let _ = crate::logcodec::seed_effective_config_from_log::<P>(log_base)?;
-        let (sections, keyframes, total_entries) = index_log::<P, _>(log_base, &time_of)?;
+        let (sections, keyframes, total_entries) =
+            index_log_with_progress::<P, _, _>(log_base, &time_of, &mut progress)?;
         let log_reader = build_read_logger(log_base)?;
         Ok(Self::new_with_cache_cap(
             log_reader,
@@ -953,6 +1005,35 @@ where
     P: CopperListTuple,
     TF: Fn(&crate::copperlist::CopperList<P>) -> Option<CuTime>,
 {
+    index_log_with_progress(log_base, time_of, |_| {})
+}
+
+fn index_log_with_progress<P, TF, PF>(
+    log_base: &Path,
+    time_of: &TF,
+    mut progress: PF,
+) -> CuResult<(Vec<SectionIndexEntry>, Vec<KeyFrame>, usize)>
+where
+    P: CopperListTuple,
+    TF: Fn(&crate::copperlist::CopperList<P>) -> Option<CuTime>,
+    PF: FnMut(LogIndexProgress),
+{
+    let sizing_logger = UnifiedLoggerBuilder::new()
+        .file_base_name(log_base)
+        .build()
+        .map_err(|e| CuError::new_with_cause("Failed to open unified log", e))?;
+    let UnifiedLogger::Read(mut sizing_reader) = sizing_logger else {
+        return Err(CuError::from("Expected read-only unified logger"));
+    };
+    let mut total_bytes = 0u64;
+    loop {
+        let header = sizing_reader.raw_skip_section()?;
+        if header.entry_type == UnifiedLogType::LastEntry {
+            break;
+        }
+        total_bytes = total_bytes.saturating_add(header.used as u64);
+    }
+
     let logger = UnifiedLoggerBuilder::new()
         .file_base_name(log_base)
         .build()
@@ -964,6 +1045,12 @@ where
     let mut sections = Vec::new();
     let mut keyframes = Vec::new();
     let mut total_entries = 0usize;
+    let mut scanned_bytes = 0u64;
+    progress(LogIndexProgress {
+        scanned_bytes,
+        total_bytes,
+        indexed_entries: total_entries,
+    });
 
     loop {
         let pos = dl.position();
@@ -976,19 +1063,18 @@ where
             UnifiedLogType::CopperList => {
                 let (len, first_id, last_id, first_ts, last_ts) =
                     scan_copperlist_section::<P, _>(&data, time_of)?;
-                if len == 0 {
-                    continue;
+                if len > 0 {
+                    sections.push(SectionIndexEntry {
+                        pos,
+                        start_idx: total_entries,
+                        len,
+                        first_id,
+                        last_id,
+                        first_ts,
+                        last_ts,
+                    });
+                    total_entries += len;
                 }
-                sections.push(SectionIndexEntry {
-                    pos,
-                    start_idx: total_entries,
-                    len,
-                    first_id,
-                    last_id,
-                    first_ts,
-                    last_ts,
-                });
-                total_entries += len;
             }
             UnifiedLogType::FrozenTasks => {
                 // Read all keyframes in this section
@@ -1015,6 +1101,12 @@ where
                 // ignore other sections
             }
         }
+        scanned_bytes = scanned_bytes.saturating_add(header.used as u64);
+        progress(LogIndexProgress {
+            scanned_bytes,
+            total_bytes,
+            indexed_entries: total_entries,
+        });
     }
 
     Ok((sections, keyframes, total_entries))

--- a/core/cu29_runtime/src/remote_debug.rs
+++ b/core/cu29_runtime/src/remote_debug.rs
@@ -28,7 +28,7 @@
 //! | `{base}/events/cursor` | server -> client(s) | event JSON (reserved, currently not emitted by handlers) |
 //! | `{base}/events/run` | server -> client(s) | event JSON (reserved, currently not emitted by handlers) |
 //! | `{base}/events/watch` | server -> client(s) | watch event JSON (topic exposed, emission helper exists) |
-//! | `{base}/events/health` | server -> client(s) | event JSON (reserved, currently not emitted by handlers) |
+//! | `{base}/events/health` | server -> client(s) | health and long-running operation progress events |
 //!
 //! ## Wire Format
 //!
@@ -256,8 +256,8 @@
 //!   even though server handles it explicitly.
 //! - `session.capabilities` and `session.open` expose lifecycle limits under
 //!   `session_lifecycle` in the capability payload.
-//! - Event publishers are declared and helper methods exist, but core handlers are
-//!   currently request/reply oriented and do not emit continuous event streams yet.
+//! - `session.open` emits correlated `session_open_progress` health events while it indexes the
+//!   log. Each event reports `scanned_bytes`, `total_bytes`, and `indexed_entries`.
 
 use crate::app::{CuSimApplication, CurrentRuntimeCopperList};
 use crate::config::{BridgeChannelConfigRepresentation, Flavor, read_configuration_str};
@@ -1841,23 +1841,51 @@ where
             Err(e) => return err_response(request_id, "SessionOpenFailed", &e.to_string()),
         };
 
+        let health_publisher = &self.event_publishers.health;
+        let progress_request_id = request_id.clone();
+        let mut report_progress = |progress: crate::debug::LogIndexProgress| {
+            let event = json!({
+                "kind": "session_open_progress",
+                "request_id": progress_request_id,
+                "phase": "indexing_log",
+                "scanned_bytes": progress.scanned_bytes,
+                "total_bytes": progress.total_bytes,
+                "indexed_entries": progress.indexed_entries,
+            });
+            if let Ok(payload) = encode_payload(
+                &event,
+                wire_codec,
+                "RemoteDebug: failed to serialize session open progress",
+            ) {
+                let _ = zenoh::Wait::wait(
+                    health_publisher
+                        .put(payload)
+                        .encoding(wire_codec.encoding()),
+                );
+            }
+        };
+
         let session = match parsed.cache_cap {
-            Some(cap) => CuDebugSession::<App, P, CB, TF, S, L>::from_log_with_cache_cap(
+            Some(cap) => {
+                CuDebugSession::<App, P, CB, TF, S, L>::from_log_with_cache_cap_and_progress(
+                    path.as_path(),
+                    app,
+                    clock,
+                    clock_mock,
+                    self.build_callback.clone(),
+                    self.time_of.clone(),
+                    cap,
+                    &mut report_progress,
+                )
+            }
+            None => CuDebugSession::<App, P, CB, TF, S, L>::from_log_with_progress(
                 path.as_path(),
                 app,
                 clock,
                 clock_mock,
                 self.build_callback.clone(),
                 self.time_of.clone(),
-                cap,
-            ),
-            None => CuDebugSession::<App, P, CB, TF, S, L>::from_log(
-                path.as_path(),
-                app,
-                clock,
-                clock_mock,
-                self.build_callback.clone(),
-                self.time_of.clone(),
+                &mut report_progress,
             ),
         };
 
@@ -3495,6 +3523,89 @@ impl RemoteDebugZenohClient {
             }
         }
     }
+
+    /// Send one RPC call while receiving events published during the operation.
+    pub fn call_with_events(
+        &self,
+        session_id: Option<&str>,
+        method: &str,
+        params: Value,
+        event_topic: &str,
+        mut on_event: impl FnMut(Value),
+    ) -> CuResult<DebugRpcResponse> {
+        let event_sub = self.subscribe_events(event_topic)?;
+        let request_id = format!("req{}", self.next_request_id.fetch_add(1, Ordering::SeqCst));
+        let request = DebugRpcRequest {
+            api: API_VERSION.to_string(),
+            request_id: request_id.clone(),
+            session_id: session_id.map(ToOwned::to_owned),
+            method: method.to_string(),
+            params,
+            reply_to: self.reply_topic.clone(),
+        };
+
+        let payload = encode_payload(
+            &request,
+            self.codec,
+            "RemoteDebugClient: request encode failed",
+        )?;
+        zenoh::Wait::wait(
+            self.request_pub
+                .put(payload)
+                .encoding(self.codec.encoding()),
+        )
+        .map_err(cu_error_map("RemoteDebugClient: failed to send request"))?;
+
+        loop {
+            while let Some(sample) = event_sub.try_recv().map_err(|e| {
+                CuError::from(format!("RemoteDebugClient: failed receiving event: {e}"))
+            })? {
+                let payload = sample.payload().to_bytes();
+                let event = decode_value(payload.as_ref(), self.codec)?;
+                if event.get("request_id").and_then(Value::as_str) == Some(request_id.as_str()) {
+                    on_event(event);
+                }
+            }
+
+            if let Some(sample) = self.reply_sub.try_recv().map_err(|e| {
+                CuError::from(format!("RemoteDebugClient: failed receiving reply: {e}"))
+            })? {
+                #[cfg(target_os = "linux")]
+                let payload_len = sample.payload().len();
+                #[cfg(target_os = "linux")]
+                let payload_is_shm = sample.payload().as_shm().is_some();
+                let payload = sample.payload().to_bytes();
+                let response = decode_response(payload.as_ref(), self.codec)?;
+                if response.request_id != request_id {
+                    continue;
+                }
+                #[cfg(target_os = "linux")]
+                if payload_len >= self.shm_config.message_size_threshold_bytes && !payload_is_shm {
+                    return Err(CuError::from(format!(
+                        "RemoteDebugClient refused a {} reply delivered outside shared memory. \
+                         Both endpoints must have SHM enabled and enough RLIMIT_MEMLOCK; \
+                         refusing silent Unix-socket fallback.",
+                        format_bytes(payload_len),
+                    )));
+                }
+                return Ok(response);
+            }
+
+            if let Some(sample) =
+                event_sub
+                    .recv_timeout(Duration::from_millis(100))
+                    .map_err(|e| {
+                        CuError::from(format!("RemoteDebugClient: failed receiving event: {e}"))
+                    })?
+            {
+                let payload = sample.payload().to_bytes();
+                let event = decode_value(payload.as_ref(), self.codec)?;
+                if event.get("request_id").and_then(Value::as_str) == Some(request_id.as_str()) {
+                    on_event(event);
+                }
+            }
+        }
+    }
 }
 
 fn capabilities_json(session_lifecycle: SessionLifecycleLimits) -> Value {
@@ -3576,6 +3687,15 @@ fn decode_response(bytes: &[u8], codec: WireCodec) -> CuResult<DebugRpcResponse>
             .map_err(|e| CuError::new_with_cause("RemoteDebugClient: invalid CBOR response", e)),
         WireCodec::Json => serde_json::from_slice::<DebugRpcResponse>(bytes)
             .map_err(|e| CuError::new_with_cause("RemoteDebugClient: invalid JSON response", e)),
+    }
+}
+
+fn decode_value(bytes: &[u8], codec: WireCodec) -> CuResult<Value> {
+    match codec {
+        WireCodec::Cbor => minicbor_serde::from_slice::<Value>(bytes)
+            .map_err(|e| CuError::new_with_cause("RemoteDebugClient: invalid CBOR event", e)),
+        WireCodec::Json => serde_json::from_slice::<Value>(bytes)
+            .map_err(|e| CuError::new_with_cause("RemoteDebugClient: invalid JSON event", e)),
     }
 }
 

--- a/core/cu29_unifiedlog/src/lib.rs
+++ b/core/cu29_unifiedlog/src/lib.rs
@@ -205,9 +205,6 @@ pub trait UnifiedLogRead {
     /// It will return the header and the byte array of the section.
     /// Note the last Entry should be of UnifiedLogType::LastEntry if the log is not corrupted.
     fn raw_read_section(&mut self) -> CuResult<(SectionHeader, Vec<u8>)>;
-
-    /// Advance past the next section without copying its payload.
-    fn raw_skip_section(&mut self) -> CuResult<SectionHeader>;
 }
 
 /// Create a new stream to write to the unifiedlogger.

--- a/core/cu29_unifiedlog/src/lib.rs
+++ b/core/cu29_unifiedlog/src/lib.rs
@@ -205,6 +205,9 @@ pub trait UnifiedLogRead {
     /// It will return the header and the byte array of the section.
     /// Note the last Entry should be of UnifiedLogType::LastEntry if the log is not corrupted.
     fn raw_read_section(&mut self) -> CuResult<(SectionHeader, Vec<u8>)>;
+
+    /// Advance past the next section without copying its payload.
+    fn raw_skip_section(&mut self) -> CuResult<SectionHeader>;
 }
 
 /// Create a new stream to write to the unifiedlogger.

--- a/core/cu29_unifiedlog/src/memmap.rs
+++ b/core/cu29_unifiedlog/src/memmap.rs
@@ -919,6 +919,28 @@ impl UnifiedLogRead for MmapUnifiedLoggerRead {
             }
         }
     }
+
+    fn raw_skip_section(&mut self) -> CuResult<SectionHeader> {
+        if self.current_reading_position >= self.current_mmap_buffer.len() {
+            self.next_slab().map_err(|e| {
+                CuError::new_with_cause("Failed to read next slab, is the log complete?", e)
+            })?;
+        }
+
+        let header = self.read_section_header().map_err(|error| {
+            CuError::new_with_cause(
+                &format!(
+                    "Could not read a sections header: {}/{}:{}",
+                    self.base_file_path.as_os_str().to_string_lossy(),
+                    self.current_slab_index,
+                    self.current_reading_position,
+                ),
+                error,
+            )
+        })?;
+        self.current_reading_position += header.offset_to_next_section as usize;
+        Ok(header)
+    }
 }
 
 impl MmapUnifiedLoggerRead {

--- a/core/cu29_unifiedlog/src/memmap.rs
+++ b/core/cu29_unifiedlog/src/memmap.rs
@@ -919,8 +919,11 @@ impl UnifiedLogRead for MmapUnifiedLoggerRead {
             }
         }
     }
+}
 
-    fn raw_skip_section(&mut self) -> CuResult<SectionHeader> {
+impl MmapUnifiedLoggerRead {
+    /// Advance past the next section without copying its payload.
+    pub fn raw_skip_section(&mut self) -> CuResult<SectionHeader> {
         if self.current_reading_position >= self.current_mmap_buffer.len() {
             self.next_slab().map_err(|e| {
                 CuError::new_with_cause("Failed to read next slab, is the log complete?", e)
@@ -941,9 +944,7 @@ impl UnifiedLogRead for MmapUnifiedLoggerRead {
         self.current_reading_position += header.offset_to_next_section as usize;
         Ok(header)
     }
-}
 
-impl MmapUnifiedLoggerRead {
     pub fn new(base_file_path: &Path) -> io::Result<Self> {
         let (file, mmap, prolog, header) = open_slab_index(base_file_path, 0)?;
         let main_header = header.ok_or_else(|| {


### PR DESCRIPTION
## Summary
- add a header-only sizing pass for unified logs
- emit correlated `session_open_progress` health events with scanned/total bytes and indexed entries
- add a client call API that consumes progress events while waiting for the RPC response

## Validation
- `cargo check -p cu29-runtime --features remote-debug`
- `cargo test -p cu29-unifiedlog --all-features`
- `cargo test -p cu29-runtime --features remote-debug` (234 passed; one pre-existing parallel bridge flake passed in isolation)
- `cargo clippy -p cu29-runtime --features remote-debug --all-targets -- -D warnings`
- live 4.8 GB flight-compute log reached 100% with continuous byte progress