### PR TITLE
Assemble logstream receivers and write native Copper archives

### DIFF
--- a/api/v1/cu29-export.txt
+++ b/api/v1/cu29-export.txt
@@ -86,6 +86,7 @@ pub fn cu29_export::copperlists_reader<P: cu29_traits::CopperListTuple>(src: imp
 pub fn cu29_export::keyframes_reader(src: impl std::io::Read) -> impl core::iter::traits::iterator::Iterator<Item = cu29_runtime::curuntime::KeyFrame>
 pub fn cu29_export::run_cli<P>() -> cu29_traits::CuResult<()> where P: cu29_traits::CopperListTuple + cu29_traits::CuPayloadRawBytes + 'static
 pub fn cu29_export::runtime_lifecycle_reader(src: impl std::io::Read) -> impl core::iter::traits::iterator::Iterator<Item = cu29_runtime::curuntime::RuntimeLifecycleRecord>
+pub fn cu29_export::stream_continuity_reader(src: impl std::io::Read) -> impl core::iter::traits::iterator::Iterator<Item = cu29_runtime::continuity::StreamContinuityRecord>
 pub fn cu29_export::structlog_reader(src: impl std::io::Read) -> impl core::iter::traits::iterator::Iterator<Item = cu29_traits::CuResult<cu29_log::CuLogEntry>>
 pub fn cu29_export::textlog_dump(src: impl std::io::Read, index: &std::path::Path) -> cu29_traits::CuResult<()>
 pub fn cu29_export::unified_log_mission(unifiedlog_base: &std::path::Path) -> cu29_traits::CuResult<core::option::Option<alloc::string::String>>

--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -615,6 +615,37 @@ pub fn cu29_runtime::context::CuContextBuilder::build(self) -> cu29_runtime::con
 pub fn cu29_runtime::context::CuContextBuilder::cl_id(self, cl_id: u64) -> Self
 pub fn cu29_runtime::context::CuContextBuilder::instance_id(self, instance_id: u32) -> Self
 pub fn cu29_runtime::context::CuContextBuilder::task_ids(self, task_ids: &'static [&'static str]) -> Self
+pub mod cu29_runtime::continuity
+pub enum cu29_runtime::continuity::SourceGapReason
+pub cu29_runtime::continuity::SourceGapReason::AnchorRecovery
+pub cu29_runtime::continuity::SourceGapReason::LateJoin
+pub cu29_runtime::continuity::SourceGapReason::RlcWindowExpired
+pub cu29_runtime::continuity::SourceGapReason::SessionEnded
+impl cu_bincode::enc::Encode for cu29_runtime::continuity::SourceGapReason
+pub fn cu29_runtime::continuity::SourceGapReason::encode<__E: cu_bincode::enc::Encoder>(&self, encoder: &mut __E) -> core::result::Result<(), cu_bincode::error::EncodeError>
+impl<'__de, __Context> cu_bincode::de::BorrowDecode<'__de, __Context> for cu29_runtime::continuity::SourceGapReason
+pub fn cu29_runtime::continuity::SourceGapReason::borrow_decode<__D: cu_bincode::de::BorrowDecoder<'__de, Context = __Context>>(decoder: &mut __D) -> core::result::Result<Self, cu_bincode::error::DecodeError>
+impl<__Context> cu_bincode::de::Decode<__Context> for cu29_runtime::continuity::SourceGapReason
+pub fn cu29_runtime::continuity::SourceGapReason::decode<__D: cu_bincode::de::Decoder<Context = __Context>>(decoder: &mut __D) -> core::result::Result<Self, cu_bincode::error::DecodeError>
+pub enum cu29_runtime::continuity::StreamContinuityRecord
+pub cu29_runtime::continuity::StreamContinuityRecord::Anchor
+pub cu29_runtime::continuity::StreamContinuityRecord::Anchor::copperlist_id: u64
+pub cu29_runtime::continuity::StreamContinuityRecord::Anchor::record: alloc::vec::Vec<u8>
+pub cu29_runtime::continuity::StreamContinuityRecord::Finished
+pub cu29_runtime::continuity::StreamContinuityRecord::Finished::next_copperlist_id: u64
+pub cu29_runtime::continuity::StreamContinuityRecord::Gap
+pub cu29_runtime::continuity::StreamContinuityRecord::Gap::first_id: u64
+pub cu29_runtime::continuity::StreamContinuityRecord::Gap::last_id: u64
+pub cu29_runtime::continuity::StreamContinuityRecord::Gap::reason: cu29_runtime::continuity::SourceGapReason
+pub cu29_runtime::continuity::StreamContinuityRecord::Manifest
+pub cu29_runtime::continuity::StreamContinuityRecord::Manifest::record: alloc::vec::Vec<u8>
+impl cu_bincode::enc::Encode for cu29_runtime::continuity::StreamContinuityRecord
+pub fn cu29_runtime::continuity::StreamContinuityRecord::encode<__E: cu_bincode::enc::Encoder>(&self, encoder: &mut __E) -> core::result::Result<(), cu_bincode::error::EncodeError>
+impl<'__de, __Context> cu_bincode::de::BorrowDecode<'__de, __Context> for cu29_runtime::continuity::StreamContinuityRecord
+pub fn cu29_runtime::continuity::StreamContinuityRecord::borrow_decode<__D: cu_bincode::de::BorrowDecoder<'__de, Context = __Context>>(decoder: &mut __D) -> core::result::Result<Self, cu_bincode::error::DecodeError>
+impl<__Context> cu_bincode::de::Decode<__Context> for cu29_runtime::continuity::StreamContinuityRecord
+pub fn cu29_runtime::continuity::StreamContinuityRecord::decode<__D: cu_bincode::de::Decoder<Context = __Context>>(decoder: &mut __D) -> core::result::Result<Self, cu_bincode::error::DecodeError>
+pub fn cu29_runtime::continuity::validate_replay_continuity(expected: u64, actual: u64, keyframe: core::option::Option<u64>) -> cu29_traits::CuResult<()>
 pub mod cu29_runtime::copperlist
 pub enum cu29_runtime::copperlist::CopperListState
 pub cu29_runtime::copperlist::CopperListState::BeingSerialized

--- a/api/v1/cu29-traits.txt
+++ b/api/v1/cu29-traits.txt
@@ -48,6 +48,7 @@ pub cu29_traits::UnifiedLogType::Empty
 pub cu29_traits::UnifiedLogType::FrozenTasks
 pub cu29_traits::UnifiedLogType::LastEntry
 pub cu29_traits::UnifiedLogType::RuntimeLifecycle
+pub cu29_traits::UnifiedLogType::StreamContinuity
 pub cu29_traits::UnifiedLogType::StructuredLogLine
 impl cu_bincode::enc::Encode for cu29_traits::UnifiedLogType
 pub fn cu29_traits::UnifiedLogType::encode<__E: cu_bincode::enc::Encoder>(&self, encoder: &mut __E) -> core::result::Result<(), cu_bincode::error::EncodeError>

--- a/api/v1/cu29-unifiedlog.txt
+++ b/api/v1/cu29-unifiedlog.txt
@@ -90,6 +90,8 @@ pub struct cu29_unifiedlog::LogPosition
 pub cu29_unifiedlog::LogPosition::offset: usize
 pub cu29_unifiedlog::LogPosition::slab_index: usize
 pub struct cu29_unifiedlog::LogStream<S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S>>
+impl<S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S>> cu29_unifiedlog::LogStream<S, L>
+pub fn cu29_unifiedlog::LogStream<S, L>::new(entry_type: cu29_traits::UnifiedLogType, parent_logger: alloc::sync::Arc<std::sync::poison::mutex::Mutex<L>>, minimum_allocation_amount: usize) -> cu29_traits::CuResult<Self>
 impl<E: cu_bincode::enc::Encode, S: cu29_unifiedlog::SectionStorage, L: cu29_unifiedlog::UnifiedLogWrite<S>> cu29_traits::WriteStream<E> for cu29_unifiedlog::LogStream<S, L>
 pub fn cu29_unifiedlog::LogStream<S, L>::last_log_bytes(&self) -> core::option::Option<usize>
 pub fn cu29_unifiedlog::LogStream<S, L>::log(&mut self, obj: &E) -> cu29_traits::CuResult<()>

--- a/api/v1/cu29.txt
+++ b/api/v1/cu29.txt
@@ -7,6 +7,7 @@ pub use cu29::bundle_resources
 pub use cu29::clock
 pub use cu29::config
 pub use cu29::context
+pub use cu29::continuity
 pub use cu29::copperlist
 pub use cu29::cuasynctask
 pub use cu29::cubridge

--- a/components/res/cu29_logstream_udp/Cargo.toml
+++ b/components/res/cu29_logstream_udp/Cargo.toml
@@ -38,6 +38,7 @@ socket2 = { workspace = true, features = ["all"] }
 libc = { workspace = true }
 
 [dev-dependencies]
+cu29-export = { workspace = true }
 bincode = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }

--- a/components/res/cu29_logstream_udp/tests/configured_sender.rs
+++ b/components/res/cu29_logstream_udp/tests/configured_sender.rs
@@ -70,6 +70,8 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
 
     // The receiver knows hard capacity limits, but no sender identity or FEC plan.
     let mut router = SessionRouter::<1128, 64, 64>::new(SessionRouterLimits {
+        max_startup_packets: 64,
+        max_recovery_records: 8,
         max_sessions: 1,
         // A startup gap can release a full window of records plus the gap event.
         max_pending_events: 65,
@@ -79,17 +81,55 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
         finite_objects: FiniteObjectLimits::new(65536, 1128, 4),
     })
     .unwrap();
