### PR TITLE
Add UDP logstream resources

### DIFF
--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -126,6 +126,9 @@ jobs:
       - name: Run Unit Tests on (ubuntu-26.04 | debug)
         if: matrix.task == 'test'
         run: cargo +${{ inputs.toolchain }} nextest run $RELEASE_FLAG --all-targets $WORKSPACE_FLAG $WORKSPACE_EXCLUDES -- --skip test_compile_fail
+      - name: Run UDP logstream integration
+        if: matrix.task == 'test'
+        run: cargo +${{ inputs.toolchain }} test -p cu29-logstream-udp --features runtime-integration
       - name: Run cu29-derive trybuild tests on (ubuntu-26.04 | debug)
         if: matrix.task == 'trybuild'
         run: cargo +${{ inputs.toolchain }} test -p cu29-derive test_compile_fail -- --nocapture
@@ -205,6 +208,9 @@ jobs:
       - name: Run Unit Tests on (${{ inputs.linux_runner_label }} | debug)
         if: matrix.task == 'test'
         run: cargo +${{ inputs.toolchain }} nextest run $RELEASE_FLAG --all-targets $WORKSPACE_FLAG $WORKSPACE_EXCLUDES -- --skip test_compile_fail
+      - name: Run UDP logstream integration
+        if: matrix.task == 'test'
+        run: cargo +${{ inputs.toolchain }} test -p cu29-logstream-udp --features runtime-integration
       - name: Run cu29-derive trybuild tests on (${{ inputs.linux_runner_label }} | debug)
         if: matrix.task == 'trybuild'
         run: cargo +${{ inputs.toolchain }} test -p cu29-derive test_compile_fail -- --nocapture
@@ -406,6 +412,9 @@ jobs:
       - name: Run Unit Tests on (${{ matrix.target_os == 'windows' && inputs.windows_runner_label || 'macos-latest' }} | debug)
         if: matrix.task == 'test'
         run: cargo +${{ inputs.toolchain }} nextest run $RELEASE_FLAG --all-targets $WORKSPACE_FLAG $WORKSPACE_EXCLUDES -- --skip test_compile_fail
+      - name: Run UDP logstream integration
+        if: matrix.task == 'test'
+        run: cargo +${{ inputs.toolchain }} test -p cu29-logstream-udp --features runtime-integration
       - name: Run cu29-derive trybuild tests on (${{ matrix.target_os == 'windows' && inputs.windows_runner_label || 'macos-latest' }} | debug)
         if: matrix.task == 'trybuild'
         run: cargo +${{ inputs.toolchain }} test -p cu29-derive test_compile_fail -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
   "components/res/cu_micoairh743",
   "components/res/cu_linux_resources",
   "components/res/cu_rng",
+  "components/res/cu29_logstream_udp",
   "components/libs/cu_sdlogger",
   "components/bridges/cu_bdshot",
   "components/sinks/cu_rp_gpio",
