### PR TITLE
Add RaptorQ keyframe anchor recovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -285,6 +285,7 @@ bincode = { package = "cu-bincode", version = "2.0", default-features = false, f
 ] }
 blake3 = { version = "1.8.7", default-features = false }
 crc = { version = "3.4.0", default-features = false }
+raptorq = { version = "2.0.1", default-features = false }
 serde = { version = "1.0", default-features = false, features = [
   "derive",
   "alloc",

--- a/core/cu29/tests/logstream_runtime.rs
+++ b/core/cu29/tests/logstream_runtime.rs
@@ -4,8 +4,10 @@ use bincode::{Decode, Encode};
 use cu29::logstream::test_support::link_sim::{LinkSimulationConfig, simulate_bad_link};
 use cu29::logstream::{
     ContinuousDecoder, ContinuousReceiveEvent, ContinuousSenderConfig, CuStreamTx, CuStreamTxError,
-    DensityThreshold, EncodingSymbolId, FecSymbolKind, Field, Lane, ReceiverLimits, RlcConfig,
-    StreamIdentity, WirePacket, decode_copperlist,
+    DensityThreshold, EncodingSymbolId, FecScheme, FecSymbolKind, Field, FiniteObjectDecoder,
+    FiniteObjectLimits, FiniteObjectSenderConfig, Lane, LogStreamSenderConfig, ReceiverLimits,
+    RecordKind, RecoverySenderConfig, RlcConfig, StreamIdentity, WirePacket, decode_anchor,
+    decode_copperlist, decode_record, encode_record,
 };
 use cu29::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -91,7 +93,7 @@ fn generated_runtime_streams_without_local_copperlist_logging() -> CuResult<()> 
     };
     let fec = RlcConfig::new(SYMBOL_SIZE, WINDOW_SYMBOLS, Field::Gf256)
         .map_err(|error| CuError::from(error.to_string()))?;
-    let sender = ContinuousSenderConfig {
+    let continuous = ContinuousSenderConfig {
         identity,
         first_packet_sequence: 0,
         lane: Lane::ReplayCritical,
@@ -101,6 +103,22 @@ fn generated_runtime_streams_without_local_copperlist_logging() -> CuResult<()> 
         repair_every_source_symbols: 1,
         first_repair_key: 1,
         repair_density: DensityThreshold::FULL,
+    };
+    let manifest = encode_record(RecordKind::Manifest, 0, b"runtime-test-manifest")
+        .map_err(|error| CuError::from(error.to_string()))?;
+    let sender = LogStreamSenderConfig {
+        continuous,
+        recovery: RecoverySenderConfig {
+            finite: FiniteObjectSenderConfig {
+                identity,
+                first_packet_sequence: 0,
+                lane: Lane::LargeObject,
+                symbol_size: SYMBOL_SIZE as u16,
+                max_object_bytes: 64 * 1024,
+                repair_symbols_per_block: 8,
+            },
+            manifest_record: manifest.clone(),
+        },
     };
 
     let app = LogstreamRuntimeApp::builder()
@@ -122,8 +140,10 @@ fn generated_runtime_streams_without_local_copperlist_logging() -> CuResult<()> 
     let source_symbols = datagrams
         .iter()
         .filter(|datagram| {
-            WirePacket::decode(datagram)
-                .is_ok_and(|packet| packet.header.symbol_kind == FecSymbolKind::Source)
+            WirePacket::decode(datagram).is_ok_and(|packet| {
+                packet.header.fec_scheme == FecScheme::RlcGf256
+                    && packet.header.symbol_kind == FecSymbolKind::Source
+            })
         })
         .count();
     let simulated_link = simulate_bad_link(
@@ -187,5 +207,35 @@ fn generated_runtime_streams_without_local_copperlist_logging() -> CuResult<()> 
             Some(&StreamMsg(expected_id as u64))
         );
     }
+
+    let mut object_decoder = FiniteObjectDecoder::new(
+        identity,
+        Lane::LargeObject,
+        FiniteObjectLimits::new(64 * 1024, SYMBOL_SIZE as u16, 4),
+    )
+    .map_err(|error| CuError::from(error.to_string()))?;
+    let mut object_records = Vec::new();
+    for datagram in &datagrams {
+        object_decoder
+            .receive_datagram(datagram, |record| {
+                object_records.push(record.bytes().to_vec());
+                Ok::<(), core::convert::Infallible>(())
+            })
+            .map_err(|error| CuError::from(format!("{error:?}")))?;
+    }
+    let keyframe = object_records
+        .iter()
+        .map(|record| decode_record(record).unwrap())
+        .find(|record| record.kind == RecordKind::KeyFrame)
+        .expect("generated runtime should stream its keyframe");
+    let anchor = object_records
+        .iter()
+        .map(|record| decode_record(record).unwrap())
+        .find(|record| record.kind == RecordKind::Anchor)
+        .map(|record| decode_anchor(record.payload).unwrap())
+        .expect("generated runtime should stream its anchor");
+    assert_eq!(anchor.copperlist_id, 0);
+    assert!(anchor.references_keyframe(keyframe));
+    assert!(anchor.references_manifest(decode_record(&manifest).unwrap()));
     Ok(())
 }

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -1943,10 +1943,14 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
         .as_ref()
         .and_then(|logging| logging.copperlist_count)
         .unwrap_or(DEFAULT_COPPERLIST_COUNT);
-    let keyframe_logging_enabled = copper_config
+    let local_keyframe_logging_enabled = copper_config
         .logging
         .as_ref()
         .is_none_or(|logging| logging.enable_keyframe_logging && logging.enable_task_logging);
+    // A feature-gated streaming destination may request keyframes even when the local archive
+    // does not. Compile the capture path in that case; runtime output requirements keep it idle
+    // when no logstream destination is configured.
+    let keyframe_logging_enabled = local_keyframe_logging_enabled || logstream_enabled;
     let copperlist_count_tokens = proc_macro2::Literal::usize_unsuffixed(copperlist_count);
     let caller_root = utils::caller_crate_root();
     let (git_commit, git_dirty) = detect_git_info(&caller_root);
@@ -4554,10 +4558,10 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 .logging
                 .as_ref()
                 .is_none_or(|logging| logging.enable_keyframe_logging && logging.enable_task_logging);
-            if configured_keyframe_logging != #keyframe_logging_enabled {
+            if configured_keyframe_logging != #local_keyframe_logging_enabled {
                 return Err(CuError::from(format!(
                     "Configured keyframe logging ({configured_keyframe_logging}) does not match the runtime compiled into this binary ({})",
-                    #keyframe_logging_enabled
+                    #local_keyframe_logging_enabled
                 )));
             }
         };
@@ -4633,7 +4637,8 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
             quote! {
                 logstream: Option<(
                     Box<dyn ::cu29::logstream::CuStreamTx>,
-                    ::cu29::logstream::ContinuousSenderConfig,
+                    Box<dyn ::cu29::logstream::CuStreamTx>,
+                    ::cu29::logstream::LogStreamSenderConfig,
                 )>,
             }
         } else {
@@ -5489,7 +5494,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
         } else {
             quote!()
         };
