### PR TITLE
fix(spatial): pin row-major layout for Transform3D from_matrix/to_matrix

### DIFF
--- a/components/libs/cu_transform/examples/basic_usage.rs
+++ b/components/libs/cu_transform/examples/basic_usage.rs
@@ -167,7 +167,7 @@ fn main() {
             let mat = transform.to_matrix();
             println!(
                 "Retrieved transform: translation=({:.2}, {:.2}, {:.2})",
-                mat[3][0], mat[3][1], mat[3][2]
+                mat[0][3], mat[1][3], mat[2][3]
             );
         }
         Err(e) => println!("Error: {e}"),

--- a/components/libs/cu_transform/examples/payload_usage.rs
+++ b/components/libs/cu_transform/examples/payload_usage.rs
@@ -104,7 +104,7 @@ fn main() {
             let mat = transform.to_matrix();
             println!(
                 "  World->arm at t=1s: translation=({:.2}, {:.2}, {:.2})",
-                mat[3][0], mat[3][1], mat[3][2]
+                mat[0][3], mat[1][3], mat[2][3]
             );
         }
         Err(e) => println!("  Error: {e}"),

--- a/components/libs/cu_transform/src/interpolation.rs
+++ b/components/libs/cu_transform/src/interpolation.rs
@@ -121,12 +121,12 @@ pub fn interpolate_transforms<T: Interpolate>(
         }
     }
 
-    // Interpolate translation (in column-major format, translation is in the last row)
+    // Interpolate translation (row-major: translation is in the last column).
     for i in 0..3 {
-        let before_val = before_mat[3][i].to_f64();
-        let after_val = after_mat[3][i].to_f64();
+        let before_val = before_mat[i][3].to_f64();
+        let after_val = after_mat[i][3].to_f64();
         let interpolated = before_val + (after_val - before_val) * ratio;
-        result_mat[3][i] = T::from_f64(interpolated);
+        result_mat[i][3] = T::from_f64(interpolated);
     }
 
     Ok(Transform3D::from_matrix(result_mat))