@@ -246,6 +247,7 @@ cu-fec = { path = "components/libs/cu_fec", version = "1.2.0-dev", default-featu
 cu-linux-resources = { path = "components/res/cu_linux_resources", version = "1.2.0-dev" }
 cu-png-codec = { path = "components/codecs/cu_png_codec", version = "1.2.0-dev" }
 cu-rng = { path = "components/res/cu_rng", version = "1.2.0-dev" }
+cu29-logstream-udp = { path = "components/res/cu29_logstream_udp", version = "1.2.0-dev" }
 
 # Copper components
 cu-ads7883-new = { path = "components/sources/cu_ads7883", version = "1.2.0-dev" }

--- a/components/res/cu29_logstream_udp/Cargo.toml
+++ b/components/res/cu29_logstream_udp/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "cu29-logstream-udp"
+description = "Nonblocking UDP packet resources for Copper log streaming"
+documentation = "https://docs.rs/cu29-logstream-udp"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[package.metadata.copper]
+kind = "resource"
+domains = ["logging/streaming", "resource/network"]
+environments = ["host"]
+host_os = ["linux", "macos", "windows"]
+
+[features]
+# Keep the generated-runtime test opt-in: the carrier itself must not enable
+# cu29/logstream (and async-cl-io) across unrelated workspace applications.
+runtime-integration = ["cu29/logstream", "cu29/reflect"]
+
+[[test]]
+name = "configured_sender"
+required-features = ["runtime-integration"]
+
+[dependencies]
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
+  "std",
+] }
+cu29-logstream = { workspace = true, features = ["std"] }
+socket2 = { workspace = true, features = ["all"] }
+
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+libc = { workspace = true }
+
+[dev-dependencies]
+bincode = { workspace = true }
+serde = { workspace = true }
+tempfile = { workspace = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/res/cu29_logstream_udp/README.md
+++ b/components/res/cu29_logstream_udp/README.md
@@ -1,0 +1,126 @@
+# UDP logstream resources
+
+`cu29-logstream-udp` provides std-only `CuUdpLogStreamTx` and `CuUdpLogStreamRx` endpoints
+implementing the existing `CuStreamTx` and `CuStreamRx` packet traits. Linux and
+macOS are the primary hosts; Windows supports the basic carrier.
+
+The carrier submits each datagram once, nonblockingly. It does not retry,
+acknowledge, pace, encode FEC, or interpret manifests. `Ok(())` means the local
+socket accepted the datagram, not that a receiver received it. UDP can silently
+drop traffic when kernel queues fill. `WouldBlock` is returned immediately when
+the OS reports it; an interrupted operation is also returned without retry.
+
+## Sender resource
+
+Add `cu29-logstream-udp` to the application and enable `cu29/logstream`. Configure the
+socket in `resources`, then bind its concrete `tx` endpoint in `log_streaming`:
+
+```ron
+resources: [
+    (
+        id: "telemetry_udp",
+        provider: "cu29_logstream_udp::CuUdpLogStreamResources",
+        config: {
+            "bind_addr": "0.0.0.0:0",
+            "remote_addr": "127.0.0.1:7447",
+            "send_buffer_bytes": 262144,
+            "ttl": 1,
+            "dscp": 46,
+        },
+    ),
+],
+```
+
+The destination's transport binding is:
+
+```ron
+transport: (
+    type: "cu29_logstream_udp::CuUdpLogStreamTx",
+    resource: "telemetry_udp.tx",
+),
+```
+
+[The integration fixture](tests/configured_sender.ron) contains a complete
+configuration, including the required link, FEC, content, and record bounds.
+MTU and stream policy belong there, not in the UDP resource. The current sender
+carries bitrate/burst/latency policy in its manifest but does not yet enforce
+pacing; link scheduling and optional feedback are a later iteration.
+
+## Receiver resource
+
+Use the same provider with an explicit listen address and optional kernel buffer:
+
+```ron
+resources: [
+    (
+        id: "listen",
+        provider: "cu29_logstream_udp::CuUdpLogStreamResources",
+        config: {
+            "bind_addr": "127.0.0.1:7447",
+            "recv_buffer_bytes": 262144,
+        },
+    ),
+],
+```
+
+Take the `listen.rx` resource as `CuUdpLogStreamRx` and pass it, with a caller-owned
+packet buffer, to `SessionRouter::try_receive`. Standalone receivers can instead
+construct `CuUdpLogStreamConfig::new(listen_addr)` and call `.open()` to obtain the
+same endpoints. There are no environment-variable fallbacks or DNS lookups.
+
+The bundle always registers `rx`; it registers `tx` only when `remote_addr` is
+present. Both slots share one bound, unconnected socket. Endpoint clones share
+that socket without a userspace mutex. Receive clones compete for packets;
+they do not broadcast copies. A receive endpoint accepts datagrams from any
+sender and does not automatically transmit responses.
+
+## Socket options and bounds
+
+| Key | Meaning |
+| --- | --- |
+| `bind_addr` | Required numeric IPv4/IPv6 address and port; port zero requests an ephemeral port. |
+| `remote_addr` | Optional transmit destination, with the same address family and a nonzero port. |
+| `send_buffer_bytes` | Optional OS send-buffer request, in 1..=2147483647. |
+| `recv_buffer_bytes` | Optional OS receive-buffer request, in 1..=2147483647. |
+| `ttl` | Optional IPv4 unicast TTL / IPv6 unicast hop limit, in 1..=255. |
+| `dscp` | Optional six-bit DSCP value, in 0..=63; encoded with ECN bits zero. |
+
+Absent options keep OS defaults. Kernel buffer requests may be rounded or
+clamped by the OS. Unknown keys, numeric overflow, invalid address families, and
+out-of-range values are rejected during setup. IPv6 sockets use IPv6-only mode.
+IPv6 DSCP is supported on Linux, macOS, and Android; explicitly requesting it on
+other targets fails during setup. Explicit DSCP configuration is rejected on
+Windows for both address families: [Winsock requires its separate QoS API](https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options)
+to set the traffic class. Omit `dscp` for the basic Windows carrier.
+
+Reception writes directly into the supplied slice without an internal packet
+allocation or an extra payload copy. `Ok(None)` means no data, and `Ok(Some(0))`
+means an empty datagram. An oversized datagram is consumed and returns
+`BufferTooSmall`, never successful partial data; ignore buffer contents on error.
+Linux/Android return the original packet length as `needed`. Other supported
+hosts return a conservative sufficient capacity of 65,535 bytes because their
+receive API does not report the original length after truncation. Ordinary UDP
+datagrams are supported; IPv6 jumbograms are outside this contract. Configured
+streams should stay within their transport MTU, normally 1200 bytes on unknown
+IP paths, to avoid IP fragmentation.
+
+## Verification and iteration boundary
+
+From the repository root, run `just logstream-udp-check`. It checks Clippy and
+tests IPv4/IPv6 loopback, empty/exact/oversized datagrams, resource options,
+invalid configuration, shared endpoints, queue pressure, and error/no-retry
+behavior. A deterministic submission test covers `WouldBlock`: real UDP queue
+pressure often drops packets silently instead of returning backpressure.
+
+The recipe enables the crate's `runtime-integration` test feature explicitly.
+Normal carrier builds do not enable `cu29/logstream` or its asynchronous runtime
+features for other workspace apps. The root PR check and host CI run the
+integration test separately from the general workspace tests.
+
+The generated-runtime integration test receives actual UDP traffic in socket
+arrival order, discovers its manifest without out-of-band FEC settings, and
+decodes correctly ordered application-typed CopperLists and recovery objects.
+The current router discards packets preceding manifest discovery; this test
+does not sort packets to hide that startup limitation or assert a complete
+session archive. Automatic verified anchor recovery and native receiver
+archival are the next PR, followed by a runnable two-process demonstrator.

--- a/components/res/cu29_logstream_udp/build.rs
+++ b/components/res/cu29_logstream_udp/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    cu29_build::setup();
+}

