### PR TITLE
Optimize replay and remote-debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,14 @@ resolver = "3"
 [profile.release]
 debug = 2
 
+# Replay and remote-debug tooling needs optimized execution without losing the
+# dev profile's Copper debug logs, debug assertions, or debugger information.
+[profile.debug-optimized]
+inherits = "dev"
+opt-level = 3
+debug = 2
+debug-assertions = true
+
 # Keep normal application code debuggable while compiling the CPU inference
 # hot path with the optimizations it requires. Cargo profiles declared by the
 # git dependency itself are ignored, so these overrides belong at the workspace

--- a/examples/cu_caterpillar/justfile
+++ b/examples/cu_caterpillar/justfile
@@ -89,7 +89,7 @@ dag-logstats bin="cu-caterpillar-logreader" log="logs/caterpillar.copper" missio
 resim:
 	#!/usr/bin/env bash
 	set -euo pipefail
-	RUST_BACKTRACE=1 cargo run -r --features sim-debug --bin cu-caterpillar-resim -- \
+	RUST_BACKTRACE=1 cargo run --profile debug-optimized --features sim-debug --bin cu-caterpillar-resim -- \
 		--log-base logs/caterpillar.copper
 
 resim-debug debug_base="copper/examples/cu_caterpillar/debug/v1" log="logs/caterpillar.copper" replay_log="logs/caterpillarresim.copper":