-        let local_keyframe_sink_init = if keyframe_logging_enabled {
+        let local_keyframe_sink_init = if local_keyframe_logging_enabled {
             quote! {
                 #[cfg(target_os = "none")]
                 ::cu29::prelude::info!("CuApp new: creating keyframes stream");
@@ -5519,25 +5524,42 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         logging.enable_task_logging && logging.enable_keyframe_logging
                     });
                 let logstream_output_required = logstream.is_some();
-                let logstream_sink = logstream
-                    .map(|(transport, mut sender_config)| {
-                        sender_config.identity.sender_id = instance_id;
-                        ::cu29::logstream::DefaultContinuousCopperListSink::<
+                let logstream_sinks = logstream
+                    .map(|(continuous_transport, recovery_transport, mut sender_config)| {
+                        sender_config.continuous.identity.sender_id = instance_id;
+                        sender_config.recovery.finite.identity.sender_id = instance_id;
+                        sender_config
+                            .validate()
+                            .map_err(|error| CuError::from(error.to_string()))?;
+                        let copperlist = ::cu29::logstream::DefaultContinuousCopperListSink::<
                             #mission_mod::CuStampedDataSet,
                             Box<dyn ::cu29::logstream::CuStreamTx>,
-                        >::new(transport, sender_config)
-                        .map_err(|error| CuError::from(error.to_string()))
+                        >::new(continuous_transport, sender_config.continuous)
+                        .map_err(|error| CuError::from(error.to_string()))?;
+                        let keyframe = ::cu29::logstream::KeyFrameAnchorSink::new(
+                            recovery_transport,
+                            sender_config.recovery,
+                        )
+                        .map_err(|error| CuError::from(error.to_string()))?;
+                        Ok::<_, CuError>((copperlist, keyframe))
                     })
                     .transpose()?;
+                let (logstream_sink, logstream_keyframe_sink) = logstream_sinks.unzip();
                 let copperlist_sink = ::cu29::fanout::StaticFanoutSink::new(
                     ::cu29::fanout::OptionalWriteStream::new(
                         local_copperlist_output_required.then_some(local_copperlist_sink),
                     ),
                     ::cu29::fanout::OptionalWriteStream::new(logstream_sink),
                 );
+                let keyframe_sink = ::cu29::fanout::StaticFanoutSink::new(
+                    ::cu29::fanout::OptionalWriteStream::new(
+                        local_keyframe_output_required.then_some(local_keyframe_sink),
+                    ),
+                    ::cu29::fanout::OptionalWriteStream::new(logstream_keyframe_sink),
+                );
                 let output_requirements = cu29::curuntime::OutputRequirements::new(
                     local_copperlist_output_required || logstream_output_required,
-                    local_keyframe_output_required,
+                    local_keyframe_output_required || logstream_output_required,
                 );
             }
         } else {
@@ -5558,6 +5580,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                     local_keyframe_output_required,
                 );
                 let copperlist_sink = local_copperlist_sink;
+                let keyframe_sink = local_keyframe_sink;
             }
         };
 
@@ -5661,7 +5684,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         #mission_mod::bridges_instanciator,
                     ),
                     copperlist_sink,
-                    local_keyframe_sink,
+                    keyframe_sink,
                     output_requirements,
                 )
                 .with_subsystem(#application_name::subsystem())
@@ -5958,7 +5981,8 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
             quote! {
                 logstream: Option<(
                     Box<dyn ::cu29::logstream::CuStreamTx>,
-                    ::cu29::logstream::ContinuousSenderConfig,
+                    Box<dyn ::cu29::logstream::CuStreamTx>,
+                    ::cu29::logstream::LogStreamSenderConfig,
                 )>,
             }
         });