--- a/components/res/cu29_logstream_udp/src/lib.rs
+++ b/components/res/cu29_logstream_udp/src/lib.rs
@@ -1,0 +1,306 @@
+//! Nonblocking UDP carriers for Copper's packet-oriented log streaming traits.
+//!
+//! Socket setup happens once, before endpoints enter the output worker. Packet calls
+//! perform one socket operation with no allocation, locking, retry, or acknowledgement.
+//! FEC, pacing, and session policy belong to logstream, above this resource.
+
+use cu29::bundle_resources;
+use cu29::config::ComponentConfig;
+use cu29::resource::{BundleContext, ResourceBundle, ResourceManager};
+use cu29::{CuError, CuResult};
+use cu29_logstream::{CuStreamRx, CuStreamRxError, CuStreamTx, CuStreamTxError};
+use socket2::{Domain, MaybeUninitSlice, Protocol, SockAddr, Socket, Type};
+use std::io;
+use std::mem::MaybeUninit;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+/// Conservative capacity for any ordinary UDP datagram (IPv6 jumbograms excluded).
+/// Used for truncation reports on OSes that do not return the original packet size.
+const UDP_DATAGRAM_CAPACITY: usize = 65_535;
+
+/// Explicit socket configuration, shared by the RON bundle and standalone receivers.
+///
+/// `bind_addr` is required. `remote_addr` enables the `tx` slot; the `rx` slot always
+/// exists. Both slots share one bound socket. Addresses must be numeric IPv4/IPv6
+/// socket addresses: setup does not perform DNS resolution. Optional socket options
+/// retain OS defaults when absent. Kernel buffer sizes are requests, subject to OS
+/// rounding and limits; they are unrelated to the stream's MTU or FEC memory budget.
+#[derive(Clone, Debug)]
+pub struct CuUdpLogStreamConfig {
+    pub bind_addr: SocketAddr,
+    pub remote_addr: Option<SocketAddr>,
+    pub send_buffer_bytes: Option<usize>,
+    pub recv_buffer_bytes: Option<usize>,
+    /// IPv4 unicast TTL or IPv6 unicast hop limit, in 1..=255.
+    pub ttl: Option<u32>,
+    /// Six-bit DSCP value, in 0..=63. ECN bits remain zero.
+    pub dscp: Option<u8>,
+}
+
+impl CuUdpLogStreamConfig {
+    /// Listen on this address with OS socket defaults and no transmit destination.
+    pub const fn new(bind_addr: SocketAddr) -> Self {
+        Self {
+            bind_addr,
+            remote_addr: None,
+            send_buffer_bytes: None,
+            recv_buffer_bytes: None,
+            ttl: None,
+            dscp: None,
+        }
+    }
+
+    /// Parse the resource-bundle configuration, rejecting unknown or mistyped keys.
+    pub fn from_component(config: &ComponentConfig) -> CuResult<Self> {
+        for key in config.0.keys() {
+            if !matches!(
+                key.as_str(),
+                "bind_addr"
+                    | "remote_addr"
+                    | "send_buffer_bytes"
+                    | "recv_buffer_bytes"
+                    | "ttl"
+                    | "dscp"
+            ) {
+                return Err(CuError::from(format!(
+                    "Unknown UDP resource option '{key}'"
+                )));
+            }
+        }
+        let bind = config
+            .get::<String>("bind_addr")?
+            .ok_or_else(|| CuError::from("UDP resource requires bind_addr"))?;
+        let mut parsed = Self::new(parse_addr(&bind)?);
+        parsed.remote_addr = config
+            .get::<String>("remote_addr")?
+            .map(|value| parse_addr(&value))
+            .transpose()?;
+        parsed.send_buffer_bytes = config.get_value("send_buffer_bytes")?;
+        parsed.recv_buffer_bytes = config.get_value("recv_buffer_bytes")?;
+        parsed.ttl = config.get_value("ttl")?;
+        parsed.dscp = config.get_value("dscp")?;
+        parsed.validate()?;
+        Ok(parsed)
+    }
+
+    fn validate(&self) -> CuResult<()> {
+        if let Some(remote) = self.remote_addr
+            && (remote.is_ipv4() != self.bind_addr.is_ipv4() || remote.port() == 0)
+        {
+            return Err(CuError::from(
+                "UDP remote_addr must match the bind address family and have a nonzero port",
+            ));
+        }
+        if [self.send_buffer_bytes, self.recv_buffer_bytes]
+            .into_iter()
+            .flatten()
+            .any(|size| size == 0 || i32::try_from(size).is_err())
+        {
+            return Err(CuError::from(
+                "UDP socket buffer sizes must be in 1..=2147483647",
+            ));
+        }
+        if self.ttl.is_some_and(|ttl| !(1..=255).contains(&ttl)) {
+            return Err(CuError::from("UDP ttl must be in 1..=255"));
+        }
+        if self.dscp.is_some_and(|dscp| dscp > 63) {
+            return Err(CuError::from("UDP dscp must be in 0..=63"));
+        }
+        #[cfg(windows)]
+        if self.dscp.is_some() {
+            // Winsock requires the separate QoS API; IP_TOS is not a portable
+            // way to honor an explicitly requested DSCP value on Windows.
+            return Err(CuError::from(
+                "UDP DSCP configuration is unsupported on Windows",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Open one nonblocking socket and create its typed endpoints.
+    ///
+    /// Clones share the socket without a userspace mutex. Receive clones compete
+    /// for datagrams; they do not subscribe to copies of the same traffic. The socket
+    /// is unconnected, so reception accepts any sender and creates no reverse channel.
+    pub fn open(&self) -> CuResult<(Option<CuUdpLogStreamTx>, CuUdpLogStreamRx)> {
+        self.validate()?;
+        let socket = self.open_socket().map_err(|error| {
+            CuError::new_with_cause("Failed to configure UDP stream socket", error)
+        })?;
+        let socket = Arc::new(socket);
+        let tx = self.remote_addr.map(|remote| CuUdpLogStreamTx {
+            socket: socket.clone(),
+            remote: remote.into(),
+        });
+        Ok((tx, CuUdpLogStreamRx { socket }))
+    }
+
+    fn open_socket(&self) -> io::Result<Socket> {
+        let socket = Socket::new(
+            Domain::for_address(self.bind_addr),
+            Type::DGRAM,
+            Some(Protocol::UDP),
+        )?;
+        socket.set_nonblocking(true)?;
+        if self.bind_addr.is_ipv6() {
+            socket.set_only_v6(true)?;
+        }
+        if let Some(size) = self.send_buffer_bytes {
+            socket.set_send_buffer_size(size)?;
+        }
+        if let Some(size) = self.recv_buffer_bytes {
+            socket.set_recv_buffer_size(size)?;
+        }
+        if let Some(ttl) = self.ttl {
+            if self.bind_addr.is_ipv4() {
+                socket.set_ttl_v4(ttl)?;
+            } else {
+                socket.set_unicast_hops_v6(ttl)?;
+            }
+        }
+        if let Some(dscp) = self.dscp {
+            let traffic_class = u32::from(dscp) << 2;
+            if self.bind_addr.is_ipv4() {
+                socket.set_tos_v4(traffic_class)?;
+            } else {
+                set_ipv6_traffic_class(&socket, traffic_class)?;
+            }
+        }
+        socket.bind(&self.bind_addr.into())?;
+        Ok(socket)
+    }
+}
+
+fn parse_addr(value: &str) -> CuResult<SocketAddr> {
+    value.parse().map_err(|error| {
+        CuError::new_with_cause("UDP address must be a numeric IP address and port", error)
+    })
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))]
+fn set_ipv6_traffic_class(socket: &Socket, value: u32) -> io::Result<()> {
+    socket.set_tclass_v6(value)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "android")))]
+fn set_ipv6_traffic_class(_socket: &Socket, _value: u32) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "IPv6 DSCP is unsupported on this platform",
+    ))
+}
+
+/// Cloneable, one-way UDP transmitter. Success means local socket acceptance only.
+#[derive(Clone, Debug)]
+pub struct CuUdpLogStreamTx {
+    socket: Arc<Socket>,
+    remote: SockAddr,
+}
+
+impl CuUdpLogStreamTx {
+    pub fn local_addr(&self) -> io::Result<SocketAddr> {
+        local_addr(&self.socket)
+    }
+}
+
+impl CuStreamTx for CuUdpLogStreamTx {
+    fn try_send(&mut self, packet: &[u8]) -> Result<(), CuStreamTxError> {
+        submit_once(packet, |packet| self.socket.send_to(packet, &self.remote))
+    }
+}
+
+// Keeping the one-call boundary explicit also lets tests force WouldBlock and
+// Interrupted without assuming that a real UDP kernel queue reports saturation.
+fn submit_once(
+    packet: &[u8],
+    send: impl FnOnce(&[u8]) -> io::Result<usize>,
+) -> Result<(), CuStreamTxError> {
+    match send(packet) {
+        Ok(len) if len == packet.len() => Ok(()),
+        Ok(_) => Err(CuStreamTxError::Failed(
+            "UDP socket accepted an incomplete datagram",
+        )),
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock => Err(CuStreamTxError::WouldBlock),
+        Err(_) => Err(CuStreamTxError::Failed("UDP datagram submission failed")),
+    }
+}
+
+/// Cloneable nonblocking receiver with no internal packet buffer.
+///
+/// An oversized datagram is consumed and rejected, never returned as a partial
+/// packet. Linux/Android report its exact length in `BufferTooSmall::needed`;
+/// other supported OSes report a conservative sufficient capacity of 65,535 bytes.
+/// The caller must ignore buffer contents on error. Empty datagrams are `Some(0)`.
+#[derive(Clone, Debug)]
+pub struct CuUdpLogStreamRx {
+    socket: Arc<Socket>,
+}
+
+impl CuUdpLogStreamRx {
+    pub fn local_addr(&self) -> io::Result<SocketAddr> {
+        local_addr(&self.socket)
+    }
+}
+
+impl CuStreamRx for CuUdpLogStreamRx {
+    fn try_recv(&mut self, packet: &mut [u8]) -> Result<Option<usize>, CuStreamRxError> {
+        let capacity = packet.len();
+        // SAFETY: u8 and MaybeUninit<u8> have identical layout. The exclusive borrow
+        // lives only for this call. socket2 guarantees recv_from_vectored_with_flags
+        // writes only initialized bytes, preserving validity even when receive fails.
+        let buffer = unsafe { &mut *(packet as *mut [u8] as *mut [MaybeUninit<u8>]) };
+        let mut buffers = [MaybeUninitSlice::new(buffer)];
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        let flags = libc::MSG_TRUNC;
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        let flags = 0;
+        match self
+            .socket
+            .recv_from_vectored_with_flags(&mut buffers, flags)
+        {
+            Ok((len, flags, _)) if flags.is_truncated() || len > capacity => {
+                let needed = if len > capacity {
+                    len
+                } else {
+                    UDP_DATAGRAM_CAPACITY
+                };
+                Err(CuStreamRxError::BufferTooSmall { needed })
+            }
+            Ok((len, _, _)) => Ok(Some(len)),
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => Ok(None),
+            Err(_) => Err(CuStreamRxError::Failed("UDP datagram reception failed")),
+        }
+    }
+}
+
+fn local_addr(socket: &Socket) -> io::Result<SocketAddr> {
+    socket
+        .local_addr()?
+        .as_socket()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "UDP socket has no IP address"))
+}
+
+/// Copper bundle exposing statically named `tx` and `rx` resource slots.
+/// `tx` is populated only when `remote_addr` is configured; `rx` is always populated.
+pub struct CuUdpLogStreamResources;
+
+bundle_resources!(CuUdpLogStreamResources: Tx, Rx);
+
+impl ResourceBundle for CuUdpLogStreamResources {
+    fn build(
+        bundle: BundleContext<Self>,
+        config: Option<&ComponentConfig>,
+        manager: &mut ResourceManager,
+    ) -> CuResult<()> {
+        let config = config.ok_or_else(|| CuError::from("UDP resource requires configuration"))?;
+        let (tx, rx) = CuUdpLogStreamConfig::from_component(config)?.open()?;
+        if let Some(tx) = tx {
+            manager.add_owned(bundle.key(CuUdpLogStreamResourcesId::Tx), tx)?;
+        }
+        manager.add_owned(bundle.key(CuUdpLogStreamResourcesId::Rx), rx)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/components/res/cu29_logstream_udp/src/tests.rs
+++ b/components/res/cu29_logstream_udp/src/tests.rs
@@ -1,0 +1,328 @@
+use super::*;
+use cu29::resource::BundleIndex;
+use std::net::UdpSocket;
+use std::time::{Duration, Instant};
+
+fn component(config: &str) -> ComponentConfig {
+    cu29::config::CuConfig::deserialize_ron(&format!(
+        "(resources: [(id: \"network\", provider: \"cu29_logstream_udp::CuUdpLogStreamResources\", config: {config})], tasks: [], cnx: [])"
+    ))
+    .unwrap()
+    .resources.remove(0).config.unwrap()
+}
+
+fn receiver() -> CuUdpLogStreamRx {
+    CuUdpLogStreamConfig::new("127.0.0.1:0".parse().unwrap())
+        .open()
+        .unwrap()
+        .1
+}
+
+fn sender(remote: SocketAddr) -> CuUdpLogStreamTx {
+    let mut config = CuUdpLogStreamConfig::new("127.0.0.1:0".parse().unwrap());
+    config.remote_addr = Some(remote);
+    config.open().unwrap().0.unwrap()
+}
+
+fn receive(rx: &mut CuUdpLogStreamRx, packet: &mut [u8]) -> Result<usize, CuStreamRxError> {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        match rx.try_recv(packet)? {
+            Some(len) => return Ok(len),
+            None => {
+                assert!(Instant::now() < deadline, "UDP packet did not arrive");
+                std::thread::yield_now();
+            }
+        }
+    }
+}
+
+#[test]
+fn packets_are_atomic_and_receive_clones_share_one_queue() {
+    let mut rx = receiver();
+    let mut tx = sender(rx.local_addr().unwrap());
+    let mut rx_clone = rx.clone();
+    let mut tx_clone = tx.clone();
+    assert_eq!(tx.local_addr().unwrap(), tx_clone.local_addr().unwrap());
+    let mut packet = [0; 32];
+    assert_eq!(rx.try_recv(&mut packet), Ok(None));
+    tx.try_send(b"first").unwrap();
+    tx_clone.try_send(b"second packet").unwrap();
+    let first = receive(&mut rx, &mut packet).unwrap();
+    assert_eq!(&packet[..first], b"first");
+    let second = receive(&mut rx_clone, &mut packet).unwrap();
+    assert_eq!(&packet[..second], b"second packet");
+    assert_eq!(rx.try_recv(&mut packet), Ok(None));
+    assert_eq!(rx_clone.try_recv(&mut packet), Ok(None));
+}
+
+#[test]
+fn truncation_consumes_one_packet_and_never_returns_partial_success() {
+    let mut rx = receiver();
+    let mut tx = sender(rx.local_addr().unwrap());
+    let mut packet = [0; 8];
+    tx.try_send(&[7; 128]).unwrap();
+    tx.try_send(b"next").unwrap();
+    let error = receive(&mut rx, &mut packet).unwrap_err();
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    assert_eq!(error, CuStreamRxError::BufferTooSmall { needed: 128 });
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    assert_eq!(
+        error,
+        CuStreamRxError::BufferTooSmall {
+            needed: UDP_DATAGRAM_CAPACITY
+        }
+    );
+    let len = receive(&mut rx, &mut packet).unwrap();
+    assert_eq!(&packet[..len], b"next");
+    assert_eq!(rx.try_recv(&mut packet), Ok(None));
+}
+
+#[test]
+fn empty_packets_and_exact_capacity_are_distinct_from_no_data() {
+    let mut rx = receiver();
+    let mut tx = sender(rx.local_addr().unwrap());
+    tx.try_send(b"").unwrap();
+    assert_eq!(receive(&mut rx, &mut []), Ok(0));
+    assert_eq!(rx.try_recv(&mut []), Ok(None));
+    tx.try_send(b"x").unwrap();
+    assert!(matches!(
+        receive(&mut rx, &mut []),
+        Err(CuStreamRxError::BufferTooSmall { .. })
+    ));
+    tx.try_send(b"12345678").unwrap();
+    let mut packet = [0; 8];
+    assert_eq!(receive(&mut rx, &mut packet), Ok(8));
+    assert_eq!(&packet, b"12345678");
+}
+
+#[test]
+fn socket_options_are_applied_and_slots_share_the_bound_socket() {
+    let config = component(
+        r#"{
+        "bind_addr": "127.0.0.1:0", "remote_addr": "127.0.0.1:7447",
+        "send_buffer_bytes": 32768, "recv_buffer_bytes": 32768,
+        "ttl": 7
+    }"#,
+    );
+    #[cfg(not(windows))]
+    let config = {
+        let mut config = config;
+        config.set("dscp", 46u8);
+        config
+    };
+    let mut manager = ResourceManager::new(&[2]);
+    CuUdpLogStreamResources::build(
+        BundleContext::new(BundleIndex::new(0), "network"),
+        Some(&config),
+        &mut manager,
+    )
+    .unwrap();
+    let context = BundleContext::<CuUdpLogStreamResources>::new(BundleIndex::new(0), "network");
+    let tx: CuUdpLogStreamTx = manager
+        .take(context.key(CuUdpLogStreamResourcesId::Tx))
+        .unwrap()
+        .0;
+    let mut rx: CuUdpLogStreamRx = manager
+        .take(context.key(CuUdpLogStreamResourcesId::Rx))
+        .unwrap()
+        .0;
+    assert_eq!(tx.local_addr().unwrap(), rx.local_addr().unwrap());
+    assert_eq!(tx.socket.ttl_v4().unwrap(), 7);
+    #[cfg(not(windows))]
+    assert_eq!(tx.socket.tos_v4().unwrap(), 46 << 2);
+    assert!(tx.socket.send_buffer_size().unwrap() >= 32768);
+    assert!(rx.socket.recv_buffer_size().unwrap() >= 32768);
+    assert_eq!(rx.try_recv(&mut [0; 8]), Ok(None));
+}
+
+#[test]
+fn receiver_only_bundle_does_not_register_a_transmitter() {
+    let config = component(r#"{"bind_addr": "127.0.0.1:0"}"#);
+    let mut manager = ResourceManager::new(&[2]);
+    CuUdpLogStreamResources::build(
+        BundleContext::new(BundleIndex::new(0), "listen"),
+        Some(&config),
+        &mut manager,
+    )
+    .unwrap();
+    let context = BundleContext::<CuUdpLogStreamResources>::new(BundleIndex::new(0), "listen");
+    assert!(
+        manager
+            .take::<CuUdpLogStreamTx>(context.key(CuUdpLogStreamResourcesId::Tx))
+            .is_err()
+    );
+    assert!(
+        manager
+            .take::<CuUdpLogStreamRx>(context.key(CuUdpLogStreamResourcesId::Rx))
+            .is_ok()
+    );
+}
+
+#[test]
+fn invalid_configuration_is_rejected_before_socket_setup() {
+    for config in [
+        r#"{}"#,
+        r#"{"bind_addr": "localhost:1234"}"#,
+        r#"{"bind_addr": 1234}"#,
+        r#"{"bind_addr": "127.0.0.1:0", "mtu_bytes": 1200}"#,
+        r#"{"bind_addr": "127.0.0.1:0", "remote_addr": "[::1]:1234"}"#,
+        r#"{"bind_addr": "127.0.0.1:0", "remote_addr": "127.0.0.1:0"}"#,
+        r#"{"bind_addr": "127.0.0.1:0", "send_buffer_bytes": 0}"#,
+        r#"{"bind_addr": "127.0.0.1:0", "send_buffer_bytes": 4294967296}"#,
+        r#"{"bind_addr": "127.0.0.1:0", "recv_buffer_bytes": -1}"#,
+        r#"{"bind_addr": "127.0.0.1:0", "ttl": 0}"#,
+        r#"{"bind_addr": "127.0.0.1:0", "ttl": 256}"#,
+        r#"{"bind_addr": "127.0.0.1:0", "ttl": 4294967297}"#,
+        r#"{"bind_addr": "127.0.0.1:0", "dscp": 64}"#,
+        r#"{"bind_addr": "127.0.0.1:0", "dscp": 256}"#,
+        r#"{"bind_addr": "127.0.0.1:0", "dscp": "46"}"#,
+    ] {
+        let component = component(config);
+        assert!(
+            CuUdpLogStreamConfig::from_component(&component).is_err(),
+            "accepted {config}"
+        );
+    }
+    let mut manager = ResourceManager::new(&[2]);
+    assert!(
+        CuUdpLogStreamResources::build(
+            BundleContext::new(BundleIndex::new(0), "missing"),
+            None,
+            &mut manager,
+        )
+        .is_err()
+    );
+    let mut typed = CuUdpLogStreamConfig::new("127.0.0.1:0".parse().unwrap());
+    typed.dscp = Some(64);
+    assert!(typed.open().is_err());
+}
+
+#[test]
+fn bind_errors_preserve_the_socket_setup_cause() {
+    let held = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let error = CuUdpLogStreamConfig::new(held.local_addr().unwrap())
+        .open()
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("Failed to configure UDP stream socket")
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_rejects_explicit_dscp_instead_of_claiming_it_was_applied() {
+    let mut config = CuUdpLogStreamConfig::new("127.0.0.1:0".parse().unwrap());
+    config.dscp = Some(46);
+    let error = config.open().unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("DSCP configuration is unsupported on Windows")
+    );
+}
+
+#[test]
+fn backpressure_and_interruption_are_returned_after_one_submission() {
+    for (kind, expected) in [
+        (io::ErrorKind::WouldBlock, CuStreamTxError::WouldBlock),
+        (
+            io::ErrorKind::Interrupted,
+            CuStreamTxError::Failed("UDP datagram submission failed"),
+        ),
+        (
+            io::ErrorKind::PermissionDenied,
+            CuStreamTxError::Failed("UDP datagram submission failed"),
+        ),
+    ] {
+        let mut calls = 0;
+        let result = submit_once(b"packet", |packet| {
+            calls += 1;
+            assert_eq!(packet, b"packet");
+            Err(kind.into())
+        });
+        assert_eq!(result, Err(expected));
+        assert_eq!(calls, 1);
+    }
+    assert!(matches!(
+        submit_once(b"packet", |_| Ok(2)),
+        Err(CuStreamTxError::Failed(_))
+    ));
+}
+
+#[test]
+fn oversized_udp_send_fails_without_splitting_or_retaining_the_packet() {
+    let mut rx = receiver();
+    let mut tx = sender(rx.local_addr().unwrap());
+    assert!(matches!(
+        tx.try_send(&vec![0; 65536]),
+        Err(CuStreamTxError::Failed(_))
+    ));
+    assert_eq!(rx.try_recv(&mut [0; 8]), Ok(None));
+    tx.try_send(b"ok").unwrap();
+    let mut packet = [0; 8];
+    assert_eq!(receive(&mut rx, &mut packet), Ok(2));
+    assert_eq!(&packet[..2], b"ok");
+}
+
+#[test]
+fn full_receive_queue_drops_packets_without_replay_or_partial_packets() {
+    let mut config = CuUdpLogStreamConfig::new("127.0.0.1:0".parse().unwrap());
+    config.recv_buffer_bytes = Some(8192);
+    let mut rx = config.open().unwrap().1;
+    let mut tx = sender(rx.local_addr().unwrap());
+    const COUNT: usize = 4096;
+    let mut sent = 0;
+    for id in 0..COUNT {
+        let mut packet = [0xa5; 1024];
+        packet[..8].copy_from_slice(&(id as u64).to_le_bytes());
+        match tx.try_send(&packet) {
+            Ok(()) => sent += 1,
+            Err(CuStreamTxError::WouldBlock) => {}
+            other => panic!("unexpected send result: {other:?}"),
+        }
+    }
+    let mut last = None;
+    let mut received = 0;
+    let mut packet = [0; 1024];
+    while let Some(len) = rx.try_recv(&mut packet).unwrap() {
+        assert_eq!(len, packet.len());
+        assert!(packet[8..].iter().all(|&byte| byte == 0xa5));
+        let id = u64::from_le_bytes(packet[..8].try_into().unwrap());
+        assert!(last.is_none_or(|previous| id > previous));
+        last = Some(id);
+        received += 1;
+        assert!(received <= COUNT);
+    }
+    assert!(received > 0);
+    assert!(
+        received < sent,
+        "small unread receive queue should shed UDP traffic"
+    );
+    tx.try_send(b"after pressure").unwrap();
+    let len = receive(&mut rx, &mut packet).unwrap();
+    assert_eq!(&packet[..len], b"after pressure");
+    assert_eq!(rx.try_recv(&mut packet), Ok(None));
+}
+
+#[test]
+fn ipv6_loopback_uses_hop_limit_and_preserves_packets() {
+    let mut config = CuUdpLogStreamConfig::new("[::1]:0".parse().unwrap());
+    config.ttl = Some(9);
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))]
+    {
+        config.dscp = Some(12);
+    }
+    let mut rx = config.open().unwrap().1;
+    config.remote_addr = Some(rx.local_addr().unwrap());
+    let mut tx = config.open().unwrap().0.unwrap();
+    assert_eq!(tx.socket.unicast_hops_v6().unwrap(), 9);
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))]
+    assert_eq!(tx.socket.tclass_v6().unwrap(), 12 << 2);
+    tx.try_send(b"ipv6").unwrap();
+    let mut packet = [0; 4];
+    assert_eq!(receive(&mut rx, &mut packet), Ok(4));
+    assert_eq!(&packet, b"ipv6");
+}

