### PR TITLE
Make keyframe output handoff nonblocking

### DIFF
--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -867,6 +867,8 @@ pub fn cu29_runtime::curuntime::KeyFramesManager::freeze_task(&mut self, culisti
 pub fn cu29_runtime::curuntime::KeyFramesManager::lock_keyframe(&mut self, keyframe: &cu29_runtime::curuntime::KeyFrame)
 pub fn cu29_runtime::curuntime::KeyFramesManager::reset(&mut self, culistid: u64, clock: &cu29_clock::RobotClock)
 pub fn cu29_runtime::curuntime::KeyFramesManager::set_forced_timestamp(&mut self, ts: cu29_clock::CuTime)
+impl core::ops::drop::Drop for cu29_runtime::curuntime::KeyFramesManager
+pub fn cu29_runtime::curuntime::KeyFramesManager::drop(&mut self)
 pub struct cu29_runtime::curuntime::LoopRateLimiter
 impl cu29_runtime::curuntime::LoopRateLimiter
 pub fn cu29_runtime::curuntime::LoopRateLimiter::from_rate_target_hz(rate_target_hz: u64, clock: &cu29_clock::RobotClock) -> cu29_traits::CuResult<Self>
@@ -1320,6 +1322,7 @@ pub const fn cu29_runtime::monitoring::CopperListInfo::new(size_bytes: usize, co
 pub struct cu29_runtime::monitoring::CopperListIoStats
 pub cu29_runtime::monitoring::CopperListIoStats::culistid: u64
 pub cu29_runtime::monitoring::CopperListIoStats::dropped_copperlists_total: u64
+pub cu29_runtime::monitoring::CopperListIoStats::dropped_keyframes_total: u64
 pub cu29_runtime::monitoring::CopperListIoStats::encoded_culist_bytes: u64
 pub cu29_runtime::monitoring::CopperListIoStats::handle_bytes: u64
 pub cu29_runtime::monitoring::CopperListIoStats::keyframe_bytes: u64

--- a/components/libs/cu_tuimon/src/model.rs
+++ b/components/libs/cu_tuimon/src/model.rs
@@ -411,6 +411,7 @@ pub(crate) struct CopperListStats {
     pub(crate) structured_total_bytes: u64,
     pub(crate) structured_bytes_per_cl: u64,
     pub(crate) dropped_copperlists_total: u64,
+    pub(crate) dropped_keyframes_total: u64,
     pub(crate) total_copperlists: u64,
     pub(crate) window_copperlists: u64,
     pub(crate) last_seen_clid: Option<u64>,
@@ -429,6 +430,7 @@ impl CopperListStats {
             structured_total_bytes: 0,
             structured_bytes_per_cl: 0,
             dropped_copperlists_total: 0,
+            dropped_keyframes_total: 0,
             total_copperlists: 0,
             window_copperlists: 0,
             last_seen_clid: None,
@@ -450,6 +452,7 @@ impl CopperListStats {
         self.structured_bytes_per_cl = total.saturating_sub(self.structured_total_bytes);
         self.structured_total_bytes = total;
         self.dropped_copperlists_total = stats.dropped_copperlists_total;
+        self.dropped_keyframes_total = stats.dropped_keyframes_total;
     }
 
     fn update_rate(&mut self, clid: u64) {
@@ -554,6 +557,7 @@ mod tests {
 
         model.observe_copperlist_io(CopperListIoStats {
             dropped_copperlists_total: 7,
+            dropped_keyframes_total: 3,
             ..CopperListIoStats::default()
         });
 
@@ -565,6 +569,15 @@ mod tests {
                 .unwrap()
                 .dropped_copperlists_total,
             7
+        );
+        assert_eq!(
+            model
+                .inner
+                .copperlist_stats
+                .lock()
+                .unwrap()
+                .dropped_keyframes_total,
+            3
         );
     }
 }

--- a/components/libs/cu_tuimon/src/ui.rs
+++ b/components/libs/cu_tuimon/src/ui.rs
@@ -708,7 +708,8 @@ impl MonitorUi {
             .saturating_add(stats.keyframe_bytes)
             .saturating_add(stats.structured_bytes_per_cl);
         let disk_total_bw = format_rate_bytes_or_na(disk_total_bytes, stats.rate_hz);
-        let dropped_display = stats.dropped_copperlists_total.to_string();
+        let dropped_copperlists_display = stats.dropped_copperlists_total.to_string();
+        let dropped_keyframes_display = stats.dropped_keyframes_total.to_string();
 
         let header_cells = ["Metric", "Value"].iter().map(|header| {
             Cell::from(Line::from(*header)).style(
@@ -728,7 +729,14 @@ impl MonitorUi {
         let spacer = row(" ", " ".to_string());
 
         let rate_style = Style::default().fg(palette::CYAN);
-        let dropped_style = if stats.dropped_copperlists_total == 0 {
+        let dropped_copperlists_style = if stats.dropped_copperlists_total == 0 {
+            Style::default()
+        } else {
+            Style::default()
+                .fg(palette::LIGHT_RED)
+                .add_modifier(Modifier::BOLD)
+        };
+        let dropped_keyframes_style = if stats.dropped_keyframes_total == 0 {
             Style::default()
         } else {
             Style::default()
@@ -747,7 +755,9 @@ impl MonitorUi {
         ];
 
         let disk_rows = vec![
-            row("Dropped CopperLists", dropped_display).style(dropped_style),
+            row("Dropped CopperLists", dropped_copperlists_display)
+                .style(dropped_copperlists_style),
+            row("Dropped keyframes", dropped_keyframes_display).style(dropped_keyframes_style),
             spacer.clone(),
             row("CL serialized size", encoded_display),
             row("Space saved", space_saved_display),
@@ -1147,10 +1157,11 @@ mod tests {
     }
 
     #[test]
-    fn copperlist_screen_highlights_dropped_count() {
+    fn copperlist_screen_highlights_dropped_counts() {
         let model = test_monitor_model();
         model.observe_copperlist_io(CopperListIoStats {
             dropped_copperlists_total: 7,
+            dropped_keyframes_total: 3,
             ..CopperListIoStats::default()
         });
         let mut ui = MonitorUi::new(model, MonitorUiOptions::default());
@@ -1175,6 +1186,24 @@ mod tests {
             .iter()
             .find(|cell| cell.symbol() == "7")
             .expect("dropped count value");
+        assert_eq!(value.fg, palette::LIGHT_RED);
+        assert!(value.modifier.contains(Modifier::BOLD));
+
+        let dropped_keyframe_row = buffer
+            .content
+            .chunks(buffer.area.width as usize)
+            .find(|cells| {
+                cells
+                    .iter()
+                    .map(|cell| cell.symbol())
+                    .collect::<String>()
+                    .contains("Dropped keyframes")
+            })
+            .expect("Dropped keyframes row");
+        let value = dropped_keyframe_row
+            .iter()
+            .find(|cell| cell.symbol() == "3")
+            .expect("dropped keyframe count value");
         assert_eq!(value.fg, palette::LIGHT_RED);
         assert!(value.modifier.contains(Modifier::BOLD));
     }

--- a/core/cu29/src/lib.rs
+++ b/core/cu29/src/lib.rs
@@ -27,8 +27,8 @@
 //! - `remote-debug`: remote debug transport support
 //! - `sysclock-perf`: use a host/system clock for runtime perf timing while keeping robot time for `tov` and `rate_target_hz`
 //! - `high-precision-limiter`: std-only hybrid sleep/spin loop limiter for tighter `rate_target_hz` cadence
-//! - `async-cl-io`: hand completed CopperLists to a dedicated std output thread without blocking;
-//!   drops are reported through `CopperListIoStats::dropped_copperlists_total`
+//! - `async-cl-io`: hand completed CopperLists and keyframes to dedicated std output threads
+//!   without blocking; drops are reported through `CopperListIoStats`
 //! - `flat-copperlist-encoding`: override the default compression for CPU-constrained applications
 //! - `parallel-rt`: prepare the runtime for a future multi-threaded deterministic executor
 //! - `cuda`: enable CUDA-backed Copper pools and handles on supported host platforms

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -4756,7 +4756,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                     let _keyframe_lock =
                         kf_lock.lock().expect("parallel keyframe lock poisoned");
                     let kf_manager = unsafe { kf_manager_ptr.as_mut() };
-                    kf_manager.reset(clid, clock);
+                    kf_manager.try_reset(clid, clock)?;
                     if kf_manager.captures_keyframe(clid) {
                         active_keyframe_clid = Some(clid);
                     }
@@ -4769,10 +4769,13 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                     kf_lock.lock().expect("parallel keyframe lock poisoned");
                 let kf_manager = unsafe { kf_manager_ptr.as_mut() };
                 kf_manager.end_of_processing(worker_result.clid)?;
-                kf_manager.last_encoded_bytes
+                (
+                    kf_manager.last_encoded_bytes,
+                    kf_manager.dropped_keyframes_total(),
+                )
             }}
         } else {
-            quote! { 0u64 }
+            quote! { (0u64, 0u64) }
         };
         let parallel_keyframe_clear = keyframe_logging_enabled.then(|| {
             quote! {
@@ -5052,7 +5055,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                             }
                                             cu29::curuntime::OwnedCopperListSubmission::Pending => {}
                                         }
-                                        let keyframe_bytes = #parallel_keyframe_finish;
+                                        let (keyframe_bytes, dropped_keyframes_total) = #parallel_keyframe_finish;
                                         monitor_result?;
                                         let stats = cu29::monitoring::CopperListIoStats {
                                             raw_culist_bytes: core::mem::size_of::<CuList>() as u64
@@ -5063,6 +5066,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                             structured_log_bytes_total: ::cu29::prelude::structured_log_bytes_total(),
                                             culistid: worker_result.clid,
                                             dropped_copperlists_total: cl_manager.dropped_copperlists_total(),
+                                            dropped_keyframes_total,
                                         };
                                         monitor.observe_copperlist_io(stats);
 
@@ -5130,11 +5134,16 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
         let keyframe_manager_binding = keyframe_logging_enabled
             .then(|| quote! { let kf_manager = &mut runtime.keyframes_manager; });
         let keyframe_reset =
-            keyframe_logging_enabled.then(|| quote! { kf_manager.reset(clid, clock); });
+            keyframe_logging_enabled.then(|| quote! { kf_manager.try_reset(clid, clock)?; });
         let keyframe_finish =
             keyframe_logging_enabled.then(|| quote! { kf_manager.end_of_processing(clid)?; });
         let keyframe_bytes = if keyframe_logging_enabled {
             quote! { kf_manager.last_encoded_bytes }
+        } else {
+            quote! { 0 }
+        };
+        let dropped_keyframes_total = if keyframe_logging_enabled {
+            quote! { kf_manager.dropped_keyframes_total() }
         } else {
             quote! { 0 }
         };
@@ -5150,6 +5159,9 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                     kf_manager.finish_capture_preallocation()?;
                 }
             }
+        });
+        let keyframe_finish_pending = keyframe_logging_enabled.then(|| {
+            quote! { self.copper_runtime.keyframes_manager.finish_pending()?; }
         });
 
         let run_methods: proc_macro2::TokenStream = quote! {
@@ -5234,6 +5246,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                     structured_log_bytes_total: ::cu29::prelude::structured_log_bytes_total(),
                     culistid: clid,
                     dropped_copperlists_total: cl_manager.dropped_copperlists_total(),
+                    dropped_keyframes_total: #dropped_keyframes_total,
                 };
                 monitor.observe_copperlist_io(stats);
                 Ok(())
@@ -5285,6 +5298,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 ctx.clear_current_task();
                 self.copper_runtime.monitor.stop(&ctx)?;
                 self.copper_runtime.copperlists_manager.finish_pending()?;
+                #keyframe_finish_pending
                 // TODO(lifecycle): emit typed stop reasons (completed/error/panic/requested)
                 // once panic/reporting flow is finalized for std and no-std.
                 let _ = self.log_runtime_lifecycle_event(RuntimeLifecycleEvent::MissionStopped {
@@ -5453,6 +5467,23 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
         } else {
             quote!()
         };
+        let local_keyframe_sink_init = if keyframe_logging_enabled {
+            quote! {
+                #[cfg(target_os = "none")]
+                ::cu29::prelude::info!("CuApp new: creating keyframes stream");
+                let local_keyframe_sink = stream_write::<KeyFrame, S>(
+                    unified_logger.clone(),
+                    UnifiedLogType::FrozenTasks,
+                    1024 * 1024 * 10, // 10 MiB
+                )?;
+                #[cfg(target_os = "none")]
+                ::cu29::prelude::info!("CuApp new: keyframes stream ready");
+            }
+        } else {
+            quote! {
+                let local_keyframe_sink = cu29::curuntime::NullWriteStream;
+            }
+        };
 
         let build_with_resources_fn = quote! {
             #build_with_resources_sig {
@@ -5503,15 +5534,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 #[cfg(target_os = "none")]
                 ::cu29::prelude::info!("CuApp new: copperlist stream ready");
 
-                #[cfg(target_os = "none")]
-                ::cu29::prelude::info!("CuApp new: creating keyframes stream");
-                let local_keyframe_sink = stream_write::<KeyFrame, S>(
-                    unified_logger.clone(),
-                    UnifiedLogType::FrozenTasks,
-                    1024 * 1024 * 10, // 10 MiB
-                )?;
-                #[cfg(target_os = "none")]
-                ::cu29::prelude::info!("CuApp new: keyframes stream ready");
+                #local_keyframe_sink_init
 
                 // Downstream record demand is independent from local logging.
                 // Streaming codegen can union its requirements here without

--- a/core/cu29_runtime/src/curuntime.rs
+++ b/core/cu29_runtime/src/curuntime.rs
@@ -436,6 +436,18 @@ pub type CompletedCopperListSink<P> = SemanticRecordSink<CopperList<P>>;
 #[doc(hidden)]
 pub type CompletedKeyFrameSink = SemanticRecordSink<KeyFrame>;
 
+/// Zero-cost placeholder emitted when a semantic record family has no consumer.
+#[derive(Clone, Copy, Debug, Default)]
+#[doc(hidden)]
+pub struct NullWriteStream;
+
+impl<E: Encode> WriteStream<E> for NullWriteStream {
+    #[inline]
+    fn log(&mut self, _record: &E) -> CuResult<()> {
+        Ok(())
+    }
+}
+
 /// Semantic record families requested by the statically generated downstream graph.
 ///
 /// This is deliberately independent from [`crate::config::LoggingConfig`]. Local
@@ -1152,10 +1164,16 @@ pub type CopperListsManager<P, const NBCL: usize> = AsyncCopperListsManager<P, N
 #[doc(hidden)]
 pub type CopperListsManager<P, const NBCL: usize> = SyncCopperListsManager<P, NBCL>;
 
-/// Manages the frozen tasks state and logging.
+#[cfg(all(feature = "std", feature = "async-cl-io"))]
+struct AsyncKeyFrameCompletion {
+    keyframe: Box<KeyFrame>,
+    sink_result: CuResult<u64>,
+}
+
+/// Manages bounded task-state keyframe capture and output.
 pub struct KeyFramesManager {
-    /// Where the serialized tasks are stored following the wave of execution of a CL.
-    inner: KeyFrame,
+    /// Active capture buffer. It is absent when no downstream consumer needs keyframes.
+    inner: Option<KeyFrame>,
 
     /// Optional override for the timestamp to stamp the next keyframe (used by deterministic replay).
     forced_timestamp: Option<CuTime>,
@@ -1163,20 +1181,48 @@ pub struct KeyFramesManager {
     /// If set, reuse this keyframe verbatim (e.g., during replay) instead of re-freezing state.
     locked: bool,
 
-    /// Consumer of completed task-state keyframes.
+    /// Consumer of completed task-state keyframes on the synchronous path.
+    #[cfg(not(all(feature = "std", feature = "async-cl-io")))]
     sink: Option<Box<CompletedKeyFrameSink>>,
 
-    /// Capture a keyframe only each...
+    /// Spare capture buffers exchanged with completed keyframes at handoff.
+    /// Boxing is intentional: ownership moves through the SPSC ring without a
+    /// hot-path allocation or copying the potentially large payload buffer.
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    #[allow(clippy::vec_box)]
+    spares: Vec<Box<KeyFrame>>,
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    pending_count: usize,
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    pending_producer: Option<Producer<Box<KeyFrame>>>,
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    completion_consumer: Option<Consumer<AsyncKeyFrameCompletion>>,
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    worker_handle: Option<JoinHandle<()>>,
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    worker_thread: Option<Thread>,
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    worker_shutdown: Option<Arc<AtomicBool>>,
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    worker_running: Option<Arc<AtomicBool>>,
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    capture_this_copperlist: Option<u64>,
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    dropped_keyframes_total: u64,
+
+    /// Capture a keyframe at this CopperList interval.
     keyframe_interval: u32,
 
-    /// Bytes written by the last keyframe log
+    /// Bytes written by the last completed keyframe output.
     pub last_encoded_bytes: u64,
 
-    /// Cold-path sizing accumulator used to reserve the capture buffer before execution.
+    /// Cold-path sizing accumulator used to reserve the capture buffers before execution.
     capture_size_hint: usize,
 }
 
 const MIN_KEYFRAME_CAPTURE_CAPACITY: usize = 4 * 1024;
+#[cfg(all(feature = "std", feature = "async-cl-io"))]
+const ASYNC_KEYFRAME_HANDOFF_CAPACITY: usize = 2;
 
 /// A `Vec` writer that is forbidden from growing its backing allocation.
 struct PreallocatedVecWriter<'a>(&'a mut Vec<u8>);
@@ -1193,13 +1239,148 @@ impl Writer for PreallocatedVecWriter<'_> {
 }
 
 impl KeyFramesManager {
-    fn is_keyframe(&self, culistid: u64) -> bool {
-        self.sink.is_some() && culistid.is_multiple_of(self.keyframe_interval as u64)
+    #[doc(hidden)]
+    pub fn new(sink: Option<Box<CompletedKeyFrameSink>>, keyframe_interval: u32) -> CuResult<Self> {
+        if sink.is_some() && keyframe_interval == 0 {
+            return Err(CuError::from(
+                "Keyframe interval cannot be zero when a downstream consumer requires keyframes",
+            ));
+        }
+
+        #[cfg(all(feature = "std", feature = "async-cl-io"))]
+        {
+            let enabled = sink.is_some();
+            let (
+                pending_producer,
+                completion_consumer,
+                worker_handle,
+                worker_thread,
+                worker_shutdown,
+                worker_running,
+            ) = if let Some(mut sink) = sink {
+                let (pending_producer, mut pending_consumer) =
+                    RingBuffer::<Box<KeyFrame>>::new(ASYNC_KEYFRAME_HANDOFF_CAPACITY);
+                let (mut completion_producer, completion_consumer) =
+                    RingBuffer::<AsyncKeyFrameCompletion>::new(ASYNC_KEYFRAME_HANDOFF_CAPACITY);
+                let worker_shutdown = Arc::new(AtomicBool::new(false));
+                let worker_running = Arc::new(AtomicBool::new(true));
+                let shutdown = worker_shutdown.clone();
+                let running = worker_running.clone();
+                let worker_handle = std::thread::Builder::new()
+                    .name("cu-async-kf-io".to_string())
+                    .spawn(move || {
+                        let _running_guard = AsyncOutputWorkerRunningGuard(running);
+                        loop {
+                            let keyframe = match pending_consumer.pop() {
+                                Ok(keyframe) => keyframe,
+                                Err(PopError::Empty) => {
+                                    if shutdown.load(Ordering::Acquire) {
+                                        break;
+                                    }
+                                    std::thread::park();
+                                    continue;
+                                }
+                            };
+                            let sink_result = sink
+                                .log(keyframe.as_ref())
+                                .map(|_| sink.last_log_bytes().unwrap_or(0) as u64);
+                            let should_stop = sink_result.is_err();
+                            let mut completion = AsyncKeyFrameCompletion {
+                                keyframe,
+                                sink_result,
+                            };
+                            loop {
+                                match completion_producer.push(completion) {
+                                    Ok(()) => break,
+                                    Err(PushError::Full(returned)) => {
+                                        completion = returned;
+                                        std::thread::yield_now();
+                                    }
+                                }
+                            }
+                            if should_stop {
+                                break;
+                            }
+                        }
+                    })
+                    .map_err(|error| {
+                        CuError::from("Failed to spawn async keyframe output thread")
+                            .add_cause(error.to_string().as_str())
+                    })?;
+                let worker_thread = worker_handle.thread().clone();
+                (
+                    Some(pending_producer),
+                    Some(completion_consumer),
+                    Some(worker_handle),
+                    Some(worker_thread),
+                    Some(worker_shutdown),
+                    Some(worker_running),
+                )
+            } else {
+                (None, None, None, None, None, None)
+            };
+
+            let spares = if enabled {
+                let mut spares = Vec::with_capacity(ASYNC_KEYFRAME_HANDOFF_CAPACITY);
+                for _ in 0..ASYNC_KEYFRAME_HANDOFF_CAPACITY {
+                    spares.push(Box::new(KeyFrame::new()));
+                }
+                spares
+            } else {
+                Vec::new()
+            };
+            Ok(Self {
+                inner: enabled.then(KeyFrame::new),
+                forced_timestamp: None,
+                locked: false,
+                spares,
+                pending_count: 0,
+                pending_producer,
+                completion_consumer,
+                worker_handle,
+                worker_thread,
+                worker_shutdown,
+                worker_running,
+                capture_this_copperlist: None,
+                dropped_keyframes_total: 0,
+                keyframe_interval,
+                last_encoded_bytes: 0,
+                capture_size_hint: KEYFRAME_PAYLOAD_HEADER.len(),
+            })
+        }
+
+        #[cfg(not(all(feature = "std", feature = "async-cl-io")))]
+        {
+            let enabled = sink.is_some();
+            Ok(Self {
+                inner: enabled.then(KeyFrame::new),
+                forced_timestamp: None,
+                locked: false,
+                sink,
+                keyframe_interval,
+                last_encoded_bytes: 0,
+                capture_size_hint: KEYFRAME_PAYLOAD_HEADER.len(),
+            })
+        }
+    }
+
+    fn is_keyframe_due(&self, culistid: u64) -> bool {
+        self.inner.is_some() && culistid.is_multiple_of(self.keyframe_interval as u64)
+    }
+
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    fn is_capturing(&self, culistid: u64) -> bool {
+        self.capture_this_copperlist == Some(culistid)
+    }
+
+    #[cfg(not(all(feature = "std", feature = "async-cl-io")))]
+    fn is_capturing(&self, culistid: u64) -> bool {
+        self.is_keyframe_due(culistid)
     }
 
     #[inline]
     pub fn captures_keyframe(&self, culistid: u64) -> bool {
-        self.is_keyframe(culistid)
+        self.is_keyframe_due(culistid)
     }
 
     /// Start a cold-path sizing pass for the next mission's keyframe buffer.
@@ -1211,7 +1392,7 @@ impl KeyFramesManager {
     /// Include one component's current frozen size in the cold-path capacity estimate.
     #[doc(hidden)]
     pub fn include_capture_capacity(&mut self, item: &impl Freezable) -> CuResult<()> {
-        if self.sink.is_none() {
+        if self.inner.is_none() {
             return Ok(());
         }
         let mut sizer = EncoderImpl::new(SizeWriter::default(), bincode::config::standard());
@@ -1230,37 +1411,65 @@ impl KeyFramesManager {
     /// Reserve the capture buffer before entering the execution loop.
     #[doc(hidden)]
     pub fn finish_capture_preallocation(&mut self) -> CuResult<()> {
-        if self.sink.is_none() {
+        if self.inner.is_none() {
             return Ok(());
         }
+        #[cfg(all(feature = "std", feature = "async-cl-io"))]
+        self.reclaim_completed()?;
         let requested = self
             .capture_size_hint
             .max(MIN_KEYFRAME_CAPTURE_CAPACITY)
             .checked_next_power_of_two()
             .ok_or_else(|| CuError::from("Keyframe capture capacity overflow"))?;
-        if self.inner.serialized_tasks.capacity() < requested {
-            let additional = requested.saturating_sub(self.inner.serialized_tasks.len());
-            self.inner
-                .serialized_tasks
-                .try_reserve_exact(additional)
-                .map_err(|error| {
-                    CuError::from("Failed to preallocate keyframe capture buffer")
-                        .add_cause(&error.to_string())
-                })?;
+        reserve_keyframe_capacity(self.inner.as_mut().unwrap(), requested)?;
+        #[cfg(all(feature = "std", feature = "async-cl-io"))]
+        for spare in &mut self.spares {
+            reserve_keyframe_capacity(spare, requested)?;
+        }
+        #[cfg(all(feature = "std", feature = "async-cl-io"))]
+        if self.spares.len() != ASYNC_KEYFRAME_HANDOFF_CAPACITY {
+            return Err(CuError::from(
+                "Keyframe output worker did not return every capture buffer before preallocation",
+            ));
         }
         Ok(())
     }
 
-    pub fn reset(&mut self, culistid: u64, clock: &RobotClock) {
-        if self.is_keyframe(culistid) {
+    /// Fallible reset used by generated runtimes so asynchronous worker failures
+    /// are returned before a new keyframe capture starts.
+    #[doc(hidden)]
+    pub fn try_reset(&mut self, culistid: u64, clock: &RobotClock) -> CuResult<()> {
+        if self.is_keyframe_due(culistid) {
+            #[cfg(all(feature = "std", feature = "async-cl-io"))]
+            {
+                self.reclaim_completed()?;
+                if self.spares.is_empty() {
+                    self.capture_this_copperlist = None;
+                    self.dropped_keyframes_total = self.dropped_keyframes_total.saturating_add(1);
+                    self.forced_timestamp = None;
+                    self.locked = false;
+                    return Ok(());
+                }
+                self.capture_this_copperlist = Some(culistid);
+            }
             // If a recorded keyframe was preloaded for this CL, keep it as-is.
-            if self.locked && self.inner.culistid == culistid {
-                return;
+            let inner = self.inner.as_mut().unwrap();
+            if self.locked && inner.culistid == culistid {
+                return Ok(());
             }
             let ts = self.forced_timestamp.take().unwrap_or_else(|| clock.now());
-            self.inner.reset(culistid, ts);
+            inner.reset(culistid, ts);
             self.locked = false;
         }
+        Ok(())
+    }
+
+    /// Reset the capture buffer at a configured keyframe boundary.
+    ///
+    /// Generated runtimes use the fallible internal variant to surface output
+    /// worker failures. This method preserves the existing direct-call API.
+    pub fn reset(&mut self, culistid: u64, clock: &RobotClock) {
+        let _ = self.try_reset(culistid, clock);
     }
 
     /// Force the timestamp of the next keyframe to a given value.
@@ -1270,19 +1479,19 @@ impl KeyFramesManager {
     }
 
     pub fn freeze_task(&mut self, culistid: u64, task: &impl Freezable) -> CuResult<usize> {
-        if self.is_keyframe(culistid) {
+        if self.is_capturing(culistid) {
             if self.locked {
                 // We are replaying a recorded keyframe verbatim; don't mutate it.
                 return Ok(0);
             }
-            if self.inner.culistid != culistid {
+            let inner = self.inner.as_mut().unwrap();
+            if inner.culistid != culistid {
                 return Err(CuError::from(format!(
                     "Freezing task for culistid {} but current keyframe is {}",
-                    culistid, self.inner.culistid
+                    culistid, inner.culistid
                 )));
             }
-            let encoded = self
-                .inner
+            let encoded = inner
                 .add_frozen_task(task)
                 .map_err(|e| CuError::from(format!("Failed to serialize task: {e}")))?;
             Ok(encoded)
@@ -1297,10 +1506,38 @@ impl KeyFramesManager {
     }
 
     pub fn end_of_processing(&mut self, culistid: u64) -> CuResult<()> {
-        if self.is_keyframe(culistid) {
-            let sink = self.sink.as_mut().unwrap();
-            sink.log(&self.inner)?;
-            self.last_encoded_bytes = sink.last_log_bytes().unwrap_or(0) as u64;
+        if self.is_capturing(culistid) {
+            #[cfg(not(all(feature = "std", feature = "async-cl-io")))]
+            {
+                let sink = self.sink.as_mut().unwrap();
+                sink.log(self.inner.as_ref().unwrap())?;
+                self.last_encoded_bytes = sink.last_log_bytes().unwrap_or(0) as u64;
+            }
+            #[cfg(all(feature = "std", feature = "async-cl-io"))]
+            {
+                self.last_encoded_bytes = 0;
+                let mut completed = self.spares.pop().ok_or_else(|| {
+                    CuError::from("Missing spare keyframe buffer at output handoff")
+                })?;
+                core::mem::swap(self.inner.as_mut().unwrap(), completed.as_mut());
+                let producer = self.pending_producer.as_mut().ok_or_else(|| {
+                    CuError::from("Missing keyframe output producer for active capture")
+                })?;
+                match producer.push(completed) {
+                    Ok(()) => {
+                        self.pending_count += 1;
+                        if let Some(worker_thread) = self.worker_thread.as_ref() {
+                            worker_thread.unpark();
+                        }
+                    }
+                    Err(PushError::Full(spare)) => {
+                        self.spares.push(spare);
+                        self.dropped_keyframes_total =
+                            self.dropped_keyframes_total.saturating_add(1);
+                    }
+                }
+                self.capture_this_copperlist = None;
+            }
             // Clear the lock so the next CL can rebuild normally unless re-locked.
             self.locked = false;
             Ok(())
@@ -1314,9 +1551,124 @@ impl KeyFramesManager {
     /// Preload a recorded keyframe so it is logged verbatim on the matching CL.
     #[cfg(feature = "std")]
     pub fn lock_keyframe(&mut self, keyframe: &KeyFrame) {
-        self.inner = keyframe.clone();
-        self.forced_timestamp = Some(keyframe.timestamp);
-        self.locked = true;
+        if let Some(inner) = self.inner.as_mut() {
+            *inner = keyframe.clone();
+            self.forced_timestamp = Some(keyframe.timestamp);
+            self.locked = true;
+        }
+    }
+
+    #[inline]
+    #[doc(hidden)]
+    pub const fn dropped_keyframes_total(&self) -> u64 {
+        #[cfg(all(feature = "std", feature = "async-cl-io"))]
+        {
+            self.dropped_keyframes_total
+        }
+        #[cfg(not(all(feature = "std", feature = "async-cl-io")))]
+        {
+            0
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn finish_pending(&mut self) -> CuResult<()> {
+        #[cfg(all(feature = "std", feature = "async-cl-io"))]
+        while self.pending_count > 0 {
+            self.wait_for_completion()?;
+        }
+        Ok(())
+    }
+
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    fn reclaim_completed(&mut self) -> CuResult<()> {
+        let pop_result = {
+            let Some(completion_consumer) = self.completion_consumer.as_mut() else {
+                return Ok(());
+            };
+            completion_consumer.pop()
+        };
+        match pop_result {
+            Ok(completion) => self.handle_completion(completion),
+            Err(PopError::Empty) => {
+                if self.pending_count > 0
+                    && self
+                        .worker_running
+                        .as_ref()
+                        .is_some_and(|running| !running.load(Ordering::Acquire))
+                {
+                    Err(CuError::from(
+                        "Async keyframe output worker stopped unexpectedly",
+                    ))
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    fn wait_for_completion(&mut self) -> CuResult<()> {
+        loop {
+            let pending_before = self.pending_count;
+            self.reclaim_completed()?;
+            if self.pending_count < pending_before {
+                return Ok(());
+            }
+            std::thread::yield_now();
+        }
+    }
+
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    fn handle_completion(&mut self, completion: AsyncKeyFrameCompletion) -> CuResult<()> {
+        self.pending_count = self.pending_count.saturating_sub(1);
+        if let Ok(encoded_bytes) = completion.sink_result.as_ref() {
+            self.last_encoded_bytes = *encoded_bytes;
+        }
+        self.spares.push(completion.keyframe);
+        completion.sink_result.map(|_| ())
+    }
+
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    fn shutdown_worker(&mut self) -> CuResult<()> {
+        self.finish_pending()?;
+        if let Some(shutdown) = self.worker_shutdown.as_ref() {
+            shutdown.store(true, Ordering::Release);
+        }
+        if let Some(worker_thread) = self.worker_thread.as_ref() {
+            worker_thread.unpark();
+        }
+        if let Some(worker_handle) = self.worker_handle.take() {
+            worker_handle.join().map_err(|_| {
+                CuError::from("Async keyframe output worker panicked while joining")
+            })?;
+        }
+        self.pending_producer.take();
+        self.worker_thread.take();
+        self.worker_shutdown.take();
+        self.worker_running.take();
+        Ok(())
+    }
+}
+
+fn reserve_keyframe_capacity(keyframe: &mut KeyFrame, requested: usize) -> CuResult<()> {
+    if keyframe.serialized_tasks.capacity() < requested {
+        let additional = requested.saturating_sub(keyframe.serialized_tasks.len());
+        keyframe
+            .serialized_tasks
+            .try_reserve_exact(additional)
+            .map_err(|error| {
+                CuError::from("Failed to preallocate keyframe capture buffer")
+                    .add_cause(&error.to_string())
+            })?;
+    }
+    Ok(())
+}
+
+#[cfg(all(feature = "std", feature = "async-cl-io"))]
+impl Drop for KeyFramesManager {
+    fn drop(&mut self) {
+        let _ = self.shutdown_worker();
     }
 }
 
@@ -1525,15 +1877,7 @@ where
             );
         }
 
-        let keyframes_manager = KeyFramesManager {
-            inner: KeyFrame::new(),
-            sink: keyframe_sink,
-            keyframe_interval,
-            last_encoded_bytes: 0,
-            forced_timestamp: None,
-            locked: false,
-            capture_size_hint: KEYFRAME_PAYLOAD_HEADER.len(),
-        };
+        let keyframes_manager = KeyFramesManager::new(keyframe_sink, keyframe_interval)?;
         #[cfg(all(feature = "std", feature = "parallel-rt"))]
         let parallel_rt = ParallelRt::new(parts.parallel_rt_metadata)?;
 
@@ -1643,15 +1987,7 @@ where
             );
         }
 
-        let keyframes_manager = KeyFramesManager {
-            inner: KeyFrame::new(),
-            sink: keyframe_sink,
-            keyframe_interval,
-            last_encoded_bytes: 0,
-            forced_timestamp: None,
-            locked: false,
-            capture_size_hint: KEYFRAME_PAYLOAD_HEADER.len(),
-        };
+        let keyframes_manager = KeyFramesManager::new(keyframe_sink, keyframe_interval)?;
 
         let runtime_config = config.runtime.clone().unwrap_or_default();
         runtime_config.validate()?;
@@ -2639,8 +2975,12 @@ mod tests {
         runtime.copperlists_manager.end_of_processing(0).unwrap();
         runtime.copperlists_manager.finish_pending().unwrap();
 
-        runtime.keyframes_manager.reset(0, &runtime.clock);
+        runtime
+            .keyframes_manager
+            .try_reset(0, &runtime.clock)
+            .unwrap();
         runtime.keyframes_manager.end_of_processing(0).unwrap();
+        runtime.keyframes_manager.finish_pending().unwrap();
 
         assert_eq!(*copperlist_ids.lock().unwrap(), vec![0]);
         assert_eq!(*keyframe_ids.lock().unwrap(), vec![0]);
@@ -2946,18 +3286,15 @@ mod tests {
     #[test]
     fn test_keyframe_manager_accepts_nonserializing_semantic_sink() {
         let ids = Arc::new(Mutex::new(Vec::new()));
-        let mut keyframes = KeyFramesManager {
-            inner: KeyFrame::new(),
-            forced_timestamp: None,
-            locked: false,
-            sink: Some(Box::new(RecordingKeyFrameSink { ids: ids.clone() })),
-            keyframe_interval: 1,
-            last_encoded_bytes: 0,
-            capture_size_hint: KEYFRAME_PAYLOAD_HEADER.len(),
-        };
+        let mut keyframes = KeyFramesManager::new(
+            Some(Box::new(RecordingKeyFrameSink { ids: ids.clone() })),
+            1,
+        )
+        .unwrap();
 
-        keyframes.reset(7, &RobotClock::default());
+        keyframes.try_reset(7, &RobotClock::default()).unwrap();
         keyframes.end_of_processing(7).unwrap();
+        keyframes.finish_pending().unwrap();
 
         assert_eq!(*ids.lock().unwrap(), vec![7]);
         assert_eq!(keyframes.last_encoded_bytes, 29);
@@ -3045,6 +3382,107 @@ mod tests {
                 .recv()
                 .map_err(|_| CuError::from("failed to release blocking writer"))
         }
+    }
+
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    #[derive(Debug)]
+    struct BlockingKeyFrameWriter {
+        ids: Arc<Mutex<Vec<u64>>>,
+        started: SyncSender<()>,
+        release: Arc<Mutex<Receiver<()>>>,
+    }
+
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    impl WriteStream<KeyFrame> for BlockingKeyFrameWriter {
+        fn log(&mut self, keyframe: &KeyFrame) -> CuResult<()> {
+            self.ids.lock().unwrap().push(keyframe.culistid);
+            self.started
+                .send(())
+                .map_err(|_| CuError::from("failed to signal blocking keyframe writer start"))?;
+            self.release
+                .lock()
+                .unwrap()
+                .recv()
+                .map_err(|_| CuError::from("failed to release blocking keyframe writer"))
+        }
+    }
+
+    #[test]
+    fn disabled_keyframes_allocate_no_capture_buffers() {
+        let keyframes = KeyFramesManager::new(None, 1).unwrap();
+
+        assert!(keyframes.inner.is_none());
+        assert!(!keyframes.captures_keyframe(0));
+        #[cfg(all(feature = "std", feature = "async-cl-io"))]
+        {
+            assert!(keyframes.spares.is_empty());
+            assert!(keyframes.pending_producer.is_none());
+            assert!(keyframes.worker_handle.is_none());
+        }
+    }
+
+    #[cfg(all(feature = "std", feature = "memory_monitoring"))]
+    #[test]
+    fn disabled_keyframe_manager_allocates_nothing() {
+        let allocations = crate::monitoring::ScopedAllocCounter::new();
+        let keyframes = KeyFramesManager::new(None, 1).unwrap();
+
+        assert_eq!(allocations.allocated(), 0);
+        assert!(keyframes.inner.is_none());
+    }
+
+    #[cfg(all(feature = "std", feature = "async-cl-io"))]
+    #[test]
+    fn saturated_keyframe_handoff_skips_capture_before_freezing() {
+        let ids = Arc::new(Mutex::new(Vec::new()));
+        let (started_tx, started_rx) = sync_channel(1);
+        let (release_tx, release_rx) = sync_channel(1);
+        let mut keyframes = KeyFramesManager::new(
+            Some(Box::new(BlockingKeyFrameWriter {
+                ids: ids.clone(),
+                started: started_tx,
+                release: Arc::new(Mutex::new(release_rx)),
+            })),
+            1,
+        )
+        .unwrap();
+        let freeze_calls = Cell::new(0);
+        let snapshot = CountingSnapshot {
+            calls: &freeze_calls,
+            value: 42,
+            fail: false,
+        };
+        keyframes.begin_capture_preallocation();
+        keyframes.include_capture_capacity(&snapshot).unwrap();
+        keyframes.finish_capture_preallocation().unwrap();
+        freeze_calls.set(0);
+
+        keyframes.try_reset(0, &RobotClock::default()).unwrap();
+        assert_ne!(keyframes.freeze_task(0, &snapshot).unwrap(), 0);
+        keyframes.end_of_processing(0).unwrap();
+        started_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap();
+
+        keyframes.try_reset(1, &RobotClock::default()).unwrap();
+        assert_ne!(keyframes.freeze_task(1, &snapshot).unwrap(), 0);
+        keyframes.end_of_processing(1).unwrap();
+
+        keyframes.try_reset(2, &RobotClock::default()).unwrap();
+        assert_eq!(keyframes.freeze_task(2, &snapshot).unwrap(), 0);
+        keyframes.end_of_processing(2).unwrap();
+
+        assert_eq!(freeze_calls.get(), 2);
+        assert_eq!(keyframes.dropped_keyframes_total(), 1);
+        assert_eq!(*ids.lock().unwrap(), vec![0]);
+
+        release_tx.send(()).unwrap();
+        started_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap();
+        release_tx.send(()).unwrap();
+        keyframes.finish_pending().unwrap();
+        assert_eq!(*ids.lock().unwrap(), vec![0, 1]);
     }
 
     #[cfg(all(feature = "std", feature = "async-cl-io"))]

--- a/core/cu29_runtime/src/monitoring.rs
+++ b/core/cu29_runtime/src/monitoring.rs
@@ -1177,6 +1177,10 @@ pub struct CopperListIoStats {
     /// Total completed CopperLists dropped because the asynchronous output
     /// handoff had no capacity. This is cumulative for the runtime instance.
     pub dropped_copperlists_total: u64,
+    /// Total scheduled keyframes skipped because the asynchronous output worker
+    /// had not returned the preallocated spare capture buffer. This is cumulative
+    /// for the runtime instance.
+    pub dropped_keyframes_total: u64,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

- extend `async-cl-io` with a dedicated bounded keyframe output worker
- preallocate one active capture buffer plus two handoff buffers, so the real-time path performs no sink I/O, allocation, or keyframe payload copy
- skip a scheduled keyframe before calling task freeze hooks when the handoff is saturated
- expose cumulative dropped-keyframe counts through `CopperListIoStats` and highlight them in tuimon
- drain accepted keyframes during runtime stop
- omit the keyframe log stream, capture buffers, worker, preallocation, and generated freeze calls entirely when no downstream consumer requests keyframes

No user-facing RON setting is added in this layer.

## Verification

- `just fmt`
- `cargo test --offline -p cu29-runtime --features async-cl-io -- --test-threads=1`
- `cargo test --offline -p cu-runtime-matrix --features async-cl-io -- --test-threads=1`
- `cargo test --offline -p cu-runtime-matrix --features async-cl-io,parallel-rt -- --test-threads=1`
- allocation-counting test with `async-cl-io,memory_monitoring`
- remote-debug compatibility test with `async-cl-io,remote-debug`
- tuimon model and rendering tests
- `cargo check --offline -p cu29-runtime --no-default-features`
- clippy with warnings denied for runtime/codegen and tuimon

`just api-check` could not run locally because the pinned nightly and `cargo-public-api` tool are unavailable; the checked-in API snapshot was updated manually.