### PR TITLE
feat(fec): Forward Erasure Correction Library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
   "components/codecs/cu_ffv1_codec",
   "components/codecs/cu_png_codec",
   "components/libs/cu_msp_lib",
+  "components/libs/cu_fec",
   "components/libs/cu_transform",
   "core/cu29_units",
   "components/libs/cu_tuimon",
@@ -238,6 +239,7 @@ cu29-unifiedlog = { path = "core/cu29_unifiedlog", default-features = false, fea
 cu29-units = { path = "core/cu29_units", version = "1.2.0-dev" }
 cu29-value = { path = "core/cu29_value", default-features = false, version = "1.2.0-dev" }
 cu-ffv1-codec = { path = "components/codecs/cu_ffv1_codec", version = "1.2.0-dev" }
+cu-fec = { path = "components/libs/cu_fec", version = "1.2.0-dev", default-features = false }
 cu-linux-resources = { path = "components/res/cu_linux_resources", version = "1.2.0-dev" }
 cu-png-codec = { path = "components/codecs/cu_png_codec", version = "1.2.0-dev" }
 cu-rng = { path = "components/res/cu_rng", version = "1.2.0-dev" }

--- a/components/libs/cu_fec/Cargo.toml
+++ b/components/libs/cu_fec/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "cu-fec"
+description = "Bounded-memory no_std RFC 8681 sliding-window FEC for lossy datagram streams"
+documentation = "https://docs.rs/cu-fec"
+readme = "README.md"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license = "Apache-2.0 AND BSD-3-Clause"
+homepage.workspace = true
+repository.workspace = true
+keywords = ["fec", "rlc", "no-std", "network-coding", "embedded"]
+categories = ["algorithms", "embedded", "no-std", "network-programming"]
+
+[package.metadata.copper]
+kind = "lib"
+domains = ["networking/fec"]
+environments = ["host", "embedded"]
+
+[features]
+default = []
+
+[[bench]]
+name = "rlc"
+harness = false

--- a/components/libs/cu_fec/Cargo.toml
+++ b/components/libs/cu_fec/Cargo.toml
@@ -24,3 +24,4 @@ default = []
 [[bench]]
 name = "rlc"
 harness = false
+test = false

--- a/components/libs/cu_fec/Cargo.toml
+++ b/components/libs/cu_fec/Cargo.toml
@@ -24,4 +24,4 @@ default = []
 [[bench]]
 name = "rlc"
 harness = false
-test = false
+bench = false

--- a/components/libs/cu_fec/LICENSE-BSD-3-Clause
+++ b/components/libs/cu_fec/LICENSE-BSD-3-Clause
@@ -1,0 +1,27 @@
+Copyright (c) 2020 IETF Trust and the persons identified as authors of the code.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of Internet Society, IETF or IETF Trust, nor the names of
+   specific contributors, may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/components/libs/cu_fec/README.md
+++ b/components/libs/cu_fec/README.md
@@ -60,6 +60,86 @@ let _ = decoder.receive_repair(id, &repair[..config.symbol_size()])?;
 # Ok::<(), cu_fec::Error>(())
 ```
 
+## What recovery to expect
+
+A received repair symbol contributes at most one independent equation. If `L` source
+symbols are missing, the decoder needs at least `L` innovative repair symbols whose
+windows cover those losses. Duplicate repairs, repairs lost in transit, and repairs
+whose windows do not cover a missing source do not help recover it.
+
+For repairs covering the same source window, these are useful rules of thumb:
+
+| Coding parameters | Received repairs needed for `L` losses | Practical expectation |
+| --- | ---: | --- |
+| GF(2^8), `DensityThreshold::FULL` | `L` | About 99.6% full-rank probability; there is no loss margin. |
+| GF(2^8), `DensityThreshold::FULL` | `L + 1` | Above 99.998% full-rank probability, assuming distinct repair keys. This is the recommended baseline. |
+| GF(2), threshold `7` (about 50% density) | `L + 4` | About 94% full-rank probability for moderate `L`. |
+| GF(2), threshold `7` | `L + 8` | About 99.6% full-rank probability for moderate `L`, at the cost of substantially more redundancy. |
+| GF(2), `DensityThreshold::FULL` | — | Every coefficient is one. Repairs for an identical window repeat the same equation, so this normally handles only one erasure in that window. |
+
+The probabilities are random-matrix approximations, not delivery guarantees. RFC
+8681 derives coefficients deterministically from the repair key, so use a different
+key for each repair. Sliding windows overlap rather than forming perfect blocks;
+packet timing and window coverage therefore matter as much as the raw repair count.
+
+For example, suppose 32 source symbols are each carried by one UDP datagram and the
+receiver gets four distinct GF(2^8), full-density repairs covering all 32 symbols:
+
+- three missing source datagrams should be recoverable with one repair to spare;
+- four missing source datagrams are usually recoverable, but have no margin if a
+  repair is lost or dependent;
+- five missing source datagrams cannot be recovered from those four repairs;
+- if two repair datagrams are also lost, only two source losses can be corrected.
+
+## Starting profiles
+
+These are deliberately conservative starting points. Measure the actual link and
+adjust them using recorded loss bursts rather than relying only on average loss.
+
+| Link and loss pattern | Symbol size | Window | Repair cadence | Field and density | Design target |
+| --- | ---: | ---: | ---: | --- | --- |
+| Ethernet/Wi-Fi, below about 2% loss | 1,024–1,200 bytes | 64 | 1 repair per 16 sources (6.25%) | GF(2^8), full | Isolated one- or two-packet losses. |
+| UDP telemetry, around 5% loss with short bursts | 1,024–1,200 bytes | 64 | 1 per 8 (12.5%) | GF(2^8), full | Bursts of roughly three to five packets. |
+| Intermittent radio, around 10% loss or longer bursts | 256–512 bytes | 64–96 | 1 per 4 (25%) | GF(2^8), full | Bursts of roughly eight to twelve packets, after trace-based validation. |
+| CPU-constrained link where extra bandwidth is acceptable | 256–512 bytes | 32–64 | Start at 1 per 4 | GF(2), threshold `7` | Keep four to eight more received repairs than losses and validate the exact workload. |
+
+As a concrete telemetry example, at 100 source datagrams per second a 64-symbol
+window retains about 640 ms of data. Sending one repair after every eight sources
+adds 12.5% FEC overhead and produces a repair every 80 ms. Recovering a three-packet
+burst with one spare repair may require up to four covering repairs, or roughly
+320 ms when no earlier repair is useful, which fits inside that window.
+
+## Choosing the parameters
+
+- `symbol_size`: If one symbol maps to one UDP datagram, start around 1,200 bytes on
+  a normal Ethernet path so the symbol, FEC payload ID, application framing, UDP,
+  and IP headers remain below the path MTU. Radios often work better at 256–512
+  bytes. Avoid IP fragmentation.
+- `window_symbols`: This is the protection horizon. At `P` source packets per
+  second, a window of `W` symbols retains approximately `W / P` seconds. It must
+  cover the longest loss burst plus the time needed to receive enough repairs.
+- Repair cadence: One repair every `N` source symbols adds `100 / N` percent FEC
+  traffic before transport headers. Redundancy must exceed the observed loss rate
+  with room for burstiness and lost repair packets.
+- `Field::Gf256` with `DensityThreshold::FULL`: Use this first. It gives much more
+  reliable rank with little repair-count overhead.
+- `Field::Gf2`: Consider it when encode CPU matters more than bandwidth. Threshold
+  `7` makes each coefficient nonzero with probability 8/16. For thresholds `0..=14`,
+  the nonzero probability is `(threshold + 1) / 16`; very sparse settings need
+  careful workload-specific testing.
+- Equation capacity: Set the active and const-generic equation capacities above the
+  largest simultaneous loss count you intend to recover. For a five-loss target,
+  eight is a reasonable GF(2^8) starting point; use more if repairs can accumulate
+  across a larger unresolved window.
+
+Const-generic capacities determine the allocated object size even when runtime
+limits are smaller. Encoder storage is approximately
+`MAX_SYMBOL_SIZE * MAX_WINDOW_SYMBOLS`. The decoder additionally stores about
+`MAX_EQUATIONS * (MAX_WINDOW_SYMBOLS + MAX_SYMBOL_SIZE)` bytes of equation data.
+Encoding work grows approximately with the active `symbol_size * window_symbols`,
+so increasing the window is not free. The included benchmark prints exact encoder
+and decoder sizes for its selected capacities.
+
 The codec operates on symbols only. Packet integrity, fragmentation, ADU framing,
 pacing, transport, and authentication belong to the integrating protocol. RFC 8681
 source and repair payload-ID helpers are included for interoperable framing.

--- a/components/libs/cu_fec/README.md
+++ b/components/libs/cu_fec/README.md
@@ -1,0 +1,86 @@
+# cu-fec
+
+Real-time and one-way streams often cannot wait for a retransmission when a packet is
+lost. Forward erasure correction (FEC) adds repair symbols to the stream so a receiver
+can reconstruct missing source symbols from the packets that do arrive.
+
+`cu-fec` provides transport-independent FEC for fixed-size symbols. It implements the
+systematic sliding-window random linear code from [RFC 8681] over GF(2) and GF(2^8).
+Unlike a block code, a sliding-window code can emit repairs continuously as new data
+arrives, making it useful when recovery latency must remain bounded.
+
+Typical uses include:
+
+- telemetry and logs over one-way or intermittent radio links;
+- live sensor, audio, or video data sent over lossy UDP;
+- Wi-Fi or cellular streams where timely recovery matters more than retransmission;
+- embedded and bare-metal systems that require fixed memory use.
+
+The crate was developed within the [Copper] umbrella project, a robotics runtime that
+needed deterministic log streaming over lossy links. It is deliberately standalone:
+it has no Copper dependencies, types, or protocol assumptions and can be used by any
+Rust project.
+
+`cu-fec` is dependency-free, `no_std`, and allocator-free. Runtime configuration
+selects the active symbol and window sizes, while const generic parameters impose
+hard memory limits.
+
+## Quick start
+
+```rust
+use cu_fec::{
+    DensityThreshold, EncodingSymbolId, Field, RepairParameters, RlcConfig,
+    RlcDecoder, RlcEncoder,
+};
+
+const SYMBOL_CAPACITY: usize = 1200;
+const WINDOW_CAPACITY: usize = 64;
+const EQUATION_CAPACITY: usize = 64;
+
+let config = RlcConfig::new(4, 16, Field::Gf256)?;
+let mut encoder = RlcEncoder::<SYMBOL_CAPACITY, WINDOW_CAPACITY>::new(
+    config,
+    EncodingSymbolId::new(0),
+)?;
+let mut decoder = RlcDecoder::<
+    SYMBOL_CAPACITY,
+    WINDOW_CAPACITY,
+    EQUATION_CAPACITY,
+>::new(config, 16)?;
+
+let esi = encoder.push_source(&[1, 2, 3, 4])?;
+let _ = decoder.receive_source(esi, &[1, 2, 3, 4])?;
+
+let mut repair = [0_u8; SYMBOL_CAPACITY];
+let id = encoder.encode_repair(
+    RepairParameters::new(7, DensityThreshold::FULL),
+    &mut repair[..config.symbol_size()],
+)?;
+let _ = decoder.receive_repair(id, &repair[..config.symbol_size()])?;
+# Ok::<(), cu_fec::Error>(())
+```
+
+The codec operates on symbols only. Packet integrity, fragmentation, ADU framing,
+pacing, transport, and authentication belong to the integrating protocol. RFC 8681
+source and repair payload-ID helpers are included for interoperable framing.
+
+FEC recovers erasures; it does not identify corrupted or malicious packets. Check
+packet integrity first, then pass only valid source and repair symbols to the decoder.
+
+The crate's original Rust code is Apache-2.0 licensed. The TinyMT32 implementation
+is translated from the [reference C implementation in RFC 8682, Section 2.1] and
+retains the IETF Trust's Revised BSD terms in `LICENSE-BSD-3-Clause`.
+
+## Verification
+
+From the repository root:
+
+```text
+cargo test -p cu-fec
+cargo check -p cu-fec --no-default-features
+cargo bench -p cu-fec --bench rlc
+```
+
+[Copper]: https://github.com/copper-project/copper-rs
+[RFC 8681]: https://www.rfc-editor.org/rfc/rfc8681.html
+[reference C implementation in RFC 8682, Section 2.1]: https://www.rfc-editor.org/rfc/rfc8682.html#section-2.1

--- a/components/libs/cu_fec/benches/rlc.rs
+++ b/components/libs/cu_fec/benches/rlc.rs
@@ -1,0 +1,104 @@
+use std::{
+    hint::black_box,
+    mem::size_of,
+    time::{Duration, Instant},
+};
+
+use cu_fec::{
+    DensityThreshold, EncodingSymbolId, Field, RepairParameters, RlcConfig, RlcDecoder, RlcEncoder,
+};
+
+const SYMBOL_SIZE: usize = 256;
+const WINDOW_SIZE: usize = 32;
+const EQUATIONS: usize = 32;
+const SAMPLE_TIME: Duration = Duration::from_millis(300);
+
+fn main() {
+    println!(
+        "bounded state: encoder={} bytes decoder={} bytes",
+        size_of::<RlcEncoder<SYMBOL_SIZE, WINDOW_SIZE>>(),
+        size_of::<RlcDecoder<SYMBOL_SIZE, WINDOW_SIZE, EQUATIONS>>()
+    );
+    benchmark_encode(Field::Gf2, DensityThreshold::FULL, "encode/gf2/full");
+    benchmark_encode(Field::Gf256, DensityThreshold::FULL, "encode/gf256/full");
+    benchmark_single_loss_recovery();
+}
+
+fn benchmark_encode(field: Field, density: DensityThreshold, name: &str) {
+    let config = RlcConfig::new(SYMBOL_SIZE, WINDOW_SIZE, field).unwrap();
+    let mut encoder =
+        RlcEncoder::<SYMBOL_SIZE, WINDOW_SIZE>::new(config, EncodingSymbolId::new(0)).unwrap();
+    for esi in 0..WINDOW_SIZE {
+        let mut symbol = [0_u8; SYMBOL_SIZE];
+        fill_symbol(esi as u32, &mut symbol);
+        encoder.push_source(black_box(&symbol)).unwrap();
+    }
+
+    let mut output = [0_u8; SYMBOL_SIZE];
+    let mut repair_key = u16::from(field == Field::Gf256);
+    measure(name, || {
+        let parameters = RepairParameters::new(repair_key, density);
+        let id = encoder
+            .encode_repair(parameters, black_box(&mut output))
+            .unwrap();
+        black_box((id, &output));
+        if field == Field::Gf256 {
+            repair_key = repair_key.wrapping_add(1);
+        }
+    });
+}
+
+fn benchmark_single_loss_recovery() {
+    let config = RlcConfig::new(SYMBOL_SIZE, WINDOW_SIZE, Field::Gf256).unwrap();
+    let mut encoder =
+        RlcEncoder::<SYMBOL_SIZE, WINDOW_SIZE>::new(config, EncodingSymbolId::new(0)).unwrap();
+    let mut sources = [[0_u8; SYMBOL_SIZE]; WINDOW_SIZE];
+    for (esi, symbol) in sources.iter_mut().enumerate() {
+        fill_symbol(esi as u32, symbol);
+        encoder.push_source(symbol).unwrap();
+    }
+    let mut repair = [0_u8; SYMBOL_SIZE];
+    let id = encoder
+        .encode_repair(
+            RepairParameters::new(1, DensityThreshold::FULL),
+            &mut repair,
+        )
+        .unwrap();
+
+    measure("decode/gf256/one-loss-window", || {
+        let mut decoder =
+            RlcDecoder::<SYMBOL_SIZE, WINDOW_SIZE, EQUATIONS>::new(config, EQUATIONS).unwrap();
+        for (esi, symbol) in sources.iter().enumerate().skip(1) {
+            let _ = decoder
+                .receive_source(EncodingSymbolId::new(esi as u32), black_box(symbol))
+                .unwrap();
+        }
+        let report = decoder.receive_repair(id, black_box(&repair)).unwrap();
+        debug_assert_eq!(report.recovered(), 1);
+        black_box(decoder);
+    });
+}
+
+fn measure(name: &str, mut operation: impl FnMut()) {
+    for _ in 0..16 {
+        operation();
+    }
+    let start = Instant::now();
+    let mut iterations = 0_u64;
+    while start.elapsed() < SAMPLE_TIME {
+        operation();
+        iterations += 1;
+    }
+    let nanoseconds = start.elapsed().as_nanos() as f64 / iterations as f64;
+    println!("{name}: {nanoseconds:.1} ns/op ({iterations} samples)");
+}
+
+fn fill_symbol(seed: u32, output: &mut [u8]) {
+    let mut state = seed ^ 0xa5a5_5a5a;
+    for byte in output {
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        *byte = state as u8;
+    }
+}

--- a/components/libs/cu_fec/src/field.rs
+++ b/components/libs/cu_fec/src/field.rs
@@ -1,0 +1,81 @@
+//! Finite-field operations used by RFC 8681.
+
+/// The finite field used for repair-symbol coefficients.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Field {
+    /// Binary coefficients. Multiplication is logical AND and symbol addition is XOR.
+    Gf2,
+    /// Byte coefficients in GF(2^8), using the RFC 8681 polynomial `0x11d`.
+    Gf256,
+}
+
+impl Field {
+    /// Returns the RFC 8681 FEC Encoding ID: 9 for GF(2), 10 for GF(2^8).
+    pub const fn fec_encoding_id(self) -> u8 {
+        match self {
+            Self::Gf2 => 9,
+            Self::Gf256 => 10,
+        }
+    }
+
+    pub(crate) fn mul(self, lhs: u8, rhs: u8) -> u8 {
+        match self {
+            Self::Gf2 => lhs & rhs,
+            Self::Gf256 => gf256_mul(lhs, rhs),
+        }
+    }
+
+    pub(crate) fn inv(self, value: u8) -> u8 {
+        debug_assert_ne!(value, 0);
+        match self {
+            Self::Gf2 => 1,
+            Self::Gf256 => gf256_pow(value, 254),
+        }
+    }
+}
+
+fn gf256_mul(mut lhs: u8, mut rhs: u8) -> u8 {
+    let mut product = 0_u8;
+    for _ in 0..8 {
+        if rhs & 1 != 0 {
+            product ^= lhs;
+        }
+        let carry = lhs & 0x80 != 0;
+        lhs <<= 1;
+        if carry {
+            lhs ^= 0x1d;
+        }
+        rhs >>= 1;
+    }
+    product
+}
+
+fn gf256_pow(mut base: u8, mut exponent: u8) -> u8 {
+    let mut result = 1_u8;
+    while exponent != 0 {
+        if exponent & 1 != 0 {
+            result = gf256_mul(result, base);
+        }
+        base = gf256_mul(base, base);
+        exponent >>= 1;
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gf256_uses_the_rfc_polynomial() {
+        assert_eq!(gf256_mul(0x80, 0x02), 0x1d);
+        assert_eq!(gf256_mul(0x57, 0x83), 0x31);
+    }
+
+    #[test]
+    fn every_nonzero_byte_has_an_inverse() {
+        for value in 1..=u8::MAX {
+            assert_eq!(gf256_mul(value, Field::Gf256.inv(value)), 1);
+        }
+    }
+}

--- a/components/libs/cu_fec/src/lib.rs
+++ b/components/libs/cu_fec/src/lib.rs
@@ -1,0 +1,64 @@
+//! Recover lost symbols without retransmission.
+//!
+//! Real-time and one-way streams often cannot wait for a lost packet to be sent
+//! again. Forward erasure correction adds repair symbols that let a receiver
+//! reconstruct missing source symbols from the packets that do arrive.
+//!
+//! This crate implements the systematic sliding-window random linear code from
+//! [RFC 8681] over GF(2) and GF(2^8). It suits lossy radio and UDP telemetry,
+//! logging, sensor, and media streams where recovery latency and memory use must
+//! remain bounded. It is transport agnostic, allocator-free, dependency-free,
+//! and usable from `no_std` targets.
+//!
+//! `cu-fec` was developed within the [Copper] robotics project for deterministic
+//! log streaming, but has no Copper dependencies, types, or protocol assumptions.
+//! Packet integrity, framing, pacing, and transport remain the caller's
+//! responsibility.
+//!
+//! # Example
+//!
+//! ```
+//! use cu_fec::{
+//!     DensityThreshold, EncodingSymbolId, Field, RepairParameters, RlcConfig,
+//!     RlcDecoder, RlcEncoder,
+//! };
+//!
+//! # fn main() -> Result<(), cu_fec::Error> {
+//! let config = RlcConfig::new(4, 16, Field::Gf256)?;
+//! let mut encoder = RlcEncoder::<1200, 64>::new(config, EncodingSymbolId::new(0))?;
+//! let mut decoder = RlcDecoder::<1200, 64, 64>::new(config, 16)?;
+//!
+//! let esi = encoder.push_source(&[1, 2, 3, 4])?;
+//! let _ = decoder.receive_source(esi, &[1, 2, 3, 4])?;
+//!
+//! let mut repair = [0_u8; 1200];
+//! let id = encoder.encode_repair(
+//!     RepairParameters::new(7, DensityThreshold::FULL),
+//!     &mut repair[..config.symbol_size()],
+//! )?;
+//! let _ = decoder.receive_repair(id, &repair[..config.symbol_size()])?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [Copper]: https://github.com/copper-project/copper-rs
+//! [RFC 8681]: https://www.rfc-editor.org/rfc/rfc8681.html
+
+#![no_std]
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+mod field;
+/// Sliding-window random linear coding from RFC 8681.
+pub mod rlc;
+mod tinymt;
+/// RFC 8681 payload identifiers and wire metadata.
+pub mod wire;
+
+pub use field::Field;
+pub use rlc::{
+    DecodeReport, Decoder as RlcDecoder, DensityThreshold, Encoder as RlcEncoder, EncodingSymbolId,
+    Error, KnownSymbols, RepairParameters, RlcConfig, SourceReport, SourceStatus,
+    generate_coding_coefficients,
+};
+pub use wire::{FecSchemeSpecificInfo, RepairPayloadId, SourcePayloadId, WireError};

--- a/components/libs/cu_fec/src/rlc.rs
+++ b/components/libs/cu_fec/src/rlc.rs
@@ -1,0 +1,1420 @@
+//! Bounded sliding-window RLC encoder and decoder.
+
+use core::fmt;
+
+use crate::{Field, RepairPayloadId, tinymt::TinyMt32};
+
+const RFC_MAX_WINDOW_SYMBOLS: usize = 0x0fff;
+
+/// A codec configuration error or an error encountered while processing a symbol.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Error {
+    /// The symbol size is zero.
+    EmptySymbol,
+    /// The configured active symbol size exceeds the type's hard capacity.
+    SymbolCapacityExceeded,
+    /// A source or repair symbol does not have the configured size.
+    SymbolSizeMismatch,
+    /// The coding window size is zero.
+    EmptyWindow,
+    /// The coding window exceeds either the RFC limit or the type's hard capacity.
+    WindowCapacityExceeded,
+    /// The active decoder equation capacity is zero or exceeds its hard capacity.
+    EquationCapacityExceeded,
+    /// The supplied density threshold is greater than 15.
+    InvalidDensityThreshold,
+    /// GF(2) at full density requires a zero repair key on the sending side.
+    RepairKeyMustBeZero,
+    /// No source symbol is currently available for repair generation.
+    EmptyEncodingWindow,
+    /// A received repair window is larger than the configured decoding window.
+    RepairWindowTooLarge,
+    /// A symbol or repair window is older than the retained decoding window.
+    WindowExpired,
+    /// Sequence ordering is ambiguous at exactly half the `u32` sequence space.
+    AmbiguousSequence,
+    /// The bounded equation store has no room for another innovative equation.
+    EquationStoreFull,
+    /// Received data contradicts data already known to the decoder.
+    ConflictingSource,
+    /// A reduced equation has no variables but has a nonzero right-hand side.
+    InconsistentEquation,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::EmptySymbol => "symbol size must be nonzero",
+            Self::SymbolCapacityExceeded => "symbol size exceeds the hard capacity",
+            Self::SymbolSizeMismatch => "symbol length does not match the configured size",
+            Self::EmptyWindow => "coding window size must be nonzero",
+            Self::WindowCapacityExceeded => "coding window exceeds a capacity",
+            Self::EquationCapacityExceeded => "invalid decoder equation capacity",
+            Self::InvalidDensityThreshold => "density threshold must be in 0..=15",
+            Self::RepairKeyMustBeZero => "full-density GF(2) repairs require repair key zero",
+            Self::EmptyEncodingWindow => "cannot encode a repair without source symbols",
+            Self::RepairWindowTooLarge => "repair window exceeds the decoder window",
+            Self::WindowExpired => "symbol range has expired from the decoder window",
+            Self::AmbiguousSequence => "sequence ordering is ambiguous",
+            Self::EquationStoreFull => "decoder equation store is full",
+            Self::ConflictingSource => "source symbol conflicts with known data",
+            Self::InconsistentEquation => "repair equation contradicts known data",
+        })
+    }
+}
+
+impl core::error::Error for Error {}
+
+/// The active parameters for an RLC encoder or decoder.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RlcConfig {
+    symbol_size: usize,
+    window_symbols: usize,
+    field: Field,
+}
+
+/// A wrapping RFC 8681 Encoding Symbol ID (ESI).
+///
+/// This transparent newtype prevents symbol identifiers from being confused
+/// with packet sequence numbers or ordinary counters.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct EncodingSymbolId(u32);
+
+impl EncodingSymbolId {
+    /// Creates an ESI from its RFC wire value.
+    pub const fn new(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// Returns the RFC wire value.
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+
+    /// Advances this ESI with RFC sequence-space wrapping.
+    pub const fn wrapping_add(self, count: u32) -> Self {
+        Self(self.0.wrapping_add(count))
+    }
+
+    /// Moves this ESI backward with RFC sequence-space wrapping.
+    pub const fn wrapping_sub(self, count: u32) -> Self {
+        Self(self.0.wrapping_sub(count))
+    }
+}
+
+impl From<u32> for EncodingSymbolId {
+    fn from(value: u32) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<EncodingSymbolId> for u32 {
+    fn from(value: EncodingSymbolId) -> Self {
+        value.get()
+    }
+}
+
+impl fmt::Display for EncodingSymbolId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl RlcConfig {
+    /// Creates a configuration.
+    pub const fn new(
+        symbol_size: usize,
+        window_symbols: usize,
+        field: Field,
+    ) -> Result<Self, Error> {
+        if symbol_size == 0 {
+            return Err(Error::EmptySymbol);
+        }
+        if symbol_size > u16::MAX as usize {
+            return Err(Error::SymbolCapacityExceeded);
+        }
+        if window_symbols == 0 {
+            return Err(Error::EmptyWindow);
+        }
+        if window_symbols > RFC_MAX_WINDOW_SYMBOLS {
+            return Err(Error::WindowCapacityExceeded);
+        }
+        Ok(Self {
+            symbol_size,
+            window_symbols,
+            field,
+        })
+    }
+
+    /// Returns the active size of every source and repair symbol, in bytes.
+    pub const fn symbol_size(self) -> usize {
+        self.symbol_size
+    }
+
+    /// Returns the maximum number of symbols in the active coding window.
+    pub const fn window_symbols(self) -> usize {
+        self.window_symbols
+    }
+
+    /// Returns the configured finite field.
+    pub const fn field(self) -> Field {
+        self.field
+    }
+}
+
+/// An RFC 8681 coding-coefficient density threshold in the range `0..=15`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DensityThreshold(u8);
+
+impl DensityThreshold {
+    /// Full density: every coding coefficient is nonzero.
+    pub const FULL: Self = Self(15);
+
+    /// Creates a checked threshold.
+    pub const fn new(value: u8) -> Result<Self, Error> {
+        if value <= 15 {
+            Ok(Self(value))
+        } else {
+            Err(Error::InvalidDensityThreshold)
+        }
+    }
+
+    /// Returns the wire value.
+    pub const fn get(self) -> u8 {
+        self.0
+    }
+}
+
+impl TryFrom<u8> for DensityThreshold {
+    type Error = Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<DensityThreshold> for u8 {
+    fn from(value: DensityThreshold) -> Self {
+        value.get()
+    }
+}
+
+/// Per-repair parameters that need not be fixed for the lifetime of an encoder.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RepairParameters {
+    repair_key: u16,
+    density: DensityThreshold,
+}
+
+impl RepairParameters {
+    /// Creates repair parameters from a coefficient-generator seed and density.
+    pub const fn new(repair_key: u16, density: DensityThreshold) -> Self {
+        Self {
+            repair_key,
+            density,
+        }
+    }
+
+    /// Returns the repair key.
+    pub const fn repair_key(self) -> u16 {
+        self.repair_key
+    }
+
+    /// Returns the density threshold.
+    pub const fn density(self) -> DensityThreshold {
+        self.density
+    }
+}
+
+/// The result of submitting a source symbol to a decoder.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SourceStatus {
+    /// This source symbol was not previously known.
+    New,
+    /// This exact source symbol was already known, either received or recovered.
+    Duplicate,
+}
+
+/// The result of submitting a repair symbol to a decoder.
+#[must_use]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DecodeReport {
+    innovative: bool,
+    recovered: usize,
+}
+
+/// The result of submitting a systematic source symbol to a decoder.
+#[must_use]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SourceReport {
+    status: SourceStatus,
+    recovered: usize,
+}
+
+impl SourceReport {
+    /// Returns whether the submitted source was new or a duplicate.
+    pub const fn status(self) -> SourceStatus {
+        self.status
+    }
+
+    /// Returns the number of other source symbols recovered while processing it.
+    pub const fn recovered(self) -> usize {
+        self.recovered
+    }
+}
+
+impl DecodeReport {
+    /// Returns whether the repair increased the decoder's equation rank.
+    pub const fn is_innovative(self) -> bool {
+        self.innovative
+    }
+
+    /// Returns the number of source symbols recovered while processing the repair.
+    pub const fn recovered(self) -> usize {
+        self.recovered
+    }
+}
+
+/// Generates RFC 8681 coding coefficients into `output`.
+///
+/// The repair key initializes RFC 8682 TinyMT32. Each output byte is `0` or `1`
+/// for [`Field::Gf2`] and is an arbitrary field element for [`Field::Gf256`].
+pub fn generate_coding_coefficients(
+    field: Field,
+    repair_key: u16,
+    density: DensityThreshold,
+    output: &mut [u8],
+) {
+    if field == Field::Gf2 && density == DensityThreshold::FULL {
+        output.fill(1);
+        return;
+    }
+
+    let mut generator = TinyMt32::new(u32::from(repair_key));
+    match field {
+        Field::Gf2 => {
+            for coefficient in output {
+                *coefficient = u8::from(generator.next_u4() <= density.get());
+            }
+        }
+        Field::Gf256 => {
+            for coefficient in output {
+                if density != DensityThreshold::FULL && generator.next_u4() > density.get() {
+                    *coefficient = 0;
+                    continue;
+                }
+                *coefficient = nonzero_byte(&mut generator);
+            }
+        }
+    }
+}
+
+fn nonzero_byte(generator: &mut TinyMt32) -> u8 {
+    loop {
+        let value = generator.next_u8();
+        if value != 0 {
+            return value;
+        }
+    }
+}
+
+/// A systematic, bounded sliding-window RFC 8681 encoder.
+///
+/// `MAX_SYMBOL_SIZE` and `MAX_WINDOW_SYMBOLS` are hard memory capacities. The
+/// active sizes come from [`RlcConfig`] and may be smaller.
+pub struct Encoder<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize> {
+    config: RlcConfig,
+    symbols: [[u8; MAX_SYMBOL_SIZE]; MAX_WINDOW_SYMBOLS],
+    head: usize,
+    len: usize,
+    first_esi: EncodingSymbolId,
+    next_esi: EncodingSymbolId,
+}
+
+impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize>
+    Encoder<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS>
+{
+    /// Creates an empty encoder whose first source symbol uses `initial_esi`.
+    pub fn new(config: RlcConfig, initial_esi: EncodingSymbolId) -> Result<Self, Error> {
+        validate_capacities::<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS>(config)?;
+        Ok(Self {
+            config,
+            symbols: [[0; MAX_SYMBOL_SIZE]; MAX_WINDOW_SYMBOLS],
+            head: 0,
+            len: 0,
+            first_esi: initial_esi,
+            next_esi: initial_esi,
+        })
+    }
+
+    /// Returns the active configuration.
+    pub const fn config(&self) -> RlcConfig {
+        self.config
+    }
+
+    /// Returns the number of source symbols currently retained.
+    pub const fn window_len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns the ESI and length of the current encoding window.
+    pub const fn window(&self) -> Option<(EncodingSymbolId, usize)> {
+        if self.len == 0 {
+            None
+        } else {
+            Some((self.first_esi, self.len))
+        }
+    }
+
+    /// Returns the ESI that will be assigned by the next [`push_source`](Self::push_source).
+    pub const fn next_esi(&self) -> EncodingSymbolId {
+        self.next_esi
+    }
+
+    /// Copies a source symbol into the encoding window and returns its ESI.
+    ///
+    /// Once the active window is full, this evicts exactly one oldest symbol.
+    pub fn push_source(&mut self, symbol: &[u8]) -> Result<EncodingSymbolId, Error> {
+        self.check_symbol_size(symbol)?;
+        let esi = self.next_esi;
+        self.next_esi = self.next_esi.wrapping_add(1);
+
+        let index = if self.len < self.config.window_symbols {
+            let index = (self.head + self.len) % self.config.window_symbols;
+            self.len += 1;
+            index
+        } else {
+            let index = self.head;
+            self.head = (self.head + 1) % self.config.window_symbols;
+            self.first_esi = self.first_esi.wrapping_add(1);
+            index
+        };
+        self.symbols[index][..self.config.symbol_size].copy_from_slice(symbol);
+        Ok(esi)
+    }
+
+    /// Removes up to `count` oldest symbols from the coding window.
+    ///
+    /// This supports application-level validity expiry in addition to automatic
+    /// eviction at the configured window size.
+    pub fn discard_oldest(&mut self, count: usize) {
+        let removed = count.min(self.len);
+        if removed == 0 {
+            return;
+        }
+        self.head = (self.head + removed) % self.config.window_symbols;
+        self.len -= removed;
+        self.first_esi = self.first_esi.wrapping_add(removed as u32);
+        if self.len == 0 {
+            self.first_esi = self.next_esi;
+        }
+    }
+
+    /// Encodes one repair symbol for the current window.
+    ///
+    /// The returned value contains all metadata needed to regenerate the coding
+    /// coefficients. The caller owns packetization and transport.
+    pub fn encode_repair(
+        &self,
+        parameters: RepairParameters,
+        output: &mut [u8],
+    ) -> Result<RepairPayloadId, Error> {
+        self.check_symbol_size(output)?;
+        if self.len == 0 {
+            return Err(Error::EmptyEncodingWindow);
+        }
+        if self.config.field == Field::Gf2
+            && parameters.density == DensityThreshold::FULL
+            && parameters.repair_key != 0
+        {
+            return Err(Error::RepairKeyMustBeZero);
+        }
+
+        output.fill(0);
+        match self.config.field {
+            Field::Gf2 if parameters.density == DensityThreshold::FULL => {
+                for offset in 0..self.len {
+                    self.add_source_to_repair(output, offset, 1);
+                }
+            }
+            Field::Gf2 => {
+                let mut generator = TinyMt32::new(u32::from(parameters.repair_key));
+                for offset in 0..self.len {
+                    let coefficient = u8::from(generator.next_u4() <= parameters.density.get());
+                    if coefficient != 0 {
+                        self.add_source_to_repair(output, offset, coefficient);
+                    }
+                }
+            }
+            Field::Gf256 => {
+                let mut generator = TinyMt32::new(u32::from(parameters.repair_key));
+                for offset in 0..self.len {
+                    if parameters.density != DensityThreshold::FULL
+                        && generator.next_u4() > parameters.density.get()
+                    {
+                        continue;
+                    }
+                    self.add_source_to_repair(output, offset, nonzero_byte(&mut generator));
+                }
+            }
+        }
+
+        RepairPayloadId::new(
+            parameters.repair_key,
+            parameters.density,
+            self.len as u16,
+            self.first_esi,
+        )
+        .map_err(|_| Error::WindowCapacityExceeded)
+    }
+
+    fn check_symbol_size(&self, symbol: &[u8]) -> Result<(), Error> {
+        if symbol.len() == self.config.symbol_size {
+            Ok(())
+        } else {
+            Err(Error::SymbolSizeMismatch)
+        }
+    }
+
+    #[inline]
+    fn add_source_to_repair(&self, output: &mut [u8], offset: usize, coefficient: u8) {
+        let index = (self.head + offset) % self.config.window_symbols;
+        add_scaled(
+            self.config.field,
+            output,
+            coefficient,
+            &self.symbols[index][..self.config.symbol_size],
+        );
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Row<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize> {
+    coefficients: [u8; MAX_WINDOW_SYMBOLS],
+    data: [u8; MAX_SYMBOL_SIZE],
+}
+
+impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize>
+    Row<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS>
+{
+    const ZERO: Self = Self {
+        coefficients: [0; MAX_WINDOW_SYMBOLS],
+        data: [0; MAX_SYMBOL_SIZE],
+    };
+}
+
+/// A bounded RFC 8681 sliding-window decoder.
+///
+/// The decoder maintains a reduced linear system without allocation. Source
+/// symbols are addressable with [`symbol`](Self::symbol) while they remain in
+/// the active window. Packet integrity must be checked before symbols are passed
+/// here because erasure coding cannot authenticate corrupted input.
+pub struct Decoder<
+    const MAX_SYMBOL_SIZE: usize,
+    const MAX_WINDOW_SYMBOLS: usize,
+    const MAX_EQUATIONS: usize,
+> {
+    config: RlcConfig,
+    equation_capacity: usize,
+    base_esi: EncodingSymbolId,
+    base_initialized: bool,
+    span: usize,
+    known: [bool; MAX_WINDOW_SYMBOLS],
+    symbols: [[u8; MAX_SYMBOL_SIZE]; MAX_WINDOW_SYMBOLS],
+    occupied: [bool; MAX_EQUATIONS],
+    rows: [Row<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS>; MAX_EQUATIONS],
+    rank: usize,
+}
+
+/// An iterator over received and recovered symbols retained by a decoder.
+pub struct KnownSymbols<
+    'a,
+    const MAX_SYMBOL_SIZE: usize,
+    const MAX_WINDOW_SYMBOLS: usize,
+    const MAX_EQUATIONS: usize,
+> {
+    decoder: &'a Decoder<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS, MAX_EQUATIONS>,
+    index: usize,
+}
+
+impl<'a, const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQUATIONS: usize>
+    Iterator for KnownSymbols<'a, MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS, MAX_EQUATIONS>
+{
+    type Item = (EncodingSymbolId, &'a [u8]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.index < self.decoder.span {
+            let index = self.index;
+            self.index += 1;
+            if self.decoder.known[index] {
+                return Some((
+                    self.decoder.base_esi.wrapping_add(index as u32),
+                    &self.decoder.symbols[index][..self.decoder.config.symbol_size],
+                ));
+            }
+        }
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(self.decoder.span.saturating_sub(self.index)))
+    }
+}
+
+impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQUATIONS: usize>
+    core::iter::FusedIterator
+    for KnownSymbols<'_, MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS, MAX_EQUATIONS>
+{
+}
+
+impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQUATIONS: usize>
+    Decoder<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS, MAX_EQUATIONS>
+{
+    /// Creates an empty decoder with a bounded active equation count.
+    pub fn new(config: RlcConfig, equation_capacity: usize) -> Result<Self, Error> {
+        validate_capacities::<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS>(config)?;
+        if equation_capacity == 0 || equation_capacity > MAX_EQUATIONS {
+            return Err(Error::EquationCapacityExceeded);
+        }
+        Ok(Self {
+            config,
+            equation_capacity,
+            base_esi: EncodingSymbolId::new(0),
+            base_initialized: false,
+            span: 0,
+            known: [false; MAX_WINDOW_SYMBOLS],
+            symbols: [[0; MAX_SYMBOL_SIZE]; MAX_WINDOW_SYMBOLS],
+            occupied: [false; MAX_EQUATIONS],
+            rows: [Row::ZERO; MAX_EQUATIONS],
+            rank: 0,
+        })
+    }
+
+    /// Returns the active configuration.
+    pub const fn config(&self) -> RlcConfig {
+        self.config
+    }
+
+    /// Returns the current rank of unresolved repair equations.
+    pub const fn rank(&self) -> usize {
+        self.rank
+    }
+
+    /// Returns the ESI and total span of the retained decoding window.
+    pub const fn window(&self) -> Option<(EncodingSymbolId, usize)> {
+        if self.span == 0 {
+            None
+        } else {
+            Some((self.base_esi, self.span))
+        }
+    }
+
+    /// Discards decoder state older than `first_retained_esi`.
+    ///
+    /// Equations that still depend on an unknown expired symbol are discarded.
+    /// This lets an integrating real-time protocol enforce its latency budget
+    /// even when no newer source symbol arrives.
+    pub fn discard_before(&mut self, first_retained_esi: EncodingSymbolId) -> Result<(), Error> {
+        if self.span == 0 {
+            if !self.base_initialized {
+                self.base_esi = first_retained_esi;
+                self.base_initialized = true;
+                return Ok(());
+            }
+            let count = sequence_delta(first_retained_esi, self.base_esi)?;
+            if count > 0 {
+                self.base_esi = first_retained_esi;
+            }
+            return Ok(());
+        }
+        let count = sequence_delta(first_retained_esi, self.base_esi)?;
+        if count > 0 {
+            self.drop_front(count as usize);
+        }
+        Ok(())
+    }
+
+    /// Returns a received or recovered symbol while it remains in the window.
+    pub fn symbol(&self, esi: EncodingSymbolId) -> Option<&[u8]> {
+        let offset = sequence_delta(esi, self.base_esi).ok()?;
+        if offset < 0 {
+            return None;
+        }
+        let index = offset as usize;
+        if index >= self.span || !self.known[index] {
+            return None;
+        }
+        Some(&self.symbols[index][..self.config.symbol_size])
+    }
+
+    /// Iterates over all known symbols in ascending wrapping ESI order.
+    pub fn known_symbols(
+        &self,
+    ) -> KnownSymbols<'_, MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS, MAX_EQUATIONS> {
+        KnownSymbols {
+            decoder: self,
+            index: 0,
+        }
+    }
+
+    /// Submits a systematic source symbol.
+    pub fn receive_source(
+        &mut self,
+        esi: EncodingSymbolId,
+        symbol: &[u8],
+    ) -> Result<SourceReport, Error> {
+        self.check_symbol_size(symbol)?;
+        let index = self.ensure_range(esi, 1)?;
+        if self.known[index] {
+            if self.symbols[index][..self.config.symbol_size] == *symbol {
+                return Ok(SourceReport {
+                    status: SourceStatus::Duplicate,
+                    recovered: 0,
+                });
+            }
+            return Err(Error::ConflictingSource);
+        }
+
+        self.store_known(index, symbol);
+        self.substitute_known(index)?;
+        let recovered = self.recover_singletons()?;
+        Ok(SourceReport {
+            status: SourceStatus::New,
+            recovered,
+        })
+    }
+
+    /// Submits one repair symbol and returns its contribution to decoding.
+    pub fn receive_repair(
+        &mut self,
+        id: RepairPayloadId,
+        symbol: &[u8],
+    ) -> Result<DecodeReport, Error> {
+        self.check_symbol_size(symbol)?;
+        let source_count = usize::from(id.source_symbols());
+        if source_count > self.config.window_symbols {
+            return Err(Error::RepairWindowTooLarge);
+        }
+        let start = self.ensure_range(id.first_source_esi(), source_count)?;
+
+        let mut row = Row::ZERO;
+        generate_coding_coefficients(
+            self.config.field,
+            id.repair_key(),
+            id.density(),
+            &mut row.coefficients[start..start + source_count],
+        );
+        row.data[..self.config.symbol_size].copy_from_slice(symbol);
+
+        for index in start..start + source_count {
+            let coefficient = row.coefficients[index];
+            if coefficient != 0 && self.known[index] {
+                add_scaled(
+                    self.config.field,
+                    &mut row.data[..self.config.symbol_size],
+                    coefficient,
+                    &self.symbols[index][..self.config.symbol_size],
+                );
+                row.coefficients[index] = 0;
+            }
+        }
+
+        for row_index in 0..self.equation_capacity {
+            if !self.occupied[row_index] {
+                continue;
+            }
+            let Some(pivot) = first_nonzero(&self.rows[row_index].coefficients[..self.span]) else {
+                continue;
+            };
+            let factor = row.coefficients[pivot];
+            if factor != 0 {
+                row_add_scaled(
+                    self.config.field,
+                    &mut row,
+                    factor,
+                    &self.rows[row_index],
+                    self.span,
+                    self.config.symbol_size,
+                );
+            }
+        }
+
+        let Some(pivot) = first_nonzero(&row.coefficients[..self.span]) else {
+            if row.data[..self.config.symbol_size]
+                .iter()
+                .any(|byte| *byte != 0)
+            {
+                return Err(Error::InconsistentEquation);
+            }
+            return Ok(DecodeReport {
+                innovative: false,
+                recovered: 0,
+            });
+        };
+
+        let Some(slot) = self.occupied[..self.equation_capacity]
+            .iter()
+            .position(|occupied| !occupied)
+        else {
+            return Err(Error::EquationStoreFull);
+        };
+
+        let inverse = self.config.field.inv(row.coefficients[pivot]);
+        row_scale(
+            self.config.field,
+            &mut row,
+            inverse,
+            self.span,
+            self.config.symbol_size,
+        );
+
+        for row_index in 0..self.equation_capacity {
+            if !self.occupied[row_index] {
+                continue;
+            }
+            let factor = self.rows[row_index].coefficients[pivot];
+            if factor != 0 {
+                row_add_scaled(
+                    self.config.field,
+                    &mut self.rows[row_index],
+                    factor,
+                    &row,
+                    self.span,
+                    self.config.symbol_size,
+                );
+            }
+        }
+
+        self.rows[slot] = row;
+        self.occupied[slot] = true;
+        self.rank += 1;
+        let recovered = self.recover_singletons()?;
+        Ok(DecodeReport {
+            innovative: true,
+            recovered,
+        })
+    }
+
+    fn check_symbol_size(&self, symbol: &[u8]) -> Result<(), Error> {
+        if symbol.len() == self.config.symbol_size {
+            Ok(())
+        } else {
+            Err(Error::SymbolSizeMismatch)
+        }
+    }
+
+    fn ensure_range(&mut self, first_esi: EncodingSymbolId, count: usize) -> Result<usize, Error> {
+        debug_assert!(count > 0);
+        if self.span == 0 {
+            if !self.base_initialized {
+                self.base_esi = first_esi;
+                self.base_initialized = true;
+                self.span = count;
+                return Ok(0);
+            }
+
+            let start = sequence_delta(first_esi, self.base_esi)?;
+            if start < 0 {
+                return Err(Error::WindowExpired);
+            }
+            let end = start as usize + count;
+            if end <= self.config.window_symbols {
+                self.extend_to(end);
+                return Ok(start as usize);
+            }
+            self.base_esi = first_esi
+                .wrapping_add(count as u32)
+                .wrapping_sub(self.config.window_symbols as u32);
+            self.span = self.config.window_symbols;
+            return Ok(self.config.window_symbols - count);
+        }
+
+        let start = sequence_delta(first_esi, self.base_esi)?;
+        let end = start + count as i64 - 1;
+        let current_end = self.span as i64 - 1;
+        let union_start = start.min(0);
+        let union_end = end.max(current_end);
+        let union_len = union_end - union_start + 1;
+        let capacity = self.config.window_symbols as i64;
+
+        if union_len <= capacity {
+            if union_start < 0 {
+                self.prepend((-union_start) as usize);
+            }
+            let wanted_span = union_len as usize;
+            self.extend_to(wanted_span);
+            return sequence_delta(first_esi, self.base_esi).map(|offset| offset as usize);
+        }
+
+        let new_base_offset = union_end - capacity + 1;
+        if new_base_offset <= 0 || start < new_base_offset {
+            return Err(Error::WindowExpired);
+        }
+        self.drop_front(new_base_offset as usize);
+        let new_end = sequence_delta(first_esi.wrapping_add((count - 1) as u32), self.base_esi)?;
+        self.extend_to(new_end as usize + 1);
+        sequence_delta(first_esi, self.base_esi).map(|offset| offset as usize)
+    }
+
+    fn prepend(&mut self, count: usize) {
+        debug_assert!(self.span + count <= self.config.window_symbols);
+        for index in (0..self.span).rev() {
+            self.known[index + count] = self.known[index];
+            self.symbols[index + count] = self.symbols[index];
+        }
+        for index in 0..count {
+            self.known[index] = false;
+            self.symbols[index].fill(0);
+        }
+        for row_index in 0..self.equation_capacity {
+            if !self.occupied[row_index] {
+                continue;
+            }
+            for index in (0..self.span).rev() {
+                self.rows[row_index].coefficients[index + count] =
+                    self.rows[row_index].coefficients[index];
+            }
+            self.rows[row_index].coefficients[..count].fill(0);
+        }
+        self.base_esi = self.base_esi.wrapping_sub(count as u32);
+        self.span += count;
+    }
+
+    fn extend_to(&mut self, new_span: usize) {
+        debug_assert!(new_span <= self.config.window_symbols);
+        for index in self.span..new_span {
+            self.known[index] = false;
+            self.symbols[index].fill(0);
+        }
+        self.span = self.span.max(new_span);
+    }
+
+    fn drop_front(&mut self, count: usize) {
+        if count >= self.span {
+            self.known[..self.span].fill(false);
+            self.clear_equations();
+            self.base_esi = self.base_esi.wrapping_add(count as u32);
+            self.span = 0;
+            return;
+        }
+
+        let old_span = self.span;
+        let retained = old_span - count;
+        for row_index in 0..self.equation_capacity {
+            if !self.occupied[row_index] {
+                continue;
+            }
+            if self.rows[row_index].coefficients[..count]
+                .iter()
+                .any(|coefficient| *coefficient != 0)
+            {
+                self.occupied[row_index] = false;
+                self.rank -= 1;
+                continue;
+            }
+            self.rows[row_index]
+                .coefficients
+                .copy_within(count..old_span, 0);
+            self.rows[row_index].coefficients[retained..old_span].fill(0);
+        }
+        self.known.copy_within(count..old_span, 0);
+        self.symbols.copy_within(count..old_span, 0);
+        self.known[retained..old_span].fill(false);
+        for symbol in &mut self.symbols[retained..old_span] {
+            symbol.fill(0);
+        }
+        self.base_esi = self.base_esi.wrapping_add(count as u32);
+        self.span = retained;
+    }
+
+    fn clear_equations(&mut self) {
+        self.occupied[..self.equation_capacity].fill(false);
+        self.rank = 0;
+    }
+
+    fn store_known(&mut self, index: usize, symbol: &[u8]) {
+        self.symbols[index][..self.config.symbol_size].copy_from_slice(symbol);
+        self.known[index] = true;
+    }
+
+    fn substitute_known(&mut self, index: usize) -> Result<(), Error> {
+        for row_index in 0..self.equation_capacity {
+            if !self.occupied[row_index] {
+                continue;
+            }
+            let coefficient = self.rows[row_index].coefficients[index];
+            if coefficient == 0 {
+                continue;
+            }
+            add_scaled(
+                self.config.field,
+                &mut self.rows[row_index].data[..self.config.symbol_size],
+                coefficient,
+                &self.symbols[index][..self.config.symbol_size],
+            );
+            self.rows[row_index].coefficients[index] = 0;
+        }
+        self.remove_zero_rows()
+    }
+
+    fn remove_zero_rows(&mut self) -> Result<(), Error> {
+        for row_index in 0..self.equation_capacity {
+            if !self.occupied[row_index]
+                || self.rows[row_index].coefficients[..self.span]
+                    .iter()
+                    .any(|coefficient| *coefficient != 0)
+            {
+                continue;
+            }
+            if self.rows[row_index].data[..self.config.symbol_size]
+                .iter()
+                .any(|byte| *byte != 0)
+            {
+                return Err(Error::InconsistentEquation);
+            }
+            self.occupied[row_index] = false;
+            self.rank -= 1;
+        }
+        Ok(())
+    }
+
+    fn recover_singletons(&mut self) -> Result<usize, Error> {
+        let mut recovered = 0;
+        loop {
+            let mut singleton = None;
+            for row_index in 0..self.equation_capacity {
+                if !self.occupied[row_index] {
+                    continue;
+                }
+                let mut only = None;
+                let mut multiple = false;
+                for (index, coefficient) in self.rows[row_index].coefficients[..self.span]
+                    .iter()
+                    .copied()
+                    .enumerate()
+                {
+                    if coefficient == 0 {
+                        continue;
+                    }
+                    if only.is_some() {
+                        multiple = true;
+                        break;
+                    }
+                    only = Some(index);
+                }
+                if !multiple && let Some(symbol_index) = only {
+                    singleton = Some((row_index, symbol_index));
+                    break;
+                }
+            }
+
+            let Some((row_index, symbol_index)) = singleton else {
+                break;
+            };
+            let coefficient = self.rows[row_index].coefficients[symbol_index];
+            let inverse = self.config.field.inv(coefficient);
+            if self.known[symbol_index] {
+                let matches = if inverse == 1 {
+                    self.symbols[symbol_index][..self.config.symbol_size]
+                        == self.rows[row_index].data[..self.config.symbol_size]
+                } else {
+                    self.symbols[symbol_index][..self.config.symbol_size]
+                        .iter()
+                        .zip(&self.rows[row_index].data[..self.config.symbol_size])
+                        .all(|(known, encoded)| *known == self.config.field.mul(*encoded, inverse))
+                };
+                if !matches {
+                    return Err(Error::ConflictingSource);
+                }
+            } else {
+                if inverse == 1 {
+                    self.symbols[symbol_index][..self.config.symbol_size]
+                        .copy_from_slice(&self.rows[row_index].data[..self.config.symbol_size]);
+                } else {
+                    for (decoded, encoded) in self.symbols[symbol_index][..self.config.symbol_size]
+                        .iter_mut()
+                        .zip(&self.rows[row_index].data[..self.config.symbol_size])
+                    {
+                        *decoded = self.config.field.mul(*encoded, inverse);
+                    }
+                }
+                self.known[symbol_index] = true;
+                recovered += 1;
+            }
+            self.occupied[row_index] = false;
+            self.rank -= 1;
+            self.substitute_known(symbol_index)?;
+        }
+        Ok(recovered)
+    }
+}
+
+fn validate_capacities<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize>(
+    config: RlcConfig,
+) -> Result<(), Error> {
+    if config.symbol_size > MAX_SYMBOL_SIZE {
+        return Err(Error::SymbolCapacityExceeded);
+    }
+    if config.window_symbols > MAX_WINDOW_SYMBOLS {
+        return Err(Error::WindowCapacityExceeded);
+    }
+    Ok(())
+}
+
+fn sequence_delta(value: EncodingSymbolId, base: EncodingSymbolId) -> Result<i64, Error> {
+    let distance = value.get().wrapping_sub(base.get());
+    if distance == 0x8000_0000 {
+        return Err(Error::AmbiguousSequence);
+    }
+    Ok(i64::from(distance as i32))
+}
+
+fn add_scaled(field: Field, target: &mut [u8], coefficient: u8, source: &[u8]) {
+    debug_assert_eq!(target.len(), source.len());
+    match (field, coefficient) {
+        (_, 0) => {}
+        (Field::Gf2, _) | (Field::Gf256, 1) => {
+            for (target, source) in target.iter_mut().zip(source) {
+                *target ^= source;
+            }
+        }
+        (Field::Gf256, _) => {
+            for (target, source) in target.iter_mut().zip(source) {
+                *target ^= field.mul(coefficient, *source);
+            }
+        }
+    }
+}
+
+fn first_nonzero(values: &[u8]) -> Option<usize> {
+    values.iter().position(|value| *value != 0)
+}
+
+fn row_add_scaled<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize>(
+    field: Field,
+    target: &mut Row<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS>,
+    coefficient: u8,
+    source: &Row<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS>,
+    span: usize,
+    symbol_size: usize,
+) {
+    for (target, source) in target.coefficients[..span]
+        .iter_mut()
+        .zip(&source.coefficients[..span])
+    {
+        *target ^= field.mul(coefficient, *source);
+    }
+    add_scaled(
+        field,
+        &mut target.data[..symbol_size],
+        coefficient,
+        &source.data[..symbol_size],
+    );
+}
+
+fn row_scale<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize>(
+    field: Field,
+    row: &mut Row<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS>,
+    coefficient: u8,
+    span: usize,
+    symbol_size: usize,
+) {
+    if coefficient == 1 {
+        return;
+    }
+    for value in &mut row.coefficients[..span] {
+        *value = field.mul(*value, coefficient);
+    }
+    for value in &mut row.data[..symbol_size] {
+        *value = field.mul(*value, coefficient);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SYMBOL_CAPACITY: usize = 16;
+    const WINDOW_CAPACITY: usize = 8;
+    const EQUATION_CAPACITY: usize = 8;
+
+    fn config(field: Field) -> RlcConfig {
+        RlcConfig::new(4, WINDOW_CAPACITY, field).unwrap()
+    }
+
+    const fn esi(value: u32) -> EncodingSymbolId {
+        EncodingSymbolId::new(value)
+    }
+
+    #[test]
+    fn coefficient_vectors_match_rfc_small_integer_outputs() {
+        let mut coefficients = [0; 10];
+        generate_coding_coefficients(Field::Gf256, 1, DensityThreshold::FULL, &mut coefficients);
+        assert_eq!(
+            coefficients,
+            [37, 225, 177, 176, 21, 246, 54, 139, 168, 237]
+        );
+
+        generate_coding_coefficients(
+            Field::Gf2,
+            1,
+            DensityThreshold::new(7).unwrap(),
+            &mut coefficients,
+        );
+        assert_eq!(coefficients, [1, 1, 1, 1, 1, 1, 1, 0, 0, 0]);
+
+        generate_coding_coefficients(
+            Field::Gf256,
+            1,
+            DensityThreshold::new(7).unwrap(),
+            &mut coefficients,
+        );
+        assert_eq!(coefficients, [225, 176, 246, 139, 0, 0, 187, 0, 0, 0]);
+    }
+
+    #[test]
+    fn encoder_is_systematic_and_slides_across_esi_wrap() {
+        let mut encoder = Encoder::<SYMBOL_CAPACITY, 3>::new(
+            RlcConfig::new(4, 3, Field::Gf2).unwrap(),
+            esi(u32::MAX - 1),
+        )
+        .unwrap();
+        assert_eq!(encoder.push_source(&[1, 2, 3, 4]), Ok(esi(u32::MAX - 1)));
+        assert_eq!(encoder.push_source(&[5, 6, 7, 8]), Ok(esi(u32::MAX)));
+        assert_eq!(encoder.push_source(&[9, 10, 11, 12]), Ok(esi(0)));
+        assert_eq!(encoder.push_source(&[13, 14, 15, 16]), Ok(esi(1)));
+
+        let mut repair = [0; 4];
+        let id = encoder
+            .encode_repair(
+                RepairParameters::new(0, DensityThreshold::FULL),
+                &mut repair,
+            )
+            .unwrap();
+        assert_eq!(id.first_source_esi(), esi(u32::MAX));
+        assert_eq!(id.source_symbols(), 3);
+        assert_eq!(repair, [1, 2, 3, 20]);
+    }
+
+    #[test]
+    fn decoder_recovers_one_missing_binary_symbol() {
+        let config = config(Field::Gf2);
+        let mut encoder =
+            Encoder::<SYMBOL_CAPACITY, WINDOW_CAPACITY>::new(config, esi(10)).unwrap();
+        let mut decoder = Decoder::<SYMBOL_CAPACITY, WINDOW_CAPACITY, EQUATION_CAPACITY>::new(
+            config,
+            EQUATION_CAPACITY,
+        )
+        .unwrap();
+
+        let symbols = [[1, 2, 3, 4], [9, 8, 7, 6], [3, 1, 4, 1]];
+        for symbol in &symbols {
+            encoder.push_source(symbol).unwrap();
+        }
+        let _ = decoder.receive_source(esi(10), &symbols[0]).unwrap();
+        let _ = decoder.receive_source(esi(12), &symbols[2]).unwrap();
+
+        let mut repair = [0; 4];
+        let id = encoder
+            .encode_repair(
+                RepairParameters::new(0, DensityThreshold::FULL),
+                &mut repair,
+            )
+            .unwrap();
+        let report = decoder.receive_repair(id, &repair).unwrap();
+        assert!(report.is_innovative());
+        assert_eq!(report.recovered(), 1);
+        assert_eq!(decoder.symbol(esi(11)), Some(symbols[1].as_slice()));
+        assert!(!decoder.receive_repair(id, &repair).unwrap().is_innovative());
+    }
+
+    #[test]
+    fn decoder_reduces_multiple_gf256_equations() {
+        let config = config(Field::Gf256);
+        let mut encoder =
+            Encoder::<SYMBOL_CAPACITY, WINDOW_CAPACITY>::new(config, esi(50)).unwrap();
+        let mut decoder = Decoder::<SYMBOL_CAPACITY, WINDOW_CAPACITY, EQUATION_CAPACITY>::new(
+            config,
+            EQUATION_CAPACITY,
+        )
+        .unwrap();
+        let symbols = [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]];
+        for symbol in &symbols {
+            encoder.push_source(symbol).unwrap();
+        }
+        let _ = decoder.receive_source(esi(50), &symbols[0]).unwrap();
+        let _ = decoder.receive_source(esi(53), &symbols[3]).unwrap();
+
+        let mut repair_a = [0; 4];
+        let mut repair_b = [0; 4];
+        let id_a = encoder
+            .encode_repair(
+                RepairParameters::new(41, DensityThreshold::FULL),
+                &mut repair_a,
+            )
+            .unwrap();
+        let id_b = encoder
+            .encode_repair(
+                RepairParameters::new(42, DensityThreshold::FULL),
+                &mut repair_b,
+            )
+            .unwrap();
+
+        let _ = decoder.receive_repair(id_b, &repair_b).unwrap();
+        let report = decoder.receive_repair(id_a, &repair_a).unwrap();
+        assert_eq!(report.recovered(), 2);
+        assert_eq!(decoder.symbol(esi(51)), Some(symbols[1].as_slice()));
+        assert_eq!(decoder.symbol(esi(52)), Some(symbols[2].as_slice()));
+        assert_eq!(decoder.rank(), 0);
+    }
+
+    #[test]
+    fn decoder_accepts_reorder_duplicates_and_wrap() {
+        let config = RlcConfig::new(4, 5, Field::Gf256).unwrap();
+        let mut decoder = Decoder::<8, 5, 5>::new(config, 5).unwrap();
+        let before_wrap = [1, 2, 3, 4];
+        let after_wrap = [5, 6, 7, 8];
+
+        assert_eq!(
+            decoder
+                .receive_source(esi(0), &after_wrap)
+                .map(SourceReport::status),
+            Ok(SourceStatus::New),
+        );
+        assert_eq!(
+            decoder
+                .receive_source(esi(u32::MAX), &before_wrap)
+                .map(SourceReport::status),
+            Ok(SourceStatus::New),
+        );
+        assert_eq!(
+            decoder
+                .receive_source(esi(0), &after_wrap)
+                .map(SourceReport::status),
+            Ok(SourceStatus::Duplicate),
+        );
+        assert_eq!(decoder.symbol(esi(u32::MAX)), Some(before_wrap.as_slice()));
+        assert_eq!(decoder.symbol(esi(0)), Some(after_wrap.as_slice()));
+    }
+
+    #[test]
+    fn repair_can_arrive_before_systematic_symbols() {
+        let config = RlcConfig::new(4, 4, Field::Gf256).unwrap();
+        let mut encoder = Encoder::<4, 4>::new(config, esi(100)).unwrap();
+        let mut decoder = Decoder::<4, 4, 4>::new(config, 4).unwrap();
+        let symbols = [[1, 3, 3, 7], [2, 4, 6, 8], [5, 5, 5, 5]];
+        for symbol in &symbols {
+            encoder.push_source(symbol).unwrap();
+        }
+        assert_eq!(encoder.window(), Some((esi(100), 3)));
+
+        let mut repair = [0; 4];
+        let id = encoder
+            .encode_repair(
+                RepairParameters::new(99, DensityThreshold::FULL),
+                &mut repair,
+            )
+            .unwrap();
+        assert_eq!(decoder.receive_repair(id, &repair).unwrap().recovered(), 0);
+        let _ = decoder.receive_source(esi(102), &symbols[2]).unwrap();
+        let source_report = decoder.receive_source(esi(100), &symbols[0]).unwrap();
+        assert_eq!(source_report.recovered(), 1);
+        assert_eq!(decoder.symbol(esi(101)), Some(symbols[1].as_slice()));
+
+        decoder.discard_before(esi(102)).unwrap();
+        assert_eq!(decoder.window(), Some((esi(102), 1)));
+        assert_eq!(decoder.symbol(esi(100)), None);
+
+        decoder.discard_before(esi(200)).unwrap();
+        assert_eq!(decoder.window(), None);
+        assert_eq!(
+            decoder.receive_source(esi(199), &[0; 4]),
+            Err(Error::WindowExpired)
+        );
+        assert_eq!(
+            decoder
+                .receive_source(esi(200), &[0; 4])
+                .map(SourceReport::status),
+            Ok(SourceStatus::New),
+        );
+        assert!(decoder.known_symbols().map(|(id, _)| id).eq([esi(200)]));
+    }
+
+    #[test]
+    fn validates_sizes_capacities_and_binary_key_rule() {
+        assert_eq!(RlcConfig::new(0, 1, Field::Gf2), Err(Error::EmptySymbol));
+        assert_eq!(
+            RlcConfig::new(1, 4096, Field::Gf2),
+            Err(Error::WindowCapacityExceeded)
+        );
+        let config = RlcConfig::new(4, 4, Field::Gf2).unwrap();
+        assert!(matches!(
+            Encoder::<3, 4>::new(config, esi(0)),
+            Err(Error::SymbolCapacityExceeded)
+        ));
+        assert!(matches!(
+            Decoder::<4, 4, 1>::new(config, 2),
+            Err(Error::EquationCapacityExceeded)
+        ));
+
+        let mut encoder = Encoder::<4, 4>::new(config, esi(0)).unwrap();
+        assert_eq!(encoder.push_source(&[1, 2]), Err(Error::SymbolSizeMismatch));
+        encoder.push_source(&[1, 2, 3, 4]).unwrap();
+        assert_eq!(
+            encoder.encode_repair(
+                RepairParameters::new(1, DensityThreshold::FULL),
+                &mut [0; 4],
+            ),
+            Err(Error::RepairKeyMustBeZero)
+        );
+    }
+
+    #[test]
+    fn equation_capacity_is_a_hard_bound() {
+        let config = RlcConfig::new(1, 3, Field::Gf256).unwrap();
+        let mut encoder = Encoder::<1, 3>::new(config, esi(0)).unwrap();
+        let mut decoder = Decoder::<1, 3, 1>::new(config, 1).unwrap();
+        for byte in 1..=3 {
+            encoder.push_source(&[byte]).unwrap();
+        }
+
+        let mut repair = [0];
+        let first = encoder
+            .encode_repair(
+                RepairParameters::new(1, DensityThreshold::FULL),
+                &mut repair,
+            )
+            .unwrap();
+        let _ = decoder.receive_repair(first, &repair).unwrap();
+        let second = encoder
+            .encode_repair(
+                RepairParameters::new(2, DensityThreshold::FULL),
+                &mut repair,
+            )
+            .unwrap();
+        assert_eq!(
+            decoder.receive_repair(second, &repair),
+            Err(Error::EquationStoreFull)
+        );
+    }
+
+    #[test]
+    fn old_ranges_and_conflicting_duplicates_are_rejected() {
+        let config = RlcConfig::new(1, 3, Field::Gf256).unwrap();
+        let mut decoder = Decoder::<1, 3, 3>::new(config, 3).unwrap();
+        let _ = decoder.receive_source(esi(10), &[10]).unwrap();
+        let _ = decoder.receive_source(esi(11), &[11]).unwrap();
+        let _ = decoder.receive_source(esi(12), &[12]).unwrap();
+        let _ = decoder.receive_source(esi(13), &[13]).unwrap();
+
+        assert_eq!(
+            decoder.receive_source(esi(10), &[10]),
+            Err(Error::WindowExpired),
+        );
+        assert_eq!(
+            decoder.receive_source(esi(13), &[99]),
+            Err(Error::ConflictingSource)
+        );
+    }
+}