--- a/components/res/cu29_logstream_udp/tests/configured_sender.ron
+++ b/components/res/cu29_logstream_udp/tests/configured_sender.ron
@@ -1,0 +1,69 @@
+(
+    logging: (
+        enable_task_logging: false,
+        enable_keyframe_logging: false,
+        keyframe_interval: 1,
+        copperlist_count: 8,
+    ),
+    resources: [
+        (
+            id: "network",
+            provider: "cu29_logstream_udp::CuUdpLogStreamResources",
+            config: {
+                "bind_addr": "127.0.0.1:0",
+                "remote_addr": "127.0.0.1:7447",
+                "send_buffer_bytes": 262144,
+                "ttl": 1,
+            },
+        ),
+    ],
+    log_streaming: (
+        destinations: [
+            (
+                id: "ground",
+                transport: (
+                    type: "cu29_logstream_udp::CuUdpLogStreamTx",
+                    resource: "network.tx",
+                ),
+                link: (
+                    mtu_bytes: 1200,
+                    bitrate_bps: 1000000,
+                    memory_budget_kib: 512,
+                    max_latency_ms: 250,
+                    burst_packets: 8,
+                ),
+                fec: (
+                    continuous: (
+                        field: Gf256,
+                        window_symbols: 64,
+                        repair_every_source_symbols: 4,
+                        repair_density: Full,
+                    ),
+                    objects: (
+                        max_object_bytes: 65536,
+                        repair_symbols_per_block: 2,
+                    ),
+                ),
+                content: (
+                    archive: true,
+                    live_viz: true,
+                    anchor_interval: 16,
+                ),
+                max_record_bytes: 4096,
+            ),
+        ],
+    ),
+    tasks: [
+        (
+            id: "source",
+            type: "UdpSource",
+        ),
+    ],
+    cnx: [
+        (
+            src: "source",
+            dst: "__nc__",
+            msg: "UdpMessage",
+        ),
+    ],
+)

