### PR TITLE
Wire cu29-logstream into generated runtimes

### DIFF
--- a/core/cu29/Cargo.toml
+++ b/core/cu29/Cargo.toml
@@ -28,6 +28,7 @@ cu29-derive = { workspace = true }
 cu29-log = { workspace = true }
 cu29-log-derive = { workspace = true }
 cu29-log-runtime = { workspace = true }
+cu29-logstream = { workspace = true, optional = true }
 cu29-reflect-derive = { workspace = true }
 cu29-runtime = { workspace = true }
 cu29-traits = { workspace = true }
@@ -65,6 +66,12 @@ signal-handler = ["dep:ctrlc", "cu29-derive/signal-handler"]
 flat-copperlist-encoding = ["cu29-derive/flat-copperlist-encoding"]
 sysclock-perf = ["std", "cu29-runtime/sysclock-perf"]
 high-precision-limiter = ["std", "cu29-runtime/high-precision-limiter"]
+logstream = [
+  "std",
+  "async-cl-io",
+  "dep:cu29-logstream",
+  "cu29-derive/logstream",
+]
 cuda = ["std", "cu29-runtime/cuda"]
 log-level-debug = ["cu29-log-derive/log-level-debug"]
 log-level-info = ["cu29-log-derive/log-level-info"]
@@ -108,6 +115,10 @@ std = [
 ]
 rtsan = ["dep:rtsan-standalone", "cu29-derive/rtsan"]
 safety-ids = ["std", "dep:inventory", "dep:serde_json"]
+
+[dev-dependencies]
+cu29-logstream = { workspace = true, features = ["test-utils"] }
+heapless = { workspace = true }
 
 [build-dependencies]
 cu29-build = { workspace = true }

--- a/core/cu29/src/lib.rs
+++ b/core/cu29/src/lib.rs
@@ -72,6 +72,8 @@ extern crate alloc;
 extern crate self as cu29;
 
 pub use cu29_derive::{bundle_resources, resources, safety_case};
+#[cfg(feature = "logstream")]
+pub use cu29_logstream as logstream;
 pub use cu29_runtime::app;
 pub use cu29_runtime::config;
 pub use cu29_runtime::context;

