### PR TITLE
Demonstrate two-process UDP log streaming and preserve replay recovery IDs

### DIFF
--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -129,6 +129,12 @@ jobs:
       - name: Run UDP logstream integration
         if: matrix.task == 'test'
         run: cargo +${{ inputs.toolchain }} test -p cu29-logstream-udp --features runtime-integration
+      - name: Check two-process UDP logstream demo
+        if: matrix.task == 'test' && runner.os != 'Windows'
+        run: |
+          cargo +${{ inputs.toolchain }} clippy -p cu-logstream-demo --all-targets --features replay -- --deny warnings
+          cargo +${{ inputs.toolchain }} build -p cu-logstream-demo --features replay --bins
+          python3 examples/cu_logstream_demo/run.py all --binary target/debug/cu-logstream-demo
       - name: Run cu29-derive trybuild tests on (ubuntu-26.04 | debug)
         if: matrix.task == 'trybuild'
         run: cargo +${{ inputs.toolchain }} test -p cu29-derive test_compile_fail -- --nocapture
@@ -211,6 +217,12 @@ jobs:
       - name: Run UDP logstream integration
         if: matrix.task == 'test'
         run: cargo +${{ inputs.toolchain }} test -p cu29-logstream-udp --features runtime-integration
+      - name: Check two-process UDP logstream demo
+        if: matrix.task == 'test' && runner.os != 'Windows'
+        run: |
+          cargo +${{ inputs.toolchain }} clippy -p cu-logstream-demo --all-targets --features replay -- --deny warnings
+          cargo +${{ inputs.toolchain }} build -p cu-logstream-demo --features replay --bins
+          python3 examples/cu_logstream_demo/run.py all --binary target/debug/cu-logstream-demo
       - name: Run cu29-derive trybuild tests on (${{ inputs.linux_runner_label }} | debug)
         if: matrix.task == 'trybuild'
         run: cargo +${{ inputs.toolchain }} test -p cu29-derive test_compile_fail -- --nocapture
@@ -415,6 +427,12 @@ jobs:
       - name: Run UDP logstream integration
         if: matrix.task == 'test'
         run: cargo +${{ inputs.toolchain }} test -p cu29-logstream-udp --features runtime-integration
+      - name: Check two-process UDP logstream demo
+        if: matrix.task == 'test' && runner.os != 'Windows'
+        run: |
+          cargo +${{ inputs.toolchain }} clippy -p cu-logstream-demo --all-targets --features replay -- --deny warnings
+          cargo +${{ inputs.toolchain }} build -p cu-logstream-demo --features replay --bins
+          python3 examples/cu_logstream_demo/run.py all --binary target/debug/cu-logstream-demo
       - name: Run cu29-derive trybuild tests on (${{ matrix.target_os == 'windows' && inputs.windows_runner_label || 'macos-latest' }} | debug)
         if: matrix.task == 'trybuild'
         run: cargo +${{ inputs.toolchain }} test -p cu29-derive test_compile_fail -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ members = [
   "examples/cu_bridge_test",
   "examples/cu_bevymon_demo",
   "examples/cu_caterpillar",
+  "examples/cu_logstream_demo",
   "examples/cu_distributed_resim_demo",
   "examples/cu_elrs_bdshot_demo",
   "examples/cu_feetech_demo",

--- a/components/res/cu29_logstream_udp/README.md
+++ b/components/res/cu29_logstream_udp/README.md
@@ -120,7 +120,9 @@ integration test separately from the general workspace tests.
 The generated-runtime integration test receives actual UDP traffic in socket
 arrival order, discovers its manifest without out-of-band FEC settings, and
 decodes correctly ordered application-typed CopperLists and recovery objects.
-The current router discards packets preceding manifest discovery; this test
-does not sort packets to hide that startup limitation or assert a complete
-session archive. Automatic verified anchor recovery and native receiver
-archival are the next PR, followed by a runnable two-process demonstrator.
+The router buffers a bounded number of packets preceding manifest discovery.
+The test verifies native archives and explicit gaps after lost prefixes or outages.
+For a runnable sender and receiver in separate processes, see the
+[UDP demo](../../../examples/cu_logstream_demo). Run `just logstream-demo-check`
+from the repository root to exercise clean reception, FEC recovery, outages,
+late start, receiver restart, and recorded replay.

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -6022,36 +6022,31 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                             copperlist.id,
                             keyframe.map(|frame| frame.culistid),
                         )?;