+    let logs = tempfile::tempdir().unwrap();
+    let archive_path = logs.path().join("received.copper");
+    let expected_schema = cu29_logstream::ApplicationSchema::from_output_specs(
+        default::CuStampedDataSet::get_output_specs(),
+    );
+    let mut archive: Option<cu29_logstream::NativeArchive<default::CuStampedDataSet>> = None;
+    let mut expected_payloads = Vec::new();
+    let mut verified_anchor_seen = false;
     let mut ids = Vec::new();
     let mut manifest_seen = false;
     let mut keyframe_seen = false;
     let mut anchor_seen = false;
     let mut gaps = Vec::new();
     let mut emit = |event| {
+        if let SessionEvent::Manifest(manifest) = &event {
+            let mut wrong_schema = manifest.clone();
+            wrong_schema.application_schema.outputs[0]
+                .payload_type
+                .push_str("::Wrong");
+            let rejected_path = logs.path().join("rejected.copper");
+            assert!(
+                cu29_logstream::NativeArchive::<default::CuStampedDataSet>::new(
+                    &rejected_path,
+                    wrong_schema,
+                    1024 * 1024,
+                    4096
+                )
+                .is_err()
+            );
+            assert!(!rejected_path.exists());
+            archive = Some(
+                cu29_logstream::NativeArchive::new(
+                    &archive_path,
+                    manifest.clone(),
+                    1024 * 1024,
+                    4096,
+                )
+                .unwrap(),
+            );
+        }
+        if let Some(writer) = archive.as_mut() {
+            writer.accept(&event).unwrap();
+        }
         match event {
             SessionEvent::Manifest(manifest) => {
                 assert_eq!(manifest.identity.sender_id, 41);
                 assert_eq!(manifest.plan.destination_id, "ground");
                 assert_eq!(manifest.plan.symbol_size, 1128);
+                assert_eq!(manifest.application_schema, expected_schema);
                 assert_eq!(manifest.application_schema.outputs.len(), 1);
                 assert_eq!(
                     manifest.application_schema.outputs[0].payload_type,
@@ -101,6 +141,7 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
                 assert!(manifest_seen);
                 assert_eq!(identity.sender_id, 41);
                 let record = record.decoded().unwrap();
+                expected_payloads.push(record.payload.to_vec());
                 let copperlist: default::CuList = decode_copperlist(record.payload).unwrap();
                 assert_eq!(record.object_id, copperlist.id);
                 assert_eq!(
@@ -116,11 +157,11 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
                 _ => {}
             },
             SessionEvent::Gap { gap, .. } => gaps.push(gap),
+            SessionEvent::VerifiedAnchor { .. } => verified_anchor_seen = true,
         }
         Ok::<(), core::convert::Infallible>(())
     };
 
-    let logs = tempfile::tempdir().unwrap();
     let app = UdpApp::builder()
         .with_instance_id(41)
         .with_config(sender_config)
@@ -128,6 +169,7 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
         .build()?;
     let mut running = app.start()?;
     let mut packet = [0; 1200];
+    let mut traffic = Vec::new();
     const ITERATIONS: u64 = 128;
     for id in 0..ITERATIONS {
         running.run_one_iteration()?;
@@ -144,6 +186,7 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
                 source_received = header.record_kind == RecordKind::CopperList
                     && header.symbol_kind == cu29_logstream::FecSymbolKind::Source
                     && header.object_id == id;
+                traffic.push(packet[..len].to_vec());
                 router.receive_datagram(&packet[..len], &mut emit).unwrap();
             } else {
                 std::thread::sleep(Duration::from_millis(1));
@@ -155,6 +198,7 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
     let deadline = Instant::now() + Duration::from_millis(100);
     while Instant::now() < deadline {
         if let Some(len) = rx.try_recv(&mut packet).unwrap() {
+            traffic.push(packet[..len].to_vec());
             router.receive_datagram(&packet[..len], &mut emit).unwrap();
         } else {
             std::thread::sleep(Duration::from_millis(1));
@@ -164,14 +208,136 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
     assert!(manifest_seen && keyframe_seen && anchor_seen);
     assert_eq!(router.stats().sessions_discovered, 1);
     assert_eq!(router.stats().malformed_datagrams, 0);
-    // Startup data can precede the manifest and be discarded by today's router.
-    // Full history and automatic anchor resume are the next PR's contract. Here
-    // require a substantial ordered, correctly typed suffix without sorting traffic.
-    assert!(
-        ids.len() >= 32,
-        "too few recovered records: {}; gaps: {gaps:?}",
-        ids.len()
+    assert!(verified_anchor_seen);
+    assert!(gaps.is_empty(), "unexpected clean-link gaps: {gaps:?}");
+    assert_eq!(ids, (0..ITERATIONS).collect::<Vec<_>>());
+    archive.take().unwrap().finish().unwrap();
+    let reader = UnifiedLoggerRead::new(&archive_path).unwrap();
+    let mut reader = UnifiedLoggerIOReader::new(reader, UnifiedLogType::CopperList);
+    let received: Vec<_> =
+        cu29_export::copperlists_reader::<default::CuStampedDataSet>(&mut reader).collect();
+    assert_eq!(received.len(), ITERATIONS as usize);
+    for (record, expected) in received.iter().zip(&expected_payloads) {
+        assert_eq!(
+            &bincode::encode_to_vec(record, bincode::config::standard()).unwrap(),
+            expected
+        );
+    }
+    let reader = UnifiedLoggerRead::new(&archive_path).unwrap();
+    let reader = UnifiedLoggerIOReader::new(reader, UnifiedLogType::FrozenTasks);
+    assert!(cu29_export::keyframes_reader(reader).next().is_some());
+    let reader = UnifiedLoggerRead::new(&archive_path).unwrap();
+    let reader = UnifiedLoggerIOReader::new(reader, UnifiedLogType::StreamContinuity);
+    let continuity: Vec<_> = cu29_export::stream_continuity_reader(reader).collect();
+    assert!(matches!(
+        continuity.first(),
+        Some(cu29::continuity::StreamContinuityRecord::Manifest { .. })
+    ));
+    assert!(matches!(
+        continuity.last(),
+        Some(cu29::continuity::StreamContinuityRecord::Finished {
+            next_copperlist_id: ITERATIONS
+        })
+    ));
+    let boundary = |id| {
+        traffic
+            .iter()
+            .position(|packet| {
+                let header = cu29_logstream::WirePacket::decode(packet).unwrap().header;
+                header.record_kind == RecordKind::CopperList && header.object_id == id
+            })
+            .unwrap()
+    };
+    let late = boundary(64);
+    validate_impaired_archive(
+        &logs.path().join("late.copper"),
+        &traffic[late..],
+        &expected_payloads,
+        true,
     );
-    assert_eq!(ids.last(), Some(&(ITERATIONS - 1)));
+    let outage_start = boundary(16);
+    let outage_end = boundary(96);
+    let outage: Vec<_> = traffic[..outage_start]
+        .iter()
+        .chain(&traffic[outage_end..])
+        .cloned()
+        .collect();
+    validate_impaired_archive(
+        &logs.path().join("outage.copper"),
+        &outage,
+        &expected_payloads,
+        false,
+    );
     Ok(())
+}
+
+// Reuse actual UDP arrival order; only remove a prefix or one contiguous outage.
+fn validate_impaired_archive(
+    path: &std::path::Path,
+    packets: &[Vec<u8>],
+    expected: &[Vec<u8>],
+    late: bool,
+) {
+    let mut router = SessionRouter::<1128, 64, 64>::new(SessionRouterLimits {
+        max_startup_packets: 64,
+        max_recovery_records: 8,
+        max_sessions: 1,
+        max_pending_events: 8,
+        max_record_bytes: 4096,
+        max_buffered_records: 64,
+        equation_capacity: 64,
+        finite_objects: FiniteObjectLimits::new(65536, 1128, 4),
+    })
+    .unwrap();
+    let mut archive: Option<cu29_logstream::NativeArchive<default::CuStampedDataSet>> = None;
+    for packet in packets {
+        router
+            .receive_datagram(packet, |event| {
+                if let SessionEvent::Manifest(manifest) = &event {
+                    archive = Some(
+                        cu29_logstream::NativeArchive::new(
+                            path,
+                            manifest.clone(),
+                            1024 * 1024,
+                            4096,
+                        )
+                        .unwrap(),
+                    );
+                }
+                if let Some(archive) = archive.as_mut() {
+                    archive.accept(&event).unwrap();
+                }
+                Ok::<(), ()>(())
+            })
+            .unwrap();
+    }
+    archive.unwrap().finish().unwrap();
+    let lists: Vec<_> =
+        cu29_export::copperlists_reader::<default::CuStampedDataSet>(UnifiedLoggerIOReader::new(
+            UnifiedLoggerRead::new(path).unwrap(),
+            UnifiedLogType::CopperList,
+        ))
+        .collect();
+    assert!(!lists.is_empty());
+    assert_eq!(lists.last().unwrap().id, 127);
+    for record in &lists {
+        assert_eq!(
+            bincode::encode_to_vec(record, bincode::config::standard()).unwrap(),
+            expected[record.id as usize]
+        );
+    }
+    let continuity: Vec<_> = cu29_export::stream_continuity_reader(UnifiedLoggerIOReader::new(
+        UnifiedLoggerRead::new(path).unwrap(),
+        UnifiedLogType::StreamContinuity,
+    ))
+    .collect();
+    assert!(continuity.iter().any(|entry| matches!(entry,
+        cu29::continuity::StreamContinuityRecord::Gap { first_id, reason, .. }
+        if if late { *first_id == 0 && *reason == cu29::continuity::SourceGapReason::LateJoin } else { *first_id > 0 })));
+    let keyframes: Vec<_> = cu29_export::keyframes_reader(UnifiedLoggerIOReader::new(
+        UnifiedLoggerRead::new(path).unwrap(),
+        UnifiedLogType::FrozenTasks,
+    ))
+    .collect();
+    assert!(keyframes.iter().any(|frame| frame.culistid >= 64));
 }

--- a/core/cu29/src/lib.rs
+++ b/core/cu29/src/lib.rs
@@ -77,6 +77,7 @@ pub use cu29_logstream as logstream;
 pub use cu29_runtime::app;
 pub use cu29_runtime::config;
 pub use cu29_runtime::context;
+pub use cu29_runtime::continuity;
 pub use cu29_runtime::copperlist;
 #[doc(hidden)]
 pub use cu29_runtime::copperlist_codec;

--- a/core/cu29/tests/logstream_configured_runtime.rs
+++ b/core/cu29/tests/logstream_configured_runtime.rs
@@ -123,6 +123,8 @@ fn generated_runtime_binds_configured_transport_and_emits_manifest() -> CuResult
     assert!(!continuous_packets.is_empty());
 
     let mut router = SessionRouter::<1128, 64, 64>::new(SessionRouterLimits {
+        max_startup_packets: 64,
+        max_recovery_records: 8,
         max_sessions: 1,
         max_pending_events: 32,
         max_record_bytes: 65_536,

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -6017,6 +6017,11 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         copperlist: &CopperList<Self::RecordedDataSet>,
                         keyframe: Option<&KeyFrame>,
                     ) -> CuResult<()> {
+                        cu29::continuity::validate_replay_continuity(
+                            self.copper_runtime_mut().copperlists_manager.next_cl_id(),
+                            copperlist.id,
+                            keyframe.map(|frame| frame.culistid),
+                        )?;
                         if let Some(keyframe) = keyframe {
                             if keyframe.culistid != copperlist.id {
                                 return Err(CuError::from(format!(

--- a/core/cu29_export/src/fsck.rs
+++ b/core/cu29_export/src/fsck.rs
@@ -269,7 +269,7 @@ where
     let mut runtime_lifecycle_events: usize = 0;
     let mut sl_entries: usize = 0;
 
-    let result = loop {
+    let result = 'scan: loop {
         // for _ in 0..4 {
         let section = dl.raw_read_section();
         match section {
@@ -389,6 +389,36 @@ where
                                     break;
                                 }
                             }
+                        }
+                    }
+                    UnifiedLogType::StreamContinuity => {
+                        let mut remaining = content.as_slice();
+                        while !remaining.is_empty() {
+                            let (record, used): (cu29::continuity::StreamContinuityRecord, usize) =
+                                match bincode::decode_from_slice(remaining, standard()) {
+                                    Ok(value) => value,
+                                    Err(error) => {
+                                        break 'scan Err(cu29::CuError::new_with_cause(
+                                            "Invalid stream continuity record",
+                                            error,
+                                        ));
+                                    }
+                                };
+                            match record {
+                                cu29::continuity::StreamContinuityRecord::Gap {
+                                    first_id,
+                                    last_id,
+                                    reason,
+                                } => println!("Source gap {first_id}..={last_id}: {reason:?}"),
+                                cu29::continuity::StreamContinuityRecord::Anchor {
+                                    copperlist_id,
+                                    ..
+                                } => {
+                                    println!("Verified stream anchor at CopperList {copperlist_id}")
+                                }
+                                _ => {}
+                            }
+                            remaining = &remaining[used..];
                         }
                     }
                     UnifiedLogType::LastEntry => {

--- a/core/cu29_export/src/lib.rs
+++ b/core/cu29_export/src/lib.rs
@@ -559,6 +559,13 @@ fn read_next_entry<T: Decode<()>>(src: &mut impl Read) -> Option<T> {
     }
 }
 
+/// Reads received archive provenance, inclusive source gaps and verified anchors.
+pub fn stream_continuity_reader(
+    mut src: impl Read,
+) -> impl Iterator<Item = cu29::continuity::StreamContinuityRecord> {
+    std::iter::from_fn(move || read_next_entry(&mut src))
+}
+
 /// Extracts the copper lists from a binary representation.
 /// P is the Payload determined by the configuration of the application.
 pub fn copperlists_reader<P: CopperListTuple>(

--- a/core/cu29_logstream/Cargo.toml
+++ b/core/cu29_logstream/Cargo.toml
@@ -24,6 +24,7 @@ crc = { workspace = true }
 cu-fec = { workspace = true }
 cu29-runtime = { workspace = true }
 cu29-traits = { workspace = true }
+cu29-unifiedlog = { workspace = true, optional = true }
 raptorq = { workspace = true }
 
 [dev-dependencies]
@@ -31,5 +32,12 @@ serde = { workspace = true }
 
 [features]
 default = ["std"]
-std = ["blake3/std", "cu29-runtime/std", "cu29-traits/std", "raptorq/std"]
+std = [
+  "dep:cu29-unifiedlog",
+  "cu29-unifiedlog/std",
+  "blake3/std",
+  "cu29-runtime/std",
+  "cu29-traits/std",
+  "raptorq/std",
+]
 test-utils = ["std"]

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -1,63 +1,44 @@
-# Semantic log streaming
+# Copper log streaming
 
-`SessionRouter` accepts complete packets from any `CuStreamRx` or through
-`receive_datagram`. It discovers sender manifests without out-of-band FEC settings.
-Use receiver-local hard limits for sessions, continuous records, startup packets,
-completed recovery records, and finite-object decoding.
+`cu29-logstream` gets a robot's execution log to another machine while the robot
+is running. Use it to collect logs at a ground station over a link that can lose
+packets, or when the robot's onboard log is hard to retrieve.
 
-Startup packets are retained in arrival order up to `max_startup_packets` per
-session. Overflow is counted and never implies that missing history was received.
-Completed keyframes and anchors use a separate `max_recovery_records` cache;
-oldest entries are evicted when full. This is additional to the bounded RaptorQ
-object storage. Repetition may recover evicted objects only while the sender
-still retains them. These are receiver allocations, outside the real-time path.
+It sits between Copper's generated runtime and a packet transport:
 
-The router verifies each anchor against the exact manifest and keyframe record
-digests, including the keyframe's CopperList id. Control objects can arrive in
-any order. A verified boundary advances ordered delivery without discarding the
-active FEC window or records at and after that boundary. Missing prefixes produce
-`LateJoin` gaps; an established stream restarting after an outage produces
-`AnchorRecovery` gaps. RLC expiration and explicit session finalization also emit
-inclusive gaps. Repeated or older anchors cannot rewind delivery.
-
-`SessionEvent::Object` is a raw recovered object, not permission to restore state.
-Use `VerifiedAnchor` for that purpose. A consumer failure leaves the event pending;
-call `drain_events` before accepting another packet. Call `finish_through` only
-when the sender's last CopperList id is known. An unknown tail stays unknown.
-
-## Native archives
-
-With `std`, `NativeArchive<P>` writes one sender/session to a native `.copper` log.
-Construct it on the manifest event. The receiver schema is derived from `P`'s
-generated `MatchingTasks::get_output_specs()` and compared with the manifest:
-
-```rust,ignore
-let archive = NativeArchive::<default::CuStampedDataSet>::new(
-    &path, manifest, slab_bytes, section_bytes,
-)?;
+```text
+Robot runtime → logstream sender → UDP / custom transport
+                                         ↓
+Logreader / replay ← .copper archive ← logstream receiver
 ```
 
-Pass that sender's ordered router events to `accept`. Each CopperList is decoded
-once into `CopperList<P>` and returned for an in-process consumer. The original
-canonical payload bytes are appended directly to `CopperList` sections; verified
-keyframes go into `FrozenTasks`. This requires the matching full-capture native
-application codec. Hybrid payload reconstruction and codec conversion are deferred.
-The section size must accommodate the largest canonical entry, including manifest
-and keyframe objects. Use a fresh output path per session.
+The sender protects log records with recovery data. The receiver reconstructs
+what it can and records explicit gaps for what it cannot. Received archives use
+Copper's native format, so your application's normal logreader and replay tools
+can read them. Sender work runs off the real-time task path.
 
-The `StreamContinuity` section preserves the canonical manifest, explicit gaps,
-verified anchor references, and the receiver's final known boundary. `finish`
-closes the archive; it does not assert that the unobserved sender tail is complete.
-A failed archive write is terminal for that writer because an event can span more
-than one native section.
+## Using it
 
-Ordinary application logreaders read these CopperLists and keyframes.
-`cu29_export::stream_continuity_reader` reads provenance and gaps; logreader `fsck`
-reports the gap ranges and verified anchors. Generated recorded replay and indexed
-state replay reject crossing missing CopperList ids without a matching keyframe.
-A later keyframe permits state replay from its boundary; it does not heal history.
+Enable `cu29/logstream` and configure a `log_streaming` destination in the app's
+RON config. Bind a transport implementing `CuStreamTx`; the
+[`cu29-logstream-udp`](../../components/res/cu29_logstream_udp) resource supplies UDP
+sender and receiver endpoints.
 
-Run `just logstream-receiver-check` at the repository root. This exercises startup,
-late join, digest rejection, consumer failure, native archive/export over real UDP,
-and replay gap handling. Packet pacing, feedback, the two-process demonstrator,
-hybrid reconstruction, and dashboard APIs remain separate follow-up work.
+On the receiving side, `SessionRouter` discovers the sender's configuration from
+its manifest. Feed its events to `NativeArchive<P>`, where `P` is your application's
+generated dataset type. The archive checks that the sender's schema matches and
+preserves the received payloads and timestamps.
+
+## What to expect
+
+- Recovery uses bounded memory. Packet loss beyond those bounds leaves gaps.
+- A late receiver can resume from a verified keyframe, but cannot recover expired
+  history. Replay refuses to cross a gap without a matching keyframe.
+- Native archival currently requires the matching application and full-capture
+  codec. Use a separate archive path for each sender session.
+- Pacing and optional feedback are deferred. The configured bitrate is not yet
+  enforced.
+
+Run `just logstream-receiver-check` from the repository root to test reception,
+archival, and replay continuity. See the Rust API docs for receiver limits and
+event handling.

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -1,0 +1,63 @@
+# Semantic log streaming
+
+`SessionRouter` accepts complete packets from any `CuStreamRx` or through
+`receive_datagram`. It discovers sender manifests without out-of-band FEC settings.
+Use receiver-local hard limits for sessions, continuous records, startup packets,
+completed recovery records, and finite-object decoding.
+
+Startup packets are retained in arrival order up to `max_startup_packets` per
+session. Overflow is counted and never implies that missing history was received.
+Completed keyframes and anchors use a separate `max_recovery_records` cache;
+oldest entries are evicted when full. This is additional to the bounded RaptorQ
+object storage. Repetition may recover evicted objects only while the sender
+still retains them. These are receiver allocations, outside the real-time path.
+
+The router verifies each anchor against the exact manifest and keyframe record
+digests, including the keyframe's CopperList id. Control objects can arrive in
+any order. A verified boundary advances ordered delivery without discarding the
+active FEC window or records at and after that boundary. Missing prefixes produce
+`LateJoin` gaps; an established stream restarting after an outage produces
+`AnchorRecovery` gaps. RLC expiration and explicit session finalization also emit
+inclusive gaps. Repeated or older anchors cannot rewind delivery.
+
+`SessionEvent::Object` is a raw recovered object, not permission to restore state.
+Use `VerifiedAnchor` for that purpose. A consumer failure leaves the event pending;
+call `drain_events` before accepting another packet. Call `finish_through` only
+when the sender's last CopperList id is known. An unknown tail stays unknown.
+
+## Native archives
+
+With `std`, `NativeArchive<P>` writes one sender/session to a native `.copper` log.
+Construct it on the manifest event. The receiver schema is derived from `P`'s
+generated `MatchingTasks::get_output_specs()` and compared with the manifest:
+
+```rust,ignore
+let archive = NativeArchive::<default::CuStampedDataSet>::new(
+    &path, manifest, slab_bytes, section_bytes,
+)?;
+```
+
+Pass that sender's ordered router events to `accept`. Each CopperList is decoded
+once into `CopperList<P>` and returned for an in-process consumer. The original
+canonical payload bytes are appended directly to `CopperList` sections; verified
+keyframes go into `FrozenTasks`. This requires the matching full-capture native
+application codec. Hybrid payload reconstruction and codec conversion are deferred.
+The section size must accommodate the largest canonical entry, including manifest
+and keyframe objects. Use a fresh output path per session.
+
+The `StreamContinuity` section preserves the canonical manifest, explicit gaps,
+verified anchor references, and the receiver's final known boundary. `finish`
+closes the archive; it does not assert that the unobserved sender tail is complete.
+A failed archive write is terminal for that writer because an event can span more
+than one native section.
+
+Ordinary application logreaders read these CopperLists and keyframes.
+`cu29_export::stream_continuity_reader` reads provenance and gaps; logreader `fsck`
+reports the gap ranges and verified anchors. Generated recorded replay and indexed
+state replay reject crossing missing CopperList ids without a matching keyframe.
+A later keyframe permits state replay from its boundary; it does not heal history.
+
+Run `just logstream-receiver-check` at the repository root. This exercises startup,
+late join, digest rejection, consumer failure, native archive/export over real UDP,
+and replay gap handling. Packet pacing, feedback, the two-process demonstrator,
+hybrid reconstruction, and dashboard APIs remain separate follow-up work.

--- a/core/cu29_logstream/src/archive.rs
+++ b/core/cu29_logstream/src/archive.rs
@@ -1,0 +1,235 @@
+//! Application-typed native archival. All work here is receiver-side.
+
+use crate::{
+    ApplicationSchema, Error, RecordKind, Result, SessionEvent, SessionManifest, StreamIdentity,
+};
+use bincode::{
+    Encode,
+    enc::{Encoder, write::Writer},
+    error::EncodeError,
+};
+use cu29_runtime::{
+    continuity::{SourceGapReason, StreamContinuityRecord},
+    copperlist::CopperList,
+};
+use cu29_traits::{CopperListTuple, UnifiedLogType, WriteStream};
+use cu29_unifiedlog::{
+    LogStream, UnifiedLogger, UnifiedLoggerBuilder, UnifiedLoggerWrite, memmap::MmapSectionStorage,
+};
+use std::{
+    marker::PhantomData,
+    path::Path,
+    sync::{Arc, Mutex},
+};
+
+type NativeStream = LogStream<MmapSectionStorage, UnifiedLoggerWrite>;
+
+/// One application-typed archive per `(session id, sender id)`. Pass all ordered
+/// router events for that sender to `accept`. The expected schema comes from
+/// `P`'s generated output specs, independently of the remote manifest.
+/// Only the full captured native codec view is supported; hybrid views are deferred.
+/// A write failure poisons the writer: do not retry a partially committed event.
+pub struct NativeArchive<P: CopperListTuple> {
+    copperlists: NativeStream,
+    keyframes: NativeStream,
+    continuity: NativeStream,
+    identity: StreamIdentity,
+    manifest: SessionManifest,
+    next_id: u64,
+    poisoned: bool,
+    payload: PhantomData<P>,
+}
+
+struct CanonicalEntry<'a>(&'a [u8]);
+impl Encode for CanonicalEntry<'_> {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> core::result::Result<(), EncodeError> {
+        encoder.writer().write(self.0)
+    }
+}
+
+impl<P: CopperListTuple> NativeArchive<P> {
+    /// Creates native CopperList, FrozenTasks and StreamContinuity sections.
+    /// The section size must fit the largest accepted canonical entry.
+    pub fn new(
+        path: &Path,
+        manifest: SessionManifest,
+        slab_bytes: usize,
+        section_bytes: usize,
+    ) -> Result<Self> {
+        manifest.plan.validate()?;
+        if manifest.version != crate::SESSION_MANIFEST_VERSION {
+            return Err(Error::UnsupportedManifestVersion(manifest.version));
+        }
+        let expected_schema = ApplicationSchema::from_output_specs(P::get_output_specs());
+        if manifest.application_schema != expected_schema || !manifest.plan.content.archive {
+            return Err(Error::InvalidConfig(
+                "archive requires the matching application schema and archive content policy",
+            ));
+        }
+        if section_bytes == 0 || section_bytes > slab_bytes {
+            return Err(Error::InvalidConfig("archive section must fit in its slab"));
+        }
+        let logger = UnifiedLoggerBuilder::new()
+            .file_base_name(path)
+            .preallocated_size(slab_bytes)
+            .write(true)
+            .create(true)
+            .build()
+            .map_err(io_error)?;
+        let UnifiedLogger::Write(logger) = logger else {
+            unreachable!()
+        };
+        let logger = Arc::new(Mutex::new(logger));
+        let mut archive = Self {
+            copperlists: NativeStream::new(
+                UnifiedLogType::CopperList,
+                logger.clone(),
+                section_bytes,
+            )
+            .map_err(io_error)?,
+            keyframes: NativeStream::new(
+                UnifiedLogType::FrozenTasks,
+                logger.clone(),
+                section_bytes,
+            )
+            .map_err(io_error)?,
+            continuity: NativeStream::new(UnifiedLogType::StreamContinuity, logger, section_bytes)
+                .map_err(io_error)?,
+            identity: manifest.identity,
+            manifest,
+            next_id: 0,
+            poisoned: false,
+            payload: PhantomData,
+        };
+        archive
+            .continuity
+            .log(&StreamContinuityRecord::Manifest {
+                record: archive.manifest.encode_record()?,
+            })
+            .map_err(io_error)?;
+        Ok(archive)
+    }
+
+    /// Validates a typed CopperList once, appends its original canonical bytes,
+    /// and returns the typed value for an in-process consumer. Keyframes are
+    /// archived only after the router has verified their anchor references.
+    pub fn accept(&mut self, event: &SessionEvent) -> Result<Option<CopperList<P>>> {
+        if self.poisoned {
+            return Err(Error::InvalidConfig(
+                "archive failed; close it before continuing",
+            ));
+        }
+        let result = self.accept_inner(event);
+        if result.is_err() {
+            self.poisoned = true;
+        }
+        result
+    }
+
+    fn accept_inner(&mut self, event: &SessionEvent) -> Result<Option<CopperList<P>>> {
+        let identity = match event {
+            SessionEvent::Manifest(manifest) => manifest.identity,
+            SessionEvent::ContinuousRecord { identity, .. }
+            | SessionEvent::Gap { identity, .. }
+            | SessionEvent::Object { identity, .. }
+            | SessionEvent::VerifiedAnchor { identity, .. } => *identity,
+        };
+        if identity != self.identity {
+            return Err(Error::InconsistentObject);
+        }
+        match event {
+            SessionEvent::Manifest(manifest) => {
+                if manifest != &self.manifest {
+                    return Err(Error::InconsistentObject);
+                }
+            }
+            SessionEvent::ContinuousRecord { record, .. } => {
+                let decoded = record.decoded()?;
+                if decoded.kind != RecordKind::CopperList || decoded.object_id != self.next_id {
+                    return Err(Error::InconsistentObject);
+                }
+                let copperlist: CopperList<P> = crate::decode_copperlist(decoded.payload)?;
+                if copperlist.id != decoded.object_id {
+                    return Err(Error::InconsistentObject);
+                }
+                let next = self
+                    .next_id
+                    .checked_add(1)
+                    .ok_or(Error::InconsistentObject)?;
+                self.copperlists
+                    .log(&CanonicalEntry(decoded.payload))
+                    .map_err(io_error)?;
+                self.next_id = next;
+                return Ok(Some(copperlist));
+            }
+            SessionEvent::Gap { gap, .. } => {
+                if gap.first_id != self.next_id || gap.last_id < gap.first_id {
+                    return Err(Error::InconsistentObject);
+                }
+                let next = gap
+                    .last_id
+                    .checked_add(1)
+                    .ok_or(Error::InconsistentObject)?;
+                let reason = match gap.reason {
+                    crate::GapReason::RlcWindowExpired => SourceGapReason::RlcWindowExpired,
+                    crate::GapReason::SessionEnded => SourceGapReason::SessionEnded,
+                    crate::GapReason::LateJoin => SourceGapReason::LateJoin,
+                    crate::GapReason::AnchorRecovery => SourceGapReason::AnchorRecovery,
+                };
+                self.continuity
+                    .log(&StreamContinuityRecord::Gap {
+                        first_id: gap.first_id,
+                        last_id: gap.last_id,
+                        reason,
+                    })
+                    .map_err(io_error)?;
+                self.next_id = next;
+            }
+            SessionEvent::VerifiedAnchor {
+                anchor, keyframe, ..
+            } => {
+                let decoded = keyframe.decoded()?;
+                let manifest_record = self.manifest.encode_record()?;
+                if !anchor.references_manifest(crate::decode_record(&manifest_record)?)
+                    || !anchor.references_keyframe(decoded)
+                    || crate::decode_keyframe(decoded.payload)?.culistid != anchor.copperlist_id
+                {
+                    return Err(Error::InconsistentObject);
+                }
+                self.keyframes
+                    .log(&CanonicalEntry(decoded.payload))
+                    .map_err(io_error)?;
+                let record = crate::encode_record(
+                    RecordKind::Anchor,
+                    anchor.copperlist_id,
+                    &crate::encode_anchor(anchor)?,
+                )?;
+                self.continuity
+                    .log(&StreamContinuityRecord::Anchor {
+                        copperlist_id: anchor.copperlist_id,
+                        record,
+                    })
+                    .map_err(io_error)?;
+            }
+            SessionEvent::Object { .. } => {}
+        }
+        Ok(None)
+    }
+
+    /// Records the receiver's final known boundary and closes native sections.
+    /// The router must first be finalized through any caller-known sender tail.
+    pub fn finish(mut self) -> Result<()> {
+        if self.poisoned {
+            return Err(Error::InvalidConfig("archive failed before finalization"));
+        }
+        self.continuity
+            .log(&StreamContinuityRecord::Finished {
+                next_copperlist_id: self.next_id,
+            })
+            .map_err(io_error)
+    }
+}
+
+fn io_error(error: impl core::fmt::Display) -> Error {
+    Error::Codec(error.to_string())
+}

--- a/core/cu29_logstream/src/lib.rs
+++ b/core/cu29_logstream/src/lib.rs
@@ -9,6 +9,11 @@ extern crate alloc;
 
 pub use cu_fec::{DensityThreshold, EncodingSymbolId, Field, RlcConfig};
 
+#[cfg(feature = "std")]
+mod archive;
+#[cfg(feature = "std")]
+pub use archive::NativeArchive;
+
 mod copper;
 mod error;
 mod manifest;

--- a/core/cu29_logstream/src/rlc.rs
+++ b/core/cu29_logstream/src/rlc.rs
@@ -45,6 +45,10 @@ impl ReceiverLimits {
 pub enum GapReason {
     /// One or more required source symbols aged out of the configured RLC window.
     RlcWindowExpired,
+    /// History unavailable before a verified late-join boundary.
+    LateJoin,
+    /// Recovery advanced to a verified anchor after an outage.
+    AnchorRecovery,
     /// The caller finalized the session before the range could be recovered.
     SessionEnded,
 }
@@ -468,6 +472,19 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
             retention_floor: None,
             stats: ContinuousRecoveryStats::default(),
         })
+    }
+
+    pub const fn next_object_id(&self) -> u64 {
+        self.next_object_id
+    }
+
+    /// Advances ordering at a verified semantic boundary, retaining the FEC
+    /// window and already assembled records at or beyond that boundary.
+    pub(crate) fn resume_at(&mut self, boundary: u64) {
+        self.next_object_id = self.next_object_id.max(boundary);
+        self.assemblies
+            .retain(|record| record.object_id >= self.next_object_id);
+        self.discard_stale_ready();
     }
 
     pub const fn stats(&self) -> ContinuousRecoveryStats {

--- a/core/cu29_logstream/src/router.rs
+++ b/core/cu29_logstream/src/router.rs
@@ -10,6 +10,10 @@ use alloc::vec::Vec;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SessionRouterLimits {
     pub max_sessions: usize,
+    /// Per-session pre-manifest datagrams, each bounded by MAX_SYMBOL_SIZE + header.
+    pub max_startup_packets: usize,
+    /// Completed keyframe/anchor records retained per session, in addition to FEC storage.
+    pub max_recovery_records: usize,
     pub max_pending_events: usize,
     pub max_record_bytes: usize,
     pub max_buffered_records: usize,
@@ -24,11 +28,18 @@ pub struct SessionRouterStats {
     pub datagrams_before_manifest: usize,
     pub sessions_discovered: usize,
     pub manifests_accepted: usize,
+    pub startup_packets_dropped: usize,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SessionEvent {
     Manifest(SessionManifest),
+    /// Emitted only after the anchor, manifest and keyframe agree by digest and id.
+    VerifiedAnchor {
+        identity: StreamIdentity,
+        anchor: crate::Anchor,
+        keyframe: RecoveredRecord,
+    },
     ContinuousRecord {
         identity: StreamIdentity,
         record: RecoveredRecord,
@@ -64,6 +75,11 @@ struct RoutedSession<
     identity: StreamIdentity,
     finite: FiniteObjectDecoder,
     manifest: Option<SessionManifest>,
+    manifest_record: Option<RecoveredRecord>,
+    startup: Vec<Vec<u8>>,
+    recovery: Vec<RecoveredRecord>,
+    last_anchor: Option<u64>,
+    delivered_record: bool,
     continuous: Option<ContinuousDecoder<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS, MAX_EQUATIONS>>,
 }
 
@@ -72,14 +88,13 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
 {
     pub fn new(limits: SessionRouterLimits) -> Result<Self> {
         if limits.max_sessions == 0
-            || limits.max_pending_events == 0
+            || limits.max_pending_events < 3
+            || limits.max_recovery_records < 2
             || limits.max_record_bytes == 0
             || limits.max_buffered_records == 0
             || limits.equation_capacity == 0
         {
-            return Err(Error::InvalidConfig(
-                "session router limits must all be nonzero",
-            ));
+            return Err(Error::InvalidConfig("invalid session router capacities"));
         }
         Ok(Self {
             limits,
@@ -160,8 +175,10 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
             .position(|session| session.identity == identity)
         {
             Some(index) => index,
-            None if packet.header.fec_scheme == FecScheme::RaptorQ
-                && packet.header.lane == Lane::Control =>
+            None if (packet.header.fec_scheme == FecScheme::RaptorQ
+                && packet.header.lane == Lane::Control)
+                || (packet.header.lane == Lane::ReplayCritical
+                    && packet.header.record_kind == crate::RecordKind::CopperList) =>
             {
                 if self.sessions.len() == self.limits.max_sessions {
                     return Err(Error::TooManySessions {
@@ -177,6 +194,11 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
                         self.limits.finite_objects,
                     )?,
                     manifest: None,
+                    manifest_record: None,
+                    startup: Vec::with_capacity(self.limits.max_startup_packets),
+                    recovery: Vec::with_capacity(self.limits.max_recovery_records),
+                    last_anchor: None,
+                    delivered_record: false,
                     continuous: None,
                 });
                 self.stats.sessions_discovered = self.stats.sessions_discovered.saturating_add(1);
@@ -191,34 +213,20 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
 
         if packet.header.fec_scheme == FecScheme::RaptorQ {
             self.receive_finite(session_index, datagram)?;
-        } else if let Some(decoder) = self.sessions[session_index].continuous.as_mut() {
-            let pending = &mut self.pending;
-            let maximum = self.limits.max_pending_events;
-            decoder
-                .receive_datagram(datagram, |event| {
-                    if pending.len() == maximum {
-                        return Err(Error::TooManyRecords {
-                            actual: pending.len().saturating_add(1),
-                            maximum,
-                        });
-                    }
-                    pending.push(match event {
-                        ContinuousReceiveEvent::Record(record) => SessionEvent::ContinuousRecord {
-                            identity,
-                            record: record.clone(),
-                        },
-                        ContinuousReceiveEvent::Gap(gap) => SessionEvent::Gap { identity, gap },
-                    });
-                    Ok(())
-                })
-                .map_err(|error| match error {
-                    ReceiveError::Stream(error) | ReceiveError::Consumer(error) => {
-                        ReceiveError::Stream(error)
-                    }
-                })?;
+        } else if self.sessions[session_index].continuous.is_some() {
+            self.receive_continuous(session_index, datagram)?;
         } else {
             self.stats.datagrams_before_manifest =
                 self.stats.datagrams_before_manifest.saturating_add(1);
+            let startup = &mut self.sessions[session_index].startup;
+            if datagram.len() <= MAX_SYMBOL_SIZE + crate::PACKET_HEADER_LEN
+                && startup.len() < self.limits.max_startup_packets
+            {
+                startup.push(datagram.to_vec());
+            } else {
+                self.stats.startup_packets_dropped =
+                    self.stats.startup_packets_dropped.saturating_add(1);
+            }
         }
         self.drain_events(&mut emit)
     }
@@ -227,9 +235,56 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
         &mut self,
         emit: &mut impl FnMut(SessionEvent) -> core::result::Result<(), E>,
     ) -> core::result::Result<(), ReceiveError<E>> {
-        while let Some(event) = self.pending.first().cloned() {
-            emit(event).map_err(ReceiveError::Consumer)?;
-            self.pending.remove(0);
+        loop {
+            while let Some(event) = self.pending.first().cloned() {
+                emit(event).map_err(ReceiveError::Consumer)?;
+                self.pending.remove(0);
+            }
+            for session in &mut self.sessions {
+                if let Some(decoder) = session.continuous.as_mut() {
+                    decoder.drain_events(|event| {
+                        let event = match event {
+                            ContinuousReceiveEvent::Record(record) => {
+                                SessionEvent::ContinuousRecord {
+                                    identity: session.identity,
+                                    record: record.clone(),
+                                }
+                            }
+                            ContinuousReceiveEvent::Gap(mut gap) => {
+                                if !session.delivered_record && session.last_anchor.is_none() {
+                                    gap.reason = crate::GapReason::LateJoin;
+                                }
+                                SessionEvent::Gap {
+                                    identity: session.identity,
+                                    gap,
+                                }
+                            }
+                        };
+                        let delivered = matches!(event, SessionEvent::ContinuousRecord { .. });
+                        emit(event)?;
+                        session.delivered_record |= delivered;
+                        Ok(())
+                    })?;
+                }
+            }
+            let startup = self
+                .sessions
+                .iter()
+                .position(|session| session.continuous.is_some() && !session.startup.is_empty());
+            if let Some(index) = startup {
+                let packet = self.sessions[index].startup.remove(0);
+                self.receive_continuous(index, &packet)?;
+                continue;
+            }
+            for index in 0..self.sessions.len() {
+                self.verify_recovery(index)?;
+                if !self.pending.is_empty() {
+                    break;
+                }
+            }
+            if self.pending.is_empty() {
+                break;
+            }
         }
         Ok(())
     }
@@ -262,9 +317,30 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
                 let continuous = self.decoder_from_manifest(&manifest)?;
                 self.sessions[session_index].continuous = Some(continuous);
                 self.sessions[session_index].manifest = Some(manifest.clone());
+                self.sessions[session_index].manifest_record = Some(record);
                 self.stats.manifests_accepted = self.stats.manifests_accepted.saturating_add(1);
                 self.push_event(SessionEvent::Manifest(manifest))?;
             } else {
+                let session = &mut self.sessions[session_index];
+                let decoded = record.decoded()?;
+                match decoded.kind {
+                    crate::RecordKind::KeyFrame => {
+                        crate::decode_keyframe(decoded.payload)?;
+                    }
+                    crate::RecordKind::Anchor => {
+                        crate::decode_anchor(decoded.payload)?;
+                    }
+                    _ => {}
+                }
+                if matches!(
+                    decoded.kind,
+                    crate::RecordKind::KeyFrame | crate::RecordKind::Anchor
+                ) {
+                    if session.recovery.len() == self.limits.max_recovery_records {
+                        session.recovery.remove(0);
+                    }
+                    session.recovery.push(record.clone());
+                }
                 self.push_event(SessionEvent::Object {
                     identity: self.sessions[session_index].identity,
                     record,
@@ -272,6 +348,145 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
             }
         }
         Ok(())
+    }
+
+    fn receive_continuous(&mut self, index: usize, datagram: &[u8]) -> Result<()> {
+        let session = &mut self.sessions[index];
+        let pending = &mut self.pending;
+        let maximum = self.limits.max_pending_events;
+        let delivered = &mut session.delivered_record;
+        match session
+            .continuous
+            .as_mut()
+            .expect("manifest accepted")
+            .receive_datagram(datagram, |event| {
+                if pending.len() == maximum {
+                    return Err(Error::TooManyRecords {
+                        actual: maximum + 1,
+                        maximum,
+                    });
+                }
+                pending.push(match event {
+                    ContinuousReceiveEvent::Record(record) => {
+                        *delivered = true;
+                        SessionEvent::ContinuousRecord {
+                            identity: session.identity,
+                            record: record.clone(),
+                        }
+                    }
+                    ContinuousReceiveEvent::Gap(mut gap) => {
+                        if !*delivered && session.last_anchor.is_none() {
+                            gap.reason = crate::GapReason::LateJoin;
+                        }
+                        SessionEvent::Gap {
+                            identity: session.identity,
+                            gap,
+                        }
+                    }
+                });
+                Ok(())
+            }) {
+            Ok(()) | Err(ReceiveError::Consumer(_)) => Ok(()),
+            Err(ReceiveError::Stream(error)) => Err(error),
+        }
+    }
+
+    fn verify_recovery(&mut self, index: usize) -> Result<()> {
+        let session = &mut self.sessions[index];
+        let Some(manifest) = session.manifest_record.as_ref() else {
+            return Ok(());
+        };
+        let mut candidate = None;
+        for record in &session.recovery {
+            let decoded = record.decoded()?;
+            if decoded.kind != crate::RecordKind::Anchor {
+                continue;
+            }
+            let anchor = crate::decode_anchor(decoded.payload)?;
+            if anchor.copperlist_id != decoded.object_id
+                || !anchor.references_manifest(manifest.decoded()?)
+                || session
+                    .last_anchor
+                    .is_some_and(|last| anchor.copperlist_id <= last)
+            {
+                continue;
+            }
+            for keyframe in &session.recovery {
+                let decoded = keyframe.decoded()?;
+                if anchor.references_keyframe(decoded)
+                    && crate::decode_keyframe(decoded.payload)?.culistid == anchor.copperlist_id
+                    && candidate.as_ref().is_none_or(
+                        |(previous, _): &(crate::Anchor, RecoveredRecord)| {
+                            previous.copperlist_id < anchor.copperlist_id
+                        },
+                    )
+                {
+                    candidate = Some((anchor.clone(), keyframe.clone()));
+                }
+            }
+        }
+        let Some((anchor, keyframe)) = candidate else {
+            return Ok(());
+        };
+        let decoder = session.continuous.as_mut().expect("manifest accepted");
+        let next = decoder.next_object_id();
+        let needed = 1 + usize::from(anchor.copperlist_id > next);
+        if self.pending.len() + needed > self.limits.max_pending_events {
+            return Err(Error::TooManyRecords {
+                actual: self.pending.len() + needed,
+                maximum: self.limits.max_pending_events,
+            });
+        }
+        if anchor.copperlist_id > next {
+            self.pending.push(SessionEvent::Gap {
+                identity: session.identity,
+                gap: crate::CopperListGap {
+                    first_id: next,
+                    last_id: anchor.copperlist_id - 1,
+                    reason: if session.delivered_record {
+                        crate::GapReason::AnchorRecovery
+                    } else {
+                        crate::GapReason::LateJoin
+                    },
+                },
+            });
+            decoder.resume_at(anchor.copperlist_id);
+        }
+        session.last_anchor = Some(anchor.copperlist_id);
+        self.pending.push(SessionEvent::VerifiedAnchor {
+            identity: session.identity,
+            anchor,
+            keyframe,
+        });
+        Ok(())
+    }
+
+    /// Finalize a known sender boundary; an unknown tail is never invented.
+    pub fn finish_through<E>(
+        &mut self,
+        identity: StreamIdentity,
+        last_id: u64,
+        mut emit: impl FnMut(SessionEvent) -> core::result::Result<(), E>,
+    ) -> core::result::Result<(), ReceiveError<E>> {
+        self.drain_events(&mut emit)?;
+        let session = self
+            .sessions
+            .iter_mut()
+            .find(|session| session.identity == identity)
+            .ok_or(Error::InvalidConfig("unknown session"))?;
+        let decoder = session
+            .continuous
+            .as_mut()
+            .ok_or(Error::InvalidConfig("session has no manifest"))?;
+        decoder.finish_through(last_id, |event| {
+            emit(match event {
+                ContinuousReceiveEvent::Record(record) => SessionEvent::ContinuousRecord {
+                    identity,
+                    record: record.clone(),
+                },
+                ContinuousReceiveEvent::Gap(gap) => SessionEvent::Gap { identity, gap },
+            })
+        })
     }
 
     fn decoder_from_manifest(

--- a/core/cu29_logstream/tests/session_router.rs
+++ b/core/cu29_logstream/tests/session_router.rs
@@ -77,6 +77,8 @@ fn manifest_bootstraps_continuous_decoder_without_out_of_band_fec_config() {
         .unwrap();
 
     let mut router = SessionRouter::<1128, 64, 64>::new(SessionRouterLimits {
+        max_startup_packets: 64,
+        max_recovery_records: 8,
         max_sessions: 2,
         max_pending_events: 16,
         max_record_bytes: 65_536,
@@ -112,4 +114,282 @@ fn manifest_bootstraps_continuous_decoder_without_out_of_band_fec_config() {
             record: recovered,
         }) if *event_identity == identity && recovered.bytes() == record
     ));
+}
+
+fn setup() -> (
+    cu29_logstream::LogStreamSenderConfig,
+    SessionRouter<1128, 64, 64>,
+) {
+    let identity = StreamIdentity {
+        session_id: *b"router-session01",
+        sender_id: 23,
+    };
+    let sender = LogStreamPlan::resolve(&destination())
+        .unwrap()
+        .sender_config(identity, ApplicationSchema { outputs: vec![] })
+        .unwrap();
+    let router = SessionRouter::new(SessionRouterLimits {
+        max_sessions: 1,
+        max_startup_packets: 8,
+        max_recovery_records: 4,
+        max_pending_events: 3,
+        max_record_bytes: 65_536,
+        max_buffered_records: 64,
+        equation_capacity: 64,
+        finite_objects: FiniteObjectLimits::new(4_194_304, 1128, 4),
+    })
+    .unwrap();
+    (sender, router)
+}
+
+fn objects(sender: &cu29_logstream::LogStreamSenderConfig, boundary: u64) -> [Vec<Vec<u8>>; 3] {
+    let manifest = &sender.recovery.manifest_record;
+    let decoded = cu29_logstream::decode_record(manifest).unwrap();
+    let keyframe = cu29_runtime::curuntime::KeyFrame {
+        culistid: boundary,
+        timestamp: Default::default(),
+        serialized_tasks: vec![1, 2, 3],
+    };
+    let (keyframe, anchor) =
+        cu29_logstream::encode_keyframe_and_anchor(&keyframe, decoded.object_id, decoded.digest)
+            .unwrap();
+    [manifest, &keyframe, &anchor].map(|record| {
+        let mut packets = Vec::new();
+        FiniteObjectEncoder::new(sender.recovery.finite)
+            .unwrap()
+            .push_record(record, &mut packets)
+            .unwrap();
+        packets
+    })
+}
+
+fn continuous(
+    sender: &cu29_logstream::LogStreamSenderConfig,
+    ids: core::ops::Range<u64>,
+) -> Vec<Vec<u8>> {
+    let mut encoder = ContinuousEncoder::<1128, 64>::new(
+        sender.continuous.identity,
+        0,
+        sender.continuous.lane,
+        sender.continuous.fec,
+        sender.continuous.max_record_bytes,
+        EncodingSymbolId::new(0),
+    )
+    .unwrap();
+    let mut packets = Vec::new();
+    for id in ids {
+        encoder
+            .push_record(
+                &encode_record(RecordKind::CopperList, id, b"record").unwrap(),
+                &mut packets,
+            )
+            .unwrap();
+    }
+    packets
+}
+
+fn receive(
+    router: &mut SessionRouter<1128, 64, 64>,
+    packets: &[Vec<u8>],
+    events: &mut Vec<SessionEvent>,
+) {
+    for packet in packets {
+        router
+            .receive_datagram(packet, |event| {
+                events.push(event);
+                Ok::<(), ()>(())
+            })
+            .unwrap();
+    }
+}
+
+fn ids(events: &[SessionEvent]) -> Vec<u64> {
+    events
+        .iter()
+        .filter_map(|event| match event {
+            SessionEvent::ContinuousRecord { record, .. } => {
+                Some(record.decoded().unwrap().object_id)
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn startup_packets_keep_arrival_order_even_with_a_small_event_queue() {
+    let (sender, mut router) = setup();
+    let mut events = Vec::new();
+    receive(&mut router, &continuous(&sender, 0..8), &mut events);
+    assert!(events.is_empty());
+    receive(&mut router, &objects(&sender, 0)[0], &mut events);
+    assert_eq!(ids(&events), (0..8).collect::<Vec<_>>());
+    assert_eq!(router.stats().startup_packets_dropped, 0);
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, SessionEvent::Gap { .. }))
+    );
+}
+
+#[test]
+fn late_join_verifies_all_control_object_arrival_orders_and_releases_buffered_boundary() {
+    for order in [
+        [0, 1, 2],
+        [0, 2, 1],
+        [1, 0, 2],
+        [1, 2, 0],
+        [2, 0, 1],
+        [2, 1, 0],
+    ] {
+        let (sender, mut router) = setup();
+        let control = objects(&sender, 100);
+        let mut events = Vec::new();
+        receive(&mut router, &continuous(&sender, 100..103), &mut events);
+        for index in order {
+            receive(&mut router, &control[index], &mut events);
+        }
+        let gaps: Vec<_> = events
+            .iter()
+            .filter_map(|event| match event {
+                SessionEvent::Gap { gap, .. } => Some(*gap),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            gaps,
+            [cu29_logstream::CopperListGap {
+                first_id: 0,
+                last_id: 99,
+                reason: cu29_logstream::GapReason::LateJoin
+            }],
+            "{order:?}"
+        );
+        assert_eq!(ids(&events), [100, 101, 102], "{order:?}");
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, SessionEvent::VerifiedAnchor { .. }))
+                .count(),
+            1
+        );
+        // Repeated objects cannot rewind or re-archive a boundary.
+        for packets in control {
+            receive(&mut router, &packets, &mut events);
+        }
+        assert_eq!(ids(&events), [100, 101, 102]);
+    }
+}
+
+#[test]
+fn wrong_digest_or_keyframe_boundary_never_authorizes_a_restart() {
+    for wrong_boundary in [false, true] {
+        let (sender, mut router) = setup();
+        let mut events = Vec::new();
+        receive(&mut router, &objects(&sender, 100)[0], &mut events);
+        receive(&mut router, &continuous(&sender, 100..101), &mut events);
+        let manifest = cu29_logstream::decode_record(&sender.recovery.manifest_record).unwrap();
+        let keyframe = cu29_runtime::curuntime::KeyFrame {
+            culistid: if wrong_boundary { 101 } else { 100 },
+            timestamp: Default::default(),
+            serialized_tasks: vec![],
+        };
+        let keyframe_record = encode_record(
+            RecordKind::KeyFrame,
+            100,
+            &cu29_logstream::encode_keyframe(&keyframe).unwrap(),
+        )
+        .unwrap();
+        let mut anchor = cu29_logstream::Anchor {
+            manifest_object_id: manifest.object_id,
+            manifest_record_digest: manifest.digest,
+            copperlist_id: 100,
+            keyframe_object_id: 100,
+            keyframe_record_digest: cu29_logstream::decode_record(&keyframe_record)
+                .unwrap()
+                .digest,
+        };
+        if !wrong_boundary {
+            anchor.keyframe_record_digest[0] ^= 1;
+        }
+        let anchor_record = encode_record(
+            RecordKind::Anchor,
+            100,
+            &cu29_logstream::encode_anchor(&anchor).unwrap(),
+        )
+        .unwrap();
+        for record in [keyframe_record, anchor_record] {
+            let mut packets = Vec::new();
+            FiniteObjectEncoder::new(sender.recovery.finite)
+                .unwrap()
+                .push_record(&record, &mut packets)
+                .unwrap();
+            receive(&mut router, &packets, &mut events);
+        }
+        assert!(ids(&events).is_empty());
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, SessionEvent::VerifiedAnchor { .. }))
+        );
+    }
+}
+
+#[test]
+fn outage_recovery_and_terminal_gap_are_explicit_and_consumer_failure_is_retryable() {
+    let (sender, mut router) = setup();
+    let mut events = Vec::new();
+    receive(&mut router, &objects(&sender, 0)[0], &mut events);
+    receive(&mut router, &continuous(&sender, 0..1), &mut events);
+    let control = objects(&sender, 100);
+    receive(&mut router, &control[1], &mut events);
+    let mut failed = false;
+    for packet in &control[2] {
+        let result = router.receive_datagram(packet, |event| {
+            if matches!(event, SessionEvent::VerifiedAnchor { .. }) {
+                return Err("archive unavailable");
+            }
+            events.push(event);
+            Ok(())
+        });
+        if result.is_err() {
+            failed = true;
+            break;
+        }
+    }
+    assert!(failed);
+    router
+        .drain_events(&mut |event| {
+            events.push(event);
+            Ok::<(), ()>(())
+        })
+        .unwrap();
+    assert!(events.iter().any(|event| matches!(event, SessionEvent::Gap { gap, .. } if gap.first_id == 1 && gap.last_id == 99 && gap.reason == cu29_logstream::GapReason::AnchorRecovery)));
+    router
+        .finish_through(sender.continuous.identity, 102, |event| {
+            events.push(event);
+            Ok::<(), ()>(())
+        })
+        .unwrap();
+    assert!(
+        matches!(events.last(), Some(SessionEvent::Gap { gap, .. }) if gap.first_id == 100 && gap.last_id == 102 && gap.reason == cu29_logstream::GapReason::SessionEnded)
+    );
+}
+
+#[test]
+fn startup_overflow_is_bounded_and_never_claims_a_complete_session() {
+    let (sender, mut router) = setup();
+    let mut events = Vec::new();
+    receive(&mut router, &continuous(&sender, 0..12), &mut events);
+    assert_eq!(router.stats().startup_packets_dropped, 4);
+    receive(&mut router, &objects(&sender, 0)[0], &mut events);
+    assert_eq!(ids(&events), (0..8).collect::<Vec<_>>());
+    router
+        .finish_through(sender.continuous.identity, 11, |event| {
+            events.push(event);
+            Ok::<(), ()>(())
+        })
+        .unwrap();
+    assert!(
+        matches!(events.last(), Some(SessionEvent::Gap { gap, .. }) if gap.first_id == 8 && gap.last_id == 11)
+    );
 }

--- a/core/cu29_runtime/src/continuity.rs
+++ b/core/cu29_runtime/src/continuity.rs
@@ -1,0 +1,45 @@
+//! Native received-log provenance and continuity, independent of packet transports.
+
+use alloc::vec::Vec;
+use bincode::{Decode, Encode};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Encode, Decode)]
+pub enum SourceGapReason {
+    RlcWindowExpired,
+    SessionEnded,
+    LateJoin,
+    AnchorRecovery,
+}
+
+/// Stored in `UnifiedLogType::StreamContinuity`. Ranges are inclusive.
+/// Gaps remain missing history even when a later keyframe permits state replay.
+#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+pub enum StreamContinuityRecord {
+    /// Canonical, versioned semantic manifest bytes bind identity, plan and schema.
+    Manifest { record: Vec<u8> },
+    Gap {
+        first_id: u64,
+        last_id: u64,
+        reason: SourceGapReason,
+    },
+    /// Verified keyframe/manifest references, retained as canonical anchor bytes.
+    Anchor { copperlist_id: u64, record: Vec<u8> },
+    /// Explicit receiver finalization, not a claim about an unobserved sender tail.
+    Finished { next_copperlist_id: u64 },
+}
+
+/// Rejects replay across missing history unless state is restored at this boundary.
+/// Call before executing any task or changing the replay clock.
+pub fn validate_replay_continuity(
+    expected: u64,
+    actual: u64,
+    keyframe: Option<u64>,
+) -> cu29_traits::CuResult<()> {
+    if keyframe.is_some_and(|boundary| boundary != actual) {
+        return Err("Replay keyframe does not match the CopperList boundary".into());
+    }
+    if actual != expected && keyframe != Some(actual) {
+        return Err("Replay cannot cross an unhealed CopperList gap without a keyframe".into());
+    }
+    Ok(())
+}

--- a/core/cu29_runtime/src/debug.rs
+++ b/core/cu29_runtime/src/debug.rs
@@ -631,6 +631,20 @@ where
         let mut replayed = 0usize;
         for idx in start..=end {
             let (entry, ts) = self.copperlist_at(idx)?;
+            let restored = (idx == start)
+                .then_some(self.last_keyframe)
+                .flatten()
+                .filter(|boundary| *boundary == entry.id);
+            let expected = if idx > 0 {
+                self.copperlist_at(idx - 1)?
+                    .0
+                    .id
+                    .checked_add(1)
+                    .ok_or_else(|| CuError::from("Replay CopperList id overflow"))?
+            } else {
+                0
+            };
+            crate::continuity::validate_replay_continuity(expected, entry.id, restored)?;
             if let Some(ts) = ts {
                 self.clock_mock.set_value(ts.as_nanos());
             }

--- a/core/cu29_runtime/src/distributed_replay.rs
+++ b/core/cu29_runtime/src/distributed_replay.rs
@@ -534,6 +534,20 @@ where
                 .or(keyframe
                     .as_ref()
                     .filter(|candidate| candidate.culistid == copperlist.id));
+            let expected = if idx > 0 {
+                self.copperlist_at(idx - 1)?
+                    .0
+                    .id
+                    .checked_add(1)
+                    .ok_or_else(|| CuError::from("Replay CopperList id overflow"))?
+            } else {
+                0
+            };
+            crate::continuity::validate_replay_continuity(
+                expected,
+                copperlist.id,
+                keyframe.map(|frame| frame.culistid),
+            )?;
             <App as CuRecordedReplayApplication<S, L>>::replay_recorded_copperlist(
                 &mut self.app,
                 &self.clock_mock,

--- a/core/cu29_runtime/src/lib.rs
+++ b/core/cu29_runtime/src/lib.rs
@@ -15,6 +15,7 @@ pub mod app;
 mod app_sim;
 pub mod config;
 pub mod context;
+pub mod continuity;
 pub mod copperlist;
 #[doc(hidden)]
 pub mod copperlist_codec;

--- a/core/cu29_runtime/tests/replay_primitives.rs
+++ b/core/cu29_runtime/tests/replay_primitives.rs
@@ -407,3 +407,35 @@ fn builder_propagates_instance_id_into_runtime() -> CuResult<()> {
     assert_eq!(app.copper_runtime_mut().instance_id(), 42);
     Ok(())
 }
+
+#[test]
+fn recorded_replay_rejects_missing_history_before_changing_clock_or_state() -> CuResult<()> {
+    let _guard = TEST_MUTEX
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let (mut recorded, mut keyframe) = record_reference_run(&temp.path().join("source.copper"))?;
+    recorded.id = 100;
+    keyframe.culistid = 100;
+    let logger = build_logger(&temp.path().join("replay.copper"))?;
+    let (clock, mock) = RobotClock::mock();
+    let mut noop = |_step: default::SimStep<'_>| SimOverride::ExecuteByRuntime;
+    let mut app = ReplayApp::builder()
+        .with_clock(clock)
+        .with_logger::<MmapSectionStorage, MmapUnifiedLoggerWrite>(logger)
+        .with_sim_callback(&mut noop)
+        .build()?
+        .into_inner();
+    app.start_all_tasks(&mut noop)?;
+    let before = mock.value();
+    let error = app
+        .replay_recorded_copperlist(&mock, &recorded, None)
+        .unwrap_err();
+    assert!(error.to_string().contains("gap"));
+    assert_eq!(mock.value(), before);
+    assert_eq!(app.copper_runtime_mut().copperlists_manager.next_cl_id(), 0);
+    // A validated received keyframe makes this boundary a legal restart.
+    app.replay_recorded_copperlist(&mock, &recorded, Some(&keyframe))?;
+    app.stop_all_tasks(&mut noop)?;
+    Ok(())
+}

--- a/core/cu29_traits/src/lib.rs
+++ b/core/cu29_traits/src/lib.rs
@@ -458,6 +458,7 @@ pub enum UnifiedLogType {
     FrozenTasks,       // Log of all frozen state of the tasks.
     LastEntry,         // This is a special entry that is used to signal the end of the log.
     RuntimeLifecycle,  // Runtime lifecycle events (mission/config/stack context).
+    StreamContinuity,  // Received archive provenance, gaps and verified restart boundaries.
 }
 /// Represent the minimum set of traits to be usable as Metadata in Copper.
 pub trait Metadata: Default + Debug + Clone + Encode + Decode<()> + Serialize {}

--- a/core/cu29_unifiedlog/src/lib.rs
+++ b/core/cu29_unifiedlog/src/lib.rs
@@ -227,7 +227,8 @@ pub struct LogStream<S: SectionStorage, L: UnifiedLogWrite<S>> {
 }
 
 impl<S: SectionStorage, L: UnifiedLogWrite<S>> LogStream<S, L> {
-    fn new(
+    /// Creates a concrete stream, including for borrowed canonical encoded entries.
+    pub fn new(
         entry_type: UnifiedLogType,
         parent_logger: Arc<Mutex<L>>,
         minimum_allocation_amount: usize,

--- a/justfile
+++ b/justfile
@@ -168,6 +168,13 @@ logstream-udp-check:
 	cargo +stable clippy -p cu29-logstream-udp --all-targets --features runtime-integration -- --deny warnings
 	cargo +stable test -p cu29-logstream-udp --features runtime-integration
 
+# Receiver assembly, native archives, UDP arrival order, and replay continuity.
+logstream-receiver-check:
+	cargo +stable test -p cu29-logstream
+	cargo +stable check -p cu29-logstream --no-default-features
+	cargo +stable test -p cu29-runtime --test replay_primitives
+	just logstream-udp-check
+
 # Check the large examples from the former extra-examples repo.
 check-extra-examples: check-extra-examples-host check-extra-examples-embedded
 


### PR DESCRIPTION
## Summary

A receiver started independently can now assemble a streamed session into a native `.copper` archive. Packets received before manifest discovery are buffered within explicit bounds; digest-verified anchors connect keyframes to restart boundaries and report missing history as inclusive gaps.

Stacked on #1321 (`gbin/cu29-logstream-udp-resources`). Companion book documentation: https://github.com/copper-project/copper-rs-book/pull/45.

## Changes

- Add bounded startup and completed recovery-object caches to `SessionRouter`, automatic manifest/keyframe/anchor verification, monotonic restart selection, explicit `LateJoin`/outage gaps, and caller-known session finalization.
- Add application-typed `NativeArchive<P>`. It derives the expected schema from generated output specs, decodes each CopperList once, and appends canonical received bytes directly into native CopperList/FrozenTasks sections. A separate StreamContinuity section preserves provenance, gaps, verified anchors, and receiver finalization.
- Expose continuity records through the ordinary exporter and report them in `fsck`. Generated recorded replay and indexed state replay reject crossing missing ids without a matching keyframe.
- Exercise all control-object arrival orders, digest/id mismatch rejection, startup overflow, consumer retry, clean UDP byte-for-byte archival, late join, outage recovery, and replay rejection before clock/state changes.

## Validation

- `just pr-check`: 972 workspace tests, 518 core tests, and 12 UDP tests passed; formatting, public API, std/no_std/embedded lint passed.
- `just logstream-receiver-check` passed, including the explicit no-default-features logstream build.
- Dependency checks passed for both changed Cargo packages. A whole-workspace run of the newer cargo-shear reports pre-existing findings outside this change.
- Book documentation build passed; wiki documentation is committed on a local companion branch because GitHub wikis do not support PRs.

## Reminder

- [x] I ran `just pr-check` from the repo root
- [x] I have updated docs or examples where needed

## Scope

Full-capture archives require the matching application/native codec. Recovery restores state at a verified boundary; it does not heal missing history or claim completeness of an unobserved tail. No encoding, allocation, or transport work is added to production real-time task execution. The runnable two-process demonstrator, pacing, optional feedback, hybrid reconstruction, and dashboard API remain follow-up work.
