### PR TITLE
Fix flight controller replay debug targets

### DIFF
--- a/examples/cu_flight_controller/README.md
+++ b/examples/cu_flight_controller/README.md
@@ -139,9 +139,7 @@ To replay a recorded simulation log through the remote debug API:
 
 ```bash
 cd examples/cu_flight_controller
-just resim
-# or, for parity with other examples:
-just resim-debug
+just resim-mcu-debug
 ```
 
 To inspect the compute-side log in Time Traveler—including the depth raster
@@ -152,7 +150,7 @@ that was actually passed to ViTFly—run:
 just sim
 
 # Serve that compute-side log to Time Traveler.
-just compute-resim
+just resim-compute-debug
 ```
 
 Then attach Time Traveler to

--- a/examples/cu_flight_controller/justfile
+++ b/examples/cu_flight_controller/justfile
@@ -90,26 +90,7 @@ sim-cuda:
   cargo run --release -p cu-flight-controller --no-default-features --features vitfly-cuda,forest-world --bin quad-sim
 
 # Run the replay-backed remote debug server for the flight controller log.
-resim debug_base="copper/examples/cu_flight_controller/debug/v1" log="logs/flight_controller_sim.copper" replay_log="logs/flight_controller_resim.copper":
-  #!/usr/bin/env bash
-  set -euo pipefail
-  example_dir="{{justfile_directory()}}"
-  log="{{log}}"
-  replay_log="{{replay_log}}"
-  if [[ "$log" != /* ]]; then
-    log="${example_dir}/${log}"
-  fi
-  if [[ "$replay_log" != /* ]]; then
-    replay_log="${example_dir}/${replay_log}"
-  fi
-  cd "{{ROOT}}"
-  cargo --config examples/cu_flight_controller/.cargo/config.toml run -p cu-flight-controller --no-default-features --features sim-debug --bin quad-resim -- \
-    --debug-base "{{debug_base}}" \
-    --log-base "$log" \
-    --replay-log-base "$replay_log"
-
-# Alias for parity with examples that expose replay debug as `resim-debug`.
-resim-debug debug_base="copper/examples/cu_flight_controller/debug/v1" log="logs/flight_controller_sim.copper" replay_log="logs/flight_controller_resim.copper":
+resim-mcu-debug debug_base="copper/examples/cu_flight_controller/debug/v1" log="logs/flight_controller_sim.copper" replay_log="logs/flight_controller_resim.copper":
   #!/usr/bin/env bash
   set -euo pipefail
   example_dir="{{justfile_directory()}}"
@@ -129,7 +110,7 @@ resim-debug debug_base="copper/examples/cu_flight_controller/debug/v1" log="logs
 
 # Run the replay-backed debugger for the compute log, including the depth
 # images that were actually presented to ViTFly.
-compute-resim debug_base="copper/examples/cu_flight_controller/compute/debug/v1" log="logs/flight_compute_sim.copper" replay_log="logs/flight_compute_resim.copper":
+resim-compute-debug debug_base="copper/examples/cu_flight_controller/compute/debug/v1" log="logs/flight_compute_sim.copper" replay_log="logs/flight_compute_resim.copper":
   #!/usr/bin/env bash
   set -euo pipefail
   example_dir="{{justfile_directory()}}"

--- a/examples/cu_flight_controller/mcu_config.ron
+++ b/examples/cu_flight_controller/mcu_config.ron
@@ -6,27 +6,18 @@
                 "control_source": "mapper",
                 "attitude_kp": 1.0,
             },
-            when: Any(
-                [
-                    Feature(
-                        "sim-debug",
-                    ),
-                    Not(
-                        Any(
-                            [
-                                Feature(
-                                    "sim",
-                                ),
-                                Feature(
-                                    "end2end",
-                                ),
-                                Feature(
-                                    "logreader",
-                                ),
-                            ],
+            when: Not(
+                Any(
+                    [
+                        Feature("sim"),
+                        Feature(
+                            "end2end",
                         ),
-                    ),
-                ],
+                        Feature(
+                            "logreader",
+                        ),
+                    ],
+                ),
             ),
         ),
         (
@@ -35,50 +26,24 @@
                 "control_source": "mode_supervisor",
                 "attitude_kp": 10.0,
             },
-            when: All(
+            when: Any(
                 [
-                    Any(
-                        [
-                            Feature(
-                                "sim",
-                            ),
-                            Feature(
-                                "end2end",
-                            ),
-                            Feature(
-                                "logreader",
-                            ),
-                        ],
-                    ),
-                    Not(
-                        Feature(
-                            "sim-debug",
-                        ),
+                    Feature("sim"),
+                    Feature("end2end"),
+                    Feature(
+                        "logreader",
                     ),
                 ],
             ),
         ),
         (
             path: "mcu_autonomy.ron",
-            when: All(
+            when: Any(
                 [
-                    Any(
-                        [
-                            Feature(
-                                "sim",
-                            ),
-                            Feature(
-                                "end2end",
-                            ),
-                            Feature(
-                                "logreader",
-                            ),
-                        ],
-                    ),
-                    Not(
-                        Feature(
-                            "sim-debug",
-                        ),
+                    Feature("sim"),
+                    Feature("end2end"),
+                    Feature(
+                        "logreader",
                     ),
                 ],
             ),

--- a/examples/cu_flight_controller/src/resim.rs
+++ b/examples/cu_flight_controller/src/resim.rs
@@ -21,13 +21,13 @@ const REPLAY_LOG_SLAB_SIZE: Option<usize> = Some(128 * 1024 * 1024);
 #[copper_runtime(config = "mcu_config.ron", sim_mode = true, ignore_resources = true)]
 struct FlightControllerReSim {}
 
-type ReplayCopperList = CopperList<gnss::CuStampedDataSet>;
+type ReplayCopperList = CopperList<default::CuStampedDataSet>;
 type ReplayBuildCallback =
     for<'a> fn(
         &'a ReplayCopperList,
         RobotClock,
         RobotClockMock,
-    ) -> Box<dyn for<'z> FnMut(gnss::SimStep<'z>) -> SimOverride + 'a>;
+    ) -> Box<dyn for<'z> FnMut(default::SimStep<'z>) -> SimOverride + 'a>;
 type ReplayTimeExtractor = fn(&ReplayCopperList) -> Option<CuTime>;
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -37,8 +37,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     );
     let replay_template = cli.replay_log_base.clone();
     serve_remote_debug::<
-        gnss::FlightControllerReSim,
-        gnss::CuStampedDataSet,
+        default::FlightControllerReSim,
+        default::CuStampedDataSet,
         ReplayBuildCallback,
         ReplayTimeExtractor,
         MmapSectionStorage,
@@ -59,7 +59,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 fn app_factory(
     params: &SessionOpenParams,
     replay_template: &Path,
-) -> CuResult<(gnss::FlightControllerReSim, RobotClock, RobotClockMock)> {
+) -> CuResult<(default::FlightControllerReSim, RobotClock, RobotClockMock)> {
     let (clock, clock_mock) = RobotClock::mock();
     let replay_log_base = per_session_replay_log_base(
         replay_template,
@@ -67,8 +67,8 @@ fn app_factory(
     );
     remove_log_family(&replay_log_base)?;
 
-    let mut default_callback = |_step: gnss::SimStep<'_>| SimOverride::ExecuteByRuntime;
-    let app = gnss::FlightControllerReSim::builder()
+    let mut default_callback = |_step: default::SimStep<'_>| SimOverride::ExecuteByRuntime;
+    let app = default::FlightControllerReSim::builder()
         .with_clock(clock.clone())
         .with_log_path(replay_log_base, REPLAY_LOG_SLAB_SIZE)?
         .with_sim_callback(&mut default_callback)
@@ -82,8 +82,10 @@ fn build_callback<'a>(
     copperlist: &'a ReplayCopperList,
     _process_clock: RobotClock,
     _clock_for_cb: RobotClockMock,
-) -> Box<dyn for<'z> FnMut(gnss::SimStep<'z>) -> SimOverride + 'a> {
-    Box::new(move |step: gnss::SimStep<'_>| gnss::recorded_debug_replay_step(step, copperlist))
+) -> Box<dyn for<'z> FnMut(default::SimStep<'z>) -> SimOverride + 'a> {
+    Box::new(move |step: default::SimStep<'_>| {
+        default::recorded_debug_replay_step(step, copperlist)
+    })
 }
 
 fn extract_time(copperlist: &ReplayCopperList) -> Option<CuTime> {

--- a/examples/cu_flight_controller/tests/config_matrix.rs
+++ b/examples/cu_flight_controller/tests/config_matrix.rs
@@ -36,13 +36,17 @@ fn mcu_feature_matrix_selects_one_control_graph() {
         &["firmware"][..],
         &["bevymon"][..],
         &["python-bindings"][..],
-        &["sim", "sim-debug"][..],
     ] {
         assert!(has_default_mcu_task(features, "attitude"));
         assert!(!has_default_mcu_task(features, "mode_supervisor"));
     }
 
-    for features in [&["sim"][..], &["end2end"][..], &["logreader"][..]] {
+    for features in [
+        &["sim"][..],
+        &["sim", "sim-debug"][..],
+        &["end2end"][..],
+        &["logreader"][..],
+    ] {
         assert!(has_default_mcu_task(features, "attitude"));
         assert!(has_default_mcu_task(features, "mode_supervisor"));
     }


### PR DESCRIPTION
## Summary
- compile MCU replay debug against the same mission graph used to record simulator logs
- replay the default mission instead of the unrelated GNSS mission
- rename recipes to `resim-mcu-debug` and `resim-compute-debug`
- update the config matrix and demo instructions

## Validation
- `just fmt`
- flight-controller config matrix: 3 passed
- `quad-resim` and `quad-compute-resim` sim-debug builds passed in an isolated master dependency layout
- release/v1.1.1 MCU attach and compute-depth live smoke tests passed