-                        if let Some(keyframe) = keyframe {
-                            if keyframe.culistid != copperlist.id {
-                                return Err(CuError::from(format!(
-                                    "Recorded keyframe culistid {} does not match copperlist {}",
-                                    keyframe.culistid, copperlist.id
-                                )));
-                            }
-
+                        let timestamp = if let Some(keyframe) = keyframe {
                             if !self.copper_runtime_mut().captures_keyframe(copperlist.id) {
                                 return Err(CuError::from(format!(
                                     "CopperList {} is not configured to capture a keyframe in this runtime",
                                     copperlist.id
                                 )));
                             }
-
-                            self.copper_runtime_mut()
-                                .set_forced_keyframe_timestamp(keyframe.timestamp);
-                            self.copper_runtime_mut().lock_keyframe(keyframe);
-                            clock_mock.set_value(keyframe.timestamp.as_nanos());
+                            keyframe.timestamp
                         } else {
-                            let timestamp =
-                                cu29::simulation::recorded_copperlist_timestamp(copperlist)
-                                    .ok_or_else(|| {
-                                        CuError::from(format!(
-                                            "Recorded copperlist {} has no process_time.start timestamps",
-                                            copperlist.id
-                                        ))
-                                    })?;
-                            clock_mock.set_value(timestamp.as_nanos());
+                            cu29::simulation::recorded_copperlist_timestamp(copperlist)
+                                .ok_or_else(|| CuError::from(format!(
+                                    "Recorded copperlist {} has no process_time.start timestamps",
+                                    copperlist.id
+                                )))?
+                        };
+                        // Recorded replay runs offline. Drain the previous output
+                        // and align allocation only after validating this boundary.
+                        self.copper_runtime_mut().copperlists_manager
+                            .prepare_recorded_replay(copperlist.id)?;
+                        self.copper_runtime_mut().keyframes_manager.finish_pending()?;
+                        if let Some(keyframe) = keyframe {
+                            self.copper_runtime_mut().set_forced_keyframe_timestamp(timestamp);
+                            self.copper_runtime_mut().lock_keyframe(keyframe);
                         }
+                        clock_mock.set_value(timestamp.as_nanos());
 
                         let mut sim_callback = |step: SimStep<'_>| -> SimOverride {
                             #mission_mod::recorded_replay_step(step, copperlist)

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -19,6 +19,11 @@ can read them. Sender work runs off the real-time task path.
 
 ## Using it
 
+For a runnable sender/receiver pair, start with the
+[UDP demo](../../examples/cu_logstream_demo). Its default `just` command verifies
+the received archive against the onboard log and runs the ordinary logreader and
+recorded replay. Loss, outage, late-start, and receiver-restart scenarios are included.
+
 Enable `cu29/logstream` and configure a `log_streaming` destination in the app's
 RON config. Bind a transport implementing `CuStreamTx`; the
 [`cu29-logstream-udp`](../../components/res/cu29_logstream_udp) resource supplies UDP

--- a/core/cu29_runtime/src/app.rs
+++ b/core/cu29_runtime/src/app.rs
@@ -274,6 +274,14 @@ pub trait CuRecordedReplayApplication<S: SectionStorage, L: UnifiedLogWrite<S> +
     type RecordedDataSet: CopperListTuple;
 
     /// Replay one recorded CopperList exactly as logged.
+    ///
+    /// Generated implementations validate continuity, drain prior asynchronous
+    /// output, and align the allocator to the recorded id before executing the
+    /// captured-output callback. This is an offline operation and may wait for
+    /// logging workers; it is not a real-time task-path API. A matching keyframe
+    /// permits a jump across missing history and preserves its recorded timing.
+    /// Call [`CuSimApplication::restore_keyframe`] separately when restoring task
+    /// state at that boundary.
     fn replay_recorded_copperlist(
         &mut self,
         clock_mock: &RobotClockMock,

--- a/core/cu29_runtime/src/copperlist.rs
+++ b/core/cu29_runtime/src/copperlist.rs
@@ -229,6 +229,11 @@ impl<P: CopperListTuple, const N: usize> CuListsManager<P, N> {
         self.current_cl_id
     }
 
+    pub(crate) fn set_next_replay_id(&mut self, id: u64) {
+        debug_assert_eq!(self.length, 0);
+        self.current_cl_id = id;
+    }
+
     /// Returns the most recently assigned copper-list id.
     ///
     /// Before the first call to [`create`](Self::create), this returns `0`.

--- a/core/cu29_runtime/src/curuntime.rs
+++ b/core/cu29_runtime/src/curuntime.rs
@@ -522,6 +522,18 @@ impl<P: CopperListTuple + Default, const NBCL: usize> SyncCopperListsManager<P, 
         self.inner.next_cl_id()
     }
 
+    /// Aligns an idle allocator to a continuity-validated recorded boundary.
+    /// Generated replay calls this off the real-time path.
+    pub fn prepare_recorded_replay(&mut self, next_id: u64) -> CuResult<()> {
+        if !self.inner.is_empty() {
+            return Err(CuError::from(
+                "Cannot reposition replay with active CopperLists",
+            ));
+        }
+        self.inner.set_next_replay_id(next_id);
+        Ok(())
+    }
+
     pub fn last_cl_id(&self) -> u64 {
         self.inner.last_cl_id()
     }
@@ -874,6 +886,14 @@ impl<P: CopperListTuple + Default, const NBCL: usize> AsyncCopperListsManager<P,
 
     pub fn next_cl_id(&self) -> u64 {
         self.next_cl_id
+    }
+
+    /// Drains offline replay output before moving to a validated recorded boundary.
+    /// This may wait for the worker; generated production task steps never call it.
+    pub fn prepare_recorded_replay(&mut self, next_id: u64) -> CuResult<()> {
+        self.finish_pending()?;
+        self.next_cl_id = next_id;
+        Ok(())
     }
 
     pub fn last_cl_id(&self) -> u64 {

--- a/core/cu29_runtime/tests/replay_primitives.rs
+++ b/core/cu29_runtime/tests/replay_primitives.rs
@@ -436,6 +436,28 @@ fn recorded_replay_rejects_missing_history_before_changing_clock_or_state() -> C
     assert_eq!(app.copper_runtime_mut().copperlists_manager.next_cl_id(), 0);
     // A validated received keyframe makes this boundary a legal restart.
     app.replay_recorded_copperlist(&mock, &recorded, Some(&keyframe))?;
+    assert_eq!(
+        app.copper_runtime_mut().copperlists_manager.next_cl_id(),
+        101
+    );
+    recorded.id = 101;
+    app.replay_recorded_copperlist(&mock, &recorded, None)?;
+    assert_eq!(
+        app.copper_runtime_mut().copperlists_manager.next_cl_id(),
+        102
+    );
     app.stop_all_tasks(&mut noop)?;
+    drop(app);
+    let replayed: Vec<_> =
+        copperlists_reader::<default::CuStampedDataSet>(UnifiedLoggerIOReader::new(
+            cu29::prelude::UnifiedLoggerRead::new(temp.path().join("replay.copper").as_path())
+                .map_err(|error| CuError::new_with_cause("Open replay archive", error))?,
+            UnifiedLogType::CopperList,
+        ))
+        .collect();
+    assert_eq!(
+        replayed.iter().map(|list| list.id).collect::<Vec<_>>(),
+        [100, 101]
+    );
     Ok(())
 }

--- a/examples/cu_logstream_demo/Cargo.toml
+++ b/examples/cu_logstream_demo/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "cu-logstream-demo"
+description = "Two-process deterministic Copper log streaming over UDP"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[features]
+default = []
+# Keep async runtime features out of ordinary workspace builds.
+demo = ["cu29/logstream", "cu29/reflect"]
+replay = ["demo", "cu29/remote-debug"]
+
+[[bin]]
+name = "cu-logstream-demo"
+path = "src/main.rs"
+required-features = ["demo"]
+
+[[bin]]
+name = "cu-logstream-demo-logreader"
+path = "src/logreader.rs"
+required-features = ["demo"]
+
+[[bin]]
+name = "cu-logstream-demo-resim"
+path = "src/resim.rs"
+required-features = ["replay"]
+
+[dependencies]
+cu29 = { workspace = true }
+cu29-logstream = { workspace = true, features = ["std"] }
+cu29-logstream-udp = { workspace = true }
+cu29-export = { workspace = true }
+cu29-unifiedlog = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+serde = { workspace = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/examples/cu_logstream_demo/README.md
+++ b/examples/cu_logstream_demo/README.md
@@ -1,0 +1,98 @@
+# UDP log streaming demo
+
+Run a deterministic Copper graph in one process and collect its native execution
+log in another over localhost UDP. The graph is `counter → accumulator`: both
+tasks freeze their state, and every output retains the sender's timestamps.
+
+From this directory:
+
+```sh
+just
+just run loss
+just run outage
+just run late
+just run restart
+```
+
+`just` builds the tools, runs the clean scenario, compares the received archive
+against the onboard archive, runs the ordinary logreader's `fsck`, and replays
+the received CopperLists. Python 3 orchestrates process lifetimes; Rust reads
+and verifies the native logs. Each run creates a fresh directory under this
+example's `logs/` and prints its path.
+
+| Scenario | What it exercises |
+| --- | --- |
+| `clean` | All 256 CopperLists match the onboard payloads and metadata. |
+| `loss` | Discard the source packets for CopperList 20; RLC repairs recover it with no semantic gap. |
+| `outage` | Discard a contiguous arrival interval beginning at CopperList 32 and ending before 160, including control traffic. Missing history remains explicit and a verified anchor enables recovery. |
+| `late` | Start the receiver after the sender is already running. Its archive contains a `LateJoin` prefix gap. |
+| `restart` | Close the first receiver after CopperList 64, leave it offline briefly, and launch a new process while the sender continues. The new archive reports unavailable history. |
+
+Loss injection runs at the receiver's packet boundary after real UDP reception,
+before FEC decoding. It preserves arrival order and adds no sender task work.
+The source-loss and outage intervals are selected by wire record IDs. Late start
+and restart use real process lifetimes, so their exact recovery IDs depend on
+host scheduling. Verification checks the resulting continuity rather than
+assuming those IDs.
+
+The status display reports received packets, the latest archived CopperList,
+latest verified anchor, gap count, and demo packet drops. Task data stays in the
+native log. Received files have separate paths for each receiver lifetime.
+
+## Run the processes yourself
+
+Start the receiver in one terminal, then the sender in another:
+
+```sh
+just receiver
+just sender
+```
+
+These use `127.0.0.1:7447` and write `logs/received.copper` and
+`logs/sender.copper`. Use fresh output paths for another run:
+
+```sh
+just receiver 127.0.0.1:7447 logs/received-2.copper
+just sender 127.0.0.1:7447 logs/sender-2.copper
+```
+
+The sender runs 256 iterations at roughly 100 Hz. The receiver exits after one
+second without a datagram, or fails if no traffic arrives within 15 seconds.
+Socket addresses are explicit CLI arguments; stream policy and static sender
+resource binding are in `copperconfig.ron`.
+
+## Read and replay
+
+Use the printed log base from an automated run with these recipes:
+
+```sh
+just cl logs/received.copper
+just fsck logs/received.copper
+just resim logs/received.copper logs/replay.copper
+just resim-debug logs/received.copper logs/debug-replay.copper
+```
+
+The replay binary uses Copper's standard `--log-base`, `--replay-log-base`, and
+`--debug-base` contract. Remote debug creates separate replay outputs per session.
+Recorded replay preserves captured outputs and checks missing CopperList ranges
+against keyframes before advancing. It does not perform hybrid reconstruction.
+The replay output is compared with the received CopperLists byte for byte.
+Offline replay drains pending output before each iteration and aligns generated
+CopperList IDs at recovery boundaries. Production task execution remains nonblocking.
+The sender/replay slabs are 16 MiB to accommodate the runtime's existing 10 MiB
+native keyframe sections.
+
+## Check the milestone
+
+From the repository root, run `just logstream-demo-check`. This checks Clippy,
+builds the opt-in binaries, and exercises all five scenarios. `just check` in this
+directory runs all scenarios. Normal workspace builds leave streaming disabled;
+`demo` enables it and `replay` also enables the remote-debug replay tools.
+
+This is a low-rate demonstrator. The configured bitrate, burst, and latency
+policy are not yet enforced by a pacer. Manifests and anchors are emitted on
+qualifying keyframe captures; independent retained-object repetition is deferred.
+Memory-bounded recovery cannot recover expired history, and receiver shutdown
+does not establish the sender's unobserved tail. Full-capture native archival
+requires the matching application schema. Feedback, hybrid reconstruction, the
+live twin API, and serial are later milestones.

--- a/examples/cu_logstream_demo/build.rs
+++ b/examples/cu_logstream_demo/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    cu29_build::setup();
+}

--- a/examples/cu_logstream_demo/copperconfig.ron
+++ b/examples/cu_logstream_demo/copperconfig.ron
@@ -1,0 +1,80 @@
+(
+    logging: (
+        enable_task_logging: true,
+        enable_keyframe_logging: true,
+        keyframe_interval: 16,
+        slab_size_mib: 16,
+        section_size_mib: 1,
+        copperlist_count: 8,
+    ),
+    resources: [
+        (
+            id: "network",
+            provider: "cu29_logstream_udp::CuUdpLogStreamResources",
+            config: {
+                "bind_addr": "127.0.0.1:0",
+                "remote_addr": "127.0.0.1:7447",
+                "send_buffer_bytes": 262144,
+                "ttl": 1,
+            },
+        ),
+    ],
+    log_streaming: (
+        destinations: [
+            (
+                id: "ground",
+                transport: (
+                    type: "cu29_logstream_udp::CuUdpLogStreamTx",
+                    resource: "network.tx",
+                ),
+                link: (
+                    mtu_bytes: 1200,
+                    bitrate_bps: 1000000,
+                    memory_budget_kib: 512,
+                    max_latency_ms: 250,
+                    burst_packets: 8,
+                ),
+                fec: (
+                    continuous: (
+                        field: Gf256,
+                        window_symbols: 64,
+                        repair_every_source_symbols: 4,
+                        repair_density: Full,
+                    ),
+                    objects: (
+                        max_object_bytes: 65536,
+                        repair_symbols_per_block: 2,
+                    ),
+                ),
+                content: (
+                    archive: true,
+                    live_viz: false,
+                    anchor_interval: 16,
+                ),
+                max_record_bytes: 4096,
+            ),
+        ],
+    ),
+    tasks: [
+        (
+            id: "counter",
+            type: "cu_logstream_demo::tasks::Counter",
+        ),
+        (
+            id: "sum",
+            type: "cu_logstream_demo::tasks::Accumulator",
+        ),
+    ],
+    cnx: [
+        (
+            src: "counter",
+            dst: "sum",
+            msg: "cu_logstream_demo::tasks::Sample",
+        ),
+        (
+            src: "sum",
+            dst: "__nc__",
+            msg: "cu_logstream_demo::tasks::Sample",
+        ),
+    ],
+)

--- a/examples/cu_logstream_demo/justfile
+++ b/examples/cu_logstream_demo/justfile
@@ -1,0 +1,32 @@
+root := "../.."
+
+# Run the clean two-process demo and verify both native logs.
+default: (run "clean")
+
+build:
+    cargo +stable build -p cu-logstream-demo --features replay --bins
+
+# Scenarios: clean, loss, outage, late, restart, all.
+run scenario="clean": build
+    python3 run.py {{scenario}} --binary {{root}}/target/debug/cu-logstream-demo
+
+check: (run "all")
+
+# Start these in separate terminals, choosing fresh output paths for each run.
+sender remote="127.0.0.1:7447" log="logs/sender.copper": build
+    {{root}}/target/debug/cu-logstream-demo sender --remote {{remote}} --log-base {{log}}
+
+receiver listen="127.0.0.1:7447" log="logs/received.copper": build
+    {{root}}/target/debug/cu-logstream-demo receiver --listen {{listen}} --log-base {{log}}
+
+cl log="logs/received.copper": build
+    {{root}}/target/debug/cu-logstream-demo-logreader {{log}} extract-copperlists
+
+fsck log="logs/received.copper": build
+    {{root}}/target/debug/cu-logstream-demo-logreader {{log}} fsck
+
+resim log="logs/received.copper" output="logs/replay.copper": build
+    {{root}}/target/debug/cu-logstream-demo-resim --log-base {{log}} --replay-log-base {{output}}
+
+resim-debug log="logs/received.copper" output="logs/replay.copper" debug_base="copper/cu-logstream-demo/debug/v1": build
+    {{root}}/target/debug/cu-logstream-demo-resim --log-base {{log}} --replay-log-base {{output}} --debug-base {{debug_base}}

--- a/examples/cu_logstream_demo/run.py
+++ b/examples/cu_logstream_demo/run.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Drive real sender/receiver processes; inspect native archives with Rust tools."""
+
+import argparse
+import pathlib
+import subprocess
+import time
+
+HERE = pathlib.Path(__file__).resolve().parent
+
+
+def run(binary, scenario):
+    directory = HERE / "logs" / f"{scenario}-{time.time_ns()}"
+    directory.mkdir(parents=True)
+    children = []
+
+    def spawn(*args):
+        child = subprocess.Popen([str(binary), *map(str, args)], cwd=HERE)
+        children.append(child)
+        return child
+
+    def wait(child):
+        code = child.wait(timeout=20)
+        if code:
+            raise RuntimeError(f"Demo process exited with {code}")
+
+    def receiver(name, listen="127.0.0.1:0", impairment="clean", stop=False):
+        ready = directory / f"{name}.endpoint"
+        args = ["receiver", "--listen", listen, "--log-base", directory / f"{name}.copper",
+                "--ready-file", ready, "--impairment", impairment]
+        if stop:
+            args += ["--stop-at", "64"]
+        child = spawn(*args)
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if child.poll() is not None:
+                raise RuntimeError("Receiver exited before becoming ready")
+            if ready.exists() and (address := ready.read_text().strip()):
+                return child, address
+            time.sleep(0.01)
+        raise TimeoutError("Receiver did not bind its socket")
+
+    def verify(name, expectation):
+        wait(spawn("verify", "--sender", directory / "sender.copper", "--received",
+                   directory / f"{name}.copper", "--expect", expectation))
+
+    try:
+        if scenario == "late":
+            # Reserve an endpoint using the actual receiver, then close it before
+            # starting the sender. This receiver receives no data or manifest.
+            initial, address = receiver("reservation")
+            initial.terminate()
+            initial.wait(timeout=5)
+            sender = spawn("sender", "--remote", address, "--log-base", directory / "sender.copper")
+            time.sleep(0.6)
+            ground, _ = receiver("received", address)
+        else:
+            ground, address = receiver("received", impairment=scenario if scenario in ("loss", "outage") else "clean",
+                                       stop=scenario == "restart")
+            sender = spawn("sender", "--remote", address, "--log-base", directory / "sender.copper")
+        if scenario == "restart":
+            wait(ground)
+            if sender.poll() is not None:
+                raise RuntimeError("Sender finished before receiver restart")
+            time.sleep(0.4)
+            restarted, _ = receiver("restarted", address)
+            wait(sender)
+            wait(restarted)
+            verify("received", "prefix")
+            verify("restarted", "late")
+            replay_names = ["received", "restarted"]
+        else:
+            wait(sender)
+            wait(ground)
+            verify("received", {"clean": "complete", "loss": "complete", "outage": "outage", "late": "late"}[scenario])
+            replay_names = ["received"]
+
+        logreader = binary.with_name("cu-logstream-demo-logreader")
+        replay = binary.with_name("cu-logstream-demo-resim")
+        for name in replay_names:
+            subprocess.run([str(logreader), str(directory / f"{name}.copper"), "fsck"], check=True, timeout=20, cwd=HERE)
+            subprocess.run([str(replay), "--log-base", str(directory / f"{name}.copper"),
+                            "--replay-log-base", str(directory / f"{name}-replay.copper")], check=True, timeout=20, cwd=HERE)
+        print(f"PASS {scenario}: {directory}", flush=True)
+    finally:
+        for child in children:
+            if child.poll() is None:
+                child.terminate()
+                try:
+                    child.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    child.kill()
+                    child.wait()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("scenario", choices=["clean", "loss", "outage", "late", "restart", "all"], default="clean", nargs="?")
+    parser.add_argument("--binary", type=pathlib.Path, required=True)
+    args = parser.parse_args()
+    binary = args.binary.resolve()
+    for scenario in (["clean", "loss", "outage", "late", "restart"] if args.scenario == "all" else [args.scenario]):
+        run(binary, scenario)

--- a/examples/cu_logstream_demo/src/lib.rs
+++ b/examples/cu_logstream_demo/src/lib.rs
@@ -1,0 +1,57 @@
+#![cfg(feature = "demo")]
+
+extern crate self as cu_logstream_demo;
+pub mod tasks;
+
+use cu29::prelude::*;
+
+#[copper_runtime(config = "copperconfig.ron")]
+struct Demo {}
+
+pub type DataSet = default::CuStampedDataSet;
+pub type List = CopperList<DataSet>;
+
+pub const ITERATIONS: u64 = 256;
+pub const TICK_NS: u64 = 10_000_000;
+// Generated native keyframe sections currently reserve 10 MiB.
+pub const SLAB_BYTES: usize = 16 * 1024 * 1024;
+
+pub fn read_lists(path: &std::path::Path) -> CuResult<Vec<List>> {
+    Ok(
+        cu29_export::copperlists_reader::<DataSet>(UnifiedLoggerIOReader::new(
+            UnifiedLoggerRead::new(path)
+                .map_err(|error| CuError::new_with_cause("Open archive", error))?,
+            UnifiedLogType::CopperList,
+        ))
+        .collect(),
+    )
+}
+
+pub fn run_sender(
+    remote: std::net::SocketAddr,
+    path: &std::path::Path,
+    iterations: u64,
+) -> CuResult<()> {
+    let mut config = CuConfig::deserialize_ron(include_str!("../copperconfig.ron"))?;
+    config.resources[0]
+        .config
+        .as_mut()
+        .unwrap()
+        .set("remote_addr", remote.to_string());
+    let (clock, mock) = RobotClock::mock();
+    let app = Demo::builder()
+        .with_clock(clock)
+        .with_instance_id(41)
+        .with_config(config)
+        .with_log_path(path, Some(SLAB_BYTES))?
+        .build()?;
+    let mut running = app.start()?;
+    for id in 0..iterations {
+        mock.set_value((id + 1) * TICK_NS);
+        running.run_one_iteration()?;
+        // Low-rate example driving, outside task execution. This is not link pacing.
+        std::thread::sleep(std::time::Duration::from_nanos(TICK_NS));
+    }
+    drop(running.stop()?);
+    Ok(())
+}

--- a/examples/cu_logstream_demo/src/logreader.rs
+++ b/examples/cu_logstream_demo/src/logreader.rs
@@ -1,0 +1,7 @@
+use cu29::prelude::*;
+
+gen_cumsgs!("copperconfig.ron");
+
+fn main() -> CuResult<()> {
+    cu29_export::run_cli::<CuMsgs>()
+}

--- a/examples/cu_logstream_demo/src/main.rs
+++ b/examples/cu_logstream_demo/src/main.rs
@@ -1,0 +1,386 @@
+use clap::{Parser, Subcommand, ValueEnum};
+use cu_logstream_demo::{DataSet, ITERATIONS, SLAB_BYTES, read_lists, tasks::Sample};
+use cu29::bincode;
+use cu29::continuity::{SourceGapReason, StreamContinuityRecord};
+use cu29::prelude::*;
+use cu29_logstream::{
+    CuStreamRx, FecSymbolKind, FiniteObjectLimits, NativeArchive, RecordKind, SessionEvent,
+    SessionRouter, SessionRouterLimits, WirePacket,
+};
+use cu29_logstream_udp::CuUdpLogStreamConfig;
+use std::{
+    error::Error,
+    fs,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    thread,
+    time::{Duration, Instant},
+};
+
+type Result<T> = std::result::Result<T, Box<dyn Error>>;
+
+#[derive(Parser)]
+#[command(about = "Stream a deterministic counter → accumulator graph over UDP")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    Sender {
+        #[arg(long, default_value = "127.0.0.1:7447")]
+        remote: SocketAddr,
+        #[arg(long)]
+        log_base: PathBuf,
+        #[arg(long, default_value_t = ITERATIONS, value_parser = clap::value_parser!(u64).range(1..))]
+        iterations: u64,
+    },
+    Receiver {
+        #[arg(long, default_value = "127.0.0.1:7447")]
+        listen: SocketAddr,
+        #[arg(long)]
+        log_base: PathBuf,
+        /// Write the bound endpoint after socket setup (used by the demo launcher).
+        #[arg(long)]
+        ready_file: Option<PathBuf>,
+        #[arg(long, value_enum, default_value_t = Impairment::Clean)]
+        impairment: Impairment,
+        /// Stop this receiver after archiving this CopperList, for the restart scenario.
+        #[arg(long)]
+        stop_at: Option<u64>,
+        /// Exit after this much silence; this does not prove the sender's tail is complete.
+        #[arg(long, default_value_t = 1000, value_parser = clap::value_parser!(u64).range(1..))]
+        idle_ms: u64,
+    },
+    Verify {
+        #[arg(long)]
+        sender: PathBuf,
+        #[arg(long)]
+        received: PathBuf,
+        #[arg(long, value_enum)]
+        expect: Expectation,
+        #[arg(long, default_value_t = ITERATIONS)]
+        iterations: u64,
+    },
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum Impairment {
+    Clean,
+    Loss,
+    Outage,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum Expectation {
+    Complete,
+    Outage,
+    Late,
+    Prefix,
+}
+
+fn prepare_log(path: &Path) -> Result<()> {
+    let first = cu29::replay::first_slab_path(path)?;
+    if first.exists() || path.exists() {
+        return Err(format!(
+            "Log already exists: {}. Choose a new log base.",
+            path.display()
+        )
+        .into());
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    Ok(())
+}
+
+fn sender(remote: SocketAddr, path: &Path, iterations: u64) -> Result<()> {
+    prepare_log(path)?;
+    cu_logstream_demo::run_sender(remote, path, iterations)?;
+    println!(
+        "Sender finished {iterations} iterations: {}",
+        path.display()
+    );
+    Ok(())
+}
+
+#[derive(Default)]
+struct Status {
+    latest: Option<u64>,
+    anchor: Option<u64>,
+    gaps: usize,
+    dropped: usize,
+}
+
+fn receiver(
+    listen: SocketAddr,
+    path: &Path,
+    ready_file: Option<&Path>,
+    impairment: Impairment,
+    stop_at: Option<u64>,
+    idle_ms: u64,
+) -> Result<()> {
+    prepare_log(path)?;
+    let mut socket = CuUdpLogStreamConfig::new(listen);
+    socket.recv_buffer_bytes = Some(262144);
+    let (_, mut rx) = socket.open()?;
+    let address = rx.local_addr()?;
+    let mut router = SessionRouter::<1128, 64, 64>::new(SessionRouterLimits {
+        max_sessions: 1,
+        max_startup_packets: 64,
+        max_recovery_records: 8,
+        max_pending_events: 64,
+        max_record_bytes: 4096,
+        max_buffered_records: 64,
+        equation_capacity: 64,
+        finite_objects: FiniteObjectLimits::new(65536, 1128, 4),
+    })?;
+    let mut archive: Option<NativeArchive<DataSet>> = None;
+    let mut status = Status::default();
+    if let Some(ready) = ready_file {
+        // Coordination metadata only; the native archive contains all task data.
+        use std::io::Write;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(ready)?;
+        writeln!(file, "{address}")?;
+    }
+    println!("Receiver listening at {address}: {}", path.display());
+    let started = Instant::now();
+    let mut last_packet = started;
+    let mut last_status = started;
+    let mut seen_packet = false;
+    let mut in_outage = false;
+    let mut packet = [0; 1200];
+    loop {
+        if let Some(len) = rx
+            .try_recv(&mut packet)
+            .map_err(|error| format!("UDP receive: {error:?}"))?
+        {
+            last_packet = Instant::now();
+            seen_packet = true;
+            // Demo-only receive-side impairment. Production sender/resource code is unchanged.
+            let wire = WirePacket::decode(&packet[..len])?;
+            let header = wire.header;
+            if header.record_kind == RecordKind::CopperList
+                && header.symbol_kind == FecSymbolKind::Source
+            {
+                in_outage = (32..160).contains(&header.object_id);
+            }
+            let discard = match impairment {
+                Impairment::Clean => false,
+                Impairment::Loss => {
+                    header.record_kind == RecordKind::CopperList
+                        && header.symbol_kind == FecSymbolKind::Source
+                        && header.object_id == 20
+                }
+                Impairment::Outage => in_outage,
+            };
+            if discard {
+                status.dropped += 1;
+                continue;
+            }
+            router
+                .receive_datagram(&packet[..len], |event| {
+                    if let SessionEvent::Manifest(manifest) = &event {
+                        println!(
+                            "Session sender={} id={:02x?}",
+                            manifest.identity.sender_id, manifest.identity.session_id
+                        );
+                        archive = Some(NativeArchive::new(
+                            path,
+                            manifest.clone(),
+                            SLAB_BYTES,
+                            65536,
+                        )?);
+                    }
+                    if let Some(writer) = archive.as_mut()
+                        && let Some(list) = writer.accept(&event)?
+                    {
+                        status.latest = Some(list.id);
+                    }
+                    match event {
+                        SessionEvent::Gap { gap, .. } => {
+                            status.gaps += 1;
+                            println!(
+                                "Missing CopperLists {}..={}: {:?}",
+                                gap.first_id, gap.last_id, gap.reason
+                            );
+                        }
+                        SessionEvent::VerifiedAnchor { anchor, .. } => {
+                            status.anchor = Some(anchor.copperlist_id)
+                        }
+                        _ => {}
+                    }
+                    Ok::<(), cu29_logstream::Error>(())
+                })
+                .map_err(|error| format!("Receiver consumer failed: {error:?}"))?;
+        } else {
+            thread::sleep(Duration::from_millis(1));
+        }
+        if last_status.elapsed() >= Duration::from_millis(500) {
+            print_status(&status, router.stats().datagrams_seen);
+            last_status = Instant::now();
+        }
+        if stop_at.is_some_and(|id| status.latest.is_some_and(|latest| latest >= id))
+            || (seen_packet && last_packet.elapsed() >= Duration::from_millis(idle_ms))
+        {
+            break;
+        }
+        if !seen_packet && started.elapsed() >= Duration::from_secs(15) {
+            return Err("No UDP traffic arrived within 15 seconds".into());
+        }
+    }
+    archive.ok_or("No session manifest received")?.finish()?;
+    print_status(&status, router.stats().datagrams_seen);
+    if !matches!(impairment, Impairment::Clean) && status.dropped == 0 {
+        return Err("Impairment scenario did not discard any packets".into());
+    }
+    println!("Archive closed at receiver's known boundary; unobserved sender tail is unknown.");
+    Ok(())
+}
+
+fn print_status(status: &Status, packets: usize) {
+    println!(
+        "packets={packets} archived={:?} verified_anchor={:?} gaps={} demo_drops={}",
+        status.latest, status.anchor, status.gaps, status.dropped
+    );
+}
+
+fn verify(sender: &Path, received: &Path, expect: Expectation, iterations: u64) -> Result<()> {
+    let onboard = read_lists(sender)?;
+    let ground = read_lists(received)?;
+    if onboard.len() as u64 != iterations || ground.is_empty() {
+        return Err(
+            "Sender archive count differs from requested run, or receiver archive is empty".into(),
+        );
+    }
+    for (id, list) in onboard.iter().enumerate() {
+        if list.id != id as u64
+            || list.msgs.get_counter_output().payload() != Some(&Sample(list.id))
+            || list.msgs.get_sum_output().payload() != Some(&Sample(list.id * (list.id + 1) / 2))
+        {
+            return Err(format!("Unexpected deterministic graph output at {id}").into());
+        }
+    }
+    let continuity: Vec<_> = cu29_export::stream_continuity_reader(UnifiedLoggerIOReader::new(
+        UnifiedLoggerRead::new(received)?,
+        UnifiedLogType::StreamContinuity,
+    ))
+    .collect();
+    let gaps: Vec<_> = continuity
+        .iter()
+        .filter_map(|entry| match entry {
+            StreamContinuityRecord::Gap {
+                first_id,
+                last_id,
+                reason,
+            } => Some((*first_id, *last_id, *reason)),
+            _ => None,
+        })
+        .collect();
+    let anchors: Vec<_> = continuity
+        .iter()
+        .filter_map(|entry| match entry {
+            StreamContinuityRecord::Anchor { copperlist_id, .. } => Some(*copperlist_id),
+            _ => None,
+        })
+        .collect();
+    let mut next = 0;
+    for list in &ground {
+        if list.id < next || list.id >= iterations {
+            return Err("Receiver CopperList IDs are not strictly ordered within the run".into());
+        }
+        for absent in next..list.id {
+            if !gaps
+                .iter()
+                .any(|&(first, last, _)| (first..=last).contains(&absent))
+            {
+                return Err(format!("Unreported missing CopperList {absent}").into());
+            }
+        }
+        if gaps
+            .iter()
+            .any(|&(first, last, _)| (first..=last).contains(&list.id))
+        {
+            return Err("Archive marks a received record as missing".into());
+        }
+        let encoding = bincode::config::standard();
+        if bincode::encode_to_vec(list, encoding)?
+            != bincode::encode_to_vec(&onboard[list.id as usize], encoding)?
+        {
+            return Err(format!(
+                "Payload or sender metadata mismatch at CopperList {}",
+                list.id
+            )
+            .into());
+        }
+        next = list.id + 1;
+    }
+    if !matches!(
+        continuity.first(),
+        Some(StreamContinuityRecord::Manifest { .. })
+    ) || !matches!(continuity.last(), Some(StreamContinuityRecord::Finished { next_copperlist_id }) if *next_copperlist_id == next)
+    {
+        return Err("Missing archive provenance/finalization".into());
+    }
+    let valid = match expect {
+        Expectation::Complete => ground.len() == onboard.len() && gaps.is_empty(),
+        Expectation::Outage => {
+            !gaps.is_empty()
+                && gaps.iter().any(|&(first, _, _)| first > 0)
+                && anchors.iter().any(|&id| id >= 160)
+                && next == iterations
+        }
+        Expectation::Late => {
+            gaps.iter()
+                .any(|&(first, _, reason)| first == 0 && reason == SourceGapReason::LateJoin)
+                && anchors.iter().any(|&id| id > 0)
+                && next == iterations
+        }
+        Expectation::Prefix => gaps.is_empty() && next >= 65 && next < iterations,
+    };
+    if !valid {
+        return Err(format!("Archive does not satisfy {expect:?}").into());
+    }
+    println!(
+        "Verified {} received CopperLists against onboard payloads and timestamps; {} explicit gaps, {} verified anchors ({expect:?}).",
+        ground.len(),
+        gaps.len(),
+        anchors.len()
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    match Cli::parse().command {
+        Command::Sender {
+            remote,
+            log_base,
+            iterations,
+        } => sender(remote, &log_base, iterations),
+        Command::Receiver {
+            listen,
+            log_base,
+            ready_file,
+            impairment,
+            stop_at,
+            idle_ms,
+        } => receiver(
+            listen,
+            &log_base,
+            ready_file.as_deref(),
+            impairment,
+            stop_at,
+            idle_ms,
+        ),
+        Command::Verify {
+            sender,
+            received,
+            expect,
+            iterations,
+        } => verify(&sender, &received, expect, iterations),
+    }
+}

--- a/examples/cu_logstream_demo/src/resim.rs
+++ b/examples/cu_logstream_demo/src/resim.rs
@@ -1,0 +1,119 @@
+// Recorded replay needs the raw application API to restore clock/keyframe boundaries.
+#![allow(deprecated)]
+
+use cu_logstream_demo::SLAB_BYTES;
+use cu29::prelude::*;
+use cu29::replay::{ReplayCli, ReplayDefaults, per_session_replay_log_base, serve_remote_debug};
+use cu29_unifiedlog::memmap::{MmapSectionStorage, MmapUnifiedLoggerWrite};
+use std::path::Path;
+
+#[copper_runtime(config = "copperconfig.ron", sim_mode = true)]
+struct Replay {}
+
+type List = CopperList<default::CuStampedDataSet>;
+type Callback = for<'a> fn(
+    &'a List,
+    RobotClock,
+    RobotClockMock,
+) -> Box<dyn for<'z> FnMut(default::SimStep<'z>) -> SimOverride + 'a>;
+type Timestamp = fn(&List) -> Option<CuTime>;
+
+fn callback<'a>(
+    list: &'a List,
+    _: RobotClock,
+    _: RobotClockMock,
+) -> Box<dyn for<'z> FnMut(default::SimStep<'z>) -> SimOverride + 'a> {
+    Box::new(move |step| default::recorded_replay_step(step, list))
+}
+
+fn build(path: &Path) -> CuResult<(Replay, RobotClock, RobotClockMock)> {
+    let (clock, mock) = RobotClock::mock();
+    let app = Replay::builder()
+        .with_clock(clock.clone())
+        .with_log_path(path, Some(SLAB_BYTES))?
+        .with_sim_callback(&mut |_| SimOverride::ExecuteByRuntime)
+        .build()?
+        .into_inner();
+    Ok((app, clock, mock))
+}
+
+fn reader(path: &Path, kind: UnifiedLogType) -> CuResult<UnifiedLoggerIOReader> {
+    Ok(UnifiedLoggerIOReader::new(
+        UnifiedLoggerRead::new(path)
+            .map_err(|error| CuError::new_with_cause("Open archive", error))?,
+        kind,
+    ))
+}
+
+fn main() -> CuResult<()> {
+    let cli = ReplayCli::parse(ReplayDefaults::new(
+        "logs/received.copper",
+        "logs/replay.copper",
+    ));
+    cu29::replay::ensure_log_family_exists(&cli.log_base)?;
+    if let Some(debug_base) = cli.debug_base {
+        let template = cli.replay_log_base;
+        return serve_remote_debug::<
+            Replay,
+            default::CuStampedDataSet,
+            Callback,
+            Timestamp,
+            MmapSectionStorage,
+            MmapUnifiedLoggerWrite,
+            _,
+        >(
+            &debug_base,
+            &cli.log_base,
+            move |params| {
+                build(&per_session_replay_log_base(
+                    &template,
+                    [params.role.as_deref().unwrap_or("session")],
+                ))
+            },
+            callback,
+            cu29::simulation::recorded_copperlist_timestamp,
+        );
+    }
+    if cu29::replay::first_slab_path(&cli.replay_log_base)?.exists() {
+        return Err("Replay output already exists; choose a new --replay-log-base".into());
+    }
+    let (mut app, _, mock) = build(&cli.replay_log_base)?;
+    app.start_all_tasks(&mut |_| SimOverride::ExecuteByRuntime)?;
+    let keyframes: Vec<_> =
+        cu29_export::keyframes_reader(reader(&cli.log_base, UnifiedLogType::FrozenTasks)?)
+            .collect();
+    let mut count = 0;
+    for list in cu29_export::copperlists_reader::<default::CuStampedDataSet>(reader(
+        &cli.log_base,
+        UnifiedLogType::CopperList,
+    )?) {
+        let keyframe = keyframes.iter().find(|frame| frame.culistid == list.id);
+        if let Some(frame) = keyframe {
+            <Replay as cu29::prelude::app::CuSimApplication<
+                MmapSectionStorage,
+                MmapUnifiedLoggerWrite,
+            >>::restore_keyframe(&mut app, frame)?;
+        }
+        // Generated replay checks continuity before touching the clock or tasks.
+        app.replay_recorded_copperlist(&mock, &list, keyframe)?;
+        count += 1;
+    }
+    app.stop_all_tasks(&mut |_| SimOverride::ExecuteByRuntime)?;
+    drop(app);
+    let recorded = cu_logstream_demo::read_lists(&cli.log_base)?;
+    let replayed = cu_logstream_demo::read_lists(&cli.replay_log_base)?;
+    if recorded.len() != replayed.len() {
+        return Err("Recorded replay lost CopperLists".into());
+    }
+    for (expected, actual) in recorded.iter().zip(&replayed) {
+        let encode = |list| {
+            cu29::bincode::encode_to_vec(list, cu29::bincode::config::standard())
+                .map_err(|error| CuError::new_with_cause("Encode replay comparison", error))
+        };
+        if encode(expected)? != encode(actual)? {
+            return Err(format!("Recorded replay changed CopperList {}", expected.id).into());
+        }
+    }
+    println!("Replayed {count} captured CopperLists with verified keyframe boundaries.");
+    Ok(())
+}

--- a/examples/cu_logstream_demo/src/tasks.rs
+++ b/examples/cu_logstream_demo/src/tasks.rs
@@ -1,0 +1,81 @@
+use cu29::bincode::{
+    Decode, Encode,
+    de::Decoder,
+    enc::Encoder,
+    error::{DecodeError, EncodeError},
+};
+use cu29::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Encode, Decode, Serialize, Deserialize, Reflect,
+)]
+#[bincode(crate = "cu29::bincode")]
+pub struct Sample(pub u64);
+
+#[derive(Default, Reflect)]
+pub struct Counter {
+    next: u64,
+}
+
+impl Freezable for Counter {
+    fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        Encode::encode(&self.next, encoder)
+    }
+    fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
+        self.next = Decode::decode(decoder)?;
+        Ok(())
+    }
+}
+
+impl CuSrcTask for Counter {
+    type Resources<'r> = ();
+    type Output<'m> = output_msg!(Sample);
+    fn new(_: Option<&ComponentConfig>, _: ()) -> CuResult<Self> {
+        Ok(Self::default())
+    }
+    fn process(&mut self, ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
+        output.set_payload(Sample(self.next));
+        output.tov = Tov::Time(ctx.now());
+        self.next += 1;
+        Ok(())
+    }
+}
+
+#[derive(Default, Reflect)]
+pub struct Accumulator {
+    sum: u64,
+}
+
+impl Freezable for Accumulator {
+    fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        Encode::encode(&self.sum, encoder)
+    }
+    fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
+        self.sum = Decode::decode(decoder)?;
+        Ok(())
+    }
+}
+
+impl CuTask for Accumulator {
+    type Resources<'r> = ();
+    type Input<'m> = input_msg!(Sample);
+    type Output<'m> = output_msg!(Sample);
+    fn new(_: Option<&ComponentConfig>, _: ()) -> CuResult<Self> {
+        Ok(Self::default())
+    }
+    fn process(
+        &mut self,
+        _: &CuContext,
+        input: &Self::Input<'_>,
+        output: &mut Self::Output<'_>,
+    ) -> CuResult<()> {
+        self.sum += input
+            .payload()
+            .ok_or_else(|| CuError::from("Counter produced no sample"))?
+            .0;
+        output.set_payload(Sample(self.sum));
+        output.tov = input.tov;
+        Ok(())
+    }
+}

--- a/justfile
+++ b/justfile
@@ -29,6 +29,7 @@ pr-check:
 	just api-check
 	just test
 	just logstream-udp-check
+	just logstream-demo-check
 
 # Reproduce the scheduled weekly audit and beta checks on the local host.
 weekly: weekly-audit
@@ -174,6 +175,12 @@ logstream-receiver-check:
 	cargo +stable check -p cu29-logstream --no-default-features
 	cargo +stable test -p cu29-runtime --test replay_primitives
 	just logstream-udp-check
+
+# Runnable two-process UDP scenarios, archive comparison, and recorded replay.
+logstream-demo-check:
+	cargo +stable clippy -p cu-logstream-demo --all-targets --features replay -- --deny warnings
+	cargo +stable test -p cu29-runtime --test replay_primitives --features cu29/async-cl-io
+	just --justfile examples/cu_logstream_demo/justfile check
 
 # Check the large examples from the former extra-examples repo.
 check-extra-examples: check-extra-examples-host check-extra-examples-embedded


### PR DESCRIPTION
Adds `examples/cu_logstream_demo`: a deterministic counter/accumulator graph streams from a sender process to a separate UDP receiver. The example-local `just` runs a clean link; `just run loss`, `outage`, `late`, and `restart` exercise FEC recovery, explicit missing history, verified anchors, and actual receiver process lifetimes. Each run compares the received native archive against onboard payloads and sender timestamps, runs the ordinary logreader, and compares recorded replay output byte for byte. Logs stay under the example's own `logs/` directory.

The demonstrator exposed a recorded-replay bug: accepting a keyframe after a gap did not align the CopperList allocator, so the following record failed continuity checks. Generated offline replay now drains pending output and aligns IDs after validating the boundary. The regression test replays both the recovery boundary and its successor and checks the archived IDs. Production task execution gains no encoding, allocation, transport, or waiting work.

Stacked on #1322 (`gbin/cu29-logstream-receiver-archive`). Adds opt-in Linux/macOS CI coverage and the root `just logstream-demo-check` target. The demo remains low-rate: pacing, independent retained-object repetition, feedback, hybrid reconstruction, and the live twin are deferred.

Validation passed:

- `just logstream-demo-check`: Clippy, asynchronous replay regression, all five process scenarios, native archive verification, logreader `fsck`, and exact-output replay comparison.
- `just logstream-receiver-check`: receiver/FEC/archive tests, no-default-features logstream build, synchronous replay regression, and UDP integration.
- `just nostd-ci`: 518 tests passed, plus no_std/embedded checks and builds.
- `just api-check`, `just fmt`, and Git whitespace checks.
- Default-feature dependency inspection confirms the example does not enable `cu29/logstream` or asynchronous runtime output in ordinary workspace builds.
- Matching book documentation builds successfully; wiki documentation is committed separately.