--- a/core/cu29/tests/logstream_runtime.rs
+++ b/core/cu29/tests/logstream_runtime.rs
@@ -1,0 +1,182 @@
+#![cfg(feature = "logstream")]
+
+use bincode::{Decode, Encode};
+use cu29::logstream::test_support::link_sim::{LinkSimulationConfig, simulate_bad_link};
+use cu29::logstream::{
+    ContinuousDecoder, ContinuousSenderConfig, CuStreamTx, CuStreamTxError, DensityThreshold,
+    EncodingSymbolId, FecSymbolKind, Field, Lane, ReceiverLimits, RlcConfig, StreamIdentity,
+    WirePacket, decode_copperlist,
+};
+use cu29::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+const SYMBOL_SIZE: usize = 256;
+const WINDOW_SYMBOLS: usize = 64;
+const MAX_EQUATIONS: usize = 32;
+const RECORD_BYTES: usize = 4_096;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Encode, Decode, Serialize, Deserialize, Reflect)]
+struct StreamMsg(u64);
+
+#[derive(Default, Reflect)]
+struct StreamSource {
+    next: u64,
+}
+
+impl Freezable for StreamSource {}
+
+impl CuSrcTask for StreamSource {
+    type Resources<'r> = ();
+    type Output<'m> = output_msg!(StreamMsg);
+
+    fn new(_config: Option<&ComponentConfig>, _resources: ()) -> CuResult<Self> {
+        Ok(Self::default())
+    }
+
+    fn process(&mut self, _ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
+        output.set_payload(StreamMsg(self.next));
+        self.next += 1;
+        Ok(())
+    }
+}
+
+const MAX_CAPTURED_PACKET_BYTES: usize = 1_024;
+const CAPTURED_PACKET_COUNT: usize = 128;
+type CapturedPacket = heapless::Vec<u8, MAX_CAPTURED_PACKET_BYTES>;
+type CapturedPackets = heapless::mpmc::Queue<CapturedPacket, CAPTURED_PACKET_COUNT>;
+
+#[derive(Clone, Default)]
+struct CapturingTx {
+    packets: Arc<CapturedPackets>,
+}
+
+impl core::fmt::Debug for CapturingTx {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str("CapturingTx")
+    }
+}
+
+impl CapturingTx {
+    fn drain(&self) -> Vec<Vec<u8>> {
+        core::iter::from_fn(|| self.packets.dequeue())
+            .map(|packet| packet.as_slice().to_vec())
+            .collect()
+    }
+}
+
+impl CuStreamTx for CapturingTx {
+    fn try_send(&mut self, datagram: &[u8]) -> Result<(), CuStreamTxError> {
+        let mut packet = CapturedPacket::new();
+        packet
+            .extend_from_slice(datagram)
+            .map_err(|_| CuStreamTxError::Failed("test packet exceeds capture capacity"))?;
+        self.packets
+            .enqueue(packet)
+            .map_err(|_| CuStreamTxError::WouldBlock)
+    }
+}
+
+#[copper_runtime(config = "tests/logstream_runtime_config.ron")]
+struct LogstreamRuntimeApp {}
+
+#[test]
+fn generated_runtime_streams_without_local_copperlist_logging() -> CuResult<()> {
+    const ITERATIONS: usize = 4;
+    let transport = CapturingTx::default();
+    let captured = transport.clone();
+    let identity = StreamIdentity {
+        session_id: *b"runtime-stream01",
+        sender_id: 23,
+    };
+    let fec = RlcConfig::new(SYMBOL_SIZE, WINDOW_SYMBOLS, Field::Gf256)
+        .map_err(|error| CuError::from(error.to_string()))?;
+    let sender = ContinuousSenderConfig {
+        identity,
+        first_packet_sequence: 0,
+        lane: Lane::ReplayCritical,
+        fec,
+        max_record_bytes: RECORD_BYTES,
+        initial_esi: EncodingSymbolId::new(0),
+        repair_every_source_symbols: 1,
+        first_repair_key: 1,
+        repair_density: DensityThreshold::FULL,
+    };
+
+    let app = LogstreamRuntimeApp::builder()
+        .with_instance_id(identity.sender_id)
+        .with_logstream(transport, sender)
+        .build()?;
+    let mut running = app.start()?;
+    for _ in 0..ITERATIONS {
+        running.run_one_iteration()?;
+    }
+    drop(running.stop()?);
+
+    let datagrams = captured.drain();
+    assert!(
+        datagrams.len() > ITERATIONS,
+        "expected source and repair datagrams, got {}",
+        datagrams.len()
+    );
+    let source_symbols = datagrams
+        .iter()
+        .filter(|datagram| {
+            WirePacket::decode(datagram)
+                .is_ok_and(|packet| packet.header.symbol_kind == FecSymbolKind::Source)
+        })
+        .count();
+    let simulated_link = simulate_bad_link(
+        &datagrams,
+        LinkSimulationConfig {
+            seed: 0x71_6d_e5,
+            drop_basis_points: 1_500,
+            corrupt_basis_points: 500,
+            duplicate_basis_points: 500,
+            reorder: true,
+        },
+    );
+    assert!(simulated_link.stats.dropped_datagrams > 0);
+    let mut decoder = ContinuousDecoder::<
+        SYMBOL_SIZE,
+        { cu29::logstream::DEFAULT_MAX_WINDOW_SYMBOLS },
+        MAX_EQUATIONS,
+    >::new(
+        identity,
+        Lane::ReplayCritical,
+        fec,
+        MAX_EQUATIONS,
+        ReceiverLimits::new(RECORD_BYTES, ITERATIONS, WINDOW_SYMBOLS, 64),
+    )
+    .map_err(|error| CuError::from(error.to_string()))?;
+    for datagram in &simulated_link.datagrams {
+        decoder
+            .receive_datagram(datagram)
+            .map_err(|error| CuError::from(error.to_string()))?;
+    }
+
+    assert_eq!(decoder.recovered_records().len(), ITERATIONS);
+    assert!(decoder.stats().source_symbols_received < source_symbols);
+    assert!(decoder.stats().source_symbols_recovered > 0);
+    for expected_id in 0..ITERATIONS {
+        let record = decoder
+            .recovered_records()
+            .iter()
+            .find(|record| {
+                record
+                    .decoded()
+                    .is_ok_and(|record| record.object_id == expected_id as u64)
+            })
+            .expect("every generated CopperList should be recovered")
+            .decoded()
+            .map_err(|error| CuError::from(error.to_string()))?;
+        let copperlist: default::CuList =
+            decode_copperlist(record.payload).map_err(|error| CuError::from(error.to_string()))?;
+        assert_eq!(copperlist.id, expected_id as u64);
+        assert_eq!(
+            copperlist.msgs.0.0.payload(),
+            Some(&StreamMsg(expected_id as u64))
+        );
+    }
+    Ok(())
+}