@@ -5967,16 +5991,24 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
             logstream_enabled.then(|| quote! { logstream: self.logstream, });
         let builder_with_logstream_method = logstream_enabled.then(|| {
             quote! {
-                /// Adds a nonblocking continuous CopperList datagram destination.
+                /// Adds a nonblocking CopperList plus keyframe/anchor packet resource.
+                ///
+                /// The endpoint is cloned once so independently scheduled semantic lanes never
+                /// serialize access through a mutex. Clones must remain fire-and-forget,
+                /// nonblocking implementations of `CuStreamTx`.
                 pub fn with_logstream<T>(
                     mut self,
                     transport: T,
-                    config: ::cu29::logstream::ContinuousSenderConfig,
+                    config: ::cu29::logstream::LogStreamSenderConfig,
                 ) -> Self
                 where
-                    T: ::cu29::logstream::CuStreamTx + 'static,
+                    T: ::cu29::logstream::CuStreamTx + Clone + 'static,
                 {
-                    self.logstream = Some((Box::new(transport), config));
+                    self.logstream = Some((
+                        Box::new(transport.clone()),
+                        Box::new(transport),
+                        config,
+                    ));
                     self
                 }
             }

--- a/core/cu29_logstream/Cargo.toml
+++ b/core/cu29_logstream/Cargo.toml
@@ -24,11 +24,12 @@ crc = { workspace = true }
 cu-fec = { workspace = true }
 cu29-runtime = { workspace = true }
 cu29-traits = { workspace = true }
+raptorq = { workspace = true }
 
 [dev-dependencies]
 serde = { workspace = true }
 
 [features]
 default = ["std"]
-std = ["blake3/std", "cu29-runtime/std", "cu29-traits/std"]
+std = ["blake3/std", "cu29-runtime/std", "cu29-traits/std", "raptorq/std"]
 test-utils = ["std"]

--- a/core/cu29_logstream/src/lib.rs
+++ b/core/cu29_logstream/src/lib.rs
@@ -11,7 +11,9 @@ pub use cu_fec::{DensityThreshold, EncodingSymbolId, Field, RlcConfig};
 
 mod copper;
 mod error;
+mod object;
 mod record;
+mod recovery;
 mod rlc;
 mod sender;
 mod stream;
@@ -26,7 +28,15 @@ pub mod test_support;
 
 pub use copper::{decode_copperlist, encode_copperlist, encode_copperlist_record_into};
 pub use error::{Error, Result};
-pub use record::{DecodedRecord, RecordKind, encode_record};
+pub use object::{
+    FiniteObjectDecoder, FiniteObjectEncoder, FiniteObjectLimits, FiniteObjectRecoveryStats,
+    FiniteObjectSenderConfig,
+};
+pub use record::{DecodedRecord, RecordKind, decode_record, encode_record};
+pub use recovery::{
+    Anchor, decode_anchor, decode_keyframe, encode_anchor, encode_keyframe,
+    encode_keyframe_and_anchor,
+};
 pub use rlc::{
     ContinuousDecoder, ContinuousEncoder, ContinuousReceiveEvent, ContinuousRecoveryStats,
     CopperListGap, GapReason, ReceiveError, ReceiverLimits, ReceiverOccupancy, RecoveredRecord,
@@ -35,6 +45,7 @@ pub use rlc::{
 pub use sender::{
     ContinuousCopperListSink, ContinuousSenderConfig, ContinuousSenderStats,
     DEFAULT_MAX_SYMBOL_SIZE, DEFAULT_MAX_WINDOW_SYMBOLS, DefaultContinuousCopperListSink,
+    KeyFrameAnchorSink, LogStreamSenderConfig, RecoverySenderConfig, RecoverySenderStats,
 };
 pub use stream::{CuStreamRx, CuStreamRxError, CuStreamTx, CuStreamTxError};
 pub use wire::{

--- a/core/cu29_logstream/src/object.rs
+++ b/core/cu29_logstream/src/object.rs
@@ -1,0 +1,464 @@
+//! Bounded finite-object transport using systematic RFC 6330 RaptorQ.
+
+use crate::{
+    Error, FecScheme, FecSymbolKind, Lane, PACKET_HEADER_LEN, ReceiveError, RecordKind,
+    RecoveredRecord, Result, StreamIdentity, WireHeader, WirePacket, decode_record,
+    encode_packet_into,
+};
+use alloc::{vec, vec::Vec};
+use raptorq::{Decoder, Encoder, EncodingPacket, ObjectTransmissionInformation, PayloadId};
+
+const RFC6330_MAX_TRANSFER_LENGTH: u64 = 942_574_504_275;
+const RFC6330_MAX_SOURCE_SYMBOLS_PER_BLOCK: u64 = 56_403;
+
+/// Sender policy for one finite-object lane.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FiniteObjectSenderConfig {
+    pub identity: StreamIdentity,
+    pub first_packet_sequence: u64,
+    pub lane: Lane,
+    /// RaptorQ symbol bytes, excluding the Copper wire header.
+    pub symbol_size: u16,
+    /// Hard limit checked before constructing the RaptorQ encoder.
+    pub max_object_bytes: u64,
+    /// Repair symbols emitted for every RaptorQ source block.
+    pub repair_symbols_per_block: u32,
+}
+
+/// Receiver-local limits checked before any RaptorQ decoder is constructed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FiniteObjectLimits {
+    pub max_object_bytes: u64,
+    pub max_symbol_size: u16,
+    pub max_concurrent_objects: usize,
+}
+
+impl FiniteObjectLimits {
+    pub const fn new(
+        max_object_bytes: u64,
+        max_symbol_size: u16,
+        max_concurrent_objects: usize,
+    ) -> Self {
+        Self {
+            max_object_bytes,
+            max_symbol_size,
+            max_concurrent_objects,
+        }
+    }
+}
+
+/// Observed finite-object receive behavior.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct FiniteObjectRecoveryStats {
+    pub datagrams_seen: usize,
+    pub valid_datagrams: usize,
+    pub invalid_datagrams: usize,
+    pub inconsistent_datagrams: usize,
+    pub duplicate_symbols: usize,
+    pub source_symbols_received: usize,
+    pub repair_symbols_received: usize,
+    pub objects_recovered: usize,
+    pub peak_concurrent_objects: usize,
+}
+
+/// RaptorQ encoder for immutable framed semantic records.
+///
+/// Construction and encoding allocate and must run on a non-real-time output worker.
+pub struct FiniteObjectEncoder {
+    config: FiniteObjectSenderConfig,
+    packet_sequence: u64,
+}
+
+impl FiniteObjectEncoder {
+    pub fn new(config: FiniteObjectSenderConfig) -> Result<Self> {
+        validate_sender_config(config)?;
+        Ok(Self {
+            packet_sequence: config.first_packet_sequence,
+            config,
+        })
+    }
+
+    pub const fn config(&self) -> FiniteObjectSenderConfig {
+        self.config
+    }
+
+    /// Encodes one already-framed semantic record and appends its datagrams.
+    pub fn push_record(&mut self, record: &[u8], output: &mut Vec<Vec<u8>>) -> Result<usize> {
+        self.push_record_with(record, |datagram| {
+            output.push(datagram.to_vec());
+            Ok(())
+        })
+    }
+
+    /// Encodes one record and emits each datagram immediately.
+    pub fn push_record_with(
+        &mut self,
+        record: &[u8],
+        mut emit: impl FnMut(&[u8]) -> Result<()>,
+    ) -> Result<usize> {
+        let decoded = decode_record(record)?;
+        let record_len = u64::try_from(record.len())
+            .map_err(|_| Error::InvalidConfig("finite object length exceeds u64"))?;
+        if record_len > self.config.max_object_bytes {
+            return Err(Error::ObjectTooLarge {
+                actual: record_len,
+                maximum: self.config.max_object_bytes,
+            });
+        }
+
+        let encoder = Encoder::with_defaults(record, self.config.symbol_size);
+        let oti = encoder.get_config().serialize();
+        let datagram_len = PACKET_HEADER_LEN
+            .checked_add(self.config.symbol_size as usize)
+            .ok_or(Error::InvalidConfig(
+                "finite-object datagram length overflow",
+            ))?;
+        let mut datagram = vec![0; datagram_len];
+        let mut emitted = 0_usize;
+
+        for block in encoder.get_block_encoders() {
+            for packet in block.source_packets() {
+                self.emit_packet(
+                    decoded,
+                    FecSymbolKind::Source,
+                    oti,
+                    packet,
+                    &mut datagram,
+                    &mut emit,
+                )?;
+                emitted = emitted.saturating_add(1);
+            }
+            for packet in block.repair_packets(0, self.config.repair_symbols_per_block) {
+                self.emit_packet(
+                    decoded,
+                    FecSymbolKind::Repair,
+                    oti,
+                    packet,
+                    &mut datagram,
+                    &mut emit,
+                )?;
+                emitted = emitted.saturating_add(1);
+            }
+        }
+        Ok(emitted)
+    }
+
+    fn emit_packet(
+        &mut self,
+        record: crate::DecodedRecord<'_>,
+        symbol_kind: FecSymbolKind,
+        oti: [u8; 12],
+        packet: EncodingPacket,
+        datagram: &mut [u8],
+        emit: &mut impl FnMut(&[u8]) -> Result<()>,
+    ) -> Result<()> {
+        let (payload_id, payload) = packet.split();
+        let header = WireHeader {
+            lane: self.config.lane,
+            record_kind: record.kind,
+            fec_scheme: FecScheme::RaptorQ,
+            symbol_kind,
+            session_id: self.config.identity.session_id,
+            sender_id: self.config.identity.sender_id,
+            packet_sequence: self.packet_sequence,
+            object_id: record.object_id,
+            fec_metadata: oti,
+            fragment_count: u32::from_be_bytes(payload_id.serialize()),
+        };
+        let encoded = encode_packet_into(header, &payload, datagram)?;
+        emit(&datagram[..encoded])?;
+        self.packet_sequence = self.packet_sequence.wrapping_add(1);
+        Ok(())
+    }
+}
+
+/// Bounded assembler for independently reorderable finite RaptorQ objects.
+pub struct FiniteObjectDecoder {
+    identity: StreamIdentity,
+    lane: Lane,
+    limits: FiniteObjectLimits,
+    objects: Vec<ObjectDecoder>,
+    ready: Vec<ReadyObject>,
+    completed: Vec<CompletedObject>,
+    stats: FiniteObjectRecoveryStats,
+}
+
+impl FiniteObjectDecoder {
+    pub fn new(identity: StreamIdentity, lane: Lane, limits: FiniteObjectLimits) -> Result<Self> {
+        validate_limits(limits)?;
+        Ok(Self {
+            identity,
+            lane,
+            limits,
+            objects: Vec::with_capacity(limits.max_concurrent_objects),
+            ready: Vec::with_capacity(limits.max_concurrent_objects),
+            completed: Vec::with_capacity(limits.max_concurrent_objects),
+            stats: FiniteObjectRecoveryStats::default(),
+        })
+    }
+
+    pub const fn stats(&self) -> FiniteObjectRecoveryStats {
+        self.stats
+    }
+
+    pub fn occupancy(&self) -> usize {
+        self.objects.len().saturating_add(self.ready.len())
+    }
+
+    /// Accepts one datagram and emits a digest-verified record when its object completes.
+    pub fn receive_datagram<E>(
+        &mut self,
+        datagram: &[u8],
+        mut emit: impl FnMut(&RecoveredRecord) -> core::result::Result<(), E>,
+    ) -> core::result::Result<(), ReceiveError<E>> {
+        self.drain_records(&mut emit)?;
+        self.stats.datagrams_seen = self.stats.datagrams_seen.saturating_add(1);
+        let packet = match WirePacket::decode(datagram) {
+            Ok(packet) => packet,
+            Err(_) => {
+                self.stats.invalid_datagrams = self.stats.invalid_datagrams.saturating_add(1);
+                return Ok(());
+            }
+        };
+        if packet.header.session_id != self.identity.session_id
+            || packet.header.sender_id != self.identity.sender_id
+            || packet.header.lane != self.lane
+            || packet.header.fec_scheme != FecScheme::RaptorQ
+            || packet.header.record_kind == RecordKind::CopperList
+        {
+            self.stats.inconsistent_datagrams = self.stats.inconsistent_datagrams.saturating_add(1);
+            return Ok(());
+        }
+
+        let oti = match validate_oti(packet.header.fec_metadata, self.limits) {
+            Ok(oti) => oti,
+            Err(_) => {
+                self.stats.invalid_datagrams = self.stats.invalid_datagrams.saturating_add(1);
+                return Ok(());
+            }
+        };
+        if packet.payload.len() != oti.symbol_size() as usize {
+            self.stats.invalid_datagrams = self.stats.invalid_datagrams.saturating_add(1);
+            return Ok(());
+        }
+
+        let payload_id = PayloadId::deserialize(&packet.header.fragment_count.to_be_bytes());
+        if payload_id.source_block_number() >= oti.source_blocks() {
+            self.stats.invalid_datagrams = self.stats.invalid_datagrams.saturating_add(1);
+            return Ok(());
+        }
+        if let Some(object) = self.ready.iter().find(|object| {
+            object.kind == packet.header.record_kind && object.object_id == packet.header.object_id
+        }) {
+            if object.oti != oti {
+                self.stats.inconsistent_datagrams =
+                    self.stats.inconsistent_datagrams.saturating_add(1);
+            } else {
+                self.stats.duplicate_symbols = self.stats.duplicate_symbols.saturating_add(1);
+            }
+            return Ok(());
+        }
+        if let Some(object) = self.completed.iter().find(|object| {
+            object.kind == packet.header.record_kind && object.object_id == packet.header.object_id
+        }) {
+            if object.oti != oti {
+                self.stats.inconsistent_datagrams =
+                    self.stats.inconsistent_datagrams.saturating_add(1);
+            } else {
+                self.stats.duplicate_symbols = self.stats.duplicate_symbols.saturating_add(1);
+            }
+            return Ok(());
+        }
+        let object_index = match self.objects.iter().position(|object| {
+            object.kind == packet.header.record_kind && object.object_id == packet.header.object_id
+        }) {
+            Some(index) => {
+                let object = &self.objects[index];
+                if object.oti != oti {
+                    self.stats.inconsistent_datagrams =
+                        self.stats.inconsistent_datagrams.saturating_add(1);
+                    return Ok(());
+                }
+                index
+            }
+            None => {
+                let actual = self
+                    .objects
+                    .len()
+                    .saturating_add(self.ready.len())
+                    .saturating_add(1);
+                if actual > self.limits.max_concurrent_objects {
+                    return Err(Error::TooManyRecords {
+                        actual,
+                        maximum: self.limits.max_concurrent_objects,
+                    }
+                    .into());
+                }
+                self.objects.push(ObjectDecoder {
+                    kind: packet.header.record_kind,
+                    object_id: packet.header.object_id,
+                    oti,
+                    decoder: Decoder::new(oti),
+                });
+                self.stats.peak_concurrent_objects =
+                    self.stats.peak_concurrent_objects.max(self.objects.len());
+                self.objects.len() - 1
+            }
+        };
+
+        match packet.header.symbol_kind {
+            FecSymbolKind::Source => {
+                self.stats.source_symbols_received =
+                    self.stats.source_symbols_received.saturating_add(1);
+            }
+            FecSymbolKind::Repair => {
+                self.stats.repair_symbols_received =
+                    self.stats.repair_symbols_received.saturating_add(1);
+            }
+        }
+        self.stats.valid_datagrams = self.stats.valid_datagrams.saturating_add(1);
+        let completed = self.objects[object_index]
+            .decoder
+            .decode(EncodingPacket::new(payload_id, packet.payload));
+        let Some(bytes) = completed else {
+            return Ok(());
+        };
+
+        let object = self.objects.swap_remove(object_index);
+        let decoded = decode_record(&bytes)?;
+        if decoded.kind != object.kind || decoded.object_id != object.object_id {
+            return Err(Error::InconsistentObject.into());
+        }
+        self.ready.push(ReadyObject {
+            kind: object.kind,
+            object_id: object.object_id,
+            oti: object.oti,
+            record: RecoveredRecord::from_bytes(bytes),
+        });
+        self.stats.objects_recovered = self.stats.objects_recovered.saturating_add(1);
+        self.drain_records(&mut emit)
+    }
+
+    /// Retries delivery of records retained after a consumer failure.
+    pub fn drain_records<E>(
+        &mut self,
+        mut emit: impl FnMut(&RecoveredRecord) -> core::result::Result<(), E>,
+    ) -> core::result::Result<(), ReceiveError<E>> {
+        while !self.ready.is_empty() {
+            emit(&self.ready[0].record).map_err(ReceiveError::Consumer)?;
+            let delivered = self.ready.remove(0);
+            if self.completed.len() == self.limits.max_concurrent_objects {
+                self.completed.remove(0);
+            }
+            self.completed.push(CompletedObject {
+                kind: delivered.kind,
+                object_id: delivered.object_id,
+                oti: delivered.oti,
+            });
+        }
+        Ok(())
+    }
+}
+
+struct ObjectDecoder {
+    kind: RecordKind,
+    object_id: u64,
+    oti: ObjectTransmissionInformation,
+    decoder: Decoder,
+}
+
+struct ReadyObject {
+    kind: RecordKind,
+    object_id: u64,
+    oti: ObjectTransmissionInformation,
+    record: RecoveredRecord,
+}
+
+struct CompletedObject {
+    kind: RecordKind,
+    object_id: u64,
+    oti: ObjectTransmissionInformation,
+}
+
+fn validate_sender_config(config: FiniteObjectSenderConfig) -> Result<()> {
+    if config.symbol_size == 0 {
+        return Err(Error::InvalidConfig("RaptorQ symbol size must be nonzero"));
+    }
+    if config.max_object_bytes == 0 || config.max_object_bytes > RFC6330_MAX_TRANSFER_LENGTH {
+        return Err(Error::InvalidConfig("invalid RaptorQ maximum object size"));
+    }
+    Ok(())
+}
+
+fn validate_limits(limits: FiniteObjectLimits) -> Result<()> {
+    if limits.max_object_bytes == 0 || limits.max_object_bytes > RFC6330_MAX_TRANSFER_LENGTH {
+        return Err(Error::InvalidConfig("invalid RaptorQ maximum object size"));
+    }
+    if limits.max_symbol_size == 0 {
+        return Err(Error::InvalidConfig(
+            "RaptorQ maximum symbol size must be nonzero",
+        ));
+    }
+    if limits.max_concurrent_objects == 0 {
+        return Err(Error::InvalidConfig(
+            "finite-object receiver capacity must be nonzero",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_oti(
+    encoded: [u8; 12],
+    limits: FiniteObjectLimits,
+) -> Result<ObjectTransmissionInformation> {
+    if encoded[5] != 0 {
+        return Err(Error::InvalidFecMetadata(
+            "RaptorQ OTI reserved byte is nonzero",
+        ));
+    }
+    let oti = ObjectTransmissionInformation::deserialize(&encoded);
+    let transfer_length = oti.transfer_length();
+    let symbol_size = oti.symbol_size();
+    let source_blocks = oti.source_blocks();
+    let sub_blocks = oti.sub_blocks();
+    let alignment = oti.symbol_alignment();
+    if transfer_length == 0 || transfer_length > limits.max_object_bytes {
+        return Err(Error::ObjectTooLarge {
+            actual: transfer_length,
+            maximum: limits.max_object_bytes,
+        });
+    }
+    if symbol_size == 0 || symbol_size > limits.max_symbol_size {
+        return Err(Error::InvalidFecMetadata(
+            "RaptorQ symbol size exceeds receiver limit",
+        ));
+    }
+    if source_blocks == 0 || sub_blocks == 0 || alignment == 0 {
+        return Err(Error::InvalidFecMetadata(
+            "RaptorQ OTI contains a zero parameter",
+        ));
+    }
+    if !symbol_size.is_multiple_of(alignment as u16) {
+        return Err(Error::InvalidFecMetadata(
+            "RaptorQ symbol alignment is invalid",
+        ));
+    }
+    let total_source_symbols = transfer_length.div_ceil(symbol_size as u64);
+    if source_blocks as u64 > total_source_symbols {
+        return Err(Error::InvalidFecMetadata(
+            "RaptorQ has more source blocks than source symbols",
+        ));
+    }
+    if sub_blocks as u32 > u32::from(symbol_size / alignment as u16) {
+        return Err(Error::InvalidFecMetadata(
+            "RaptorQ sub-block count exceeds symbol geometry",
+        ));
+    }
+    let largest_block = total_source_symbols.div_ceil(source_blocks as u64);
+    if largest_block > RFC6330_MAX_SOURCE_SYMBOLS_PER_BLOCK {
+        return Err(Error::InvalidFecMetadata(
+            "RaptorQ source block is too large",
+        ));
+    }
+    Ok(oti)
+}

--- a/core/cu29_logstream/src/record.rs
+++ b/core/cu29_logstream/src/record.rs
@@ -41,6 +41,8 @@ impl TryFrom<u8> for RecordKind {
 pub struct DecodedRecord<'a> {
     pub kind: RecordKind,
     pub object_id: u64,
+    /// Digest binding the record version, kind, identity, length, and payload.
+    pub digest: [u8; 32],
     pub payload: &'a [u8],
 }
 
@@ -94,7 +96,8 @@ pub(crate) fn encode_record_header(
     Ok(())
 }
 
-pub(crate) fn decode_record(record: &[u8]) -> Result<DecodedRecord<'_>> {
+/// Validates and decodes one complete semantic record envelope.
+pub fn decode_record(record: &[u8]) -> Result<DecodedRecord<'_>> {
     if record.len() < RECORD_HEADER_LEN {
         return Err(Error::TruncatedRecord);
     }
@@ -123,6 +126,7 @@ pub(crate) fn decode_record(record: &[u8]) -> Result<DecodedRecord<'_>> {
     Ok(DecodedRecord {
         kind,
         object_id,
+        digest: *expected_digest.as_bytes(),
         payload,
     })
 }

--- a/core/cu29_logstream/src/recovery.rs
+++ b/core/cu29_logstream/src/recovery.rs
@@ -1,0 +1,90 @@
+//! Semantic keyframe and anchor records used to restart exact reconstruction.
+
+use crate::{DecodedRecord, Error, RecordKind, Result, decode_record, encode_record};
+use alloc::{string::ToString, vec::Vec};
+use bincode::{Decode, Encode};
+use cu29_runtime::curuntime::KeyFrame;
+
+/// A verified restart point for one sender.
+///
+/// The keyframe restores component state immediately before `copperlist_id`.
+/// The manifest supplies the continuous-lane FEC and schema configuration.
+#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+pub struct Anchor {
+    pub manifest_object_id: u64,
+    pub manifest_record_digest: [u8; 32],
+    pub copperlist_id: u64,
+    pub keyframe_object_id: u64,
+    pub keyframe_record_digest: [u8; 32],
+}
+
+impl Anchor {
+    /// Checks that a recovered keyframe is exactly the record referenced here.
+    pub fn references_keyframe(&self, record: DecodedRecord<'_>) -> bool {
+        record.kind == RecordKind::KeyFrame
+            && record.object_id == self.keyframe_object_id
+            && record.digest == self.keyframe_record_digest
+    }
+
+    /// Checks that a recovered manifest is exactly the record referenced here.
+    pub fn references_manifest(&self, record: DecodedRecord<'_>) -> bool {
+        record.kind == RecordKind::Manifest
+            && record.object_id == self.manifest_object_id
+            && record.digest == self.manifest_record_digest
+    }
+}
+
+/// Encodes a runtime keyframe as its canonical bincode semantic payload.
+pub fn encode_keyframe(keyframe: &KeyFrame) -> Result<Vec<u8>> {
+    bincode::encode_to_vec(keyframe, bincode::config::standard())
+        .map_err(|error| Error::Codec(error.to_string()))
+}
+
+/// Decodes a complete keyframe payload and rejects trailing bytes.
+pub fn decode_keyframe(payload: &[u8]) -> Result<KeyFrame> {
+    decode_exact(payload, "keyframe")
+}
+
+/// Encodes an anchor as its canonical bincode semantic payload.
+pub fn encode_anchor(anchor: &Anchor) -> Result<Vec<u8>> {
+    bincode::encode_to_vec(anchor, bincode::config::standard())
+        .map_err(|error| Error::Codec(error.to_string()))
+}
+
+/// Decodes a complete anchor payload and rejects trailing bytes.
+pub fn decode_anchor(payload: &[u8]) -> Result<Anchor> {
+    decode_exact(payload, "anchor")
+}
+
+/// Creates the separately transportable keyframe and anchor records.
+///
+/// Both use the CopperList boundary as their family-local object identifier.
+pub fn encode_keyframe_and_anchor(
+    keyframe: &KeyFrame,
+    manifest_object_id: u64,
+    manifest_record_digest: [u8; 32],
+) -> Result<(Vec<u8>, Vec<u8>)> {
+    let keyframe_payload = encode_keyframe(keyframe)?;
+    let keyframe_record =
+        encode_record(RecordKind::KeyFrame, keyframe.culistid, &keyframe_payload)?;
+    let keyframe_decoded = decode_record(&keyframe_record)?;
+    let anchor = Anchor {
+        manifest_object_id,
+        manifest_record_digest,
+        copperlist_id: keyframe.culistid,
+        keyframe_object_id: keyframe.culistid,
+        keyframe_record_digest: keyframe_decoded.digest,
+    };
+    let anchor_payload = encode_anchor(&anchor)?;
+    let anchor_record = encode_record(RecordKind::Anchor, keyframe.culistid, &anchor_payload)?;
+    Ok((keyframe_record, anchor_record))
+}
+
+fn decode_exact<T: Decode<()>>(payload: &[u8], name: &'static str) -> Result<T> {
+    let (value, consumed) = bincode::decode_from_slice(payload, bincode::config::standard())
+        .map_err(|error| Error::Codec(error.to_string()))?;
+    if consumed != payload.len() {
+        return Err(Error::Codec(alloc::format!("{name} has trailing bytes")));
+    }
+    Ok(value)
+}

--- a/core/cu29_logstream/src/rlc.rs
+++ b/core/cu29_logstream/src/rlc.rs
@@ -1,7 +1,6 @@
-use crate::record::decode_record;
 use crate::{
     DecodedRecord, Error, FecScheme, FecSymbolKind, Lane, PACKET_HEADER_LEN, RecordKind, Result,
-    WireHeader, WirePacket, encode_packet_into,
+    WireHeader, WirePacket, decode_record, encode_packet_into,
 };
 use alloc::{vec, vec::Vec};
 use core::fmt::{Display, Formatter};
@@ -174,6 +173,10 @@ pub struct RecoveredRecord {
 }
 
 impl RecoveredRecord {
+    pub(crate) fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self { bytes }
+    }
+
     pub fn bytes(&self) -> &[u8] {
         &self.bytes
     }
@@ -694,9 +697,7 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
         self.ready.push(ReadyRecord {
             object_id: assembly.object_id,
             first_esi: assembly.first_esi,
-            record: RecoveredRecord {
-                bytes: assembly.bytes,
-            },
+            record: RecoveredRecord::from_bytes(assembly.bytes),
         });
         self.stats.records_recovered = self.stats.records_recovered.saturating_add(1);
         self.observe_peak_buffered_records();

--- a/core/cu29_logstream/src/sender.rs
+++ b/core/cu29_logstream/src/sender.rs
@@ -1,12 +1,13 @@
 use crate::rlc::RepairSchedule;
 use crate::{
-    ContinuousEncoder, CuStreamTx, CuStreamTxError, Error, Lane, PACKET_HEADER_LEN, Result,
-    StreamIdentity, encode_copperlist_record_into,
+    ContinuousEncoder, CuStreamTx, CuStreamTxError, Error, FiniteObjectEncoder,
+    FiniteObjectSenderConfig, Lane, PACKET_HEADER_LEN, RecordKind, Result, StreamIdentity,
+    decode_record, encode_copperlist_record_into, encode_keyframe_and_anchor,
 };
 use alloc::{boxed::Box, string::ToString, vec, vec::Vec};
 use core::{fmt::Debug, marker::PhantomData};
 use cu_fec::{DensityThreshold, EncodingSymbolId, RlcConfig};
-use cu29_runtime::copperlist::CopperList;
+use cu29_runtime::{copperlist::CopperList, curuntime::KeyFrame};
 use cu29_traits::{CopperListTuple, CuError, CuResult, WriteStream};
 
 /// Maximum source-symbol storage used by generated runtime integration.
@@ -33,6 +34,42 @@ pub struct ContinuousSenderConfig {
     pub repair_density: DensityThreshold,
 }
 
+/// Finite-object recovery policy and the canonical manifest record repeated at every anchor.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecoverySenderConfig {
+    pub finite: FiniteObjectSenderConfig,
+    pub manifest_record: Vec<u8>,
+}
+
+/// Complete sender configuration for continuous CopperLists and restart anchors.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LogStreamSenderConfig {
+    pub continuous: ContinuousSenderConfig,
+    pub recovery: RecoverySenderConfig,
+}
+
+impl LogStreamSenderConfig {
+    pub fn validate(&self) -> Result<()> {
+        if self.continuous.identity != self.recovery.finite.identity {
+            return Err(Error::InvalidConfig(
+                "continuous and recovery sender identities differ",
+            ));
+        }
+        if self.continuous.lane == self.recovery.finite.lane {
+            return Err(Error::InvalidConfig(
+                "continuous and finite objects require distinct lanes",
+            ));
+        }
+        let manifest = decode_record(&self.recovery.manifest_record)?;
+        if manifest.kind != RecordKind::Manifest {
+            return Err(Error::InvalidConfig(
+                "recovery configuration requires a manifest record",
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// Sender-side delivery counters. Transport backpressure is observable but never blocks.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ContinuousSenderStats {
@@ -41,6 +78,125 @@ pub struct ContinuousSenderStats {
     pub repair_datagrams: u64,
     pub datagrams_sent: u64,
     pub datagrams_dropped: u64,
+}
+
+/// Sender counters for repeated manifests, keyframes, and anchors.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RecoverySenderStats {
+    pub keyframes_encoded: u64,
+    pub object_datagrams: u64,
+    pub datagrams_sent: u64,
+    pub datagrams_dropped: u64,
+}
+
+/// Runtime keyframe sink that sends a repeated manifest, keyframe, and binding anchor.
+pub struct KeyFrameAnchorSink<T: CuStreamTx> {
+    transport: T,
+    encoder: FiniteObjectEncoder,
+    manifest_record: Vec<u8>,
+    manifest_object_id: u64,
+    manifest_record_digest: [u8; 32],
+    stats: RecoverySenderStats,
+}
+
+impl<T: CuStreamTx> Debug for KeyFrameAnchorSink<T> {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("KeyFrameAnchorSink")
+            .field("transport", &self.transport)
+            .field("config", &self.encoder.config())
+            .field("stats", &self.stats)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T: CuStreamTx> KeyFrameAnchorSink<T> {
+    pub fn new(transport: T, config: RecoverySenderConfig) -> Result<Self> {
+        let manifest = decode_record(&config.manifest_record)?;
+        if manifest.kind != RecordKind::Manifest {
+            return Err(Error::InvalidConfig(
+                "recovery configuration requires a manifest record",
+            ));
+        }
+        let manifest_object_id = manifest.object_id;
+        let manifest_record_digest = manifest.digest;
+        Ok(Self {
+            transport,
+            encoder: FiniteObjectEncoder::new(config.finite)?,
+            manifest_record: config.manifest_record,
+            manifest_object_id,
+            manifest_record_digest,
+            stats: RecoverySenderStats::default(),
+        })
+    }
+
+    pub const fn stats(&self) -> RecoverySenderStats {
+        self.stats
+    }
+
+    pub fn transport(&self) -> &T {
+        &self.transport
+    }
+
+    pub fn transport_mut(&mut self) -> &mut T {
+        &mut self.transport
+    }
+
+    pub fn into_transport(self) -> T {
+        self.transport
+    }
+
+    fn emit_record(&mut self, record: &[u8]) -> Result<()> {
+        emit_finite_record(
+            &mut self.encoder,
+            &mut self.transport,
+            &mut self.stats,
+            record,
+        )
+    }
+}
+
+fn emit_finite_record<T: CuStreamTx>(
+    encoder: &mut FiniteObjectEncoder,
+    transport: &mut T,
+    stats: &mut RecoverySenderStats,
+    record: &[u8],
+) -> Result<()> {
+    let datagrams = encoder.push_record_with(record, |datagram| {
+        stats.object_datagrams = stats.object_datagrams.saturating_add(1);
+        match transport.try_send(datagram) {
+            Ok(()) => stats.datagrams_sent = stats.datagrams_sent.saturating_add(1),
+            Err(CuStreamTxError::WouldBlock) => {
+                stats.datagrams_dropped = stats.datagrams_dropped.saturating_add(1);
+            }
+            Err(CuStreamTxError::Failed(message)) => return Err(Error::Transport(message)),
+        }
+        Ok(())
+    })?;
+    debug_assert!(datagrams > 0);
+    Ok(())
+}
+
+impl<T: CuStreamTx> WriteStream<KeyFrame> for KeyFrameAnchorSink<T> {
+    fn log(&mut self, keyframe: &KeyFrame) -> CuResult<()> {
+        let (keyframe_record, anchor_record) = encode_keyframe_and_anchor(
+            keyframe,
+            self.manifest_object_id,
+            self.manifest_record_digest,
+        )
+        .map_err(|error| CuError::from(error.to_string()))?;
+        emit_finite_record(
+            &mut self.encoder,
+            &mut self.transport,
+            &mut self.stats,
+            &self.manifest_record,
+        )
+        .and_then(|()| self.emit_record(&keyframe_record))
+        .and_then(|()| self.emit_record(&anchor_record))
+        .map_err(|error| CuError::from(error.to_string()))?;
+        self.stats.keyframes_encoded = self.stats.keyframes_encoded.saturating_add(1);
+        Ok(())
+    }
 }
 
 /// CopperList semantic sink backed by continuous RLC and a nonblocking datagram transport.

--- a/core/cu29_logstream/src/wire.rs
+++ b/core/cu29_logstream/src/wire.rs
@@ -87,7 +87,7 @@ pub struct WireHeader {
     pub object_id: u64,
     /// Scheme-specific fixed-width FEC metadata.
     pub fec_metadata: [u8; 12],
-    /// Fragment count for a systematic symbol; zero for a repair symbol.
+    /// Scheme-specific 32-bit identifier: RLC fragment count or RaptorQ payload ID.
     pub fragment_count: u32,
 }
 

--- a/core/cu29_logstream/tests/finite_objects.rs
+++ b/core/cu29_logstream/tests/finite_objects.rs
@@ -1,0 +1,272 @@
+mod common;
+
+use common::link_sim::{LinkSimulationConfig, simulate_bad_link};
+use cu_fec::{DensityThreshold, RepairParameters};
+use cu29_logstream::{
+    ContinuousDecoder, ContinuousEncoder, ContinuousReceiveEvent, EncodingSymbolId, Field,
+    FiniteObjectDecoder, FiniteObjectEncoder, FiniteObjectLimits, FiniteObjectSenderConfig, Lane,
+    ReceiverLimits, RecordKind, RlcConfig, StreamIdentity, WirePacket, decode_anchor,
+    decode_keyframe, decode_record, encode_keyframe_and_anchor, encode_record,
+};
+use cu29_runtime::curuntime::KeyFrame;
+
+const SYMBOL_SIZE: u16 = 256;
+const MAX_OBJECT_BYTES: u64 = 64 * 1024;
+
+fn identity() -> StreamIdentity {
+    StreamIdentity {
+        session_id: *b"object-session01",
+        sender_id: 17,
+    }
+}
+
+fn encoder() -> FiniteObjectEncoder {
+    FiniteObjectEncoder::new(FiniteObjectSenderConfig {
+        identity: identity(),
+        first_packet_sequence: 0,
+        lane: Lane::LargeObject,
+        symbol_size: SYMBOL_SIZE,
+        max_object_bytes: MAX_OBJECT_BYTES,
+        repair_symbols_per_block: 16,
+    })
+    .unwrap()
+}
+
+fn decoder() -> FiniteObjectDecoder {
+    FiniteObjectDecoder::new(
+        identity(),
+        Lane::LargeObject,
+        FiniteObjectLimits::new(MAX_OBJECT_BYTES, SYMBOL_SIZE, 4),
+    )
+    .unwrap()
+}
+
+#[test]
+fn raptorq_recovers_a_finite_record_over_a_bad_link() {
+    let payload = (0..7_000)
+        .map(|index| (index as u8).wrapping_mul(31))
+        .collect::<Vec<_>>();
+    let expected = encode_record(RecordKind::Manifest, 3, &payload).unwrap();
+    let mut datagrams = Vec::new();
+    encoder().push_record(&expected, &mut datagrams).unwrap();
+
+    let damaged = simulate_bad_link(
+        &datagrams,
+        LinkSimulationConfig {
+            seed: 0x6330_cafe,
+            drop_basis_points: 2_000,
+            corrupt_basis_points: 500,
+            duplicate_basis_points: 1_000,
+            reorder: true,
+        },
+    );
+    assert!(damaged.stats.dropped_datagrams > 0);
+    assert!(damaged.stats.corrupted_datagrams > 0);
+
+    let mut decoder = decoder();
+    let mut recovered = Vec::new();
+    for datagram in &damaged.datagrams {
+        decoder
+            .receive_datagram(datagram, |record| {
+                recovered.push(record.bytes().to_vec());
+                Ok::<(), core::convert::Infallible>(())
+            })
+            .unwrap();
+    }
+    assert_eq!(recovered, vec![expected]);
+    assert_eq!(decoder.occupancy(), 0);
+    assert_eq!(decoder.stats().objects_recovered, 1);
+    assert!(decoder.stats().repair_symbols_received > 0);
+}
+
+#[test]
+fn finite_object_consumer_failure_retains_the_record_for_retry() {
+    let expected = encode_record(RecordKind::Manifest, 4, b"retry-me").unwrap();
+    let mut datagrams = Vec::new();
+    encoder().push_record(&expected, &mut datagrams).unwrap();
+    let mut receiver = decoder();
+    let mut failed = false;
+    for datagram in &datagrams {
+        let result = receiver.receive_datagram(datagram, |_| Err("consumer unavailable"));
+        if result.is_err() {
+            failed = true;
+            break;
+        }
+    }
+    assert!(failed);
+    assert_eq!(receiver.occupancy(), 1);
+
+    let mut retried = Vec::new();
+    receiver
+        .drain_records(|record| {
+            retried.push(record.bytes().to_vec());
+            Ok::<(), core::convert::Infallible>(())
+        })
+        .unwrap();
+    assert_eq!(retried, vec![expected]);
+    assert_eq!(receiver.occupancy(), 0);
+}
+
+#[test]
+fn keyframe_and_anchor_recover_independently_and_bind_by_digest() {
+    let manifest = encode_record(RecordKind::Manifest, 9, b"resolved-session-plan").unwrap();
+    let manifest_digest = decode_record(&manifest).unwrap().digest;
+    let keyframe = KeyFrame {
+        culistid: 4_200,
+        timestamp: Default::default(),
+        serialized_tasks: (0..5_000)
+            .map(|index| (index as u8).wrapping_mul(17))
+            .collect(),
+    };
+    let (keyframe_record, anchor_record) =
+        encode_keyframe_and_anchor(&keyframe, 9, manifest_digest).unwrap();
+
+    let mut encoder = encoder();
+    let mut datagrams = Vec::new();
+    encoder
+        .push_record(&keyframe_record, &mut datagrams)
+        .unwrap();
+    encoder.push_record(&anchor_record, &mut datagrams).unwrap();
+    datagrams.reverse();
+    datagrams.retain(|datagram| {
+        let packet = WirePacket::decode(datagram).unwrap();
+        !packet.header.packet_sequence.is_multiple_of(7)
+    });
+
+    let mut receiver = decoder();
+    let mut recovered = Vec::new();
+    for datagram in &datagrams {
+        receiver
+            .receive_datagram(datagram, |record| {
+                recovered.push(record.bytes().to_vec());
+                Ok::<(), core::convert::Infallible>(())
+            })
+            .unwrap();
+    }
+    assert_eq!(recovered.len(), 2);
+
+    let recovered_keyframe = recovered
+        .iter()
+        .map(|bytes| decode_record(bytes).unwrap())
+        .find(|record| record.kind == RecordKind::KeyFrame)
+        .unwrap();
+    let recovered_anchor = recovered
+        .iter()
+        .map(|bytes| decode_record(bytes).unwrap())
+        .find(|record| record.kind == RecordKind::Anchor)
+        .unwrap();
+    let decoded_keyframe = decode_keyframe(recovered_keyframe.payload).unwrap();
+    let anchor = decode_anchor(recovered_anchor.payload).unwrap();
+
+    assert_eq!(decoded_keyframe.culistid, 4_200);
+    assert_eq!(decoded_keyframe.serialized_tasks, keyframe.serialized_tasks);
+    assert_eq!(anchor.copperlist_id, 4_200);
+    assert!(anchor.references_keyframe(recovered_keyframe));
+    assert!(anchor.references_manifest(decode_record(&manifest).unwrap()));
+}
+
+#[test]
+fn a_late_receiver_restarts_the_continuous_stream_at_the_anchor() {
+    const MAX_RLC_SYMBOL_SIZE: usize = 192;
+    const WINDOW_SYMBOLS: usize = 64;
+    const MAX_EQUATIONS: usize = 32;
+    const ANCHOR_ID: u64 = 12;
+    const LAST_ID: u64 = 20;
+
+    let rlc = RlcConfig::new(160, WINDOW_SYMBOLS, Field::Gf256).unwrap();
+    let mut continuous = ContinuousEncoder::<MAX_RLC_SYMBOL_SIZE, WINDOW_SYMBOLS>::new(
+        identity(),
+        0,
+        Lane::ReplayCritical,
+        rlc,
+        1_024,
+        EncodingSymbolId::new(0),
+    )
+    .unwrap();
+    let mut continuous_datagrams = Vec::new();
+    for id in 0..=LAST_ID {
+        let record = encode_record(RecordKind::CopperList, id, &[id as u8; 96]).unwrap();
+        continuous
+            .push_record(&record, &mut continuous_datagrams)
+            .unwrap();
+    }
+    for repair_key in 1..=12 {
+        continuous
+            .push_repair(
+                RepairParameters::new(repair_key, DensityThreshold::FULL),
+                &mut continuous_datagrams,
+            )
+            .unwrap();
+    }
+
+    // Everything before this boundary is intentionally unavailable to the late receiver.
+    continuous_datagrams.retain(|datagram| {
+        let packet = WirePacket::decode(datagram).unwrap();
+        packet.header.symbol_kind == cu29_logstream::FecSymbolKind::Repair
+            || packet.header.object_id >= ANCHOR_ID
+    });
+
+    let manifest = encode_record(RecordKind::Manifest, 1, b"late-join-manifest").unwrap();
+    let keyframe = KeyFrame {
+        culistid: ANCHOR_ID,
+        timestamp: Default::default(),
+        serialized_tasks: b"CUKF\x01".to_vec(),
+    };
+    let (keyframe_record, anchor_record) =
+        encode_keyframe_and_anchor(&keyframe, 1, decode_record(&manifest).unwrap().digest).unwrap();
+    let mut objects = encoder();
+    let mut object_datagrams = Vec::new();
+    objects
+        .push_record(&keyframe_record, &mut object_datagrams)
+        .unwrap();
+    objects
+        .push_record(&anchor_record, &mut object_datagrams)
+        .unwrap();
+    object_datagrams.reverse();
+
+    let mut object_receiver = decoder();
+    let mut recovered_objects = Vec::new();
+    for datagram in &object_datagrams {
+        object_receiver
+            .receive_datagram(datagram, |record| {
+                recovered_objects.push(record.bytes().to_vec());
+                Ok::<(), core::convert::Infallible>(())
+            })
+            .unwrap();
+    }
+    let anchor = recovered_objects
+        .iter()
+        .map(|record| decode_record(record).unwrap())
+        .find(|record| record.kind == RecordKind::Anchor)
+        .map(|record| decode_anchor(record.payload).unwrap())
+        .unwrap();
+    assert_eq!(anchor.copperlist_id, ANCHOR_ID);
+
+    let mut receiver =
+        ContinuousDecoder::<MAX_RLC_SYMBOL_SIZE, WINDOW_SYMBOLS, MAX_EQUATIONS>::new(
+            identity(),
+            Lane::ReplayCritical,
+            rlc,
+            MAX_EQUATIONS,
+            anchor.copperlist_id,
+            ReceiverLimits::new(1_024, WINDOW_SYMBOLS),
+        )
+        .unwrap();
+    let mut recovered_ids = Vec::new();
+    let mut gaps = Vec::new();
+    for datagram in &continuous_datagrams {
+        receiver
+            .receive_datagram(datagram, |event| {
+                match event {
+                    ContinuousReceiveEvent::Record(record) => {
+                        recovered_ids.push(record.decoded().unwrap().object_id);
+                    }
+                    ContinuousReceiveEvent::Gap(gap) => gaps.push(gap),
+                }
+                Ok::<(), core::convert::Infallible>(())
+            })
+            .unwrap();
+    }
+    assert!(gaps.is_empty());
+    assert_eq!(recovered_ids, (ANCHOR_ID..=LAST_ID).collect::<Vec<_>>());
+}

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -2319,9 +2319,9 @@ pub struct LoggingConfig {
 
     /// Generate and record task-state keyframes.
     ///
-    /// This is a compile-time application property: `#[copper_runtime]` emits no
-    /// keyframe capture calls when it is `false`. CopperList and structured logging
-    /// remain available.
+    /// Without another generated keyframe consumer, this is a compile-time application
+    /// property and `#[copper_runtime]` emits no capture calls when it is `false`.
+    /// A log-stream destination independently requests keyframe capture for anchors.
     #[serde(default = "default_as_true", skip_serializing_if = "Clone::clone")]
     pub enable_keyframe_logging: bool,
 


### PR DESCRIPTION
Stacked on #1317.

- adds bounded RFC 6330 RaptorQ encoding/decoding for finite semantic objects with receiver-local OTI and memory limits
- defines bincode keyframe and logical anchor records bound to manifest/keyframe record digests
- makes generated logstream runtimes capture keyframes independently of local keyframe logging
- emits repeated manifest, keyframe, and anchor objects through the nonblocking finite-object lane
- retains recovered objects across consumer failures and suppresses bounded duplicate deliveries
- proves bad-link object recovery and restart of the continuous CopperList stream at a late-join anchor

Validation:
- cargo +stable test -p cu29-logstream
- cargo +stable test -p cu29 --features logstream --test logstream_runtime
- cargo +stable check -p cu29-logstream --no-default-features
- focused Clippy with warnings denied
- just pr-check: formatting, std/no_std Clippy, embedded checks, and API checks passed; workspace tests stopped on unrelated cu_python_task tests because Python cbor2 is not installed locally
- cargo shear unavailable locally