--- a/components/res/cu29_logstream_udp/tests/configured_sender.rs
+++ b/components/res/cu29_logstream_udp/tests/configured_sender.rs
@@ -1,0 +1,159 @@
+use bincode::{Decode, Encode};
+use cu29::prelude::*;
+use cu29::resource::{BundleContext, BundleIndex, ResourceBundle, ResourceManager};
+use cu29_logstream::{
+    FiniteObjectLimits, RecordKind, SessionEvent, SessionRouter, SessionRouterLimits,
+    decode_copperlist,
+};
+use cu29_logstream_udp::{CuUdpLogStreamResources, CuUdpLogStreamResourcesId, CuUdpLogStreamRx};
+use serde::{Deserialize, Serialize};
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Encode, Decode, Serialize, Deserialize, Reflect)]
+struct UdpMessage(u64);
+
+#[derive(Default, Reflect)]
+struct UdpSource {
+    next: u64,
+}
+
+impl Freezable for UdpSource {}
+
+impl CuSrcTask for UdpSource {
+    type Resources<'r> = ();
+    type Output<'m> = output_msg!(UdpMessage);
+
+    fn new(_config: Option<&ComponentConfig>, _resources: ()) -> CuResult<Self> {
+        Ok(Self::default())
+    }
+
+    fn process(&mut self, _ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
+        output.set_payload(UdpMessage(self.next));
+        self.next += 1;
+        Ok(())
+    }
+}
+
+#[copper_runtime(config = "tests/configured_sender.ron")]
+struct UdpApp {}
+
+#[test]
+fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<()> {
+    // Construct the receiver from the same public RON resource contract, before
+    // starting the sender. Port zero keeps parallel tests independent.
+    let receiver_config = CuConfig::deserialize_ron(
+        r#"(
+        resources: [(
+            id: "listen",
+            provider: "cu29_logstream_udp::CuUdpLogStreamResources",
+            config: {"bind_addr": "127.0.0.1:0", "recv_buffer_bytes": 262144},
+        )],
+        tasks: [], cnx: [],
+    )"#,
+    )?;
+    let mut resources = ResourceManager::new(&[2]);
+    CuUdpLogStreamResources::build(
+        BundleContext::new(BundleIndex::new(0), "listen"),
+        receiver_config.resources[0].config.as_ref(),
+        &mut resources,
+    )?;
+    let context = BundleContext::<CuUdpLogStreamResources>::new(BundleIndex::new(0), "listen");
+    let mut rx: CuUdpLogStreamRx = resources
+        .take(context.key(CuUdpLogStreamResourcesId::Rx))?
+        .0;
+    let mut sender_config = CuConfig::deserialize_ron(include_str!("configured_sender.ron"))?;
+    sender_config.resources[0]
+        .config
+        .as_mut()
+        .unwrap()
+        .set("remote_addr", rx.local_addr().unwrap().to_string());
+
+    // The receiver knows hard capacity limits, but no sender identity or FEC plan.
+    let mut router = SessionRouter::<1128, 64, 64>::new(SessionRouterLimits {
+        max_sessions: 1,
+        max_pending_events: 64,
+        max_record_bytes: 4096,
+        max_buffered_records: 64,
+        equation_capacity: 64,
+        finite_objects: FiniteObjectLimits::new(65536, 1128, 4),
+    })
+    .unwrap();
+    let mut ids = Vec::new();
+    let mut manifest_seen = false;
+    let mut keyframe_seen = false;
+    let mut anchor_seen = false;
+    let mut gaps = Vec::new();
+    let mut emit = |event| {
+        match event {
+            SessionEvent::Manifest(manifest) => {
+                assert_eq!(manifest.identity.sender_id, 41);
+                assert_eq!(manifest.plan.destination_id, "ground");
+                assert_eq!(manifest.plan.symbol_size, 1128);
+                assert_eq!(manifest.application_schema.outputs.len(), 1);
+                assert_eq!(
+                    manifest.application_schema.outputs[0].payload_type,
+                    core::any::type_name::<UdpMessage>()
+                );
+                manifest_seen = true;
+            }
+            SessionEvent::ContinuousRecord { identity, record } => {
+                assert!(manifest_seen);
+                assert_eq!(identity.sender_id, 41);
+                let record = record.decoded().unwrap();
+                let copperlist: default::CuList = decode_copperlist(record.payload).unwrap();
+                assert_eq!(record.object_id, copperlist.id);
+                assert_eq!(
+                    copperlist.msgs.0.0.payload(),
+                    Some(&UdpMessage(copperlist.id))
+                );
+                assert!(ids.last().is_none_or(|&id| copperlist.id > id));
+                ids.push(copperlist.id);
+            }
+            SessionEvent::Object { record, .. } => match record.decoded().unwrap().kind {
+                RecordKind::KeyFrame => keyframe_seen = true,
+                RecordKind::Anchor => anchor_seen = true,
+                _ => {}
+            },
+            SessionEvent::Gap { gap, .. } => gaps.push(gap),
+        }
+        Ok::<(), core::convert::Infallible>(())
+    };
+
+    let logs = tempfile::tempdir().unwrap();
+    let app = UdpApp::builder()
+        .with_instance_id(41)
+        .with_config(sender_config)
+        .with_log_path(logs.path().join("sender.copper"), Some(1024 * 1024))?
+        .build()?;
+    let mut running = app.start()?;
+    let mut packet = [0; 1200];
+    const ITERATIONS: u64 = 128;
+    for _ in 0..ITERATIONS {
+        running.run_one_iteration()?;
+        // Allow the asynchronous output workers to progress. This is test driving,
+        // not carrier pacing. Every datagram is consumed in actual socket order.
+        std::thread::sleep(Duration::from_millis(1));
+        while router.try_receive(&mut rx, &mut packet, &mut emit).unwrap() {}
+    }
+    drop(running.stop()?);
+    let deadline = Instant::now() + Duration::from_millis(100);
+    while Instant::now() < deadline {
+        if !router.try_receive(&mut rx, &mut packet, &mut emit).unwrap() {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+    }
+
+    assert!(manifest_seen && keyframe_seen && anchor_seen);
+    assert_eq!(router.stats().sessions_discovered, 1);
+    assert_eq!(router.stats().malformed_datagrams, 0);
+    // Startup data can precede the manifest and be discarded by today's router.
+    // Full history and automatic anchor resume are the next PR's contract. Here
+    // require a substantial ordered, correctly typed suffix without sorting traffic.
+    assert!(
+        ids.len() >= 32,
+        "too few recovered records: {}; gaps: {gaps:?}",
+        ids.len()
+    );
+    assert_eq!(ids.last(), Some(&(ITERATIONS - 1)));
+    Ok(())
+}