--- a/components/libs/cu_fec/src/tinymt.rs
+++ b/components/libs/cu_fec/src/tinymt.rs
@@ -1,0 +1,147 @@
+//! RFC 8682 TinyMT32 with the parameter set mandated by that RFC.
+//!
+//! This code was derived from IETF RFC 8682. Please reproduce this note if possible.
+
+const MAT1: u32 = 0x8f70_11ee;
+const MAT2: u32 = 0xfc78_ff1f;
+const TMAT: u32 = 0x3793_fdff;
+const MASK: u32 = 0x7fff_ffff;
+
+pub(crate) struct TinyMt32 {
+    status: [u32; 4],
+}
+
+impl TinyMt32 {
+    pub(crate) fn new(seed: u32) -> Self {
+        let mut generator = Self {
+            status: [seed, MAT1, MAT2, TMAT],
+        };
+        for i in 1_u32..8 {
+            let previous = generator.status[((i - 1) & 3) as usize];
+            generator.status[(i & 3) as usize] ^=
+                i.wrapping_add(1_812_433_253_u32.wrapping_mul(previous ^ (previous >> 30)));
+        }
+        for _ in 0..8 {
+            generator.next_state();
+        }
+        generator
+    }
+
+    pub(crate) fn next_u32(&mut self) -> u32 {
+        self.next_state();
+        self.temper()
+    }
+
+    pub(crate) fn next_u4(&mut self) -> u8 {
+        (self.next_u32() & 0x0f) as u8
+    }
+
+    pub(crate) fn next_u8(&mut self) -> u8 {
+        (self.next_u32() & 0xff) as u8
+    }
+
+    fn next_state(&mut self) {
+        let mut y = self.status[3];
+        let mut x = (self.status[0] & MASK) ^ self.status[1] ^ self.status[2];
+        x ^= x << 1;
+        y ^= (y >> 1) ^ x;
+        self.status[0] = self.status[1];
+        self.status[1] = self.status[2];
+        self.status[2] = x ^ (y << 10);
+        self.status[3] = y;
+        if y & 1 != 0 {
+            self.status[1] ^= MAT1;
+            self.status[2] ^= MAT2;
+        }
+    }
+
+    fn temper(&self) -> u32 {
+        let t1 = self.status[0].wrapping_add(self.status[2] >> 8);
+        let mut t0 = self.status[3] ^ t1;
+        if t1 & 1 != 0 {
+            t0 ^= TMAT;
+        }
+        t0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_rfc_8682_seed_one_vector() {
+        let expected = [
+            2_545_341_989,
+            981_918_433,
+            3_715_302_833,
+            2_387_538_352,
+            3_591_001_365,
+            3_820_442_102,
+            2_114_400_566,
+            2_196_103_051,
+            2_783_359_912,
+            764_534_509,
+            643_179_475,
+            1_822_416_315,
+            881_558_334,
+            4_207_026_366,
+            3_690_273_640,
+            3_240_535_687,
+            2_921_447_122,
+            3_984_931_427,
+            4_092_394_160,
+            44_209_675,
+            2_188_315_343,
+            2_908_663_843,
+            1_834_519_336,
+            3_774_670_961,
+            3_019_990_707,
+            4_065_554_902,
+            1_239_765_502,
+            4_035_716_197,
+            3_412_127_188,
+            552_822_483,
+            161_364_450,
+            353_727_785,
+            140_085_994,
+            149_132_008,
+            2_547_770_827,
+            4_064_042_525,
+            4_078_297_538,
+            2_057_335_507,
+            622_384_752,
+            2_041_665_899,
+            2_193_913_817,
+            1_080_849_512,
+            33_160_901,
+            662_956_935,
+            642_999_063,
+            3_384_709_977,
+            1_723_175_122,
+            3_866_752_252,
+            521_822_317,
+            2_292_524_454,
+        ];
+        let mut generator = TinyMt32::new(1);
+        for value in expected {
+            assert_eq!(generator.next_u32(), value);
+        }
+    }
+
+    #[test]
+    fn matches_rfc_8681_small_integer_vectors() {
+        let expected_u8 = [37, 225, 177, 176, 21, 246, 54, 139, 168, 237];
+        let expected_u4 = [5, 1, 1, 0, 5, 6, 6, 11, 8, 13];
+
+        let mut bytes = TinyMt32::new(1);
+        for value in expected_u8 {
+            assert_eq!(bytes.next_u8(), value);
+        }
+
+        let mut nibbles = TinyMt32::new(1);
+        for value in expected_u4 {
+            assert_eq!(nibbles.next_u4(), value);
+        }
+    }
+}

--- a/components/libs/cu_fec/src/wire.rs
+++ b/components/libs/cu_fec/src/wire.rs
@@ -1,0 +1,336 @@
+//! RFC 8681 FEC Scheme-Specific Information and payload identifiers.
+
+use core::fmt;
+
+use crate::{DensityThreshold, EncodingSymbolId};
+
+/// An error in RFC 8681 wire metadata.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WireError {
+    /// A byte slice does not have the required fixed wire length.
+    InvalidLength {
+        /// Required byte count.
+        expected: usize,
+        /// Supplied byte count.
+        actual: usize,
+    },
+    /// A repair window must contain at least one source symbol.
+    EmptyRepairWindow,
+    /// The 12-bit NSS field cannot represent the requested window size.
+    RepairWindowTooLarge,
+}
+
+impl fmt::Display for WireError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidLength { expected, actual } => {
+                write!(formatter, "expected {expected} bytes, received {actual}")
+            }
+            Self::EmptyRepairWindow => formatter.write_str("repair window must not be empty"),
+            Self::RepairWindowTooLarge => {
+                formatter.write_str("repair window exceeds the 12-bit NSS field")
+            }
+        }
+    }
+}
+
+impl core::error::Error for WireError {}
+
+/// The three-octet RFC 8681 FEC Scheme-Specific Information value.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FecSchemeSpecificInfo {
+    symbol_size: u16,
+    window_size_ratio: u8,
+}
+
+impl TryFrom<&[u8]> for FecSchemeSpecificInfo {
+    type Error = WireError;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        let bytes: [u8; 3] = bytes.try_into().map_err(|_| WireError::InvalidLength {
+            expected: 3,
+            actual: bytes.len(),
+        })?;
+        Ok(Self::from_bytes(bytes))
+    }
+}
+
+impl From<FecSchemeSpecificInfo> for [u8; 3] {
+    fn from(value: FecSchemeSpecificInfo) -> Self {
+        value.to_bytes()
+    }
+}
+
+impl From<[u8; 3]> for FecSchemeSpecificInfo {
+    fn from(bytes: [u8; 3]) -> Self {
+        Self::from_bytes(bytes)
+    }
+}
+
+impl FecSchemeSpecificInfo {
+    /// Creates scheme-specific information from the symbol size and WSR value.
+    pub const fn new(symbol_size: u16, window_size_ratio: u8) -> Self {
+        Self {
+            symbol_size,
+            window_size_ratio,
+        }
+    }
+
+    /// Returns the encoding symbol size in bytes.
+    pub const fn symbol_size(self) -> u16 {
+        self.symbol_size
+    }
+
+    /// Returns the window size ratio, where zero means unspecified.
+    pub const fn window_size_ratio(self) -> u8 {
+        self.window_size_ratio
+    }
+
+    /// Encodes the value in network byte order.
+    pub const fn to_bytes(self) -> [u8; 3] {
+        let size = self.symbol_size.to_be_bytes();
+        [size[0], size[1], self.window_size_ratio]
+    }
+
+    /// Decodes a value in network byte order.
+    pub const fn from_bytes(bytes: [u8; 3]) -> Self {
+        Self::new(u16::from_be_bytes([bytes[0], bytes[1]]), bytes[2])
+    }
+}
+
+/// The four-octet Explicit Source FEC Payload ID from RFC 8681.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SourcePayloadId {
+    esi: EncodingSymbolId,
+}
+
+impl SourcePayloadId {
+    /// Creates an identifier for an encoding symbol.
+    pub const fn new(esi: EncodingSymbolId) -> Self {
+        Self { esi }
+    }
+
+    /// Returns the Encoding Symbol ID (ESI).
+    pub const fn esi(self) -> EncodingSymbolId {
+        self.esi
+    }
+
+    /// Encodes the identifier in network byte order.
+    pub const fn to_bytes(self) -> [u8; 4] {
+        self.esi.get().to_be_bytes()
+    }
+
+    /// Decodes an identifier in network byte order.
+    pub const fn from_bytes(bytes: [u8; 4]) -> Self {
+        Self::new(EncodingSymbolId::new(u32::from_be_bytes(bytes)))
+    }
+}
+
+impl TryFrom<&[u8]> for SourcePayloadId {
+    type Error = WireError;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        let bytes: [u8; 4] = bytes.try_into().map_err(|_| WireError::InvalidLength {
+            expected: 4,
+            actual: bytes.len(),
+        })?;
+        Ok(Self::from_bytes(bytes))
+    }
+}
+
+impl From<SourcePayloadId> for [u8; 4] {
+    fn from(value: SourcePayloadId) -> Self {
+        value.to_bytes()
+    }
+}
+
+impl From<[u8; 4]> for SourcePayloadId {
+    fn from(bytes: [u8; 4]) -> Self {
+        Self::from_bytes(bytes)
+    }
+}
+
+/// The eight-octet Repair FEC Payload ID from RFC 8681.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RepairPayloadId {
+    repair_key: u16,
+    density: DensityThreshold,
+    source_symbols: u16,
+    first_source_esi: EncodingSymbolId,
+}
+
+impl RepairPayloadId {
+    /// Creates a repair payload identifier.
+    pub const fn new(
+        repair_key: u16,
+        density: DensityThreshold,
+        source_symbols: u16,
+        first_source_esi: EncodingSymbolId,
+    ) -> Result<Self, WireError> {
+        if source_symbols == 0 {
+            return Err(WireError::EmptyRepairWindow);
+        }
+        if source_symbols > 0x0fff {
+            return Err(WireError::RepairWindowTooLarge);
+        }
+        Ok(Self {
+            repair_key,
+            density,
+            source_symbols,
+            first_source_esi,
+        })
+    }
+
+    /// Returns the coefficient-generator seed.
+    pub const fn repair_key(self) -> u16 {
+        self.repair_key
+    }
+
+    /// Returns the coding-coefficient density threshold.
+    pub const fn density(self) -> DensityThreshold {
+        self.density
+    }
+
+    /// Returns the number of source symbols in the encoding window.
+    pub const fn source_symbols(self) -> u16 {
+        self.source_symbols
+    }
+
+    /// Returns the ESI of the first source symbol in the encoding window.
+    pub const fn first_source_esi(self) -> EncodingSymbolId {
+        self.first_source_esi
+    }
+
+    /// Advances the repair key for another symbol packed in the same packet.
+    pub const fn for_symbol_offset(self, offset: u16) -> Self {
+        Self {
+            repair_key: self.repair_key.wrapping_add(offset),
+            ..self
+        }
+    }
+
+    /// Encodes the identifier in network byte order.
+    pub const fn to_bytes(self) -> [u8; 8] {
+        let key = self.repair_key.to_be_bytes();
+        let density_and_count =
+            (((self.density.get() as u16) << 12) | self.source_symbols).to_be_bytes();
+        let first = self.first_source_esi.get().to_be_bytes();
+        [
+            key[0],
+            key[1],
+            density_and_count[0],
+            density_and_count[1],
+            first[0],
+            first[1],
+            first[2],
+            first[3],
+        ]
+    }
+
+    /// Decodes an identifier in network byte order.
+    pub fn from_bytes(bytes: [u8; 8]) -> Result<Self, WireError> {
+        let repair_key = u16::from_be_bytes([bytes[0], bytes[1]]);
+        let density_and_count = u16::from_be_bytes([bytes[2], bytes[3]]);
+        let density = DensityThreshold::new((density_and_count >> 12) as u8)
+            .expect("a four-bit density is always valid");
+        let source_symbols = density_and_count & 0x0fff;
+        let first_source_esi =
+            EncodingSymbolId::new(u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]));
+        Self::new(repair_key, density, source_symbols, first_source_esi)
+    }
+}
+
+impl TryFrom<&[u8]> for RepairPayloadId {
+    type Error = WireError;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        let bytes: [u8; 8] = bytes.try_into().map_err(|_| WireError::InvalidLength {
+            expected: 8,
+            actual: bytes.len(),
+        })?;
+        Self::from_bytes(bytes)
+    }
+}
+
+impl TryFrom<[u8; 8]> for RepairPayloadId {
+    type Error = WireError;
+
+    fn try_from(bytes: [u8; 8]) -> Result<Self, Self::Error> {
+        Self::from_bytes(bytes)
+    }
+}
+
+impl From<RepairPayloadId> for [u8; 8] {
+    fn from(value: RepairPayloadId) -> Self {
+        value.to_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Field;
+
+    #[test]
+    fn wire_values_are_big_endian_and_round_trip() {
+        let info = FecSchemeSpecificInfo::new(0x0578, 191);
+        assert_eq!(info.to_bytes(), [0x05, 0x78, 191]);
+        assert_eq!(FecSchemeSpecificInfo::from_bytes(info.to_bytes()), info);
+
+        let source = SourcePayloadId::new(EncodingSymbolId::new(0x1234_5678));
+        assert_eq!(source.to_bytes(), [0x12, 0x34, 0x56, 0x78]);
+        assert_eq!(SourcePayloadId::from_bytes(source.to_bytes()), source);
+
+        let repair = RepairPayloadId::new(
+            0x1234,
+            DensityThreshold::new(10).unwrap(),
+            0x0bcd,
+            EncodingSymbolId::new(0x89ab_cdef),
+        )
+        .unwrap();
+        assert_eq!(
+            repair.to_bytes(),
+            [0x12, 0x34, 0xab, 0xcd, 0x89, 0xab, 0xcd, 0xef]
+        );
+        assert_eq!(RepairPayloadId::from_bytes(repair.to_bytes()), Ok(repair));
+        assert_eq!(repair.for_symbol_offset(u16::MAX).repair_key(), 0x1233);
+        assert_eq!(Field::Gf2.fec_encoding_id(), 9);
+        assert_eq!(Field::Gf256.fec_encoding_id(), 10);
+
+        assert_eq!(
+            FecSchemeSpecificInfo::try_from(info.to_bytes().as_slice()),
+            Ok(info)
+        );
+        assert_eq!(
+            SourcePayloadId::try_from(source.to_bytes().as_slice()),
+            Ok(source)
+        );
+        assert_eq!(
+            RepairPayloadId::try_from(repair.to_bytes().as_slice()),
+            Ok(repair)
+        );
+    }
+
+    #[test]
+    fn rejects_unrepresentable_windows() {
+        assert_eq!(
+            RepairPayloadId::new(0, DensityThreshold::FULL, 0, EncodingSymbolId::new(0)),
+            Err(WireError::EmptyRepairWindow)
+        );
+        assert_eq!(
+            RepairPayloadId::new(0, DensityThreshold::FULL, 4096, EncodingSymbolId::new(0),),
+            Err(WireError::RepairWindowTooLarge)
+        );
+        assert_eq!(
+            RepairPayloadId::from_bytes([0; 8]),
+            Err(WireError::EmptyRepairWindow)
+        );
+        assert_eq!(
+            SourcePayloadId::try_from([0_u8; 3].as_slice()),
+            Err(WireError::InvalidLength {
+                expected: 4,
+                actual: 3,
+            })
+        );
+    }
+}

--- a/components/libs/cu_fec/tests/impairment.rs
+++ b/components/libs/cu_fec/tests/impairment.rs
@@ -1,0 +1,101 @@
+use cu_fec::{
+    DensityThreshold, EncodingSymbolId, Field, RepairParameters, RepairPayloadId, RlcConfig,
+    RlcDecoder, RlcEncoder,
+};
+
+const SYMBOL_SIZE: usize = 32;
+const WINDOW_SIZE: usize = 24;
+const EQUATIONS: usize = 24;
+const BATCH: usize = 12;
+
+#[derive(Clone)]
+struct RepairPacket {
+    id: [u8; 8],
+    symbol: [u8; SYMBOL_SIZE],
+}
+
+fn source_symbol(esi: EncodingSymbolId) -> [u8; SYMBOL_SIZE] {
+    let mut state = esi.get() ^ 0xa5a5_5a5a;
+    let mut symbol = [0; SYMBOL_SIZE];
+    for byte in &mut symbol {
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        *byte = state as u8;
+    }
+    symbol
+}
+
+fn run_burst_loss_scenario(field: Field) {
+    let config = RlcConfig::new(SYMBOL_SIZE, WINDOW_SIZE, field).unwrap();
+    let mut encoder =
+        RlcEncoder::<SYMBOL_SIZE, WINDOW_SIZE>::new(config, EncodingSymbolId::new(u32::MAX - 47))
+            .unwrap();
+    let mut decoder =
+        RlcDecoder::<SYMBOL_SIZE, WINDOW_SIZE, EQUATIONS>::new(config, EQUATIONS).unwrap();
+    let density = if field == Field::Gf2 {
+        DensityThreshold::new(7).unwrap()
+    } else {
+        DensityThreshold::FULL
+    };
+
+    for batch in 0..8_u16 {
+        let mut received = Vec::new();
+        let mut lost = Vec::new();
+        for offset in 0..BATCH {
+            let esi = encoder.next_esi();
+            let symbol = source_symbol(esi);
+            assert_eq!(encoder.push_source(&symbol), Ok(esi));
+            if (3..6).contains(&offset) {
+                lost.push((esi, symbol));
+            } else {
+                received.push((esi, symbol));
+            }
+        }
+
+        // Reorder all systematic packets inside the bounded receiver window.
+        for (esi, symbol) in received.iter().rev() {
+            let _ = decoder.receive_source(*esi, symbol).unwrap();
+        }
+
+        let mut repairs = Vec::new();
+        for offset in 0..10_u16 {
+            let repair_key = if field == Field::Gf2 {
+                batch.wrapping_mul(31).wrapping_add(offset)
+            } else {
+                batch.wrapping_mul(31).wrapping_add(offset).wrapping_add(1)
+            };
+            let mut symbol = [0; SYMBOL_SIZE];
+            let id = encoder
+                .encode_repair(RepairParameters::new(repair_key, density), &mut symbol)
+                .unwrap();
+            repairs.push(RepairPacket {
+                id: id.to_bytes(),
+                symbol,
+            });
+        }
+
+        // Deliver repair packets in reverse order and duplicate every third packet.
+        for (index, packet) in repairs.iter().rev().enumerate() {
+            let id = RepairPayloadId::from_bytes(packet.id).unwrap();
+            let _ = decoder.receive_repair(id, &packet.symbol).unwrap();
+            if index.is_multiple_of(3) {
+                let _ = decoder.receive_repair(id, &packet.symbol).unwrap();
+            }
+        }
+
+        for (esi, expected) in lost {
+            assert_eq!(decoder.symbol(esi), Some(expected.as_slice()), "ESI {esi}");
+        }
+    }
+}
+
+#[test]
+fn gf256_recovers_reordered_bursts_across_sequence_wrap() {
+    run_burst_loss_scenario(Field::Gf256);
+}
+
+#[test]
+fn gf2_recovers_reordered_bursts_across_sequence_wrap() {
+    run_burst_loss_scenario(Field::Gf2);
+}


### PR DESCRIPTION
## Summary

Adds `cu-fec`, an independently publishable Forward Erasure Correction library developed within the Copper project for deterministic streaming over lossy links.

Real-time and one-way streams cannot always wait for retransmission. This crate adds bounded-latency recovery symbols so receivers can reconstruct missing UDP, radio, telemetry, log, sensor, or media packets from the packets that do arrive.

The crate is deliberately independent of Copper: it is dependency-free, `no_std`, allocator-free, contains no Copper types or protocol assumptions, and uses no unsafe code.

## Changes

- Implements RFC 8681 systematic sliding-window Random Linear Coding over GF(2) and GF(2^8).
- Implements RFC 8682 TinyMT32 coefficient generation with compatibility vectors from the RFC.
- Provides const-generic, bounded-memory `RlcEncoder` and `RlcDecoder` types.
- Supports sequence-number wrap, reordered and duplicate packets, explicit expiry, configurable repair density, and bounded equation storage.
- Adds typed `EncodingSymbolId`, source/repair processing reports, and zero-allocation iteration over recovered symbols.
- Adds RFC 8681 source/repair payload-ID and scheme-specific wire helpers with standard `From`/`TryFrom` conversions.
- Includes unit, impairment, wraparound, burst-loss, wire-format, and interoperability-vector tests.
- Includes a dependency-free release benchmark for codec cost and exact encoder/decoder object sizes.
- Documents realistic recovery limits, UDP/radio starting profiles, repair cadence, field/density selection, window sizing, equation capacity, MTU considerations, and memory costs.

## Recovery expectations

For `L` missing source symbols, at least `L` innovative repairs covering those symbols must arrive. With full-density GF(2^8), `L + 1` received repairs is the recommended baseline and has a random-matrix full-rank probability above 99.998%. GF(2) is faster but generally needs several more repairs; full-density GF(2) repeats the same all-ones equation for an identical window and is normally useful only for one erasure.

A practical starting point for UDP telemetry with short bursts is a 64-symbol window, full-density GF(2^8), and one repair per eight source packets (12.5% FEC overhead), then tuning against recorded loss traces.

## Licensing

Original Rust code is Apache-2.0 licensed. The TinyMT32 implementation is translated from the [RFC 8682 Section 2.1 reference C implementation](https://www.rfc-editor.org/rfc/rfc8682.html#section-2.1) and retains the IETF Trust Revised BSD terms in `LICENSE-BSD-3-Clause`.

## Validation

- 15 unit tests and 2 burst-loss/reordering impairment tests pass for GF(2) and GF(2^8).
- Rustdoc example passes.
- Clippy passes with warnings denied.
- Direct `no_std` compilation passes for `thumbv6m-none-eabi`.
- `cargo package` succeeds with the expected standalone crate contents.
- Release benchmark comparison against the pre-cleanup implementation found unchanged state size, no measurable GF(2^8)/decode regression, and approximately 7% faster full-density GF(2) encoding.

## Checklist

- [x] Focused formatting, tests, Clippy, `no_std`, packaging, and benchmark checks completed.
- [x] README and rustdoc examples updated.
