### PR TITLE
Add bounded logstream receiver gap reporting

### DIFF
--- a/core/cu29/tests/logstream_runtime.rs
+++ b/core/cu29/tests/logstream_runtime.rs
@@ -3,9 +3,9 @@
 use bincode::{Decode, Encode};
 use cu29::logstream::test_support::link_sim::{LinkSimulationConfig, simulate_bad_link};
 use cu29::logstream::{
-    ContinuousDecoder, ContinuousSenderConfig, CuStreamTx, CuStreamTxError, DensityThreshold,
-    EncodingSymbolId, FecSymbolKind, Field, Lane, ReceiverLimits, RlcConfig, StreamIdentity,
-    WirePacket, decode_copperlist,
+    ContinuousDecoder, ContinuousReceiveEvent, ContinuousSenderConfig, CuStreamTx, CuStreamTxError,
+    DensityThreshold, EncodingSymbolId, FecSymbolKind, Field, Lane, ReceiverLimits, RlcConfig,
+    StreamIdentity, WirePacket, decode_copperlist,
 };
 use cu29::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -146,21 +146,30 @@ fn generated_runtime_streams_without_local_copperlist_logging() -> CuResult<()> 
         Lane::ReplayCritical,
         fec,
         MAX_EQUATIONS,
-        ReceiverLimits::new(RECORD_BYTES, ITERATIONS, WINDOW_SYMBOLS, 64),
+        0,
+        ReceiverLimits::new(RECORD_BYTES, WINDOW_SYMBOLS),
     )
     .map_err(|error| CuError::from(error.to_string()))?;
+    let mut records = Vec::new();
+    let mut gaps = Vec::new();
     for datagram in &simulated_link.datagrams {
         decoder
-            .receive_datagram(datagram)
-            .map_err(|error| CuError::from(error.to_string()))?;
+            .receive_datagram(datagram, |event| {
+                match event {
+                    ContinuousReceiveEvent::Record(record) => records.push(record.clone()),
+                    ContinuousReceiveEvent::Gap(gap) => gaps.push(gap),
+                }
+                Ok::<(), core::convert::Infallible>(())
+            })
+            .map_err(|error| CuError::from(format!("{error:?}")))?;
     }
 