--- a/core/cu29/tests/logstream_runtime_config.ron
+++ b/core/cu29/tests/logstream_runtime_config.ron
@@ -1,0 +1,20 @@
+(
+    logging: (
+        enable_task_logging: false,
+        enable_keyframe_logging: false,
+        copperlist_count: 8,
+    ),
+    tasks: [
+        (
+            id: "source",
+            type: "StreamSource",
+        ),
+    ],
+    cnx: [
+        (
+            src: "source",
+            dst: "__nc__",
+            msg: "StreamMsg",
+        ),
+    ],
+)

--- a/core/cu29/tests/logstream_sim_compile.rs
+++ b/core/cu29/tests/logstream_sim_compile.rs
@@ -1,0 +1,36 @@
+#![cfg(feature = "logstream")]
+
+use bincode::{Decode, Encode};
+use cu29::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, Encode, Decode, Serialize, Deserialize, Reflect)]
+struct StreamMsg(u64);
+
+#[derive(Default, Reflect)]
+#[allow(dead_code)]
+struct StreamSource;
+
+impl Freezable for StreamSource {}
+
+impl CuSrcTask for StreamSource {
+    type Resources<'r> = ();
+    type Output<'m> = output_msg!(StreamMsg);
+
+    fn new(_config: Option<&ComponentConfig>, _resources: ()) -> CuResult<Self> {
+        Ok(Self)
+    }
+
+    fn process(&mut self, _ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
+        output.set_payload(StreamMsg(1));
+        Ok(())
+    }
+}
+
+#[copper_runtime(config = "tests/logstream_runtime_config.ron", sim_mode = true)]
+struct LogstreamSimApp {}
+
+#[test]
+fn generated_sim_logstream_builder_compiles() {
+    let _ = core::mem::size_of::<LogstreamSimApp>();
+}

--- a/core/cu29_derive/Cargo.toml
+++ b/core/cu29_derive/Cargo.toml
@@ -44,6 +44,7 @@ macro_debug = ["cu29-runtime/macro_debug"]
 std = ["cu29-traits/std", "cu29-unifiedlog/std"]
 async-cl-io = ["cu29-runtime/async-cl-io"]
 parallel-rt = ["cu29-runtime/parallel-rt"]
+logstream = []
 # Emit per-task allocation scopes around each task/bridge lifecycle step in the
 # generated runtime so a monitor can fan deltas out via `observe_alloc`. The
 # `cu29` umbrella crate's `memory_monitoring` feature forwards to this one; you

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -1886,6 +1886,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
     let std = false;
     let signal_handler = cfg!(feature = "signal-handler");
     let parallel_rt_enabled = cfg!(feature = "parallel-rt");