@@ -104,7 +104,7 @@ resim-debug debug_base="copper/examples/cu_caterpillar/debug/v1" log="logs/cater
 	if [[ "$replay_log" != /* ]]; then
 		replay_log="${invocation_dir}/${replay_log}"
 	fi
-	RUST_BACKTRACE=1 cargo run -r --features sim-debug --bin cu-caterpillar-resim -- \
+	RUST_BACKTRACE=1 cargo run --profile debug-optimized --features sim-debug --bin cu-caterpillar-resim -- \
 		--debug-base "{{debug_base}}" \
 		--log-base "$log" \
 		--replay-log-base "$replay_log"

--- a/examples/cu_flight_controller/justfile
+++ b/examples/cu_flight_controller/justfile
@@ -103,7 +103,7 @@ resim-mcu-debug debug_base="copper/examples/cu_flight_controller/debug/v1" log="
     replay_log="${example_dir}/${replay_log}"
   fi
   cd "{{ROOT}}"
-  cargo --config examples/cu_flight_controller/.cargo/config.toml run -p cu-flight-controller --no-default-features --features sim-debug --bin quad-resim -- \
+  cargo --config examples/cu_flight_controller/.cargo/config.toml run --profile debug-optimized -p cu-flight-controller --no-default-features --features sim-debug --bin quad-resim -- \
     --debug-base "{{debug_base}}" \
     --log-base "$log" \
     --replay-log-base "$replay_log"
@@ -123,7 +123,7 @@ resim-compute-debug debug_base="copper/examples/cu_flight_controller/compute/deb
     replay_log="${example_dir}/${replay_log}"
   fi
   cd "{{ROOT}}"
-  cargo --config examples/cu_flight_controller/.cargo/config.toml run -p cu-flight-controller --no-default-features --features sim-debug --bin quad-compute-resim -- \
+  cargo --config examples/cu_flight_controller/.cargo/config.toml run --profile debug-optimized -p cu-flight-controller --no-default-features --features sim-debug --bin quad-compute-resim -- \
     --debug-base "{{debug_base}}" \
     --log-base "$log" \
     --replay-log-base "$replay_log"

--- a/examples/cu_remote_debug_session/justfile
+++ b/examples/cu_remote_debug_session/justfile
@@ -11,7 +11,7 @@ default: record
 record:
 	#!/usr/bin/env bash
 	set -euo pipefail
-	cargo run -p {{package}} -- record
+	cargo run --profile debug-optimized -p {{package}} -- record
 
 # Start the remote debug server against the recorded baseline log.
 resim-debug debug_base=debug_base log=log replay_log=replay_log: record
@@ -26,7 +26,7 @@ resim-debug debug_base=debug_base log=log replay_log=replay_log: record
 	if [[ "$replay_log" != /* ]]; then
 		replay_log="${invocation_dir}/${replay_log}"
 	fi
-	RUST_BACKTRACE=1 cargo run -p {{package}} -- resim-debug \
+	RUST_BACKTRACE=1 cargo run --profile debug-optimized -p {{package}} -- resim-debug \
 		--debug-base "{{debug_base}}" \
 		--log-base "$log" \
 		--replay-log-base "$replay_log"
@@ -35,7 +35,7 @@ resim-debug debug_base=debug_base log=log replay_log=replay_log: record
 smoke: record
 	#!/usr/bin/env bash
 	set -euo pipefail
-	cargo run -p {{package}} -- smoke
+	cargo run --profile debug-optimized -p {{package}} -- smoke
 
 # Run the full end-to-end demo in one command.
 demo: smoke

--- a/examples/cu_rp_balancebot/README.md
+++ b/examples/cu_rp_balancebot/README.md
@@ -50,10 +50,12 @@ This writes a relocatable static Trunk bundle into `dist/balancebot/` with hashe
 
 ```bash
 $ cd examples/cu_rp_balancebot
-$ cargo run --no-default-features --features sim-debug --bin balancebot-resim --release
+$ cargo run --profile debug-optimized --no-default-features --features sim-debug --bin balancebot-resim
 ```
 
 This replay-only build enables Copper's debug API feature set without pulling the Bevy simulator.
+The `debug-optimized` profile keeps Copper debug structured logs and debug information while
+optimizing replay and remote-debug operations.
 It will recreate the logs from only the inputs of the previous run in `logs/balanceresim*.copper`.
 
 To start the replay-backed remote debug server instead of a one-shot replay:

--- a/examples/cu_rp_balancebot/justfile
+++ b/examples/cu_rp_balancebot/justfile
@@ -200,7 +200,7 @@ mcap:
 resim:
 	#!/usr/bin/env bash
 	set -euo pipefail
-	cargo run --no-default-features --features sim-debug --bin balancebot-resim -r -- \
+	cargo run --profile debug-optimized --no-default-features --features sim-debug --bin balancebot-resim -- \
 		--log-base logs/balance.copper
 
 resim-debug debug_base="copper/examples/cu_rp_balancebot/debug/v1" log="logs/balance.copper" replay_log="logs/balanceresim.copper":
@@ -215,7 +215,7 @@ resim-debug debug_base="copper/examples/cu_rp_balancebot/debug/v1" log="logs/bal
 	if [[ "$replay_log" != /* ]]; then
 		replay_log="${invocation_dir}/${replay_log}"
 	fi
-	cargo run --no-default-features --features sim-debug --bin balancebot-resim -r -- \
+	cargo run --profile debug-optimized --no-default-features --features sim-debug --bin balancebot-resim -- \
 		--debug-base "{{debug_base}}" \
 		--log-base "$log" \
 		--replay-log-base "$replay_log"
@@ -224,4 +224,4 @@ resim-debug debug_base="copper/examples/cu_rp_balancebot/debug/v1" log="logs/bal
 resim-debug-build:
 	#!/usr/bin/env bash
 	set -euo pipefail
-	cargo build --no-default-features --features sim-debug --bin balancebot-resim -r
+	cargo build --profile debug-optimized --no-default-features --features sim-debug --bin balancebot-resim

--- a/support/cargo_cunew/src/lib.rs
+++ b/support/cargo_cunew/src/lib.rs
@@ -603,7 +603,9 @@ mod tests {
         assert!(manifest.contains("version = \"9.9.9\""));
         assert!(manifest.contains("version = \"9.9.8\""));
         assert!(manifest.contains("cu29-export"));
+        assert!(manifest.contains("[profile.debug-optimized]"));
         assert!(!manifest.contains("\n[workspace]\n"));
+        assert!(justfile.contains("--profile debug-optimized"));
         assert!(justfile.contains("cargo install --locked cu29-runtime --version \"9.9.9\""));
         assert!(justfile.contains("dag:"));
         assert!(justfile.contains("[positional-arguments]"));
@@ -647,7 +649,9 @@ mod tests {
 
         assert!(manifest.contains("core/cu29"));
         assert!(manifest.contains("core/cu29_export"));
+        assert!(manifest.contains("[profile.debug-optimized]"));
         assert!(app_manifest.contains("edition = \"2024\""));
+        assert!(justfile.contains("--profile debug-optimized"));
         assert!(justfile.contains("cu29-rendercfg"));
         assert!(justfile.contains("cu29-plan"));
         assert!(justfile.contains("plan-log:"));

--- a/support/cargo_cunew/templates/README.md
+++ b/support/cargo_cunew/templates/README.md
@@ -93,6 +93,9 @@ The generated project includes helper commands in its `justfile`:
 * `just plan`: Render the exact generated per-CopperList process order as `plan.svg`, with serial and `parallel-rt` projections. Pass `log=logs/<app>.copper` to append packed typical/slowest timelines whose back-to-back segments remain proportional to recorded task duration, or `mission=<id>` / `features=<a,b>` when needed. Templates use the local `cu29-plan` binary or install the matching `cu29-runtime` on demand.
 * `just plan-log`: Render the same SVG with observed timing from the project's default Copper log.
 
+The replay recipes use the generated `debug-optimized` Cargo profile. It enables optimization
+without losing Copper `debug!` structured logs, debug assertions, or debug information.
+
 Set `APP_NAME=test-workspace-demo APP_DIR=test_workspace-demo` to target the demo app (for example, `APP_NAME=test-workspace-demo APP_DIR=test_workspace-demo just log`).
 
 ## Replay Target Contract

--- a/support/cargo_cunew/templates/cu_full/Cargo.toml.template
+++ b/support/cargo_cunew/templates/cu_full/Cargo.toml.template
@@ -5,6 +5,12 @@ members = [
 ]
 resolver = "2"
 
+[profile.debug-optimized]
+inherits = "dev"
+opt-level = 3
+debug = 2
+debug-assertions = true
+
 [workspace.dependencies]
 cu29 = { {%if copper_source == "crates.io" %} version = "{{copper_version}}" {%elsif copper_source == "git" %} git = "{{copper_git_url}}"{{copper_git_ref_snippet}} {%elsif copper_source == "local" %} path = "{{copper_root_path}}/core/cu29" {%endif %} }
 cu29-build = { {%if copper_source == "crates.io" %} version = "{{copper_version}}" {%elsif copper_source == "git" %} git = "{{copper_git_url}}"{{copper_git_ref_snippet}} {%elsif copper_source == "local" %} path = "{{copper_root_path}}/core/cu29_build" {%endif %} }

--- a/support/cargo_cunew/templates/cu_full/README.md
+++ b/support/cargo_cunew/templates/cu_full/README.md
@@ -37,3 +37,6 @@ To start the replay-backed remote debug server manually:
 ```bash
 just resim-debug
 ```
+
+Both replay recipes use the `debug-optimized` Cargo profile so replay stays fast while
+preserving Copper `debug!` structured logs and debug information.

--- a/support/cargo_cunew/templates/cu_full/justfile
+++ b/support/cargo_cunew/templates/cu_full/justfile
@@ -112,7 +112,7 @@ resim:
   set -euo pipefail
   APP_DIR="${APP_DIR:-cu_example_app}"
   APP_NAME="${APP_NAME:-${APP_DIR}}"
-  RUST_BACKTRACE=1 cargo run -p "${APP_NAME}" --features=sim-debug --bin "${APP_NAME}-resim" -- \
+  RUST_BACKTRACE=1 cargo run --profile debug-optimized -p "${APP_NAME}" --features=sim-debug --bin "${APP_NAME}-resim" -- \
     --log-base "apps/${APP_DIR}/logs/${APP_NAME}.copper"
 
 resim-debug debug_base="":
@@ -124,7 +124,7 @@ resim-debug debug_base="":
   if [[ -z "$DEBUG_BASE" ]]; then
     DEBUG_BASE="copper/apps/${APP_NAME}/debug/v1"
   fi
-  RUST_BACKTRACE=1 cargo run -p "${APP_NAME}" --features=sim-debug --bin "${APP_NAME}-resim" -- \
+  RUST_BACKTRACE=1 cargo run --profile debug-optimized -p "${APP_NAME}" --features=sim-debug --bin "${APP_NAME}-resim" -- \
     --debug-base "$DEBUG_BASE" \
     --log-base "apps/${APP_DIR}/logs/${APP_NAME}.copper" \
     --replay-log-base "apps/${APP_DIR}/logs/${APP_NAME}_resim.copper"

--- a/support/cargo_cunew/templates/cu_project/Cargo.toml.template
+++ b/support/cargo_cunew/templates/cu_project/Cargo.toml.template
@@ -8,6 +8,13 @@ default-run = "{{project-name|kebab_case}}"
 {% comment %} We must be part of a root workspace if we're in the copper repo {% endcomment %}
 [workspace]
 {%endif %}
+
+[profile.debug-optimized]
+inherits = "dev"
+opt-level = 3
+debug = 2
+debug-assertions = true
+
 # The main executable of your application
 [[bin]]
 name = "{{project-name|kebab_case}}"

--- a/support/cargo_cunew/templates/cu_project/README.md
+++ b/support/cargo_cunew/templates/cu_project/README.md
@@ -31,6 +31,9 @@ To start the replay-backed remote debug server manually:
 just resim-debug
 ```
 
+Both replay recipes use the `debug-optimized` Cargo profile so replay stays fast while
+preserving Copper `debug!` structured logs and debug information.
+
 ## Monitors
 
 Copper runs without a monitor by default. To enable the per-task

--- a/support/cargo_cunew/templates/cu_project/justfile
+++ b/support/cargo_cunew/templates/cu_project/justfile
@@ -15,7 +15,7 @@ cl:
 resim:
   #!/usr/bin/env bash
   set -euo pipefail
-  RUST_BACKTRACE=1 cargo run --features=sim-debug --bin {{project-name|kebab_case}}-resim -- \
+  RUST_BACKTRACE=1 cargo run --profile debug-optimized --features=sim-debug --bin {{project-name|kebab_case}}-resim -- \
     --log-base logs/{{project-name|kebab_case}}.copper
 
 resim-debug debug_base="copper/projects/{{project-name|snake_case}}/debug/v1" log="logs/{{project-name|kebab_case}}.copper" replay_log="logs/{{project-name|kebab_case}}_resim.copper":
@@ -30,7 +30,7 @@ resim-debug debug_base="copper/projects/{{project-name|snake_case}}/debug/v1" lo
   if [[ "$replay_log" != /* ]]; then
     replay_log="${invocation_dir}/${replay_log}"
   fi
-  RUST_BACKTRACE=1 cargo run --features=sim-debug --bin {{project-name|kebab_case}}-resim -- \
+  RUST_BACKTRACE=1 cargo run --profile debug-optimized --features=sim-debug --bin {{project-name|kebab_case}}-resim -- \
     --debug-base "{% raw %}{{debug_base}}{% endraw %}" \
     --log-base "$log" \
     --replay-log-base "$replay_log"

--- a/support/cargo_cunew/templates/smoke_generated.sh
+++ b/support/cargo_cunew/templates/smoke_generated.sh
@@ -16,7 +16,7 @@ smoke_project() {
   (
     cd "$dir"
     cargo +"$toolchain" build
-    cargo +"$toolchain" build --features sim-debug --bins
+    cargo +"$toolchain" build --profile debug-optimized --features sim-debug --bins
   )
 }
 
@@ -25,7 +25,7 @@ smoke_workspace() {
   (
     cd "$dir"
     cargo +"$toolchain" build
-    cargo +"$toolchain" build -p cu_example_app --features sim-debug --bins
+    cargo +"$toolchain" build --profile debug-optimized -p cu_example_app --features sim-debug --bins
   )
 }
 


### PR DESCRIPTION
## Summary
- add a `debug-optimized` Cargo profile with optimization, debug info, and debug assertions
- use it for replay and remote-debug recipes across the examples
- generate the profile and matching recipes in both `cargo-cunew` project templates
- document the profile in generated project guidance

This avoids the severe runtime cost of Cargo’s unoptimized dev profile without dropping Copper `debug!` structured logs.

## Validation
- `just fmt`
- `cargo check --profile debug-optimized -p cu-remote-debug-session` (`optimized + debuginfo`)
- `cargo test -p cargo-cunew`
- dry-run expansion of Caterpillar, BalanceBot, Flight Controller, and remote-debug-session recipes