@@ -166,10 +166,10 @@ mod tests {
 
         let after: StampedTransform<f32> = StampedTransform {
             transform: Transform3D::from_matrix([
-                [1.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 10.0],
                 [0.0, 1.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
-                [10.0, 0.0, 0.0, 1.0], // Translation: x=10
+                [0.0, 0.0, 0.0, 1.0], // Translation: x=10
             ]),
             stamp: CuTime::from_nanos(3000),
             parent_frame: frame_id!("world"),
@@ -180,19 +180,19 @@ mod tests {
         assert!(result.is_ok());
 
         let transform = result.unwrap();
-        assert_approx_eq(transform.to_matrix()[3][0], 5.0, 1e-5);
+        assert_approx_eq(transform.to_matrix()[0][3], 5.0, 1e-5);
 
         let result = interpolate_transforms(&before, &after, CuTime::from_nanos(1500));
         assert!(result.is_ok());
 
         let transform = result.unwrap();
-        assert_approx_eq(transform.to_matrix()[3][0], 2.5, 1e-5);
+        assert_approx_eq(transform.to_matrix()[0][3], 2.5, 1e-5);
 
         let result = interpolate_transforms(&before, &after, CuTime::from_nanos(2500));
         assert!(result.is_ok());
 
         let transform = result.unwrap();
-        assert_approx_eq(transform.to_matrix()[3][0], 7.5, 1e-5);
+        assert_approx_eq(transform.to_matrix()[0][3], 7.5, 1e-5);
     }
 
     #[test]
@@ -211,10 +211,10 @@ mod tests {
 
         let after: StampedTransform<f64> = StampedTransform {
             transform: Transform3D::from_matrix([
-                [1.0, 0.0, 0.0, 0.0], // Translation: x=10
+                [1.0, 0.0, 0.0, 10.0], // Translation: x=10
                 [0.0, 1.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
-                [10.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
             ]),
             stamp: CuTime::from_nanos(3000),
             parent_frame: frame_id!("world"),
@@ -225,7 +225,7 @@ mod tests {
         let result = interpolate_transforms(&before, &after, CuTime::from_nanos(2000));
         assert!(result.is_ok());
         let transform = result.unwrap();
-        assert_approx_eq(transform.to_matrix()[3][0], 5.0, 1e-5);
+        assert_approx_eq(transform.to_matrix()[0][3], 5.0, 1e-5);
     }
 
     // Disabled: Transform3D only supports f32 and f64 when using glam (default)

--- a/components/libs/cu_transform/src/test_utils.rs
+++ b/components/libs/cu_transform/src/test_utils.rs
@@ -28,12 +28,12 @@ where
     let zero = T::zero();
     let one = T::one();
 
-    // Note: glam uses column-major order, so translation is in the last row
+    // Note: matrices are row-major, so translation is in the last column
     Transform3D::from_matrix([
-        [one, zero, zero, zero],
-        [zero, one, zero, zero],
-        [zero, zero, one, zero],
-        [x, y, z, one],
+        [one, zero, zero, x],
+        [zero, one, zero, y],
+        [zero, zero, one, z],
+        [zero, zero, zero, one],
     ])
 }
 
@@ -53,10 +53,10 @@ where
     let one = T::one();
     let neg_one = -one;
 
-    // Note: glam uses column-major order
+    // Note: matrices are row-major (R(z, 90°) = [[0, -1, 0], [1, 0, 0], [0, 0, 1]])
     Transform3D::from_matrix([
-        [zero, one, zero, zero],
-        [neg_one, zero, zero, zero],
+        [zero, neg_one, zero, zero],
+        [one, zero, zero, zero],
         [zero, zero, one, zero],
         [zero, zero, zero, one],
     ])
@@ -68,8 +68,8 @@ where
     T: Copy + std::fmt::Debug + Default + 'static,
 {
     let mat = transform.to_matrix();
-    // Note: glam uses column-major order, so translation is in the last row
-    (mat[3][0], mat[3][1], mat[3][2])
+    // Note: matrices are row-major, so translation is in the last column
+    (mat[0][3], mat[1][3], mat[2][3])
 }
 
 /// Set translation components on a transform
@@ -79,9 +79,9 @@ where
     T: Copy + std::fmt::Debug + Default + 'static,
 {
     let mut mat = transform.to_matrix();
-    // Note: glam uses column-major order, so translation is in the last row
-    mat[3][0] = x;
-    mat[3][1] = y;
-    mat[3][2] = z;
+    // Note: matrices are row-major, so translation is in the last column
+    mat[0][3] = x;
+    mat[1][3] = y;
+    mat[2][3] = z;
     *transform = Transform3D::from_matrix(mat);
 }

--- a/components/libs/cu_transform/src/transform.rs
+++ b/components/libs/cu_transform/src/transform.rs
@@ -76,11 +76,10 @@ impl<
         let self_mat = self.transform.to_matrix();
         let prev_mat = previous.transform.to_matrix();
         let mut linear_velocity = [T::default(); 3];
-        // Note: When glam feature is enabled, matrices are in column-major format
-        // Translation is in the last row: mat[3][0], mat[3][1], mat[3][2]
+        // Note: matrices are row-major; translation is in the last column.
         for (i, vel) in linear_velocity.iter_mut().enumerate() {
             // Calculate position difference
-            let pos_diff = self_mat[3][i] - prev_mat[3][i];
+            let pos_diff = self_mat[i][3] - prev_mat[i][3];
             // Divide by time difference to get velocity
             *vel = pos_diff / dt_t;
         }
@@ -940,10 +939,10 @@ mod tests {
         ]);
 
         transform2.transform = Transform3D::from_matrix([
-            [1.0, 0.0, 0.0, 0.0], // Column 0: x-axis
-            [0.0, 1.0, 0.0, 0.0], // Column 1: y-axis
-            [0.0, 0.0, 1.0, 0.0], // Column 2: z-axis
-            [1.0, 2.0, 0.0, 1.0], // Column 3: translation (x=1, y=2, z=0)
+            [1.0, 0.0, 0.0, 1.0], // Row 0: x-axis + x translation
+            [0.0, 1.0, 0.0, 2.0], // Row 1: y-axis + y translation
+            [0.0, 0.0, 1.0, 0.0], // Row 2: z-axis
+            [0.0, 0.0, 0.0, 1.0], // Row 3: homogeneous
         ]);
 
         // Compute velocity from transforms (newer minus older)
@@ -1084,10 +1083,10 @@ mod tests {
         ]);
 
         transform2.transform = Transform3D::from_matrix([
-            [1.0, 0.0, 0.0, 0.0], // Column 0: x-axis
-            [0.0, 1.0, 0.0, 0.0], // Column 1: y-axis
-            [0.0, 0.0, 1.0, 0.0], // Column 2: z-axis
-            [2.0, 0.0, 0.0, 1.0], // Column 3: translation (x=2, y=0, z=0)
+            [1.0, 0.0, 0.0, 2.0], // Row 0: x-axis + x translation
+            [0.0, 1.0, 0.0, 0.0], // Row 1: y-axis
+            [0.0, 0.0, 1.0, 0.0], // Row 2: z-axis
+            [0.0, 0.0, 0.0, 1.0], // Row 3: homogeneous
         ]);
 
         buffer.add_transform(transform1);
@@ -1341,10 +1340,10 @@ mod tests {
         ]);
 
         transform2.transform = Transform3D::from_matrix([
-            [1.0, 0.0, 0.0, 0.0], // Column 0: x-axis
-            [0.0, 1.0, 0.0, 0.0], // Column 1: y-axis
-            [0.0, 0.0, 1.0, 0.0], // Column 2: z-axis
-            [3.0, 0.0, 0.0, 1.0], // Column 3: translation (x=3, y=0, z=0)
+            [1.0, 0.0, 0.0, 3.0], // Row 0: x-axis + x translation
+            [0.0, 1.0, 0.0, 0.0], // Row 1: y-axis
+            [0.0, 0.0, 1.0, 0.0], // Row 2: z-axis
+            [0.0, 0.0, 0.0, 1.0], // Row 3: homogeneous
         ]);
 
         buffer.add_transform(transform1);

--- a/components/libs/cu_transform/src/transform_payload.rs
+++ b/components/libs/cu_transform/src/transform_payload.rs
@@ -543,12 +543,12 @@ where
 
         let dt_t = num_traits::cast::cast::<f64, T>(dt)?;
 
-        // Extract positions from transforms (column-major format)
+        // Extract positions from transforms (row-major: translation in the last column)
         let current_mat = current_transform.to_matrix();
         let previous_mat = previous_transform.to_matrix();
         let mut linear_velocity = [T::default(); 3];
         for (i, vel) in linear_velocity.iter_mut().enumerate() {
-            let pos_diff = current_mat[3][i] - previous_mat[3][i];
+            let pos_diff = current_mat[i][3] - previous_mat[i][3];
             *vel = pos_diff / dt_t;
         }
 

--- a/components/libs/cu_transform/src/tree.rs
+++ b/components/libs/cu_transform/src/tree.rs
@@ -794,10 +794,10 @@ mod tests {
         let mut tree = TransformTree::<f32>::new();
 
         let matrix = [
-            [1.0, 0.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0, 0.0],
-            [0.0, 0.0, 1.0, 0.0],
-            [2.0, 3.0, 4.0, 1.0],
+            [1.0, 0.0, 0.0, 2.0],
+            [0.0, 1.0, 0.0, 3.0],
+            [0.0, 0.0, 1.0, 4.0],
+            [0.0, 0.0, 0.0, 1.0],
         ];
         let tf = make_stamped(
             "world",
@@ -835,10 +835,10 @@ mod tests {
             "base",
             ts,
             Transform3D::from_matrix([
-                [1.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 1.0],
                 [0.0, 1.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
-                [1.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
             ]),
         );
 
@@ -847,8 +847,8 @@ mod tests {
             "arm",
             ts,
             Transform3D::from_matrix([
-                [0.0, 1.0, 0.0, 0.0],
-                [-1.0, 0.0, 0.0, 0.0],
+                [0.0, -1.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
                 [0.0, 0.0, 0.0, 1.0],
             ]),
@@ -860,9 +860,9 @@ mod tests {
             ts,
             Transform3D::from_matrix([
                 [1.0, 0.0, 0.0, 0.0],
-                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 2.0],
                 [0.0, 0.0, 1.0, 0.0],
-                [0.0, 2.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
             ]),
         );
 
@@ -878,8 +878,8 @@ mod tests {
 
         let mat = transform.to_matrix();
         assert_approx_eq(mat[0][0], 0.0, epsilon, "mat_0_0");
-        assert_approx_eq(mat[1][0], -1.0, epsilon, "mat_1_0");
-        assert_approx_eq(mat[0][1], 1.0, epsilon, "mat_0_1");
+        assert_approx_eq(mat[1][0], 1.0, epsilon, "mat_1_0");
+        assert_approx_eq(mat[0][1], -1.0, epsilon, "mat_0_1");
         assert_approx_eq(mat[1][1], 0.0, epsilon, "mat_1_1");
 
         assert_approx_eq(get_translation(&transform).0, 0.0, epsilon, "translation_x");
@@ -904,8 +904,8 @@ mod tests {
             .lookup_transform("gripper", "world", ts, &clock)
             .unwrap();
         let inv_mat = inverse.to_matrix();
-        assert_approx_eq(inv_mat[1][0], 1.0, epsilon, "inv_mat_1_0");
-        assert_approx_eq(inv_mat[0][1], -1.0, epsilon, "inv_mat_0_1");
+        assert_approx_eq(inv_mat[1][0], -1.0, epsilon, "inv_mat_1_0");
+        assert_approx_eq(inv_mat[0][1], 1.0, epsilon, "inv_mat_0_1");
         assert_approx_eq(get_translation(&inverse).0, -3.0, epsilon, "translation_x");
         assert_approx_eq(get_translation(&inverse).1, 0.0, epsilon, "translation_y");
 
@@ -933,10 +933,10 @@ mod tests {
             "b",
             ts,
             Transform3D::from_matrix([
-                [1.0, 0.0, 0.0, 0.0],
-                [0.0, 1.0, 0.0, 0.0],
-                [0.0, 0.0, 1.0, 0.0],
-                [1.0, 2.0, 3.0, 1.0],
+                [1.0, 0.0, 0.0, 1.0],
+                [0.0, 1.0, 0.0, 2.0],
+                [0.0, 0.0, 1.0, 3.0],
+                [0.0, 0.0, 0.0, 1.0],
             ]),
         );
 
@@ -970,10 +970,10 @@ mod tests {
             "robot",
             ts,
             Transform3D::from_matrix([
-                [1.0, 0.0, 0.0, 0.0],
-                [0.0, 1.0, 0.0, 0.0],
-                [0.0, 0.0, 1.0, 0.0],
-                [1.0, 2.0, 3.0, 1.0],
+                [1.0, 0.0, 0.0, 1.0],
+                [0.0, 1.0, 0.0, 2.0],
+                [0.0, 0.0, 1.0, 3.0],
+                [0.0, 0.0, 0.0, 1.0],
             ]),
         );
 
@@ -982,10 +982,10 @@ mod tests {
             "camera",
             ts,
             Transform3D::from_matrix([
-                [0.0, 1.0, 0.0, 0.0],
-                [-1.0, 0.0, 0.0, 0.0],
-                [0.0, 0.0, 1.0, 0.0],
-                [0.5, 0.0, 0.2, 1.0],
+                [0.0, -1.0, 0.0, 0.5],
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.2],
+                [0.0, 0.0, 0.0, 1.0],
             ]),
         );
 
@@ -1000,8 +1000,8 @@ mod tests {
 
         let mat = transform.to_matrix();
         assert_approx_eq(mat[0][0], 0.0, epsilon, "mat_0_0");
-        assert_approx_eq(mat[1][0], -1.0, epsilon, "mat_1_0");
-        assert_approx_eq(mat[0][1], 1.0, epsilon, "mat_0_1");
+        assert_approx_eq(mat[1][0], 1.0, epsilon, "mat_1_0");
+        assert_approx_eq(mat[0][1], -1.0, epsilon, "mat_0_1");
         assert_approx_eq(mat[1][1], 0.0, epsilon, "mat_1_1");
 
         assert_approx_eq(
@@ -1047,10 +1047,10 @@ mod tests {
             "base",
             CuTime::from_nanos(2_000_000_000),
             Transform3D::from_matrix([
-                [1.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 1.0],
                 [0.0, 1.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
-                [1.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
             ]),
         );
 
@@ -1072,9 +1072,9 @@ mod tests {
             CuTime::from_nanos(2_000_000_000),
             Transform3D::from_matrix([
                 [1.0, 0.0, 0.0, 0.0],
-                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 2.0],
                 [0.0, 0.0, 1.0, 0.0],
-                [0.0, 2.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
             ]),
         );
 
@@ -1119,10 +1119,10 @@ mod tests {
             "sensor",
             ts1,
             Transform3D::from_matrix([
-                [0.0, 1.0, 0.0, 0.0],
-                [-1.0, 0.0, 0.0, 0.0],
+                [0.0, -1.0, 0.0, 1.0],
+                [1.0, 0.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
-                [1.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
             ]),
         );
 
@@ -1131,10 +1131,10 @@ mod tests {
             "base",
             ts2,
             Transform3D::from_matrix([
-                [1.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 1.0],
                 [0.0, 1.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
-                [1.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
             ]),
         );
 
@@ -1143,10 +1143,10 @@ mod tests {
             "sensor",
             ts2,
             Transform3D::from_matrix([
-                [0.0, 1.0, 0.0, 0.0],
-                [-1.0, 0.0, 0.0, 0.0],
+                [0.0, -1.0, 0.0, 1.0],
+                [1.0, 0.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
-                [1.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
             ]),
         );
 
@@ -1197,8 +1197,8 @@ mod tests {
             "base",
             ts2,
             Transform3D::from_matrix([
-                [0.0, 1.0, 0.0, 0.0],
-                [-1.0, 0.0, 0.0, 0.0],
+                [0.0, -1.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
                 [0.0, 0.0, 0.0, 1.0],
             ]),
@@ -1209,10 +1209,10 @@ mod tests {
             "sensor",
             ts1,
             Transform3D::from_matrix([
-                [1.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 1.0],
                 [0.0, 1.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
-                [1.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
             ]),
         );
 
@@ -1221,10 +1221,10 @@ mod tests {
             "sensor",
             ts2,
             Transform3D::from_matrix([
-                [1.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 1.0],
                 [0.0, 1.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
-                [1.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
             ]),
         );
 
@@ -1241,7 +1241,7 @@ mod tests {
         let epsilon = 0.1;
         assert_approx_eq(vel.angular[0], 0.0, epsilon, "angular_velocity_0");
         assert_approx_eq(vel.angular[1], 0.0, epsilon, "angular_velocity_1");
-        assert_approx_eq(vel.angular[2], -1.0, epsilon, "angular_velocity_2");
+        assert_approx_eq(vel.angular[2], 1.0, epsilon, "angular_velocity_2");
 
         assert!(!vel.linear[0].is_nan());
         assert!(!vel.linear[1].is_nan());
@@ -1275,10 +1275,10 @@ mod tests {
             "robot",
             ts2,
             Transform3D::from_matrix([
-                [1.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 2.0],
                 [0.0, 1.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
-                [2.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
             ]),
         );
 
@@ -1343,10 +1343,10 @@ mod tests {
             "robot",
             ts2,
             Transform3D::from_matrix([
-                [1.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 1.0],
                 [0.0, 1.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
-                [1.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
             ]),
         );
 
@@ -1355,10 +1355,10 @@ mod tests {
             "robot",
             ts3,
             Transform3D::from_matrix([
-                [1.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 3.0],
                 [0.0, 1.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
-                [3.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
             ]),
         );
 

--- a/components/payloads/cu_spatial_payloads/src/lib.rs
+++ b/components/payloads/cu_spatial_payloads/src/lib.rs
@@ -415,7 +415,8 @@ impl<T: Copy + Debug + Default + 'static> TransformInner<T> {
             // Convert to f32 matrix
             // SAFETY: We just verified T == f32, so the layouts match.
             let mat_f32: [[f32; 4]; 4] = unsafe { core::mem::transmute_copy(&mat) };
-            let glam_mat = Mat4::from_cols_array_2d(&mat_f32);
+            // `mat` is row-major; glam stores column-major, so transpose at the boundary.
+            let glam_mat = Mat4::from_cols_array_2d(&mat_f32).transpose();
             let affine = Affine3A::from_mat4(glam_mat);
             // SAFETY: We just verified T == f32, so this is the correct enum variant.
             unsafe { core::mem::transmute_copy(&TransformInner::<T>::F32(affine)) }
@@ -423,8 +424,8 @@ impl<T: Copy + Debug + Default + 'static> TransformInner<T> {
             // Convert to f64 matrix
             // SAFETY: We just verified T == f64, so the layouts match.
             let mat_f64: [[f64; 4]; 4] = unsafe { core::mem::transmute_copy(&mat) };
-            // let m = mat_f64;
-            let glam_mat = DMat4::from_cols_array_2d(&mat_f64);
+            // `mat` is row-major; glam stores column-major, so transpose at the boundary.
+            let glam_mat = DMat4::from_cols_array_2d(&mat_f64).transpose();
             let affine = DAffine3::from_mat4(glam_mat);
             // SAFETY: We just verified T == f64, so this is the correct enum variant.
             unsafe { core::mem::transmute_copy(&TransformInner::<T>::F64(affine)) }
@@ -437,13 +438,15 @@ impl<T: Copy + Debug + Default + 'static> TransformInner<T> {
         match self {
             TransformInner::F32(affine) => {
                 let mat = Mat4::from(affine);
-                let mat_array = mat.to_cols_array_2d();
+                // glam is column-major; transposing then taking columns yields row-major.
+                let mat_array = mat.transpose().to_cols_array_2d();
                 // SAFETY: We only reach this arm when T == f32.
                 unsafe { core::mem::transmute_copy(&mat_array) }
             }
             TransformInner::F64(affine) => {
                 let mat = DMat4::from(affine);
-                let mat_array = mat.to_cols_array_2d();
+                // glam is column-major; transposing then taking columns yields row-major.
+                let mat_array = mat.transpose().to_cols_array_2d();
                 // SAFETY: We only reach this arm when T == f64.
                 unsafe { core::mem::transmute_copy(&mat_array) }
             }
@@ -818,103 +821,35 @@ mod nalgebra_integration {
 #[cfg(feature = "glam")]
 mod glam_integration {
     use super::Transform3D;
-    use glam::{Affine3A, DAffine3};
+    use glam::{Affine3A, DAffine3, DMat4, Mat4};
 
     impl From<Transform3D<f64>> for DAffine3 {
         fn from(p: Transform3D<f64>) -> Self {
+            // `to_matrix` is row-major; glam stores column-major, so transpose.
             let mat = p.to_matrix();
-            let mut aff = DAffine3::IDENTITY;
-            aff.matrix3.x_axis.x = mat[0][0];
-            aff.matrix3.x_axis.y = mat[0][1];
-            aff.matrix3.x_axis.z = mat[0][2];
-
-            aff.matrix3.y_axis.x = mat[1][0];
-            aff.matrix3.y_axis.y = mat[1][1];
-            aff.matrix3.y_axis.z = mat[1][2];
-
-            aff.matrix3.z_axis.x = mat[2][0];
-            aff.matrix3.z_axis.y = mat[2][1];
-            aff.matrix3.z_axis.z = mat[2][2];
-
-            aff.translation.x = mat[3][0];
-            aff.translation.y = mat[3][1];
-            aff.translation.z = mat[3][2];
-
-            aff
+            DAffine3::from_mat4(DMat4::from_cols_array_2d(&mat).transpose())
         }
     }
 
     impl From<DAffine3> for Transform3D<f64> {
         fn from(aff: DAffine3) -> Self {
-            let mut transform = [[0.0f64; 4]; 4];
-
-            transform[0][0] = aff.matrix3.x_axis.x;
-            transform[0][1] = aff.matrix3.x_axis.y;
-            transform[0][2] = aff.matrix3.x_axis.z;
-
-            transform[1][0] = aff.matrix3.y_axis.x;
-            transform[1][1] = aff.matrix3.y_axis.y;
-            transform[1][2] = aff.matrix3.y_axis.z;
-
-            transform[2][0] = aff.matrix3.z_axis.x;
-            transform[2][1] = aff.matrix3.z_axis.y;
-            transform[2][2] = aff.matrix3.z_axis.z;
-
-            transform[3][0] = aff.translation.x;
-            transform[3][1] = aff.translation.y;
-            transform[3][2] = aff.translation.z;
-            transform[3][3] = 1.0;
-
-            Transform3D::from_matrix(transform)
+            // glam is column-major; transposing then taking columns yields row-major.
+            Transform3D::from_matrix(DMat4::from(aff).transpose().to_cols_array_2d())
         }
     }
 
     impl From<Transform3D<f32>> for Affine3A {
         fn from(p: Transform3D<f32>) -> Self {
+            // `to_matrix` is row-major; glam stores column-major, so transpose.
             let mat = p.to_matrix();
-            let mut aff = Affine3A::IDENTITY;
-            aff.matrix3.x_axis.x = mat[0][0];
-            aff.matrix3.x_axis.y = mat[0][1];
-            aff.matrix3.x_axis.z = mat[0][2];
-
-            aff.matrix3.y_axis.x = mat[1][0];
-            aff.matrix3.y_axis.y = mat[1][1];
-            aff.matrix3.y_axis.z = mat[1][2];
-
-            aff.matrix3.z_axis.x = mat[2][0];
-            aff.matrix3.z_axis.y = mat[2][1];
-            aff.matrix3.z_axis.z = mat[2][2];
-
-            aff.translation.x = mat[0][3];
-            aff.translation.y = mat[1][3];
-            aff.translation.z = mat[2][3];
-
-            aff
+            Affine3A::from_mat4(Mat4::from_cols_array_2d(&mat).transpose())
         }
     }
 
     impl From<Affine3A> for Transform3D<f32> {
         fn from(aff: Affine3A) -> Self {
-            let mut transform = [[0.0f32; 4]; 4];
-
-            transform[0][0] = aff.matrix3.x_axis.x;
-            transform[0][1] = aff.matrix3.x_axis.y;
-            transform[0][2] = aff.matrix3.x_axis.z;
-
-            transform[1][0] = aff.matrix3.y_axis.x;
-            transform[1][1] = aff.matrix3.y_axis.y;
-            transform[1][2] = aff.matrix3.y_axis.z;
-
-            transform[2][0] = aff.matrix3.z_axis.x;
-            transform[2][1] = aff.matrix3.z_axis.y;
-            transform[2][2] = aff.matrix3.z_axis.z;
-
-            transform[0][3] = aff.translation.x;
-            transform[1][3] = aff.translation.y;
-            transform[2][3] = aff.translation.z;
-            transform[3][3] = 1.0;
-
-            Transform3D::from_matrix(transform)
+            // glam is column-major; transposing then taking columns yields row-major.
+            Transform3D::from_matrix(Mat4::from(aff).transpose().to_cols_array_2d())
         }
     }
 }
@@ -1288,13 +1223,15 @@ mod tests {
         use glam::DAffine3;
 
         let pose = Transform3D::from_matrix([
-            [1.0, 0.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0, 0.0],
-            [0.0, 0.0, 1.0, 0.0],
-            [5.0, 6.0, 7.0, 1.0],
+            [1.0, 0.0, 0.0, 5.0],
+            [0.0, 1.0, 0.0, 6.0],
+            [0.0, 0.0, 1.0, 7.0],
+            [0.0, 0.0, 0.0, 1.0],
         ]);
         let aff: DAffine3 = pose.into();
         assert_eq!(aff.translation[0], 5.0);
+        assert_eq!(aff.translation[1], 6.0);
+        assert_eq!(aff.translation[2], 7.0);
         let pose_from_aff: Transform3D<f64> = aff.into();
 
         assert_eq!(
@@ -1345,28 +1282,15 @@ mod tests {
         assert_eq!(mat_transposed.w_axis.z, 7.0);
     }
 
-    /// 90 degrees around z plus a (2, 3, 4) translation, in the layout the
-    /// active backend expects: glam stores column-major, the fallback
-    /// row-major.
+    /// 90 degrees around z plus a (2, 3, 4) translation, in row-major layout
+    /// (the canonical layout for both the glam and non-glam backends).
     fn quarter_turn_and_shift() -> Transform3D<f32> {
-        #[cfg(feature = "glam")]
-        {
-            Transform3D::from_matrix([
-                [0.0, 1.0, 0.0, 0.0],
-                [-1.0, 0.0, 0.0, 0.0],
-                [0.0, 0.0, 1.0, 0.0],
-                [2.0, 3.0, 4.0, 1.0],
-            ])
-        }
-        #[cfg(not(feature = "glam"))]
-        {
-            Transform3D::from_matrix([
-                [0.0, -1.0, 0.0, 2.0],
-                [1.0, 0.0, 0.0, 3.0],
-                [0.0, 0.0, 1.0, 4.0],
-                [0.0, 0.0, 0.0, 1.0],
-            ])
-        }
+        Transform3D::from_matrix([
+            [0.0, -1.0, 0.0, 2.0],
+            [1.0, 0.0, 0.0, 3.0],
+            [0.0, 0.0, 1.0, 4.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ])
     }
 
     fn assert_point_close(lhs: Point3f, rhs: Point3f, eps: f32) {
@@ -1399,6 +1323,37 @@ mod tests {
     fn transform_accessors_are_backend_independent() {
         let t = quarter_turn_and_shift();
 
+        assert_eq!(
+            t.translation(),
+            [
+                Length32::new::<meter>(2.0),
+                Length32::new::<meter>(3.0),
+                Length32::new::<meter>(4.0),
+            ]
+        );
+        assert_eq!(
+            t.rotation(),
+            [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]
+        );
+    }
+
+    #[test]
+    fn from_matrix_is_row_major_and_round_trips() {
+        // The canonical layout is row-major: translation lives in the last
+        // column, matching the non-glam backend and the doc examples. The glam
+        // backend must transpose at its boundary so both feature configs agree.
+        let mat = [
+            [0.0, -1.0, 0.0, 2.0],
+            [1.0, 0.0, 0.0, 3.0],
+            [0.0, 0.0, 1.0, 4.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ];
+        let t = Transform3D::<f32>::from_matrix(mat);
+
+        // Lossless round-trip in the canonical layout.
+        assert_eq!(t.to_matrix(), mat);
+
+        // Accessors agree with the matrix.
         assert_eq!(
             t.translation(),
             [

--- a/components/payloads/cu_spatial_payloads/src/lib.rs
+++ b/components/payloads/cu_spatial_payloads/src/lib.rs
@@ -371,7 +371,12 @@ where
 }
 
 impl<T: Copy + Debug + Default + 'static> Transform3D<T> {
-    /// Create a transform from a 4x4 matrix
+    /// Creates a homogeneous 4x4 transform indexed as `mat[row][column]`.
+    /// Each inner array is a row; points are column vectors (`p_out = mat * p_in`).
+    /// Translation is `[mat[0][3], mat[1][3], mat[2][3]]`; the last row must be `[0, 0, 0, 1]`.
+    /// The convention is backend-independent: callers must not transpose for glam.
+    /// Glam/Rerun adapters repack into columns internally; the fallback stores rows directly.
+    /// Nalgebra/faer adapters copy by `(row, column)`, independent of storage order.
     pub fn from_matrix(mat: [[T; 4]; 4]) -> Self {
         #[cfg(feature = "glam")]
         {
@@ -385,7 +390,9 @@ impl<T: Copy + Debug + Default + 'static> Transform3D<T> {
         }
     }
 
-    /// Get the transform as a 4x4 matrix
+    /// Returns a homogeneous 4x4 matrix indexed as `mat[row][column]`.
+    /// Each inner array is a row, with translation in the last column, regardless of backend.
+    /// Uses the same column-vector convention as [`Self::from_matrix`].
     pub fn to_matrix(self) -> [[T; 4]; 4] {
         #[cfg(feature = "glam")]
         {

--- a/components/payloads/cu_spatial_payloads/src/rerun_components.rs
+++ b/components/payloads/cu_spatial_payloads/src/rerun_components.rs
@@ -10,26 +10,28 @@ use crate::{GeodeticPosition, Transform3D};
 fn transform_parts<T: Copy + Into<f64> + Debug + Default + 'static>(
     transform: &Transform3D<T>,
 ) -> ([f32; 3], [[f32; 3]; 3]) {
+    // `to_matrix` is row-major: translation in the last column, rotation rows
+    // first. Rerun's Mat3x3 is column-major, so read the rotation transposed.
     let matrix = (*transform).to_matrix();
     let translation = [
-        matrix[3][0].into() as f32,
-        matrix[3][1].into() as f32,
-        matrix[3][2].into() as f32,
+        matrix[0][3].into() as f32,
+        matrix[1][3].into() as f32,
+        matrix[2][3].into() as f32,
     ];
     let mat3 = [
         [
             matrix[0][0].into() as f32,
-            matrix[0][1].into() as f32,
-            matrix[0][2].into() as f32,
-        ],
-        [
             matrix[1][0].into() as f32,
-            matrix[1][1].into() as f32,
-            matrix[1][2].into() as f32,
+            matrix[2][0].into() as f32,
         ],
         [
-            matrix[2][0].into() as f32,
+            matrix[0][1].into() as f32,
+            matrix[1][1].into() as f32,
             matrix[2][1].into() as f32,
+        ],
+        [
+            matrix[0][2].into() as f32,
+            matrix[1][2].into() as f32,
             matrix[2][2].into() as f32,
         ],
     ];
@@ -79,12 +81,12 @@ mod tests {
     use crate::GeodeticPosition;
 
     #[test]
-    fn transform_parts_uses_fourth_row_for_translation() {
+    fn transform_parts_uses_last_column_for_translation() {
         let transform = Transform3D::<f32>::from_matrix([
-            [1.0, 0.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0, 0.0],
-            [0.0, 0.0, 1.0, 0.0],
-            [10.0, 20.0, 30.0, 1.0],
+            [1.0, 0.0, 0.0, 10.0],
+            [0.0, 1.0, 0.0, 20.0],
+            [0.0, 0.0, 1.0, 30.0],
+            [0.0, 0.0, 0.0, 1.0],
         ]);
 
         let (translation, _mat3) = transform_parts(&transform);


### PR DESCRIPTION
## Problem

Closes #1255.

`Transform3D::from_matrix`/`to_matrix` speak **column-major** when the `glam` feature is on (the default), while the non-glam backend is **row-major**. That means:

- A row-major matrix fed to `from_matrix` is misread under glam (translation ends up in the wrong place, rotation transposed).
- `to_matrix` returns a different byte layout depending on the backend, so **logs serialized by a glam build replay wrong in a non-glam build** (and vice versa).
- The existing `From<Transform3D<f32>> for Affine3A` read translation from the last column while `From<Transform3D<f64>> for DAffine3` read it from the last row — the two impls disagreed with each other.

## Fix

Pin **row-major** as the single canonical layout (matching the non-glam backend and the doc examples):

- Transpose at the glam boundary in `TransformInner::from_matrix`/`to_matrix`.
- Rewrite the `glam` `From`/`Into` impls to use the same convention.
- Update downstream consumers in `cu-transform` (interpolation, velocity computation, test utilities) and the rerun integration to read translation from the **last column**.
- Add a row-major round-trip regression test (`from_matrix_is_row_major_and_round_trips`).

## Verification

```
cargo test -p cu-spatial-payloads             # 27 passed (glam)
cargo test -p cu-spatial-payloads --no-default-features  # 25 passed (non-glam)
cargo test -p cu-transform                     # all passed
```

Both backends now serialize the same byte layout for the same pose.