-    assert_eq!(decoder.recovered_records().len(), ITERATIONS);
+    assert_eq!(records.len(), ITERATIONS);
+    assert!(gaps.is_empty());
     assert!(decoder.stats().source_symbols_received < source_symbols);
     assert!(decoder.stats().source_symbols_recovered > 0);
     for expected_id in 0..ITERATIONS {
-        let record = decoder
-            .recovered_records()
+        let record = records
             .iter()
             .find(|record| {
                 record

--- a/core/cu29_logstream/src/error.rs
+++ b/core/cu29_logstream/src/error.rs
@@ -8,8 +8,6 @@ pub enum Error {
     InvalidConfig(&'static str),
     ObjectTooLarge { actual: u64, maximum: u64 },
     TooManyRecords { actual: usize, maximum: usize },
-    TooManySourceSymbols { actual: usize, maximum: usize },
-    TooManyDatagrams { actual: usize, maximum: usize },
     BufferTooSmall { needed: usize, available: usize },
     TruncatedPacket,
     InvalidMagic,
@@ -38,22 +36,10 @@ impl Display for Error {
             Self::ObjectTooLarge { actual, maximum } => {
                 write!(formatter, "object has {actual} bytes; maximum is {maximum}")
             }
-            Self::TooManyDatagrams { actual, maximum } => {
-                write!(
-                    formatter,
-                    "object needs {actual} datagrams; maximum is {maximum}"
-                )
-            }
             Self::TooManyRecords { actual, maximum } => {
                 write!(
                     formatter,
                     "stream has {actual} records; maximum is {maximum}"
-                )
-            }
-            Self::TooManySourceSymbols { actual, maximum } => {
-                write!(
-                    formatter,
-                    "stream has {actual} source symbols; maximum is {maximum}"
                 )
             }
             Self::BufferTooSmall { needed, available } => {

--- a/core/cu29_logstream/src/lib.rs
+++ b/core/cu29_logstream/src/lib.rs
@@ -28,7 +28,8 @@ pub use copper::{decode_copperlist, encode_copperlist, encode_copperlist_record_
 pub use error::{Error, Result};
 pub use record::{DecodedRecord, RecordKind, encode_record};
 pub use rlc::{
-    ContinuousDecoder, ContinuousEncoder, ContinuousRecoveryStats, ReceiverLimits, RecoveredRecord,
+    ContinuousDecoder, ContinuousEncoder, ContinuousReceiveEvent, ContinuousRecoveryStats,
+    CopperListGap, GapReason, ReceiveError, ReceiverLimits, ReceiverOccupancy, RecoveredRecord,
     StreamIdentity,
 };
 pub use sender::{

--- a/core/cu29_logstream/src/rlc.rs
+++ b/core/cu29_logstream/src/rlc.rs
@@ -4,9 +4,10 @@ use crate::{
     WireHeader, WirePacket, encode_packet_into,
 };
 use alloc::{vec, vec::Vec};
+use core::fmt::{Display, Formatter};
 use cu_fec::{
     DensityThreshold, EncodingSymbolId, Field, RepairParameters, RepairPayloadId, RlcConfig,
-    RlcDecoder, RlcEncoder, SourcePayloadId,
+    RlcDecoder, RlcEncoder, SourcePayloadId, SourceStatus,
 };
 
 const FRAGMENT_MAGIC: [u8; 4] = *b"CUFR";
@@ -23,26 +24,87 @@ pub struct StreamIdentity {
 /// Receiver-side bounds for one continuous stream.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ReceiverLimits {
+    /// Largest accepted framed semantic record.
     pub max_record_bytes: usize,
-    pub max_incomplete_records: usize,
-    pub max_source_symbols: usize,
-    pub max_datagrams: usize,
+    /// Maximum number of incomplete and completed-but-ordered records retained.
+    /// This must be at least the active RLC window size.
+    pub max_buffered_records: usize,
 }
 
 impl ReceiverLimits {
-    pub const fn new(
-        max_record_bytes: usize,
-        max_incomplete_records: usize,
-        max_source_symbols: usize,
-        max_datagrams: usize,
-    ) -> Self {
+    pub const fn new(max_record_bytes: usize, max_buffered_records: usize) -> Self {
         Self {
             max_record_bytes,
-            max_incomplete_records,
-            max_source_symbols,
-            max_datagrams,
+            max_buffered_records,
         }
     }
+}
+
+/// Why a range of CopperLists can no longer be reconstructed exactly.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GapReason {
+    /// One or more required source symbols aged out of the configured RLC window.
+    RlcWindowExpired,
+    /// The caller finalized the session before the range could be recovered.
+    SessionEnded,
+}
+
+/// An inclusive range of unrecoverable CopperList identifiers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CopperListGap {
+    /// First missing CopperList identifier, inclusive.
+    pub first_id: u64,
+    /// Last missing CopperList identifier, inclusive.
+    pub last_id: u64,
+    /// Condition that made this range definitive.
+    pub reason: GapReason,
+}
+
+/// Ordered output from a continuous receiver.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ContinuousReceiveEvent<'a> {
+    /// One complete, digest-verified semantic record.
+    Record(&'a RecoveredRecord),
+    /// An inclusive CopperList range that can no longer be recovered.
+    Gap(CopperListGap),
+}
+
+/// Separates malformed stream input from a downstream consumer failure.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ReceiveError<E> {
+    /// Packet, FEC, assembly, or semantic-record failure.
+    Stream(Error),
+    /// Failure returned by the supplied event consumer.
+    Consumer(E),
+}
+
+impl<E> From<Error> for ReceiveError<E> {
+    fn from(error: Error) -> Self {
+        Self::Stream(error)
+    }
+}
+
+impl<E: Display> Display for ReceiveError<E> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Stream(error) => write!(formatter, "log stream receive failed: {error}"),
+            Self::Consumer(error) => write!(formatter, "log stream consumer failed: {error}"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<E: core::fmt::Debug + Display> std::error::Error for ReceiveError<E> {}
+
+/// Current bounded receiver occupancy, exposed for monitoring and tests.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ReceiverOccupancy {
+    /// Source symbols marked as processed inside the active RLC window.
+    pub processed_symbols: usize,
+    /// Records awaiting one or more source symbols.
+    pub incomplete_records: usize,
+    /// Complete records waiting for an earlier record or definitive gap.
+    pub ready_records: usize,
 }
 
 /// Observed delivery and recovery behavior for one continuous stream.
@@ -53,11 +115,18 @@ pub struct ContinuousRecoveryStats {
     pub invalid_datagrams: usize,
     pub inconsistent_datagrams: usize,
     pub duplicate_symbols: usize,
+    pub expired_datagrams: usize,
     pub source_symbols_received: usize,
     pub source_symbols_recovered: usize,
     pub repair_symbols_received: usize,
     pub innovative_repairs: usize,
+    pub redundant_repairs: usize,
     pub records_recovered: usize,
+    pub records_emitted: usize,
+    pub records_expired: usize,
+    pub gaps_emitted: usize,
+    pub missing_copperlists: u64,
+    pub peak_buffered_records: usize,
 }
 
 impl ContinuousRecoveryStats {
@@ -341,7 +410,12 @@ impl RepairSchedule {
     }
 }
 
-/// Stateful RFC 8681 decoder and partial-CopperList record assembler.
+/// Stateful, bounded RFC 8681 decoder and ordered CopperList assembler.
+///
+/// Recovered records are delivered to the caller immediately and are never
+/// retained in an ever-growing history. Exact gap reporting assumes the sender
+/// serializes CopperLists in increasing identifier order, as generated Copper
+/// runtimes do.
 pub struct ContinuousDecoder<
     const MAX_SYMBOL_SIZE: usize,
     const MAX_WINDOW_SYMBOLS: usize,
@@ -351,11 +425,12 @@ pub struct ContinuousDecoder<
     lane: Lane,
     limits: ReceiverLimits,
     fec: RlcDecoder<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS, MAX_EQUATIONS>,
-    source_ids: Vec<EncodingSymbolId>,
     processed_symbols: Vec<EncodingSymbolId>,
-    repair_ids: Vec<[u8; 8]>,
     assemblies: Vec<RecordAssembly>,
-    recovered: Vec<RecoveredRecord>,
+    ready: Vec<ReadyRecord>,
+    next_object_id: u64,
+    observed_window_base: Option<EncodingSymbolId>,
+    retention_floor: Option<EncodingSymbolId>,
     stats: ContinuousRecoveryStats,
 }
 
@@ -367,25 +442,26 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
         lane: Lane,
         config: RlcConfig,
         equation_capacity: usize,
+        first_object_id: u64,
         limits: ReceiverLimits,
     ) -> Result<Self> {
         validate_config(config, limits.max_record_bytes)?;
-        if limits.max_incomplete_records == 0
-            || limits.max_source_symbols == 0
-            || limits.max_datagrams == 0
-        {
-            return Err(Error::InvalidConfig("receiver limits must be nonzero"));
+        if limits.max_buffered_records < config.window_symbols() {
+            return Err(Error::InvalidConfig(
+                "buffered-record capacity must cover the RLC symbol window",
+            ));
         }
         Ok(Self {
             identity,
             lane,
             limits,
             fec: RlcDecoder::new(config, equation_capacity)?,
-            source_ids: Vec::new(),
-            processed_symbols: Vec::new(),
-            repair_ids: Vec::new(),
-            assemblies: Vec::new(),
-            recovered: Vec::new(),
+            processed_symbols: Vec::with_capacity(config.window_symbols()),
+            assemblies: Vec::with_capacity(limits.max_buffered_records),
+            ready: Vec::with_capacity(limits.max_buffered_records),
+            next_object_id: first_object_id,
+            observed_window_base: None,
+            retention_floor: None,
             stats: ContinuousRecoveryStats::default(),
         })
     }
@@ -394,24 +470,59 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
         self.stats
     }
 
-    pub fn recovered_records(&self) -> &[RecoveredRecord] {
-        &self.recovered
+    pub fn occupancy(&self) -> ReceiverOccupancy {
+        ReceiverOccupancy {
+            processed_symbols: self.processed_symbols.len(),
+            incomplete_records: self.assemblies.len(),
+            ready_records: self.ready.len(),
+        }
     }
 
-    pub fn into_recovered_records(self) -> Vec<RecoveredRecord> {
-        self.recovered
+    /// Retries delivery of ordered records or gaps already ready in receiver state.
+    ///
+    /// This is useful after a consumer error and when shutting down a transport
+    /// after its final datagram. A consumer failure leaves the current event
+    /// pending so a later call can retry it.
+    pub fn drain_events<E>(
+        &mut self,
+        mut emit: impl FnMut(ContinuousReceiveEvent<'_>) -> core::result::Result<(), E>,
+    ) -> core::result::Result<(), ReceiveError<E>> {
+        self.expire_and_emit(&mut emit)
+    }
+
+    /// Finalizes ordered delivery through an inclusive CopperList identifier.
+    ///
+    /// Any unresolved record or wholly absent identifier through `last_object_id`
+    /// is emitted as a terminal gap. Calling this method is an explicit promise
+    /// that no more useful repair symbols for that range will arrive.
+    pub fn finish_through<E>(
+        &mut self,
+        last_object_id: u64,
+        mut emit: impl FnMut(ContinuousReceiveEvent<'_>) -> core::result::Result<(), E>,
+    ) -> core::result::Result<(), ReceiveError<E>> {
+        self.process_new_symbols()?;
+        self.emit_through(last_object_id, GapReason::SessionEnded, &mut emit)?;
+        let unresolved = self
+            .assemblies
+            .iter()
+            .filter(|assembly| assembly.object_id <= last_object_id)
+            .count();
+        self.assemblies
+            .retain(|assembly| assembly.object_id > last_object_id);
+        self.stats.records_expired = self.stats.records_expired.saturating_add(unresolved);
+        self.discard_stale_ready();
+        Ok(())
     }
 
     /// Validates and submits one datagram. Corrupt or foreign packets are counted
-    /// and ignored before they can contaminate the FEC decoder.
-    pub fn receive_datagram(&mut self, datagram: &[u8]) -> Result<()> {
+    /// and ignored before they can contaminate the FEC decoder. Recovered records
+    /// and definitive gaps are emitted in CopperList-id order.
+    pub fn receive_datagram<E>(
+        &mut self,
+        datagram: &[u8],
+        mut emit: impl FnMut(ContinuousReceiveEvent<'_>) -> core::result::Result<(), E>,
+    ) -> core::result::Result<(), ReceiveError<E>> {
         self.stats.datagrams_seen = self.stats.datagrams_seen.saturating_add(1);
-        if self.stats.datagrams_seen > self.limits.max_datagrams {
-            return Err(Error::TooManyDatagrams {
-                actual: self.stats.datagrams_seen,
-                maximum: self.limits.max_datagrams,
-            });
-        }
         let packet = match WirePacket::decode(datagram) {
             Ok(packet) => packet,
             Err(_) => {
@@ -441,7 +552,10 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
             return Ok(());
         }
         self.stats.valid_datagrams = self.stats.valid_datagrams.saturating_add(1);
-        self.process_new_symbols()
+        self.update_retention_floor();
+        self.expire_and_emit(&mut emit)?;
+        self.process_new_symbols()?;
+        self.expire_and_emit(&mut emit)
     }
 
     fn receive_source_packet(&mut self, packet: &WirePacket) -> Result<bool> {
@@ -467,13 +581,19 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
             self.stats.inconsistent_datagrams = self.stats.inconsistent_datagrams.saturating_add(1);
             return Ok(false);
         }
-        if self.source_ids.contains(&id.esi()) {
+        let report = match self.fec.receive_source(id.esi(), &packet.payload) {
+            Ok(report) => report,
+            Err(cu_fec::Error::WindowExpired) => {
+                self.stats.expired_datagrams = self.stats.expired_datagrams.saturating_add(1);
+                return Ok(false);
+            }
+            Err(error) => return Err(error.into()),
+        };
+        if report.status() == SourceStatus::Duplicate {
             self.stats.duplicate_symbols = self.stats.duplicate_symbols.saturating_add(1);
             return Ok(false);
         }
-        self.source_ids.push(id.esi());
         self.stats.source_symbols_received = self.stats.source_symbols_received.saturating_add(1);
-        let report = self.fec.receive_source(id.esi(), &packet.payload)?;
         self.stats.source_symbols_recovered = self
             .stats
             .source_symbols_recovered
@@ -492,16 +612,20 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
             return Ok(false);
         }
         let raw_id: [u8; 8] = packet.header.fec_metadata[..8].try_into().unwrap();
-        if self.repair_ids.contains(&raw_id) {
-            self.stats.duplicate_symbols = self.stats.duplicate_symbols.saturating_add(1);
-            return Ok(false);
-        }
         let id = RepairPayloadId::from_bytes(raw_id)?;
-        let report = self.fec.receive_repair(id, &packet.payload)?;
-        self.repair_ids.push(raw_id);
+        let report = match self.fec.receive_repair(id, &packet.payload) {
+            Ok(report) => report,
+            Err(cu_fec::Error::WindowExpired) => {
+                self.stats.expired_datagrams = self.stats.expired_datagrams.saturating_add(1);
+                return Ok(false);
+            }
+            Err(error) => return Err(error.into()),
+        };
         self.stats.repair_symbols_received = self.stats.repair_symbols_received.saturating_add(1);
         if report.is_innovative() {
             self.stats.innovative_repairs = self.stats.innovative_repairs.saturating_add(1);
+        } else {
+            self.stats.redundant_repairs = self.stats.redundant_repairs.saturating_add(1);
         }
         self.stats.source_symbols_recovered = self
             .stats
@@ -511,27 +635,24 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
     }
 
     fn process_new_symbols(&mut self) -> Result<()> {
-        let pending = self
+        while let Some(esi) = self
             .fec
             .known_symbols()
-            .filter(|(esi, _)| !self.processed_symbols.contains(esi))
-            .map(|(esi, symbol)| (esi, symbol.to_vec()))
-            .collect::<Vec<_>>();
-        for (esi, symbol) in pending {
-            let symbol_count = self.processed_symbols.len().saturating_add(1);
-            if symbol_count > self.limits.max_source_symbols {
-                return Err(Error::TooManySourceSymbols {
-                    actual: symbol_count,
-                    maximum: self.limits.max_source_symbols,
-                });
-            }
-            self.process_fragment(&symbol)?;
+            .map(|(esi, _)| esi)
+            .find(|esi| !self.processed_symbols.contains(esi))
+        {
+            let symbol = self
+                .fec
+                .symbol(esi)
+                .expect("known symbol disappeared from the retained RLC window")
+                .to_vec();
+            self.process_fragment(esi, &symbol)?;
             self.processed_symbols.push(esi);
         }
         Ok(())
     }
 
-    fn process_fragment(&mut self, symbol: &[u8]) -> Result<()> {
+    fn process_fragment(&mut self, esi: EncodingSymbolId, symbol: &[u8]) -> Result<()> {
         let fragment = decode_fragment(symbol, fragment_capacity(self.fec.config())?)?;
         if fragment.record_len > self.limits.max_record_bytes {
             return Err(Error::ObjectTooLarge {
@@ -544,18 +665,23 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
         }) {
             Some(index) => index,
             None => {
-                let count = self.assemblies.len().saturating_add(1);
-                if count > self.limits.max_incomplete_records {
+                let count = self
+                    .assemblies
+                    .len()
+                    .saturating_add(self.ready.len())
+                    .saturating_add(1);
+                if count > self.limits.max_buffered_records {
                     return Err(Error::TooManyRecords {
                         actual: count,
-                        maximum: self.limits.max_incomplete_records,
+                        maximum: self.limits.max_buffered_records,
                     });
                 }
-                self.assemblies.push(RecordAssembly::new(&fragment));
+                self.assemblies.push(RecordAssembly::new(esi, &fragment));
+                self.observe_peak_buffered_records();
                 self.assemblies.len() - 1
             }
         };
-        let complete = self.assemblies[assembly_index].insert(&fragment)?;
+        let complete = self.assemblies[assembly_index].insert(esi, &fragment)?;
         if !complete {
             return Ok(());
         }
@@ -565,12 +691,178 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
         if decoded.kind != assembly.kind || decoded.object_id != assembly.object_id {
             return Err(Error::InconsistentObject);
         }
-        self.recovered.push(RecoveredRecord {
-            bytes: assembly.bytes,
+        self.ready.push(ReadyRecord {
+            object_id: assembly.object_id,
+            first_esi: assembly.first_esi,
+            record: RecoveredRecord {
+                bytes: assembly.bytes,
+            },
         });
         self.stats.records_recovered = self.stats.records_recovered.saturating_add(1);
+        self.observe_peak_buffered_records();
         Ok(())
     }
+
+    fn expire_and_emit<E>(
+        &mut self,
+        emit: &mut impl FnMut(ContinuousReceiveEvent<'_>) -> core::result::Result<(), E>,
+    ) -> core::result::Result<(), ReceiveError<E>> {
+        let Some((base_esi, _)) = self.fec.window() else {
+            return Ok(());
+        };
+        self.processed_symbols
+            .retain(|esi| !esi_is_before(*esi, base_esi));
+
+        if let Some(retention_floor) = self.retention_floor {
+            loop {
+                let expired = self
+                    .assemblies
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, assembly)| assembly.has_expired_fragment(retention_floor))
+                    .min_by_key(|(_, assembly)| assembly.object_id)
+                    .map(|(index, _)| index);
+                let Some(index) = expired else {
+                    break;
+                };
+                let object_id = self.assemblies[index].object_id;
+                self.emit_through(object_id, GapReason::RlcWindowExpired, emit)?;
+                self.assemblies.swap_remove(index);
+                self.stats.records_expired = self.stats.records_expired.saturating_add(1);
+            }
+        }
+
+        self.emit_ready(self.retention_floor, emit)
+    }
+
+    fn emit_ready<E>(
+        &mut self,
+        retention_floor: Option<EncodingSymbolId>,
+        emit: &mut impl FnMut(ContinuousReceiveEvent<'_>) -> core::result::Result<(), E>,
+    ) -> core::result::Result<(), ReceiveError<E>> {
+        loop {
+            self.discard_stale_ready();
+            if self.emit_next_ready(emit)? {
+                continue;
+            }
+
+            let Some(retention_floor) = retention_floor else {
+                return Ok(());
+            };
+            let expired_boundary = self
+                .ready
+                .iter()
+                .filter(|record| {
+                    record.object_id > self.next_object_id
+                        && !esi_is_after(record.first_esi, retention_floor)
+                })
+                .min_by_key(|record| record.object_id)
+                .map(|record| record.object_id);
+            let Some(boundary) = expired_boundary else {
+                return Ok(());
+            };
+            self.emit_gap(boundary - 1, GapReason::RlcWindowExpired, emit)?;
+        }
+    }
+
+    fn emit_through<E>(
+        &mut self,
+        last_id: u64,
+        reason: GapReason,
+        emit: &mut impl FnMut(ContinuousReceiveEvent<'_>) -> core::result::Result<(), E>,
+    ) -> core::result::Result<(), ReceiveError<E>> {
+        while self.next_object_id <= last_id {
+            self.discard_stale_ready();
+            if self.emit_next_ready(emit)? {
+                continue;
+            }
+            let next_ready = self
+                .ready
+                .iter()
+                .map(|record| record.object_id)
+                .filter(|object_id| *object_id <= last_id)
+                .min();
+            let gap_last = next_ready.map_or(last_id, |object_id| object_id - 1);
+            self.emit_gap(gap_last, reason, emit)?;
+        }
+        Ok(())
+    }
+
+    fn emit_next_ready<E>(
+        &mut self,
+        emit: &mut impl FnMut(ContinuousReceiveEvent<'_>) -> core::result::Result<(), E>,
+    ) -> core::result::Result<bool, ReceiveError<E>> {
+        let Some(index) = self
+            .ready
+            .iter()
+            .position(|record| record.object_id == self.next_object_id)
+        else {
+            return Ok(false);
+        };
+        emit(ContinuousReceiveEvent::Record(&self.ready[index].record))
+            .map_err(ReceiveError::Consumer)?;
+        self.ready.swap_remove(index);
+        self.stats.records_emitted = self.stats.records_emitted.saturating_add(1);
+        self.next_object_id = self.next_object_id.wrapping_add(1);
+        Ok(true)
+    }
+
+    fn emit_gap<E>(
+        &mut self,
+        last_id: u64,
+        reason: GapReason,
+        emit: &mut impl FnMut(ContinuousReceiveEvent<'_>) -> core::result::Result<(), E>,
+    ) -> core::result::Result<(), ReceiveError<E>> {
+        if last_id < self.next_object_id {
+            return Ok(());
+        }
+        let first_id = self.next_object_id;
+        emit(ContinuousReceiveEvent::Gap(CopperListGap {
+            first_id,
+            last_id,
+            reason,
+        }))
+        .map_err(ReceiveError::Consumer)?;
+        self.stats.gaps_emitted = self.stats.gaps_emitted.saturating_add(1);
+        self.stats.missing_copperlists = self
+            .stats
+            .missing_copperlists
+            .saturating_add(last_id - first_id + 1);
+        self.next_object_id = last_id.wrapping_add(1);
+        Ok(())
+    }
+
+    fn discard_stale_ready(&mut self) {
+        self.ready
+            .retain(|record| record.object_id >= self.next_object_id);
+    }
+
+    fn observe_peak_buffered_records(&mut self) {
+        self.stats.peak_buffered_records = self
+            .stats
+            .peak_buffered_records
+            .max(self.assemblies.len().saturating_add(self.ready.len()));
+    }
+
+    fn update_retention_floor(&mut self) {
+        let Some((base_esi, _)) = self.fec.window() else {
+            return;
+        };
+        if self
+            .observed_window_base
+            .is_some_and(|previous| esi_is_after(base_esi, previous))
+        {
+            self.retention_floor = Some(base_esi);
+        }
+        self.observed_window_base = Some(base_esi);
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ReadyRecord {
+    object_id: u64,
+    first_esi: EncodingSymbolId,
+    record: RecoveredRecord,
 }
 
 #[derive(Debug)]
@@ -587,6 +879,7 @@ struct Fragment<'a> {
 struct RecordAssembly {
     kind: RecordKind,
     object_id: u64,
+    first_esi: EncodingSymbolId,
     bytes: Vec<u8>,
     received: Vec<bool>,
     received_count: usize,
@@ -594,10 +887,11 @@ struct RecordAssembly {
 }
 
 impl RecordAssembly {
-    fn new(fragment: &Fragment<'_>) -> Self {
+    fn new(esi: EncodingSymbolId, fragment: &Fragment<'_>) -> Self {
         Self {
             kind: fragment.kind,
             object_id: fragment.object_id,
+            first_esi: esi.wrapping_sub(fragment.fragment_index as u32),
             bytes: vec![0; fragment.record_len],
             received: vec![false; fragment.fragment_count],
             received_count: 0,
@@ -605,10 +899,15 @@ impl RecordAssembly {
         }
     }
 
-    fn insert(&mut self, fragment: &Fragment<'_>) -> Result<bool> {
+    fn insert(&mut self, esi: EncodingSymbolId, fragment: &Fragment<'_>) -> Result<bool> {
         if self.bytes.len() != fragment.record_len || self.received.len() != fragment.fragment_count
         {
             return Err(Error::InvalidFragment("record geometry changed"));
+        }
+        if self.first_esi.wrapping_add(fragment.fragment_index as u32) != esi {
+            return Err(Error::InvalidFragment(
+                "fragment ESI does not match record geometry",
+            ));
         }
         let offset = fragment
             .fragment_index
@@ -631,6 +930,20 @@ impl RecordAssembly {
         self.received_count += 1;
         Ok(self.received_count == self.received.len())
     }
+
+    fn has_expired_fragment(&self, base_esi: EncodingSymbolId) -> bool {
+        self.received.iter().enumerate().any(|(index, received)| {
+            !received && esi_is_before(self.first_esi.wrapping_add(index as u32), base_esi)
+        })
+    }
+}
+
+fn esi_is_before(candidate: EncodingSymbolId, reference: EncodingSymbolId) -> bool {
+    (candidate.get().wrapping_sub(reference.get()) as i32) < 0
+}
+
+fn esi_is_after(candidate: EncodingSymbolId, reference: EncodingSymbolId) -> bool {
+    (candidate.get().wrapping_sub(reference.get()) as i32) > 0
 }
 
 fn validate_config(config: RlcConfig, max_record_bytes: usize) -> Result<()> {

--- a/core/cu29_logstream/tests/continuous_copperlist.rs
+++ b/core/cu29_logstream/tests/continuous_copperlist.rs
@@ -4,9 +4,9 @@ use bincode::{Decode, Encode};
 use common::link_sim::{LinkSimulationConfig, simulate_bad_link};
 use cu_fec::{DensityThreshold, EncodingSymbolId, Field, RepairParameters, RlcConfig};
 use cu29_logstream::{
-    ContinuousCopperListSink, ContinuousDecoder, ContinuousEncoder, ContinuousSenderConfig,
-    CuStreamTx, CuStreamTxError, Lane, ReceiverLimits, RecordKind, StreamIdentity,
-    decode_copperlist, encode_copperlist, encode_record,
+    ContinuousCopperListSink, ContinuousDecoder, ContinuousEncoder, ContinuousReceiveEvent,
+    ContinuousSenderConfig, CopperListGap, CuStreamTx, CuStreamTxError, Lane, ReceiverLimits,
+    RecordKind, StreamIdentity, decode_copperlist, encode_copperlist, encode_record,
 };
 use cu29_runtime::copperlist::CopperList;
 use cu29_traits::{ErasedCuStampedData, ErasedCuStampedDataSet, MatchingTasks, WriteStream};
@@ -16,6 +16,21 @@ const MAX_SYMBOL_SIZE: usize = 192;
 const SYMBOL_SIZE: usize = 160;
 const WINDOW_SYMBOLS: usize = 64;
 const MAX_EQUATIONS: usize = 32;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ObservedEvent {
+    Record(u64),
+    Gap(CopperListGap),
+}
+
+fn observe_event(event: ContinuousReceiveEvent<'_>) -> ObservedEvent {
+    match event {
+        ContinuousReceiveEvent::Record(record) => {
+            ObservedEvent::Record(record.decoded().unwrap().object_id)
+        }
+        ContinuousReceiveEvent::Gap(gap) => ObservedEvent::Gap(gap),
+    }
+}
 
 #[derive(Debug, Default)]
 struct BackpressureTx {
@@ -138,16 +153,29 @@ fn partial_copperlists_survive_a_deterministically_simulated_bad_link() {
         Lane::ReplayCritical,
         fec_config,
         MAX_EQUATIONS,
-        ReceiverLimits::new(4_096, 8, WINDOW_SYMBOLS, 256),
+        4_200,
+        ReceiverLimits::new(4_096, WINDOW_SYMBOLS),
     )
     .unwrap();
+    let mut recovered_records = Vec::new();
+    let mut gaps = Vec::new();
     for datagram in &simulated_link.datagrams {
-        decoder.receive_datagram(datagram).unwrap();
+        decoder
+            .receive_datagram(datagram, |event| {
+                match event {
+                    ContinuousReceiveEvent::Record(record) => {
+                        recovered_records.push(record.clone());
+                    }
+                    ContinuousReceiveEvent::Gap(gap) => gaps.push(gap),
+                }
+                Ok::<(), core::convert::Infallible>(())
+            })
+            .unwrap();
     }
+    assert!(gaps.is_empty());
 
     for expected in &source {
-        let recovered = decoder
-            .recovered_records()
+        let recovered = recovered_records
             .iter()
             .find(|record| record.decoded().unwrap().object_id == expected.id)
             .expect("every partial CopperList should be recovered");
@@ -219,19 +247,110 @@ fn missing_unrepaired_fragments_do_not_claim_semantic_recovery() {
         Lane::ReplayCritical,
         fec_config,
         MAX_EQUATIONS,
-        ReceiverLimits::new(4_096, 8, WINDOW_SYMBOLS, 256),
+        9_000,
+        ReceiverLimits::new(4_096, WINDOW_SYMBOLS),
     )
     .unwrap();
+    let mut event_count = 0;
     for datagram in &retained {
-        decoder.receive_datagram(datagram).unwrap();
+        decoder
+            .receive_datagram(datagram, |_| {
+                event_count += 1;
+                Ok::<(), core::convert::Infallible>(())
+            })
+            .unwrap();
     }
 
     let stats = decoder.stats();
-    assert!(decoder.recovered_records().is_empty());
+    assert_eq!(event_count, 0);
     assert_eq!(stats.source_symbols_received, source_symbols - source.len());
     assert_eq!(stats.source_symbols_recovered, 0);
     assert_eq!(stats.source_recovery_basis_points(source_symbols), 0);
     assert_eq!(stats.semantic_recovery_basis_points(source.len()), 0);
+
+    let mut final_events = Vec::new();
+    decoder
+        .finish_through(9_001, |event| {
+            final_events.push(observe_event(event));
+            Ok::<(), core::convert::Infallible>(())
+        })
+        .unwrap();
+    assert_eq!(
+        final_events,
+        vec![ObservedEvent::Gap(CopperListGap {
+            first_id: 9_000,
+            last_id: 9_001,
+            reason: cu29_logstream::GapReason::SessionEnded,
+        })]
+    );
+}
+
+#[test]
+fn receiver_reports_an_incomplete_record_when_its_missing_fragment_expires() {
+    const RECORD_COUNT: u64 = 30;
+    let identity = StreamIdentity {
+        session_id: *b"test-session-006",
+        sender_id: 19,
+    };
+    let fec_config = RlcConfig::new(SYMBOL_SIZE, 16, Field::Gf256).unwrap();
+    let mut encoder = ContinuousEncoder::<MAX_SYMBOL_SIZE, WINDOW_SYMBOLS>::new(
+        identity,
+        0,
+        Lane::ReplayCritical,
+        fec_config,
+        4_096,
+        EncodingSymbolId::new(0),
+    )
+    .unwrap();
+    let mut datagrams = Vec::new();
+    for id in 0..RECORD_COUNT {
+        let payload = encode_copperlist(&partial_copperlist(id)).unwrap();
+        let record = encode_record(RecordKind::CopperList, id, &payload).unwrap();
+        encoder.push_record(&record, &mut datagrams).unwrap();
+    }
+    let mut omitted_fragment = false;
+    datagrams.retain(|datagram| {
+        let packet = cu29_logstream::WirePacket::decode(datagram).unwrap();
+        if packet.header.object_id == 4 && !omitted_fragment {
+            omitted_fragment = true;
+            false
+        } else {
+            true
+        }
+    });
+    assert!(omitted_fragment);
+
+    let mut decoder = ContinuousDecoder::<MAX_SYMBOL_SIZE, WINDOW_SYMBOLS, MAX_EQUATIONS>::new(
+        identity,
+        Lane::ReplayCritical,
+        fec_config,
+        MAX_EQUATIONS,
+        0,
+        ReceiverLimits::new(4_096, WINDOW_SYMBOLS),
+    )
+    .unwrap();
+    let mut events = Vec::new();
+    for datagram in &datagrams {
+        decoder
+            .receive_datagram(datagram, |event| {
+                events.push(observe_event(event));
+                Ok::<(), core::convert::Infallible>(())
+            })
+            .unwrap();
+    }
+
+    let gaps = events
+        .iter()
+        .filter_map(|event| match event {
+            ObservedEvent::Gap(gap) => Some(*gap),
+            ObservedEvent::Record(_) => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(gaps.len(), 1);
+    assert_eq!(gaps[0].first_id, 4);
+    assert_eq!(gaps[0].last_id, 4);
+    assert_eq!(decoder.stats().records_expired, 1);
+    assert_eq!(decoder.stats().missing_copperlists, 1);
 }
 
 #[test]
@@ -272,4 +391,203 @@ fn sender_drops_transport_backpressure_without_blocking_the_output_worker() {
         stats.datagrams_sent + stats.datagrams_dropped,
         stats.source_datagrams + stats.repair_datagrams
     );
+}
+
+#[test]
+fn receiver_runs_past_many_windows_with_bounded_state_and_wrapping_sequences() {
+    const RECORD_COUNT: u64 = 600;
+    let identity = StreamIdentity {
+        session_id: *b"test-session-004",
+        sender_id: 13,
+    };
+    let fec_config = RlcConfig::new(SYMBOL_SIZE, WINDOW_SYMBOLS, Field::Gf256).unwrap();
+    let mut encoder = ContinuousEncoder::<MAX_SYMBOL_SIZE, WINDOW_SYMBOLS>::new(
+        identity,
+        u64::MAX - 32,
+        Lane::ReplayCritical,
+        fec_config,
+        4_096,
+        EncodingSymbolId::new(u32::MAX - 32),
+    )
+    .unwrap();
+    let mut decoder = ContinuousDecoder::<MAX_SYMBOL_SIZE, WINDOW_SYMBOLS, MAX_EQUATIONS>::new(
+        identity,
+        Lane::ReplayCritical,
+        fec_config,
+        MAX_EQUATIONS,
+        0,
+        ReceiverLimits::new(4_096, WINDOW_SYMBOLS),
+    )
+    .unwrap();
+    let mut record_ids = Vec::new();
+
+    for id in 0..RECORD_COUNT {
+        let payload = encode_copperlist(&partial_copperlist(id)).unwrap();
+        let record = encode_record(RecordKind::CopperList, id, &payload).unwrap();
+        let mut datagrams = Vec::new();
+        encoder.push_record(&record, &mut datagrams).unwrap();
+        for datagram in &datagrams {
+            decoder
+                .receive_datagram(datagram, |event| {
+                    match event {
+                        ContinuousReceiveEvent::Record(record) => {
+                            record_ids.push(record.decoded().unwrap().object_id);
+                        }
+                        ContinuousReceiveEvent::Gap(gap) => panic!("unexpected gap: {gap:?}"),
+                    }
+                    Ok::<(), core::convert::Infallible>(())
+                })
+                .unwrap();
+            let occupancy = decoder.occupancy();
+            assert!(occupancy.processed_symbols <= WINDOW_SYMBOLS);
+            assert!(occupancy.incomplete_records + occupancy.ready_records <= WINDOW_SYMBOLS);
+        }
+    }
+
+    assert_eq!(record_ids, (0..RECORD_COUNT).collect::<Vec<_>>());
+    assert_eq!(decoder.stats().records_emitted, RECORD_COUNT as usize);
+    assert!(decoder.stats().datagrams_seen > 256);
+    assert!(decoder.stats().peak_buffered_records <= WINDOW_SYMBOLS);
+}
+
+#[test]
+fn receiver_coalesces_wholly_missing_records_after_the_rlc_window_expires() {
+    const RECORD_COUNT: u64 = 40;
+    let identity = StreamIdentity {
+        session_id: *b"test-session-005",
+        sender_id: 17,
+    };
+    let fec_config = RlcConfig::new(SYMBOL_SIZE, 16, Field::Gf256).unwrap();
+    let mut encoder = ContinuousEncoder::<MAX_SYMBOL_SIZE, WINDOW_SYMBOLS>::new(
+        identity,
+        0,
+        Lane::ReplayCritical,
+        fec_config,
+        4_096,
+        EncodingSymbolId::new(0),
+    )
+    .unwrap();
+    let mut datagrams = Vec::new();
+    for id in 0..RECORD_COUNT {
+        let payload = encode_copperlist(&partial_copperlist(id)).unwrap();
+        let record = encode_record(RecordKind::CopperList, id, &payload).unwrap();
+        encoder.push_record(&record, &mut datagrams).unwrap();
+    }
+    datagrams.retain(|datagram| {
+        let object_id = cu29_logstream::WirePacket::decode(datagram)
+            .unwrap()
+            .header
+            .object_id;
+        !(4..=6).contains(&object_id)
+    });
+
+    let mut decoder = ContinuousDecoder::<MAX_SYMBOL_SIZE, WINDOW_SYMBOLS, MAX_EQUATIONS>::new(
+        identity,
+        Lane::ReplayCritical,
+        fec_config,
+        MAX_EQUATIONS,
+        0,
+        ReceiverLimits::new(4_096, WINDOW_SYMBOLS),
+    )
+    .unwrap();
+    let mut events = Vec::new();
+    for datagram in &datagrams {
+        decoder
+            .receive_datagram(datagram, |event| {
+                events.push(observe_event(event));
+                Ok::<(), core::convert::Infallible>(())
+            })
+            .unwrap();
+    }
+
+    let gaps = events
+        .iter()
+        .filter_map(|event| match event {
+            ObservedEvent::Gap(gap) => Some(*gap),
+            ObservedEvent::Record(_) => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(gaps.len(), 1);
+    assert_eq!(gaps[0].first_id, 4);
+    assert_eq!(gaps[0].last_id, 6);
+    assert_eq!(decoder.stats().gaps_emitted, 1);
+    assert_eq!(decoder.stats().missing_copperlists, 3);
+
+    let record_ids = events
+        .iter()
+        .filter_map(|event| match event {
+            ObservedEvent::Record(object_id) => Some(*object_id),
+            ObservedEvent::Gap(_) => None,
+        })
+        .collect::<Vec<_>>();
+    let expected = (0..RECORD_COUNT)
+        .filter(|id| !(4..=6).contains(id))
+        .collect::<Vec<_>>();
+    assert_eq!(record_ids, expected);
+}
+
+#[test]
+fn consumer_failure_leaves_the_record_available_for_retry() {
+    let identity = StreamIdentity {
+        session_id: *b"test-session-007",
+        sender_id: 23,
+    };
+    let fec_config = RlcConfig::new(SYMBOL_SIZE, WINDOW_SYMBOLS, Field::Gf256).unwrap();
+    let mut encoder = ContinuousEncoder::<MAX_SYMBOL_SIZE, WINDOW_SYMBOLS>::new(
+        identity,
+        0,
+        Lane::ReplayCritical,
+        fec_config,
+        4_096,
+        EncodingSymbolId::new(0),
+    )
+    .unwrap();
+    let payload = encode_copperlist(&partial_copperlist(42)).unwrap();
+    let record = encode_record(RecordKind::CopperList, 42, &payload).unwrap();
+    let mut datagrams = Vec::new();
+    encoder.push_record(&record, &mut datagrams).unwrap();
+
+    let mut decoder = ContinuousDecoder::<MAX_SYMBOL_SIZE, WINDOW_SYMBOLS, MAX_EQUATIONS>::new(
+        identity,
+        Lane::ReplayCritical,
+        fec_config,
+        MAX_EQUATIONS,
+        42,
+        ReceiverLimits::new(4_096, WINDOW_SYMBOLS),
+    )
+    .unwrap();
+    let mut consumer_failed = false;
+    for datagram in &datagrams {
+        let result = decoder.receive_datagram(datagram, |event| match event {
+            ContinuousReceiveEvent::Record(_) if !consumer_failed => {
+                consumer_failed = true;
+                Err("consumer busy")
+            }
+            _ => Ok(()),
+        });
+        if consumer_failed {
+            assert_eq!(
+                result,
+                Err(cu29_logstream::ReceiveError::Consumer("consumer busy"))
+            );
+            break;
+        }
+        result.unwrap();
+    }
+
+    assert!(consumer_failed);
+    assert_eq!(decoder.stats().records_emitted, 0);
+    assert_eq!(decoder.occupancy().ready_records, 1);
+    let mut retried_id = None;
+    decoder
+        .drain_events(|event| {
+            if let ContinuousReceiveEvent::Record(record) = event {
+                retried_id = Some(record.decoded().unwrap().object_id);
+            }
+            Ok::<(), core::convert::Infallible>(())
+        })
+        .unwrap();
+    assert_eq!(retried_id, Some(42));
+    assert_eq!(decoder.stats().records_emitted, 1);
+    assert_eq!(decoder.occupancy().ready_records, 0);
 }


### PR DESCRIPTION
Stacked on #1315.

- replaces lifetime-capped recovered-record accumulation with ordered borrowed-event callbacks
- keeps processed-symbol, incomplete-record, and ready-record state bounded by the active RLC window
- emits coalesced CopperList gaps after definitive RLC-window expiry and at explicit session finalization
- uses a monotonic retention floor so reordered early symbols do not create false gaps
- preserves pending records across consumer errors for explicit retry
- adds long-running sequence-wrap, whole-record loss, partial-record expiry, reorder/corruption, and consumer-retry coverage

Validation:
- just fmt
- cargo test -p cu29-logstream --offline
- cargo test -p cu29 --features logstream --test logstream_runtime --test logstream_sim_compile --offline
- cargo clippy -p cu29-logstream --all-targets --all-features --offline -- --deny warnings
- cargo check -p cu29-logstream --no-default-features --offline
- just api-check
- just nostd-ci completed the no-default-features build; its nextest phase could not resolve an uncached candle-kernels package in offline mode
- just pr-check reached workspace Clippy but is locally blocked by a compile failure inside newly resolved tinyvec 1.13.0