+    let logstream_enabled = cfg!(feature = "logstream");
     let rt_guard = rtsan_guard_tokens();
 
     if ignore_resources && !sim_mode {
@@ -4628,6 +4629,16 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
             })
         };
 
+        let build_with_resources_logstream_param = if logstream_enabled {
+            quote! {
+                logstream: Option<(
+                    Box<dyn ::cu29::logstream::CuStreamTx>,
+                    ::cu29::logstream::ContinuousSenderConfig,
+                )>,
+            }
+        } else {
+            quote! {}
+        };
         let build_with_resources_sig = if sim_mode {
             quote! {
                 fn build_with_resources<S: SectionStorage + 'static, L: UnifiedLogWrite<S> + 'static>(
@@ -4635,6 +4646,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                     unified_logger: Arc<Mutex<L>>,
                     app_resources: AppResources,
                     instance_id: u32,
+                    #build_with_resources_logstream_param
                     sim_callback: &mut impl FnMut(SimStep) -> SimOverride,
                 ) -> CuResult<Self>
             }
@@ -4645,6 +4657,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                     unified_logger: Arc<Mutex<L>>,
                     app_resources: AppResources,
                     instance_id: u32,
+                    #build_with_resources_logstream_param
                 ) -> CuResult<Self>
             }
         };
@@ -5426,6 +5439,8 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
             }
         };
 
+        let no_logstream_arg = logstream_enabled.then(|| quote! { None, });
+        let builder_logstream_arg = logstream_enabled.then(|| quote! { self.logstream, });
         let new_with_resources_compat_fn = if sim_mode {
             quote! {
                 pub fn new_with_resources<S: SectionStorage + 'static, L: UnifiedLogWrite<S> + 'static>(
@@ -5440,6 +5455,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         unified_logger,
                         app_resources,
                         instance_id,
+                        #no_logstream_arg
                         sim_callback,
                     )
                 }
@@ -5452,7 +5468,13 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                     app_resources: AppResources,
                     instance_id: u32,
                 ) -> CuResult<Self> {
-                    Self::build_with_resources(clock, unified_logger, app_resources, instance_id)
+                    Self::build_with_resources(
+                        clock,
+                        unified_logger,
+                        app_resources,
+                        instance_id,
+                        #no_logstream_arg
+                    )
                 }
             }
         };
@@ -5482,6 +5504,60 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
         } else {
             quote! {
                 let local_keyframe_sink = cu29::curuntime::NullWriteStream;
+            }
+        };
+        let copperlist_output_graph = if logstream_enabled {
+            quote! {
+                let local_copperlist_output_required = config
+                    .logging
+                    .as_ref()
+                    .is_none_or(|logging| logging.enable_task_logging);
+                let local_keyframe_output_required = config
+                    .logging
+                    .as_ref()
+                    .is_none_or(|logging| {
+                        logging.enable_task_logging && logging.enable_keyframe_logging
+                    });
+                let logstream_output_required = logstream.is_some();
+                let logstream_sink = logstream
+                    .map(|(transport, mut sender_config)| {
+                        sender_config.identity.sender_id = instance_id;
+                        ::cu29::logstream::DefaultContinuousCopperListSink::<
+                            #mission_mod::CuStampedDataSet,
+                            Box<dyn ::cu29::logstream::CuStreamTx>,
+                        >::new(transport, sender_config)
+                        .map_err(|error| CuError::from(error.to_string()))
+                    })
+                    .transpose()?;
+                let copperlist_sink = ::cu29::fanout::StaticFanoutSink::new(
+                    ::cu29::fanout::OptionalWriteStream::new(
+                        local_copperlist_output_required.then_some(local_copperlist_sink),
+                    ),
+                    ::cu29::fanout::OptionalWriteStream::new(logstream_sink),
+                );
+                let output_requirements = cu29::curuntime::OutputRequirements::new(
+                    local_copperlist_output_required || logstream_output_required,
+                    local_keyframe_output_required,
+                );
+            }
+        } else {
+            quote! {
+                // Downstream record demand is independent from local logging.
+                let local_copperlist_output_required = config
+                    .logging
+                    .as_ref()
+                    .is_none_or(|logging| logging.enable_task_logging);
+                let local_keyframe_output_required = config
+                    .logging
+                    .as_ref()
+                    .is_none_or(|logging| {
+                        logging.enable_task_logging && logging.enable_keyframe_logging
+                    });
+                let output_requirements = cu29::curuntime::OutputRequirements::new(
+                    local_copperlist_output_required,
+                    local_keyframe_output_required,
+                );
+                let copperlist_sink = local_copperlist_sink;
             }
         };
 