--- a/components/res/cu29_logstream_udp/tests/configured_sender.rs
+++ b/components/res/cu29_logstream_udp/tests/configured_sender.rs
@@ -2,7 +2,7 @@ use bincode::{Decode, Encode};
 use cu29::prelude::*;
 use cu29::resource::{BundleContext, BundleIndex, ResourceBundle, ResourceManager};
 use cu29_logstream::{
-    FiniteObjectLimits, RecordKind, SessionEvent, SessionRouter, SessionRouterLimits,
+    CuStreamRx, FiniteObjectLimits, RecordKind, SessionEvent, SessionRouter, SessionRouterLimits,
     decode_copperlist,
 };
 use cu29_logstream_udp::{CuUdpLogStreamResources, CuUdpLogStreamResourcesId, CuUdpLogStreamRx};
@@ -71,7 +71,8 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
     // The receiver knows hard capacity limits, but no sender identity or FEC plan.
     let mut router = SessionRouter::<1128, 64, 64>::new(SessionRouterLimits {
         max_sessions: 1,
-        max_pending_events: 64,
+        // A startup gap can release a full window of records plus the gap event.
+        max_pending_events: 65,
         max_record_bytes: 4096,
         max_buffered_records: 64,
         equation_capacity: 64,
@@ -128,17 +129,34 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
     let mut running = app.start()?;
     let mut packet = [0; 1200];
     const ITERATIONS: u64 = 128;
-    for _ in 0..ITERATIONS {
+    for id in 0..ITERATIONS {
         running.run_one_iteration()?;
-        // Allow the asynchronous output workers to progress. This is test driving,
-        // not carrier pacing. Every datagram is consumed in actual socket order.
-        std::thread::sleep(Duration::from_millis(1));
-        while router.try_receive(&mut rx, &mut packet, &mut emit).unwrap() {}
+        // Drive the clean fixture by observable wire progress, not assumptions
+        // about debug-build FEC speed or an unenforced link budget. This wait is
+        // entirely in the test harness; the production sender remains one-way.
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut source_received = false;
+        while !source_received && Instant::now() < deadline {
+            if let Some(len) = rx.try_recv(&mut packet).unwrap() {
+                let header = cu29_logstream::WirePacket::decode(&packet[..len])
+                    .unwrap()
+                    .header;
+                source_received = header.record_kind == RecordKind::CopperList
+                    && header.symbol_kind == cu29_logstream::FecSymbolKind::Source
+                    && header.object_id == id;
+                router.receive_datagram(&packet[..len], &mut emit).unwrap();
+            } else {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        }
+        assert!(source_received, "sender did not transmit CopperList {id}");
     }
     drop(running.stop()?);
     let deadline = Instant::now() + Duration::from_millis(100);
     while Instant::now() < deadline {
-        if !router.try_receive(&mut rx, &mut packet, &mut emit).unwrap() {
+        if let Some(len) = rx.try_recv(&mut packet).unwrap() {
+            router.receive_datagram(&packet[..len], &mut emit).unwrap();
+        } else {
             std::thread::sleep(Duration::from_millis(1));
         }
     }

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -6435,7 +6435,7 @@ mod tests {
             resources: [
                 (
                     id: "telemetry_udp",
-                    provider: "cu29_stream_udp::CuUdpStreamResources",
+                    provider: "cu29_logstream_udp::CuUdpLogStreamResources",
                     config: {
                         "bind_addr": "0.0.0.0:0",
                         "remote_addr": "192.168.10.20:7447",
@@ -6450,7 +6450,7 @@ mod tests {
                     (
                         id: "ground",
                         transport: (
-                            type: "cu29_stream_udp::CuUdpStreamTx",
+                            type: "cu29_logstream_udp::CuUdpLogStreamTx",
                             resource: "telemetry_udp.tx",
                         ),
                         link: (

--- a/justfile
+++ b/justfile
@@ -28,6 +28,7 @@ pr-check:
 	just lint
 	just api-check
 	just test
+	just logstream-udp-check
 
 # Reproduce the scheduled weekly audit and beta checks on the local host.
 weekly: weekly-audit
@@ -161,6 +162,11 @@ test:
 
 	cargo +stable nextest run --all-targets --workspace {{WORKSPACE_EXCLUDES}}
 	cargo +stable nextest run --no-default-features
+
+# UDP carrier contracts and generated sender/session-router localhost integration.
+logstream-udp-check:
+	cargo +stable clippy -p cu29-logstream-udp --all-targets --features runtime-integration -- --deny warnings
+	cargo +stable test -p cu29-logstream-udp --features runtime-integration
 
 # Check the large examples from the former extra-examples repo.
 check-extra-examples: check-extra-examples-host check-extra-examples-embedded


### PR DESCRIPTION
## Summary

Add `cu29-logstream-udp`, a std-only Copper resource bundle that connects configured logstream destinations to real nonblocking UDP sockets. Generated applications bind `CuUdpLogStreamTx` through `CuUdpLogStreamResources`; an independently constructed `CuUdpLogStreamRx` feeds `SessionRouter` without out-of-band sender identity or FEC settings.

## Related issues

Stacked on #1320 (`gbin/cu29-logstream-config-manifest`). This is the UDP carrier slice toward the local end-to-end demonstrator.

## Changes

- Add explicit numeric endpoint, kernel-buffer, TTL/hop-limit, and DSCP configuration. The `tx`/`rx` slots share a bound socket; endpoint clones use no userspace mutex. Each packet call performs one nonblocking socket operation with no allocation, retry, or acknowledgement.
- Receive directly into caller-owned storage and reject consumed oversized datagrams as `BufferTooSmall`. Linux reports the original length; other supported hosts report a conservative sufficient buffer capacity. Unsupported DSCP configuration fails explicitly on Windows.
- Test IPv4/IPv6 loopback, atomicity, empty/exact/oversized packets, socket options, configuration bounds, queue pressure, and no-retry error handling. The generated-runtime test consumes actual UDP arrival order and verifies manifest discovery, typed CopperLists, and keyframe/anchor objects.
- Add `just logstream-udp-check` to the root PR check and dedicated integration coverage to Linux/macOS/Windows CI. The generated-runtime test uses an explicit `runtime-integration` feature so ordinary carrier builds do not enable asynchronous logstream runtime features across unrelated workspace applications.

## Reminder

- [x] I ran `just pr-check` from the repo root: formatting, std/no_std/embedded Clippy, public API check, 966 workspace tests, 512 core tests without default features, and 12 focused UDP tests passed on Linux.
- [x] I updated documentation and the RON configuration references. `cargo-shear` reports no unused dependencies for the new crate.

## Additional context

The existing router can discard packets arriving before manifest discovery. The integration test does not reorder traffic or claim complete startup history. Automatic verified anchor recovery and native receiver archival are the next slice, followed by the two-process demonstrator. Pacing and optional advisory feedback are deferred to another iteration and do not belong in the UDP carrier.

macOS and Windows runtime validation is delegated to the added CI coverage; only Linux was exercised locally.
