### PR TITLE
feature(logging): Make async CopperList handoff nonblocking

### DIFF
--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -1319,6 +1319,7 @@ impl cu29_runtime::monitoring::CopperListInfo
 pub const fn cu29_runtime::monitoring::CopperListInfo::new(size_bytes: usize, count: usize) -> Self
 pub struct cu29_runtime::monitoring::CopperListIoStats
 pub cu29_runtime::monitoring::CopperListIoStats::culistid: u64
+pub cu29_runtime::monitoring::CopperListIoStats::dropped_copperlists_total: u64
 pub cu29_runtime::monitoring::CopperListIoStats::encoded_culist_bytes: u64
 pub cu29_runtime::monitoring::CopperListIoStats::handle_bytes: u64
 pub cu29_runtime::monitoring::CopperListIoStats::keyframe_bytes: u64

--- a/components/libs/cu_tuimon/src/model.rs
+++ b/components/libs/cu_tuimon/src/model.rs
@@ -410,6 +410,7 @@ pub(crate) struct CopperListStats {
     pub(crate) keyframe_bytes: u64,
     pub(crate) structured_total_bytes: u64,
     pub(crate) structured_bytes_per_cl: u64,
+    pub(crate) dropped_copperlists_total: u64,
     pub(crate) total_copperlists: u64,
     pub(crate) window_copperlists: u64,
     pub(crate) last_seen_clid: Option<u64>,
@@ -427,6 +428,7 @@ impl CopperListStats {
             keyframe_bytes: 0,
             structured_total_bytes: 0,
             structured_bytes_per_cl: 0,
+            dropped_copperlists_total: 0,
             total_copperlists: 0,
             window_copperlists: 0,
             last_seen_clid: None,
@@ -447,6 +449,7 @@ impl CopperListStats {
         let total = stats.structured_log_bytes_total;
         self.structured_bytes_per_cl = total.saturating_sub(self.structured_total_bytes);
         self.structured_total_bytes = total;
+        self.dropped_copperlists_total = stats.dropped_copperlists_total;
     }
 
     fn update_rate(&mut self, clid: u64) {
@@ -538,5 +541,30 @@ mod tests {
         assert!(identity.subsystem_name.is_none());
         assert_eq!(identity.mission_name.as_str(), "default");
         assert_eq!(identity.instance_id, 0);
+    }
+
+    #[test]
+    fn copperlist_io_tracks_cumulative_handoff_drops() {
+        static COMPONENTS: &[MonitorComponentMetadata] = &[];
+        let model = MonitorModel::from_parts(
+            COMPONENTS,
+            CopperListInfo::new(0, 0),
+            MonitorTopology::default(),
+        );
+
+        model.observe_copperlist_io(CopperListIoStats {
+            dropped_copperlists_total: 7,
+            ..CopperListIoStats::default()
+        });
+
+        assert_eq!(
+            model
+                .inner
+                .copperlist_stats
+                .lock()
+                .unwrap()
+                .dropped_copperlists_total,
+            7
+        );
     }
 }

--- a/components/libs/cu_tuimon/src/ui.rs
+++ b/components/libs/cu_tuimon/src/ui.rs
@@ -708,6 +708,7 @@ impl MonitorUi {
             .saturating_add(stats.keyframe_bytes)
             .saturating_add(stats.structured_bytes_per_cl);
         let disk_total_bw = format_rate_bytes_or_na(disk_total_bytes, stats.rate_hz);
+        let dropped_display = stats.dropped_copperlists_total.to_string();
 
         let header_cells = ["Metric", "Value"].iter().map(|header| {
             Cell::from(Line::from(*header)).style(
@@ -727,6 +728,13 @@ impl MonitorUi {
         let spacer = row(" ", " ".to_string());
 
         let rate_style = Style::default().fg(palette::CYAN);
+        let dropped_style = if stats.dropped_copperlists_total == 0 {
+            Style::default()
+        } else {
+            Style::default()
+                .fg(palette::LIGHT_RED)
+                .add_modifier(Modifier::BOLD)
+        };
         let mem_rows = vec![
             row("Observed rate", rate_display).style(rate_style),
             spacer.clone(),
@@ -739,6 +747,8 @@ impl MonitorUi {
         ];
 
         let disk_rows = vec![
+            row("Dropped CopperLists", dropped_display).style(dropped_style),
+            spacer.clone(),
             row("CL serialized size", encoded_display),
             row("Space saved", space_saved_display),
             row("Structured log / CL", structured_display),
@@ -1109,9 +1119,11 @@ impl MonitorUi {
 mod tests {
     use super::*;
     use cu29::monitoring::{
-        ComponentType, CopperListInfo, MonitorComponentMetadata, MonitorConnection, MonitorNode,
-        MonitorTopology,
+        ComponentType, CopperListInfo, CopperListIoStats, MonitorComponentMetadata,
+        MonitorConnection, MonitorNode, MonitorTopology,
     };
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
 
     #[test]
     fn normalize_text_colors_replaces_reset_fg_and_bg() {
@@ -1132,6 +1144,39 @@ mod tests {
         let ui = MonitorUi::new(test_monitor_model(), MonitorUiOptions::default());
 
         assert_eq!(ui.active_screen(), MonitorScreen::Dag);
+    }
+
+    #[test]
+    fn copperlist_screen_highlights_dropped_count() {
+        let model = test_monitor_model();
+        model.observe_copperlist_io(CopperListIoStats {
+            dropped_copperlists_total: 7,
+            ..CopperListIoStats::default()
+        });
+        let mut ui = MonitorUi::new(model, MonitorUiOptions::default());
+        ui.set_active_screen(MonitorScreen::CopperList);
+        let mut terminal = Terminal::new(TestBackend::new(90, 18)).unwrap();
+
+        terminal.draw(|frame| ui.draw(frame)).unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let dropped_row = buffer
+            .content
+            .chunks(buffer.area.width as usize)
+            .find(|cells| {
+                cells
+                    .iter()
+                    .map(|cell| cell.symbol())
+                    .collect::<String>()
+                    .contains("Dropped CopperLists")
+            })
+            .expect("Dropped CopperLists row");
+        let value = dropped_row
+            .iter()
+            .find(|cell| cell.symbol() == "7")
+            .expect("dropped count value");
+        assert_eq!(value.fg, palette::LIGHT_RED);
+        assert!(value.modifier.contains(Modifier::BOLD));
     }
 
     #[test]

--- a/core/cu29/src/lib.rs
+++ b/core/cu29/src/lib.rs
@@ -27,7 +27,8 @@
 //! - `remote-debug`: remote debug transport support
 //! - `sysclock-perf`: use a host/system clock for runtime perf timing while keeping robot time for `tov` and `rate_target_hz`
 //! - `high-precision-limiter`: std-only hybrid sleep/spin loop limiter for tighter `rate_target_hz` cadence
-//! - `async-cl-io`: offload CopperList serialization/logging to a dedicated std thread
+//! - `async-cl-io`: hand completed CopperLists to a dedicated std output thread without blocking;
+//!   drops are reported through `CopperListIoStats::dropped_copperlists_total`
 //! - `flat-copperlist-encoding`: override the default compression for CPU-constrained applications
 //! - `parallel-rt`: prepare the runtime for a future multi-threaded deterministic executor
 //! - `cuda`: enable CUDA-backed Copper pools and handles on supported host platforms

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -5062,6 +5062,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                             keyframe_bytes,
                                             structured_log_bytes_total: ::cu29::prelude::structured_log_bytes_total(),
                                             culistid: worker_result.clid,
+                                            dropped_copperlists_total: cl_manager.dropped_copperlists_total(),
                                         };
                                         monitor.observe_copperlist_io(stats);
 
@@ -5232,6 +5233,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                     keyframe_bytes: #keyframe_bytes,
                     structured_log_bytes_total: ::cu29::prelude::structured_log_bytes_total(),
                     culistid: clid,
+                    dropped_copperlists_total: cl_manager.dropped_copperlists_total(),
                 };
                 monitor.observe_copperlist_io(stats);
                 Ok(())

--- a/core/cu29_export/src/fsck.rs
+++ b/core/cu29_export/src/fsck.rs
@@ -8,6 +8,57 @@ use cu29::{CopperListTuple, CuResult};
 use num_format::{Locale, ToFormattedString};
 use std::io::Cursor;
 
+const MAX_REPORTED_COPPERLIST_HOLES: usize = 16;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct CopperListHole {
+    first: u64,
+    last: u64,
+}
+
+impl CopperListHole {
+    fn len(self) -> u64 {
+        self.last.saturating_sub(self.first).saturating_add(1)
+    }
+}
+
+#[derive(Default)]
+struct CopperListSequence {
+    entries: u64,
+    first_id: Option<u64>,
+    last_id: Option<u64>,
+    missing: u64,
+    holes: Vec<CopperListHole>,
+}
+
+impl CopperListSequence {
+    fn observe(&mut self, id: u64) {
+        self.entries = self.entries.saturating_add(1);
+
+        let Some(previous) = self.last_id else {
+            self.first_id = Some(id);
+            self.last_id = Some(id);
+            if id > 0 {
+                self.push_hole(0, id - 1);
+            }
+            return;
+        };
+
+        if id > previous.saturating_add(1) {
+            self.push_hole(previous + 1, id - 1);
+        }
+        if id > previous {
+            self.last_id = Some(id);
+        }
+    }
+
+    fn push_hole(&mut self, first: u64, last: u64) {
+        let hole = CopperListHole { first, last };
+        self.missing = self.missing.saturating_add(hole.len());
+        self.holes.push(hole);
+    }
+}
+
 struct ByteEntropy {
     counts: [u64; 256],
     total: u64,
@@ -206,7 +257,7 @@ where
     }
     let mut overall_first_ts: OptionCuTime = OptionCuTime::none();
     let mut last_ts: OptionCuTime = OptionCuTime::none();
-    let mut last_cl = 0;
+    let mut copperlist_sequence = CopperListSequence::default();
     let mut keyframes = 0;
     let mut useful_size: usize = 0;
     let mut structured_log_size: usize = 0;
@@ -246,7 +297,8 @@ where
                         cls_entropy.observe(&content);
 
                         let mut reader = Cursor::new(content.as_slice());
-                        let mut first_cl = 0;
+                        let mut first_cl = None;
+                        let mut section_last_cl = None;
                         let mut first_ts: OptionCuTime = OptionCuTime::none();
                         while reader.position() < content.len() as u64 {
                             let entry_start = reader.position() as usize;
@@ -256,15 +308,19 @@ where
                             ) {
                                 Ok(entry) => entry,
                                 Err(error) => {
-                                    println!("CopperList after #{last_cl} is corrupted: {error:?}");
+                                    let after = copperlist_sequence
+                                        .last_id
+                                        .map_or_else(|| "start".to_string(), |id| format!("#{id}"));
+                                    println!("CopperList after {after} is corrupted: {error:?}");
                                     break;
                                 }
                             };
                             let entry_end = reader.position() as usize;
                             cl_entropy_samples.observe(&content[entry_start..entry_end]);
-                            last_cl = entry.id;
+                            copperlist_sequence.observe(entry.id);
+                            section_last_cl = Some(entry.id);
                             if first_ts.is_none() {
-                                first_cl = entry.id;
+                                first_cl = Some(entry.id);
                                 first_ts = entry
                                     .cumsgs()
                                     .first()
@@ -280,9 +336,12 @@ where
                             last_ts = last_msg.metadata().process_time().end;
                         }
                         if verbose > 0 {
-                            println!(
-                                "    CopperLists => OK (id range: [{first_cl}-{last_cl}] timerange: [{first_ts}-{last_ts}])"
-                            );
+                            match (first_cl, section_last_cl) {
+                                (Some(first_cl), Some(last_cl)) => println!(
+                                    "    CopperLists => OK (id range: [{first_cl}-{last_cl}] timerange: [{first_ts}-{last_ts}])"
+                                ),
+                                _ => println!("    CopperLists => OK (empty section)"),
+                            }
                         }
                     }
                     UnifiedLogType::FrozenTasks => {
@@ -356,8 +415,12 @@ where
     } else {
         0.0
     };
-    let cl_rate = if last_cl != 0 && total_time_nanos > 0.0 {
-        let cl_time_nanos = total_time_nanos / last_cl as f64;
+    let cl_intervals = copperlist_sequence
+        .first_id
+        .zip(copperlist_sequence.last_id)
+        .map_or(0, |(first, last)| last.saturating_sub(first));
+    let cl_rate = if cl_intervals != 0 && total_time_nanos > 0.0 {
+        let cl_time_nanos = total_time_nanos / cl_intervals as f64;
         1_000_000_000f64 / cl_time_nanos
     } else {
         0.0
@@ -370,8 +433,10 @@ where
         0.0
     };
 
-    if result.is_ok() {
+    if result.is_ok() && copperlist_sequence.holes.is_empty() {
         println!("The log checked out OK.");
+    } else if result.is_ok() {
+        println!("The log is structurally valid but contains CopperList holes.");
     } else {
         println!("** The log is corrupted.");
     }
@@ -401,7 +466,41 @@ where
     println!("  Logging rate     -> {mib_per_sec:.02} MiB/s (effective)");
 
     println!();
-    println!("  # of CL          -> {}", last_cl.to_formatted_string(l));
+    println!(
+        "  # of CL          -> {}",
+        copperlist_sequence.entries.to_formatted_string(l)
+    );
+    match (copperlist_sequence.first_id, copperlist_sequence.last_id) {
+        (Some(first), Some(last)) => println!("  CL id range      -> [{first}-{last}]"),
+        _ => println!("  CL id range      -> n/a"),
+    }
+    if copperlist_sequence.holes.is_empty() {
+        println!("  CL holes         -> none");
+    } else {
+        println!(
+            "  CL holes         -> {} missing across {} range(s)",
+            copperlist_sequence.missing.to_formatted_string(l),
+            copperlist_sequence.holes.len().to_formatted_string(l)
+        );
+        for hole in copperlist_sequence
+            .holes
+            .iter()
+            .take(MAX_REPORTED_COPPERLIST_HOLES)
+        {
+            if hole.first == hole.last {
+                println!("    missing CL #{}", hole.first);
+            } else {
+                println!("    missing CLs #{}-#{}", hole.first, hole.last);
+            }
+        }
+        let omitted = copperlist_sequence
+            .holes
+            .len()
+            .saturating_sub(MAX_REPORTED_COPPERLIST_HOLES);
+        if omitted > 0 {
+            println!("    ... and {omitted} more hole range(s)");
+        }
+    }
     println!(
         "  CL rate          -> {}.{:02} Hz",
         (cl_rate.trunc() as u64).to_formatted_string(&Locale::en),
@@ -459,7 +558,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{ByteEntropy, EntropySamples, EntropySummary};
+    use super::{ByteEntropy, CopperListHole, CopperListSequence, EntropySamples, EntropySummary};
 
     #[test]
     fn empty_entropy_is_absent() {
@@ -507,5 +606,40 @@ mod tests {
                 p95: 5.0,
             })
         );
+    }
+
+    #[test]
+    fn copperlist_sequence_reports_initial_and_internal_holes() {
+        let mut sequence = CopperListSequence::default();
+        for id in [2, 3, 6, 9, 10] {
+            sequence.observe(id);
+        }
+
+        assert_eq!(sequence.entries, 5);
+        assert_eq!(sequence.first_id, Some(2));
+        assert_eq!(sequence.last_id, Some(10));
+        assert_eq!(sequence.missing, 6);
+        assert_eq!(
+            sequence.holes,
+            vec![
+                CopperListHole { first: 0, last: 1 },
+                CopperListHole { first: 4, last: 5 },
+                CopperListHole { first: 7, last: 8 },
+            ]
+        );
+    }
+
+    #[test]
+    fn copperlist_sequence_does_not_invent_holes_for_duplicates_or_reordering() {
+        let mut sequence = CopperListSequence::default();
+        for id in [0, 1, 1, 0, 2] {
+            sequence.observe(id);
+        }
+
+        assert_eq!(sequence.entries, 5);
+        assert_eq!(sequence.first_id, Some(0));
+        assert_eq!(sequence.last_id, Some(2));
+        assert_eq!(sequence.missing, 0);
+        assert!(sequence.holes.is_empty());
     }
 }

--- a/core/cu29_runtime/Cargo.toml
+++ b/core/cu29_runtime/Cargo.toml
@@ -112,7 +112,7 @@ macro_debug = []
 reflect = ["dep:bevy_reflect", "cu29-traits/reflect"]
 sysclock-perf = ["std"]
 high-precision-limiter = ["std"]
-async-cl-io = ["std"]
+async-cl-io = ["std", "dep:rtrb"]
 parallel-rt = ["std", "dep:rtrb"]
 # CPU affinity + real-time scheduler policy/priority for thread pools.
 rt-scheduling = ["std", "dep:core_affinity", "dep:libc"]

--- a/core/cu29_runtime/src/curuntime.rs
+++ b/core/cu29_runtime/src/curuntime.rs
@@ -67,9 +67,11 @@ use core::fmt::{Debug, Formatter};
 use core::marker::PhantomData;
 
 #[cfg(all(feature = "std", feature = "async-cl-io"))]
-use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, sync_channel};
+use rtrb::{Consumer, PopError, Producer, PushError, RingBuffer};
 #[cfg(all(feature = "std", feature = "async-cl-io"))]
-use std::thread::JoinHandle;
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(all(feature = "std", feature = "async-cl-io"))]
+use std::thread::{JoinHandle, Thread};
 
 #[cfg(feature = "std")]
 #[doc(hidden)]
@@ -544,6 +546,11 @@ impl<P: CopperListTuple + Default, const NBCL: usize> SyncCopperListsManager<P, 
         Ok(NBCL - self.inner.len())
     }
 
+    #[inline]
+    pub const fn dropped_copperlists_total(&self) -> u64 {
+        0
+    }
+
     #[cfg(feature = "std")]
     pub fn end_of_processing_boxed(
         &mut self,
@@ -620,6 +627,18 @@ pub enum OwnedCopperListSubmission<P: CopperListTuple> {
 struct AsyncCopperListCompletion<P: CopperListTuple> {
     culist: Box<CopperList<P>>,
     sink_result: CuResult<(u64, u64)>,
+    #[cfg(feature = "remote-debug")]
+    completed_snapshot: CuResult<Vec<u8>>,
+}
+
+#[cfg(all(feature = "std", feature = "async-cl-io"))]
+struct AsyncOutputWorkerRunningGuard(Arc<AtomicBool>);
+
+#[cfg(all(feature = "std", feature = "async-cl-io"))]
+impl Drop for AsyncOutputWorkerRunningGuard {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
 }
 
 #[cfg(all(feature = "std", any(feature = "async-cl-io", feature = "parallel-rt")))]
@@ -662,9 +681,13 @@ pub struct AsyncCopperListsManager<P: CopperListTuple + Default, const NBCL: usi
     last_completed_encoded: Option<Vec<u8>>,
     pending_count: usize,
     next_cl_id: u64,
-    pending_sender: Option<SyncSender<Box<CopperList<P>>>>,
-    completion_receiver: Option<Receiver<AsyncCopperListCompletion<P>>>,
+    pending_producer: Option<Producer<Box<CopperList<P>>>>,
+    completion_consumer: Option<Consumer<AsyncCopperListCompletion<P>>>,
     worker_handle: Option<JoinHandle<()>>,
+    worker_thread: Option<Thread>,
+    worker_shutdown: Option<Arc<AtomicBool>>,
+    worker_running: Option<Arc<AtomicBool>>,
+    dropped_copperlists_total: u64,
     /// Last local-log encoded size reported by the sink.
     pub last_encoded_bytes: u64,
     /// Last handle-backed payload bytes observed while the sink ran.
@@ -682,14 +705,51 @@ impl<P: CopperListTuple + Default, const NBCL: usize> AsyncCopperListsManager<P,
             free_pool.push(allocate_zeroed_copperlist::<P>());
         }
 
-        let (pending_sender, completion_receiver, worker_handle) = if let Some(mut sink) = sink {
-            let (pending_sender, pending_receiver) = sync_channel::<Box<CopperList<P>>>(NBCL);
-            let (completion_sender, completion_receiver) =
-                sync_channel::<AsyncCopperListCompletion<P>>(NBCL);
+        if sink.is_some() && NBCL < 2 {
+            return Err(CuError::from(
+                "async CopperList output requires at least two CopperList slots",
+            ));
+        }
+
+        let (
+            pending_producer,
+            completion_consumer,
+            worker_handle,
+            worker_thread,
+            worker_shutdown,
+            worker_running,
+        ) = if let Some(mut sink) = sink {
+            let handoff_capacity = NBCL - 1;
+            let (pending_producer, mut pending_consumer) =
+                RingBuffer::<Box<CopperList<P>>>::new(handoff_capacity);
+            let (mut completion_producer, completion_consumer) =
+                RingBuffer::<AsyncCopperListCompletion<P>>::new(handoff_capacity);
+            let worker_shutdown = Arc::new(AtomicBool::new(false));
+            let worker_running = Arc::new(AtomicBool::new(true));
+            let shutdown = worker_shutdown.clone();
+            let running = worker_running.clone();
             let worker_handle = std::thread::Builder::new()
                 .name("cu-async-cl-io".to_string())
                 .spawn(move || {
-                    while let Ok(mut culist) = pending_receiver.recv() {
+                    let _running_guard = AsyncOutputWorkerRunningGuard(running);
+                    loop {
+                        let mut culist = match pending_consumer.pop() {
+                            Ok(culist) => culist,
+                            Err(PopError::Empty) => {
+                                if shutdown.load(Ordering::Acquire) {
+                                    break;
+                                }
+                                std::thread::park();
+                                continue;
+                            }
+                        };
+                        #[cfg(feature = "remote-debug")]
+                        let completed_snapshot = {
+                            // Preserve the pre-handoff snapshot contract while
+                            // keeping its allocation and encoding off the RT path.
+                            culist.change_state(CopperListState::DoneProcessing);
+                            encode_completed_copperlist_snapshot(&culist)
+                        };
                         culist.change_state(CopperListState::BeingSerialized);
                         let sink_result = sink.log(&culist).map(|_| {
                             (
@@ -698,14 +758,22 @@ impl<P: CopperListTuple + Default, const NBCL: usize> AsyncCopperListsManager<P,
                             )
                         });
                         let should_stop = sink_result.is_err();
-                        if completion_sender
-                            .send(AsyncCopperListCompletion {
-                                culist,
-                                sink_result,
-                            })
-                            .is_err()
-                        {
-                            break;
+                        #[cfg(feature = "remote-debug")]
+                        let should_stop = should_stop || completed_snapshot.is_err();
+                        let mut completion = AsyncCopperListCompletion {
+                            culist,
+                            sink_result,
+                            #[cfg(feature = "remote-debug")]
+                            completed_snapshot,
+                        };
+                        loop {
+                            match completion_producer.push(completion) {
+                                Ok(()) => break,
+                                Err(PushError::Full(returned)) => {
+                                    completion = returned;
+                                    std::thread::yield_now();
+                                }
+                            }
                         }
                         if should_stop {
                             break;
@@ -716,13 +784,17 @@ impl<P: CopperListTuple + Default, const NBCL: usize> AsyncCopperListsManager<P,
                     CuError::from("Failed to spawn async CopperList serializer thread")
                         .add_cause(e.to_string().as_str())
                 })?;
+            let worker_thread = worker_handle.thread().clone();
             (
-                Some(pending_sender),
-                Some(completion_receiver),
+                Some(pending_producer),
+                Some(completion_consumer),
                 Some(worker_handle),
+                Some(worker_thread),
+                Some(worker_shutdown),
+                Some(worker_running),
             )
         } else {
-            (None, None, None)
+            (None, None, None, None, None, None)
         };
 
         Ok(Self {
@@ -732,9 +804,13 @@ impl<P: CopperListTuple + Default, const NBCL: usize> AsyncCopperListsManager<P,
             last_completed_encoded: None,
             pending_count: 0,
             next_cl_id: 0,
-            pending_sender,
-            completion_receiver,
+            pending_producer,
+            completion_consumer,
             worker_handle,
+            worker_thread,
+            worker_shutdown,
+            worker_running,
+            dropped_copperlists_total: 0,
             last_encoded_bytes: 0,
             last_handle_bytes: 0,
         })
@@ -781,14 +857,10 @@ impl<P: CopperListTuple + Default, const NBCL: usize> AsyncCopperListsManager<P,
         }
 
         self.reclaim_completed()?;
-        while self.free_pool.is_empty() {
-            self.wait_for_completion()?;
-        }
 
-        let culist = self
-            .free_pool
-            .pop()
-            .ok_or_else(|| CuError::from("Ran out of space for copper lists"))?;
+        let culist = self.free_pool.pop().ok_or_else(|| {
+            CuError::from("CopperList output handoff exhausted the slot reserved for execution")
+        })?;
         self.current = Some(culist);
 
         let current = self
@@ -798,17 +870,6 @@ impl<P: CopperListTuple + Default, const NBCL: usize> AsyncCopperListsManager<P,
         current.reset_for_runtime_use(self.next_cl_id);
         self.next_cl_id += 1;
         Ok(current.as_mut())
-    }
-
-    #[cfg(feature = "remote-debug")]
-    fn capture_completed_snapshot(&mut self, cl: &CopperList<P>) -> CuResult<()> {
-        self.last_completed_encoded = Some(encode_completed_copperlist_snapshot(cl)?);
-        Ok(())
-    }
-
-    #[cfg(not(feature = "remote-debug"))]
-    fn capture_completed_snapshot(&mut self, _cl: &CopperList<P>) -> CuResult<()> {
-        Ok(())
     }
 
     pub fn end_of_processing(&mut self, culistid: u64) -> CuResult<()> {
@@ -828,21 +889,12 @@ impl<P: CopperListTuple + Default, const NBCL: usize> AsyncCopperListsManager<P,
         debug_assert_processing_completion_state(culist.as_ref(), "async end_of_processing");
 
         culist.change_state(CopperListState::DoneProcessing);
-        self.capture_completed_snapshot(&culist)?;
         self.last_encoded_bytes = 0;
         self.last_handle_bytes = 0;
 
-        if let Some(pending_sender) = &self.pending_sender {
-            culist.change_state(CopperListState::QueuedForSerialization);
-            pending_sender.send(culist).map_err(|e| {
-                CuError::from("Failed to enqueue CopperList for async serialization")
-                    .add_cause(e.to_string().as_str())
-            })?;
-            self.pending_count += 1;
-            self.reclaim_completed()?;
-        } else {
-            culist.change_state(CopperListState::Free);
-            self.free_pool.push(culist);
+        match self.try_submit(culist)? {
+            OwnedCopperListSubmission::Recycled(culist) => self.free_pool.push(culist),
+            OwnedCopperListSubmission::Pending => {}
         }
 
         Ok(())
@@ -866,62 +918,97 @@ impl<P: CopperListTuple + Default, const NBCL: usize> AsyncCopperListsManager<P,
         Ok(self.free_pool.len())
     }
 
+    #[inline]
+    pub const fn dropped_copperlists_total(&self) -> u64 {
+        self.dropped_copperlists_total
+    }
+
     pub fn end_of_processing_boxed(
         &mut self,
         mut culist: Box<CopperList<P>>,
     ) -> CuResult<OwnedCopperListSubmission<P>> {
-        self.reclaim_completed()?;
         #[cfg(debug_assertions)]
         debug_assert_processing_completion_state(culist.as_ref(), "async boxed end_of_processing");
         culist.change_state(CopperListState::DoneProcessing);
-        self.capture_completed_snapshot(&culist)?;
         self.last_encoded_bytes = 0;
         self.last_handle_bytes = 0;
 
-        if let Some(pending_sender) = &self.pending_sender {
-            culist.change_state(CopperListState::QueuedForSerialization);
-            pending_sender.send(culist).map_err(|e| {
-                CuError::from("Failed to enqueue CopperList for async serialization")
-                    .add_cause(e.to_string().as_str())
-            })?;
-            self.pending_count += 1;
-            self.reclaim_completed()?;
-            Ok(OwnedCopperListSubmission::Pending)
-        } else {
+        self.try_submit(culist)
+    }
+
+    fn try_submit(
+        &mut self,
+        mut culist: Box<CopperList<P>>,
+    ) -> CuResult<OwnedCopperListSubmission<P>> {
+        let Some(pending_producer) = self.pending_producer.as_mut() else {
             culist.change_state(CopperListState::Free);
-            Ok(OwnedCopperListSubmission::Recycled(culist))
+            return Ok(OwnedCopperListSubmission::Recycled(culist));
+        };
+
+        // Keep one of the preallocated CopperLists available to execute the
+        // next iteration. Queue capacity alone cannot enforce this because a
+        // record may be in the worker or waiting on the completion channel.
+        if self.pending_count >= NBCL - 1 {
+            return Ok(self.drop_copperlist(culist));
+        }
+
+        culist.change_state(CopperListState::QueuedForSerialization);
+        match pending_producer.push(culist) {
+            Ok(()) => {
+                self.pending_count += 1;
+                if let Some(worker_thread) = self.worker_thread.as_ref() {
+                    worker_thread.unpark();
+                }
+                Ok(OwnedCopperListSubmission::Pending)
+            }
+            Err(PushError::Full(culist)) => Ok(self.drop_copperlist(culist)),
         }
     }
 
+    fn drop_copperlist(&mut self, mut culist: Box<CopperList<P>>) -> OwnedCopperListSubmission<P> {
+        self.dropped_copperlists_total = self.dropped_copperlists_total.saturating_add(1);
+        culist.change_state(CopperListState::Free);
+        OwnedCopperListSubmission::Recycled(culist)
+    }
+
     pub fn try_reclaim_boxed(&mut self) -> CuResult<Option<Box<CopperList<P>>>> {
-        let recv_result = {
-            let Some(completion_receiver) = self.completion_receiver.as_ref() else {
+        let pop_result = {
+            let Some(completion_consumer) = self.completion_consumer.as_mut() else {
                 return Ok(None);
             };
-            completion_receiver.try_recv()
+            completion_consumer.pop()
         };
-        match recv_result {
+        match pop_result {
             Ok(completion) => self.handle_completion(completion).map(Some),
-            Err(TryRecvError::Empty) => Ok(None),
-            Err(TryRecvError::Disconnected) => Err(CuError::from(
-                "Async CopperList serializer thread disconnected unexpectedly",
-            )),
+            Err(PopError::Empty) => {
+                if self.pending_count > 0
+                    && self
+                        .worker_running
+                        .as_ref()
+                        .is_some_and(|running| !running.load(Ordering::Acquire))
+                {
+                    Err(CuError::from(
+                        "Async CopperList output worker stopped unexpectedly",
+                    ))
+                } else {
+                    Ok(None)
+                }
+            }
         }
     }
 
     pub fn wait_reclaim_boxed(&mut self) -> CuResult<Box<CopperList<P>>> {
-        let completion = self
-            .completion_receiver
-            .as_ref()
-            .ok_or_else(|| {
-                CuError::from("No async CopperList serializer is active to return a free slot")
-            })?
-            .recv()
-            .map_err(|e| {
-                CuError::from("Failed to receive completion from async CopperList serializer")
-                    .add_cause(e.to_string().as_str())
-            })?;
-        self.handle_completion(completion)
+        if self.completion_consumer.is_none() {
+            return Err(CuError::from(
+                "No async CopperList output worker is active to return a free slot",
+            ));
+        }
+        loop {
+            if let Some(culist) = self.try_reclaim_boxed()? {
+                return Ok(culist);
+            }
+            std::thread::yield_now();
+        }
     }
 
     pub fn finish_pending_boxed(&mut self) -> CuResult<Vec<Box<CopperList<P>>>> {
@@ -964,17 +1051,30 @@ impl<P: CopperListTuple + Default, const NBCL: usize> AsyncCopperListsManager<P,
         }
         completion.culist.change_state(CopperListState::Free);
         completion.sink_result?;
+        #[cfg(feature = "remote-debug")]
+        {
+            self.last_completed_encoded = Some(completion.completed_snapshot?);
+        }
         Ok(completion.culist)
     }
 
     fn shutdown_worker(&mut self) -> CuResult<()> {
         self.finish_pending()?;
-        self.pending_sender.take();
+        if let Some(shutdown) = self.worker_shutdown.as_ref() {
+            shutdown.store(true, Ordering::Release);
+        }
+        if let Some(worker_thread) = self.worker_thread.as_ref() {
+            worker_thread.unpark();
+        }
         if let Some(worker_handle) = self.worker_handle.take() {
             worker_handle.join().map_err(|_| {
-                CuError::from("Async CopperList serializer thread panicked while joining")
+                CuError::from("Async CopperList output worker panicked while joining")
             })?;
         }
+        self.pending_producer.take();
+        self.worker_thread.take();
+        self.worker_shutdown.take();
+        self.worker_running.take();
         Ok(())
     }
 }
@@ -2090,6 +2190,8 @@ mod tests {
     use core::cell::Cell;
     use cu29_traits::{ErasedCuStampedData, ErasedCuStampedDataSet, MatchingTasks};
     use serde_derive::{Deserialize, Serialize};
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
     #[cfg(feature = "std")]
     use std::sync::{Arc, Mutex};
 
@@ -2821,10 +2923,33 @@ mod tests {
     }
 
     #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    #[derive(Debug)]
+    struct BlockingWriter {
+        ids: Arc<Mutex<Vec<u64>>>,
+        started: SyncSender<()>,
+        release: Arc<Mutex<Receiver<()>>>,
+    }
+
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    impl WriteStream<CopperList<Msgs>> for BlockingWriter {
+        fn log(&mut self, culist: &CopperList<Msgs>) -> CuResult<()> {
+            self.ids.lock().unwrap().push(culist.id);
+            self.started
+                .send(())
+                .map_err(|_| CuError::from("failed to signal blocking writer start"))?;
+            self.release
+                .lock()
+                .unwrap()
+                .recv()
+                .map_err(|_| CuError::from("failed to release blocking writer"))
+        }
+    }
+
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
     #[test]
     fn test_async_copperlists_manager_flushes_in_order() {
         let ids = Arc::new(Mutex::new(Vec::new()));
-        let mut copperlists = CopperListsManager::<Msgs, 4>::new(Some(Box::new(RecordingWriter {
+        let mut copperlists = CopperListsManager::<Msgs, 5>::new(Some(Box::new(RecordingWriter {
             ids: ids.clone(),
         })))
         .unwrap();
@@ -2837,8 +2962,95 @@ mod tests {
         }
 
         copperlists.finish_pending().unwrap();
-        assert_eq!(copperlists.available_copper_lists().unwrap(), 4);
+        assert_eq!(copperlists.available_copper_lists().unwrap(), 5);
         assert_eq!(*ids.lock().unwrap(), vec![0, 1, 2, 3]);
+        assert_eq!(copperlists.dropped_copperlists_total(), 0);
+    }
+
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    #[test]
+    fn test_async_handoff_drops_without_exhausting_execution_slot() {
+        let ids = Arc::new(Mutex::new(Vec::new()));
+        let (started_tx, started_rx) = sync_channel(1);
+        let (release_tx, release_rx) = sync_channel(1);
+        let mut copperlists = CopperListsManager::<Msgs, 2>::new(Some(Box::new(BlockingWriter {
+            ids: ids.clone(),
+            started: started_tx,
+            release: Arc::new(Mutex::new(release_rx)),
+        })))
+        .unwrap();
+
+        let first = copperlists.create().unwrap();
+        first.change_state(CopperListState::Processing);
+        copperlists.end_of_processing(0).unwrap();
+        started_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap();
+
+        let second = copperlists.create().unwrap();
+        second.change_state(CopperListState::Processing);
+        copperlists.end_of_processing(1).unwrap();
+
+        assert_eq!(copperlists.dropped_copperlists_total(), 1);
+        assert_eq!(copperlists.available_copper_lists().unwrap(), 1);
+        assert_eq!(*ids.lock().unwrap(), vec![0]);
+
+        release_tx.send(()).unwrap();
+        copperlists.finish_pending().unwrap();
+        assert_eq!(copperlists.available_copper_lists().unwrap(), 2);
+    }
+
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    #[test]
+    fn test_async_boxed_handoff_returns_dropped_copperlist_to_caller() {
+        let ids = Arc::new(Mutex::new(Vec::new()));
+        let (started_tx, started_rx) = sync_channel(1);
+        let (release_tx, release_rx) = sync_channel(1);
+        let mut copperlists = CopperListsManager::<Msgs, 2>::new(Some(Box::new(BlockingWriter {
+            ids: ids.clone(),
+            started: started_tx,
+            release: Arc::new(Mutex::new(release_rx)),
+        })))
+        .unwrap();
+
+        let mut first = Box::new(CopperList::new(0, Msgs::default()));
+        first.change_state(CopperListState::Processing);
+        assert!(matches!(
+            copperlists.end_of_processing_boxed(first).unwrap(),
+            OwnedCopperListSubmission::Pending
+        ));
+        started_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap();
+
+        let mut second = Box::new(CopperList::new(1, Msgs::default()));
+        second.change_state(CopperListState::Processing);
+        let recycled = match copperlists.end_of_processing_boxed(second).unwrap() {
+            OwnedCopperListSubmission::Recycled(culist) => culist,
+            OwnedCopperListSubmission::Pending => panic!("saturated handoff accepted CopperList"),
+        };
+
+        assert_eq!(recycled.id, 1);
+        assert_eq!(recycled.get_state(), CopperListState::Free);
+        assert_eq!(copperlists.dropped_copperlists_total(), 1);
+        assert_eq!(*ids.lock().unwrap(), vec![0]);
+
+        release_tx.send(()).unwrap();
+        let completed = copperlists.finish_pending_boxed().unwrap();
+        assert_eq!(completed.len(), 1);
+        assert_eq!(completed[0].id, 0);
+    }
+
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    #[test]
+    fn test_async_output_requires_a_spare_execution_slot() {
+        let error =
+            match CopperListsManager::<Msgs, 1>::new(Some(Box::new(RecordingWriter::default()))) {
+                Ok(_) => panic!("async output unexpectedly accepted a single CopperList slot"),
+                Err(error) => error,
+            };
+
+        assert!(error.to_string().contains("at least two CopperList slots"));
     }
 
     #[cfg(all(feature = "std", feature = "async-cl-io"))]

--- a/core/cu29_runtime/src/monitoring.rs
+++ b/core/cu29_runtime/src/monitoring.rs
@@ -1174,6 +1174,9 @@ pub struct CopperListIoStats {
     pub structured_log_bytes_total: u64,
     /// CopperList identifier for reference in monitors
     pub culistid: u64,
+    /// Total completed CopperLists dropped because the asynchronous output
+    /// handoff had no capacity. This is cumulative for the runtime instance.
+    pub dropped_copperlists_total: u64,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/core/cu29_runtime/tests/replay_anytime_config.ron
+++ b/core/cu29_runtime/tests/replay_anytime_config.ron
@@ -3,6 +3,9 @@
         enable_task_logging: true,
         slab_size_mib: 16,
         keyframe_interval: 8,
+        // This regression asserts a lossless 64-CL recording even when the
+        // async output worker is enabled and the producer runs without pacing.
+        copperlist_count: 65,
     ),
     tasks: [
         (

--- a/core/cu29_runtime/tests/sim_bridge_config.ron
+++ b/core/cu29_runtime/tests/sim_bridge_config.ron
@@ -1,5 +1,10 @@
 (
-    logging: (keyframe_interval: 1),
+    logging: (
+        keyframe_interval: 1,
+        // The replay tests require both recorded iterations regardless of
+        // async serializer scheduling, plus one slot for continued execution.
+        copperlist_count: 3,
+    ),
     tasks: [
         (
             id: "src",

--- a/core/cu29_runtime/tests/sim_substituted_keyframes_config.ron
+++ b/core/cu29_runtime/tests/sim_substituted_keyframes_config.ron
@@ -1,5 +1,10 @@
 (
-    logging: (keyframe_interval: 1),
+    logging: (
+        keyframe_interval: 1,
+        // The replay test requires both recorded iterations regardless of
+        // async serializer scheduling, plus one slot for continued execution.
+        copperlist_count: 3,
+    ),
     tasks: [
         (
             id: "src",

--- a/examples/cu_runtime_matrix/copperconfig.ron
+++ b/examples/cu_runtime_matrix/copperconfig.ron
@@ -11,7 +11,10 @@
     ],
     logging: (
         enable_task_logging: true,
-        copperlist_count: 4,
+        // Repeatability checks run 9 CopperLists without depending on the
+        // async serializer's scheduling. Keep those 9 handoff slots plus the
+        // slot reserved for the next real-time iteration.
+        copperlist_count: 10,
         slab_size_mib: 32,
         section_size_mib: 4,
         keyframe_interval: 2,


### PR DESCRIPTION
## Summary

- replace the blocking async CopperList channel with a bounded lock-free ownership handoff
- reserve one preallocated CopperList for continued real-time execution and drop completed CopperLists when the output backlog is saturated
- publish the cumulative drop count through CopperListIoStats and show nonzero drops in red in the TUI BW view
- make log fsck report persisted CopperList ID holes, including initial holes and bounded hole ranges
- provision explicitly lossless replay and runtime-matrix fixtures with enough CopperList slots

## Saturation policy

When the async handoff is full, the completed CopperList is recycled immediately. Because local logging and future streaming destinations share the fanout sink, the entire record is absent from every output. The real-time path does not wait, allocate, retry, emit a live gap record, or run recovery logic.

The live monitor exposes the cumulative producer-side count. Offline fsck independently detects holes from the persisted CopperList ID sequence.

## Stack

Built on #1307. The base branch is intentionally gbin/streaming-log-fanout.

## Verification

- cargo test -p cu29-runtime --features async-cl-io -- --test-threads=1
- cargo test -p cu-runtime-matrix --features async-cl-io -- --test-threads=1
- cargo test -p cu-runtime-matrix --features async-cl-io,parallel-rt -- --test-threads=1
- cargo test -p cu-tuimon -p cu29-export
- cargo clippy -p cu29-runtime -p cu29 -p cu29-derive --all-targets --features async-cl-io -- -D warnings
- cargo clippy -p cu-tuimon --all-targets --features log_pane -- -D warnings
- cargo clippy -p cu29-export --all-targets -- -D warnings
- cargo check -p cu29-runtime --no-default-features
- just fmt

The async-cl-io plus remote-debug build was checked only for feature compatibility; remote debug is not part of the runtime handoff design.