@@ -5536,23 +5612,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
 
                 #local_keyframe_sink_init
 
-                // Downstream record demand is independent from local logging.
-                // Streaming codegen can union its requirements here without
-                // making the runtime infer demand from `logging`.
-                let local_copperlist_output_required = config
-                    .logging
-                    .as_ref()
-                    .is_none_or(|logging| logging.enable_task_logging);
-                let local_keyframe_output_required = config
-                    .logging
-                    .as_ref()
-                    .is_none_or(|logging| {
-                        logging.enable_task_logging && logging.enable_keyframe_logging
-                    });
-                let output_requirements = cu29::curuntime::OutputRequirements::new(
-                    local_copperlist_output_required,
-                    local_keyframe_output_required,
-                );
+                #copperlist_output_graph
 
                 #[cfg(target_os = "none")]
                 ::cu29::prelude::info!("CuApp new: creating runtime lifecycle stream");
@@ -5600,7 +5660,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         #mission_mod::monitor_instanciator,
                         #mission_mod::bridges_instanciator,
                     ),
-                    local_copperlist_sink,
+                    copperlist_sink,
                     local_keyframe_sink,
                     output_requirements,
                 )
@@ -5894,6 +5954,34 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
             quote! { None }
         };
 
+        let builder_logstream_field = logstream_enabled.then(|| {
+            quote! {
+                logstream: Option<(
+                    Box<dyn ::cu29::logstream::CuStreamTx>,
+                    ::cu29::logstream::ContinuousSenderConfig,
+                )>,
+            }
+        });
+        let builder_logstream_init = logstream_enabled.then(|| quote! { logstream: None, });
+        let builder_logstream_copy =
+            logstream_enabled.then(|| quote! { logstream: self.logstream, });
+        let builder_with_logstream_method = logstream_enabled.then(|| {
+            quote! {
+                /// Adds a nonblocking continuous CopperList datagram destination.
+                pub fn with_logstream<T>(
+                    mut self,
+                    transport: T,
+                    config: ::cu29::logstream::ContinuousSenderConfig,
+                ) -> Self
+                where
+                    T: ::cu29::logstream::CuStreamTx + 'static,
+                {
+                    self.logstream = Some((Box::new(transport), config));
+                    self
+                }
+            }
+        });
+
         let (
             builder_struct,
             builder_impl,
@@ -5918,6 +6006,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         config_override: Option<CuConfig>,
                         resources_factory: R,
                         sim_callback: Option<&'a mut F>,
+                        #builder_logstream_field
                         _storage: core::marker::PhantomData<S>,
                     }
                 },
@@ -5942,6 +6031,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                             config_override: None,
                             resources_factory: #mission_mod::resources_instanciator as fn(&CuConfig) -> CuResult<ResourceManager>,
                             sim_callback: None,
+                            #builder_logstream_init
                             _storage: core::marker::PhantomData,
                         }
                     }
@@ -5974,6 +6064,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         instance_id: u32,
                         config_override: Option<CuConfig>,
                         resources_factory: R,
+                        #builder_logstream_field
                         _storage: core::marker::PhantomData<S>,
                     }
                 },
@@ -5993,6 +6084,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                             instance_id: 0,
                             config_override: None,
                             resources_factory: #mission_mod::resources_instanciator as fn(&CuConfig) -> CuResult<ResourceManager>,
+                            #builder_logstream_init
                             _storage: core::marker::PhantomData,
                         }
                     }
@@ -6203,6 +6295,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         config_override: self.config_override,
                         resources_factory: self.resources_factory,
                         #builder_sim_callback_field_copy
+                        #builder_logstream_copy
                         _storage: core::marker::PhantomData,
                     }
                 }
@@ -6226,6 +6319,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         config_override: self.config_override,
                         resources_factory,
                         #builder_sim_callback_field_copy
+                        #builder_logstream_copy
                         _storage: core::marker::PhantomData,
                     }
                 }
@@ -6233,6 +6327,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 #builder_with_config_method
                 #builder_with_log_path_method
                 #builder_sim_callback_method
+                #builder_with_logstream_method
 
                 /// Builds the application wrapped in its compile-time checked
                 /// lifecycle, in the `Initialized` state: start it with
@@ -6262,6 +6357,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         self.unified_logger,
                         app_resources,
                         self.instance_id,
+                        #builder_logstream_arg
                         #builder_build_sim_callback_arg
                     )
                 }

--- a/core/cu29_runtime/src/fanout.rs
+++ b/core/cu29_runtime/src/fanout.rs
@@ -3,6 +3,60 @@
 use bincode::Encode;
 use cu29_traits::{CuResult, WriteStream};
 
+/// Compile-time sink slot whose concrete type is retained when disabled at runtime.
+#[derive(Debug)]
+pub struct OptionalWriteStream<S> {
+    inner: Option<S>,
+}
+
+impl<S> OptionalWriteStream<S> {
+    #[inline]
+    pub const fn new(inner: Option<S>) -> Self {
+        Self { inner }
+    }
+
+    #[inline]
+    pub const fn is_some(&self) -> bool {
+        self.inner.is_some()
+    }
+
+    #[inline]
+    pub fn as_ref(&self) -> Option<&S> {
+        self.inner.as_ref()
+    }
+
+    #[inline]
+    pub fn as_mut(&mut self) -> Option<&mut S> {
+        self.inner.as_mut()
+    }
+
+    #[inline]
+    pub fn into_inner(self) -> Option<S> {
+        self.inner
+    }
+}
+
+impl<E, S> WriteStream<E> for OptionalWriteStream<S>
+where
+    E: Encode,
+    S: WriteStream<E>,
+{
+    #[inline]
+    fn log(&mut self, record: &E) -> CuResult<()> {
+        self.inner.as_mut().map_or(Ok(()), |sink| sink.log(record))
+    }
+
+    #[inline]
+    fn flush(&mut self) -> CuResult<()> {
+        self.inner.as_mut().map_or(Ok(()), WriteStream::flush)
+    }
+
+    #[inline]
+    fn last_log_bytes(&self) -> Option<usize> {
+        self.inner.as_ref().and_then(WriteStream::last_log_bytes)
+    }
+}
+
 /// Fans one borrowed semantic record out to two concrete sinks.
 ///
 /// Both sinks are called, in field order, even when the first one fails. If
@@ -212,5 +266,13 @@ mod tests {
 
         let ids: Vec<_> = calls.lock().unwrap().iter().map(|(id, _)| *id).collect();
         assert_eq!(ids, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn optional_sink_is_a_noop_when_absent() {
+        let mut sink = OptionalWriteStream::<ProbeSink>::new(None);
+        sink.log(&42).unwrap();
+        sink.flush().unwrap();
+        assert_eq!(sink.last_log_bytes(), None);
     }
 }


### PR DESCRIPTION
Stacked on #1314.

- adds the cu29 logstream feature and generated builder with_logstream API
- composes local logging and the continuous sender through generated static fanout
- keeps runtime output requirements correct when local CopperList logging is disabled
- adds generated runtime and sim-mode compile coverage plus end-to-end typed CopperList impairment/FEC recovery

The protocol, sender, and RLC implementation are owned by #1314; this PR only integrates that API with generated applications.

Validation: just pr-check passed (1,433 tests).