### PR TITLE
Pace logstream senders and repeat recovery without new captures

### DIFF
--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -132,6 +132,8 @@ jobs:
       - name: Check two-process UDP logstream demo
         if: matrix.task == 'test' && runner.os != 'Windows'
         run: |
+          cargo +${{ inputs.toolchain }} test -p cu29-logstream --test pacing
+          cargo +${{ inputs.toolchain }} test -p cu29 --features logstream --test logstream_runtime
           cargo +${{ inputs.toolchain }} clippy -p cu-logstream-demo --all-targets --features replay -- --deny warnings
           cargo +${{ inputs.toolchain }} build -p cu-logstream-demo --features replay --bins
           python3 examples/cu_logstream_demo/run.py all --binary target/debug/cu-logstream-demo
@@ -220,6 +222,8 @@ jobs:
       - name: Check two-process UDP logstream demo
         if: matrix.task == 'test' && runner.os != 'Windows'
         run: |
+          cargo +${{ inputs.toolchain }} test -p cu29-logstream --test pacing
+          cargo +${{ inputs.toolchain }} test -p cu29 --features logstream --test logstream_runtime
           cargo +${{ inputs.toolchain }} clippy -p cu-logstream-demo --all-targets --features replay -- --deny warnings
           cargo +${{ inputs.toolchain }} build -p cu-logstream-demo --features replay --bins
           python3 examples/cu_logstream_demo/run.py all --binary target/debug/cu-logstream-demo
@@ -430,6 +434,8 @@ jobs:
       - name: Check two-process UDP logstream demo
         if: matrix.task == 'test' && runner.os != 'Windows'
         run: |
+          cargo +${{ inputs.toolchain }} test -p cu29-logstream --test pacing
+          cargo +${{ inputs.toolchain }} test -p cu29 --features logstream --test logstream_runtime
           cargo +${{ inputs.toolchain }} clippy -p cu-logstream-demo --all-targets --features replay -- --deny warnings
           cargo +${{ inputs.toolchain }} build -p cu-logstream-demo --features replay --bins
           python3 examples/cu_logstream_demo/run.py all --binary target/debug/cu-logstream-demo

--- a/components/res/cu29_logstream_udp/README.md
+++ b/components/res/cu29_logstream_udp/README.md
@@ -42,9 +42,11 @@ transport: (
 
 [The integration fixture](tests/configured_sender.ron) contains a complete
 configuration, including the required link, FEC, content, and record bounds.
-MTU and stream policy belong there, not in the UDP resource. The current sender
-carries bitrate/burst/latency policy in its manifest but does not yet enforce
-pacing; link scheduling and optional feedback are a later iteration.
+MTU and stream policy belong there, not in the UDP resource. Generated senders
+schedule all lanes through one background worker enforcing the configured
+bitrate/burst budget and data expiry. Retained bootstrap data repeats without
+new captures. Optional feedback remains deferred; its logical receive interface
+may share this carrier and does not require a separate physical uplink.
 
 ## Receiver resource
 

--- a/components/res/cu29_logstream_udp/tests/configured_sender.rs
+++ b/components/res/cu29_logstream_udp/tests/configured_sender.rs
@@ -209,6 +209,20 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
     assert_eq!(router.stats().sessions_discovered, 1);
     assert_eq!(router.stats().malformed_datagrams, 0);
     assert!(verified_anchor_seen);
+    let source_ids: std::collections::BTreeSet<_> = traffic
+        .iter()
+        .filter_map(|packet| {
+            let header = cu29_logstream::WirePacket::decode(packet).unwrap().header;
+            (header.record_kind == RecordKind::CopperList
+                && header.symbol_kind == cu29_logstream::FecSymbolKind::Source)
+                .then_some(header.object_id)
+        })
+        .collect();
+    assert_eq!(
+        source_ids,
+        (0..ITERATIONS).collect(),
+        "clean fixture must admit every source record"
+    );
     assert!(gaps.is_empty(), "unexpected clean-link gaps: {gaps:?}");
     assert_eq!(ids, (0..ITERATIONS).collect::<Vec<_>>());
     archive.take().unwrap().finish().unwrap();

--- a/core/cu29/tests/logstream_runtime.rs
+++ b/core/cu29/tests/logstream_runtime.rs
@@ -91,36 +91,9 @@ fn generated_runtime_streams_without_local_copperlist_logging() -> CuResult<()> 
         session_id: *b"runtime-stream01",
         sender_id: 23,
     };
-    let fec = RlcConfig::new(SYMBOL_SIZE, WINDOW_SYMBOLS, Field::Gf256)
-        .map_err(|error| CuError::from(error.to_string()))?;
-    let continuous = ContinuousSenderConfig {
-        identity,
-        first_packet_sequence: 0,
-        lane: Lane::ReplayCritical,
-        fec,
-        max_record_bytes: RECORD_BYTES,
-        initial_esi: EncodingSymbolId::new(0),
-        repair_every_source_symbols: 1,
-        first_repair_key: 1,
-        repair_density: DensityThreshold::FULL,
-    };
-    let manifest = encode_record(RecordKind::Manifest, 0, b"runtime-test-manifest")
-        .map_err(|error| CuError::from(error.to_string()))?;
-    let sender = LogStreamSenderConfig {
-        continuous,
-        recovery: RecoverySenderConfig {
-            finite: FiniteObjectSenderConfig {
-                identity,
-                first_packet_sequence: 0,
-                lane: Lane::LargeObject,
-                symbol_size: SYMBOL_SIZE as u16,
-                max_object_bytes: 64 * 1024,
-                repair_symbols_per_block: 8,
-            },
-            manifest_record: manifest.clone(),
-            anchor_interval: 1,
-        },
-    };
+    let sender = sender_config(identity)?;
+    let fec = sender.continuous.fec;
+    let manifest = sender.recovery.manifest_record.clone();
 
     let app = LogstreamRuntimeApp::builder()
         .with_instance_id(identity.sender_id)
@@ -147,17 +120,30 @@ fn generated_runtime_streams_without_local_copperlist_logging() -> CuResult<()> 
             })
         })
         .count();
+    // Scheduling changes cross-lane arrival order. Select a known source loss
+    // by semantic identity so this integration test stays inside its FEC budget;
+    // random loss/corruption matrices are exercised by the codec tests.
+    let impaired: Vec<_> = datagrams
+        .iter()
+        .filter(|datagram| {
+            let header = WirePacket::decode(datagram).unwrap().header;
+            !(header.record_kind == RecordKind::CopperList
+                && header.symbol_kind == FecSymbolKind::Source
+                && header.object_id == 1)
+        })
+        .cloned()
+        .collect();
+    assert!(impaired.len() < datagrams.len());
     let simulated_link = simulate_bad_link(
-        &datagrams,
+        &impaired,
         LinkSimulationConfig {
             seed: 0x71_6d_e5,
-            drop_basis_points: 1_500,
-            corrupt_basis_points: 500,
+            drop_basis_points: 0,
+            corrupt_basis_points: 0,
             duplicate_basis_points: 500,
             reorder: true,
         },
     );
-    assert!(simulated_link.stats.dropped_datagrams > 0);
     let mut decoder = ContinuousDecoder::<
         SYMBOL_SIZE,
         { cu29::logstream::DEFAULT_MAX_WINDOW_SYMBOLS },
@@ -238,5 +224,97 @@ fn generated_runtime_streams_without_local_copperlist_logging() -> CuResult<()> 
     assert_eq!(anchor.copperlist_id, 0);
     assert!(anchor.references_keyframe(keyframe));
     assert!(anchor.references_manifest(decode_record(&manifest).unwrap()));
+    Ok(())
+}
+
+fn sender_config(identity: StreamIdentity) -> CuResult<LogStreamSenderConfig> {
+    let fec = RlcConfig::new(SYMBOL_SIZE, WINDOW_SYMBOLS, Field::Gf256)
+        .map_err(|error| CuError::from(error.to_string()))?;
+    let continuous = ContinuousSenderConfig {
+        identity,
+        first_packet_sequence: 0,
+        lane: Lane::ReplayCritical,
+        fec,
+        max_record_bytes: RECORD_BYTES,
+        initial_esi: EncodingSymbolId::new(0),
+        repair_every_source_symbols: 1,
+        first_repair_key: 1,
+        repair_density: DensityThreshold::FULL,
+    };
+    let manifest = encode_record(RecordKind::Manifest, 0, b"runtime-test-manifest")
+        .map_err(|error| CuError::from(error.to_string()))?;
+    Ok(LogStreamSenderConfig {
+        pacing: cu29::logstream::PacingConfig {
+            bitrate_bps: 10_000_000,
+            burst_packets: 8,
+            max_latency: cu29::clock::CuDuration::from_millis(1000),
+            memory_budget_bytes: 1024 * 1024,
+        },
+        continuous,
+        recovery: RecoverySenderConfig {
+            finite: FiniteObjectSenderConfig {
+                identity,
+                first_packet_sequence: 0,
+                lane: Lane::LargeObject,
+                symbol_size: SYMBOL_SIZE as u16,
+                max_object_bytes: 64 * 1024,
+                repair_symbols_per_block: 8,
+            },
+            manifest_record: manifest.clone(),
+            anchor_interval: 1,
+        },
+    })
+}
+
+#[test]
+fn scheduled_worker_shutdown_is_bounded_with_frozen_robotclock() -> CuResult<()> {
+    let mut config = sender_config(StreamIdentity {
+        session_id: *b"frozen-stream001",
+        sender_id: 1,
+    })?;
+    config.pacing.bitrate_bps = 1;
+    config.pacing.burst_packets = 1;
+    config.pacing.max_latency = CuDuration::from_millis(20);
+    let (clock, _mock) = RobotClock::mock();
+    let (mut lists, keyframes, monitor) = cu29::logstream::scheduled_sinks::<
+        default::CuStampedDataSet,
+        _,
+    >(CapturingTx::default(), config, clock)?;
+    lists.log(&default::CuList::default())?;
+    let started = std::time::Instant::now();
+    drop(lists);
+    drop(keyframes);
+    assert!(started.elapsed() < std::time::Duration::from_secs(1));
+    assert!(!monitor.failed());
+    assert!(monitor.final_stats().unwrap().shutdown_drops > 0);
+    Ok(())
+}
+
+#[derive(Debug)]
+struct FailedTx;
+impl CuStreamTx for FailedTx {
+    fn try_send(&mut self, _: &[u8]) -> Result<(), CuStreamTxError> {
+        Err(CuStreamTxError::Failed("test carrier failure"))
+    }
+}
+
+#[test]
+fn scheduled_worker_reports_carrier_failure_to_its_producer() -> CuResult<()> {
+    let config = sender_config(StreamIdentity {
+        session_id: *b"failed-stream001",
+        sender_id: 1,
+    })?;
+    let (mut lists, keyframes, monitor) = cu29::logstream::scheduled_sinks::<
+        default::CuStampedDataSet,
+        _,
+    >(FailedTx, config, RobotClock::new())?;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while !monitor.failed() && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+    assert!(monitor.failed());
+    assert!(lists.log(&default::CuList::default()).is_err());
+    drop(lists);
+    drop(keyframes);
     Ok(())
 }

--- a/core/cu29_clock/src/lib.rs
+++ b/core/cu29_clock/src/lib.rs
@@ -884,6 +884,12 @@ impl RobotClockMock {
 }
 
 impl RobotClock {
+    /// Whether this clock is driven explicitly by a RobotClockMock. Physical link
+    /// pacing must select a running clock when application time is mocked.
+    pub fn is_mock(&self) -> bool {
+        self.inner.mock_state.is_some()
+    }
+
     /// Creates a RobotClock using now as its reference time.
     /// It will start at 0ns incrementing monotonically.
     /// This uses the std System Time as a reference clock.

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -4702,7 +4702,6 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
             quote! {
                 logstream: Option<(
                     Box<dyn ::cu29::logstream::CuStreamTx>,
-                    Box<dyn ::cu29::logstream::CuStreamTx>,
                     ::cu29::logstream::LogStreamSenderConfig,
                 )>,
             }
@@ -5620,20 +5619,11 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         .typed::<#transport_type>(),
                     )?
                     .0;
-                let continuous_transport: Box<dyn ::cu29::logstream::CuStreamTx> =
-                    Box::new(#transport_ident.clone());
-                let recovery_transport: Box<dyn ::cu29::logstream::CuStreamTx> =
-                    Box::new(#transport_ident);
-                let #continuous_ident = ::cu29::logstream::DefaultContinuousCopperListSink::<
-                    #mission_mod::CuStampedDataSet,
-                    Box<dyn ::cu29::logstream::CuStreamTx>,
-                >::new(continuous_transport, sender_config.continuous)
-                .map_err(|error| CuError::from(error.to_string()))?;
-                let #recovery_ident = ::cu29::logstream::KeyFrameAnchorSink::new(
-                    recovery_transport,
-                    sender_config.recovery,
-                )
-                .map_err(|error| CuError::from(error.to_string()))?;
+                let (#continuous_ident, #recovery_ident, _) =
+                    ::cu29::logstream::scheduled_sinks::<#mission_mod::CuStampedDataSet, _>(
+                        #transport_ident, sender_config,
+                        if clock.is_mock() { RobotClock::new() } else { clock.clone() },
+                    )?;
             }
         });
         let configured_logstream_fanouts = logstream_resource_specs.iter().map(|spec| {
@@ -5671,22 +5661,13 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 #configured_logstream_session
                 #(#configured_logstream_initializers)*
                 let injected_logstream_sinks = logstream
-                    .map(|(continuous_transport, recovery_transport, mut sender_config)| {
+                    .map(|(transport, mut sender_config)| {
                         sender_config.continuous.identity.sender_id = instance_id;
                         sender_config.recovery.finite.identity.sender_id = instance_id;
-                        sender_config
-                            .validate()
-                            .map_err(|error| CuError::from(error.to_string()))?;
-                        let copperlist = ::cu29::logstream::DefaultContinuousCopperListSink::<
-                            #mission_mod::CuStampedDataSet,
-                            Box<dyn ::cu29::logstream::CuStreamTx>,
-                        >::new(continuous_transport, sender_config.continuous)
-                        .map_err(|error| CuError::from(error.to_string()))?;
-                        let keyframe = ::cu29::logstream::KeyFrameAnchorSink::new(
-                            recovery_transport,
-                            sender_config.recovery,
-                        )
-                        .map_err(|error| CuError::from(error.to_string()))?;
+                        let (copperlist, keyframe, _) = ::cu29::logstream::scheduled_sinks::<
+                            #mission_mod::CuStampedDataSet, _
+                        >(transport, sender_config,
+                            if clock.is_mock() { RobotClock::new() } else { clock.clone() })?;
                         Ok::<_, CuError>((copperlist, keyframe))
                     })
                     .transpose()?;
@@ -6131,7 +6112,6 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
             quote! {
                 logstream: Option<(
                     Box<dyn ::cu29::logstream::CuStreamTx>,
-                    Box<dyn ::cu29::logstream::CuStreamTx>,
                     ::cu29::logstream::LogStreamSenderConfig,
                 )>,
             }
@@ -6143,22 +6123,18 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
             quote! {
                 /// Adds a nonblocking CopperList plus keyframe/anchor packet resource.
                 ///
-                /// The endpoint is cloned once so independently scheduled semantic lanes never
-                /// serialize access through a mutex. Clones must remain fire-and-forget,
-                /// nonblocking implementations of `CuStreamTx`.
+                /// One sender worker owns the endpoint and schedules both semantic lanes
+                /// against the same budget. Physical pacing uses a running RobotClock,
+                /// even when the application's clock is mocked.
                 pub fn with_logstream<T>(
                     mut self,
                     transport: T,
                     config: ::cu29::logstream::LogStreamSenderConfig,
                 ) -> Self
                 where
-                    T: ::cu29::logstream::CuStreamTx + Clone + 'static,
+                    T: ::cu29::logstream::CuStreamTx + 'static,
                 {
-                    self.logstream = Some((
-                        Box::new(transport.clone()),
-                        Box::new(transport),
-                        config,
-                    ));
+                    self.logstream = Some((Box::new(transport), config));
                     self
                 }
             }

--- a/core/cu29_logstream/Cargo.toml
+++ b/core/cu29_logstream/Cargo.toml
@@ -22,10 +22,18 @@ bincode = { workspace = true }
 blake3 = { workspace = true }
 crc = { workspace = true }
 cu-fec = { workspace = true }
+cu29-clock = { workspace = true }
+cu29-log = { workspace = true, optional = true }
+cu29-log-derive = { workspace = true, optional = true }
+cu29-log-runtime = { workspace = true, optional = true }
+cu29-value = { workspace = true, optional = true }
 cu29-runtime = { workspace = true }
 cu29-traits = { workspace = true }
 cu29-unifiedlog = { workspace = true, optional = true }
 raptorq = { workspace = true }
+
+[build-dependencies]
+cu29-build = { workspace = true }
 
 [dev-dependencies]
 serde = { workspace = true }
@@ -33,10 +41,18 @@ serde = { workspace = true }
 [features]
 default = ["std"]
 std = [
+  "dep:cu29-log-derive",
+  "dep:cu29-log",
+  "cu29-log/std",
+  "dep:cu29-log-runtime",
+  "cu29-log-runtime/std",
+  "dep:cu29-value",
+  "cu29-value/std",
   "dep:cu29-unifiedlog",
   "cu29-unifiedlog/std",
   "blake3/std",
   "cu29-runtime/std",
+  "cu29-clock/std",
   "cu29-traits/std",
   "raptorq/std",
 ]

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -22,7 +22,8 @@ can read them. Sender work runs off the real-time task path.
 For a runnable sender/receiver pair, start with the
 [UDP demo](../../examples/cu_logstream_demo). Its default `just` command verifies
 the received archive against the onboard log and runs the ordinary logreader and
-recorded replay. Loss, outage, late-start, and receiver-restart scenarios are included.
+recorded replay. Loss, outage, late-start, receiver-restart, and idle recovery
+scenarios are included.
 
 Enable `cu29/logstream` and configure a `log_streaming` destination in the app's
 RON config. Bind a transport implementing `CuStreamTx`; the
@@ -41,9 +42,58 @@ preserves the received payloads and timestamps.
   history. Replay refuses to cross a gap without a matching keyframe.
 - Native archival currently requires the matching application and full-capture
   codec. Use a separate archive path for each sender session.
-- Pacing and optional feedback are deferred. The configured bitrate is not yet
-  enforced.
+- Generated senders enforce one bitrate/burst budget across continuous data,
+  repairs, and recovery packets. The budget counts Copper packet bytes, excluding
+  UDP/IP or other carrier overhead. Replay and recovery share byte-deficit
+  scheduling with weights 3:1; unused capacity is available to either lane.
+- Manifest and latest complete keyframe/anchor/boundary recovery repeat on a
+  250 ms local deadline, with overlapping requests coalesced. A pending bundle
+  finishes before a newer one replaces it. New anchors wait for older queued
+  source packets to be attempted or expired, preventing avoidable receiver gaps. No new task capture is required.
+- Pacing uses `RobotClock` and requires no robot/receiver time synchronization.
+  Generated real-link senders select a running clock when application time is
+  mocked. Direct driver tests can supply a mock clock.
+- Feedback packet traits and static one-way/separate-endpoint adapters are
+  available. A duplex resource may implement stream TX and feedback RX on one
+  carrier. Feedback protocol, negotiation, and adaptation remain deferred.
 
 Run `just logstream-receiver-check` from the repository root to test reception,
 archival, and replay continuity. See the Rust API docs for receiver limits and
 event handling.
+
+## Sender storage and lifecycle
+
+`scheduled_sinks` creates one worker owning the transport and FEC state, a pool
+of four encoded CL buffers and two encoded keyframe buffers, and fixed packet
+storage. Encoding writes directly into these buffers on the existing output
+workers. Runtime CopperLists and keyframe capture objects are released before
+transmission. Packet staging and recovery retention add bounded copies only on
+the background sender path; repeated transmissions borrow the retained packets.
+
+The destination memory budget covers the record pool, continuous encoder, packet
+queues, retained packets, and their explicitly counted storage. Thread stacks,
+channel/allocator bookkeeping, and RaptorQ's temporary codec allocations are
+additional. RaptorQ input is capped by `max_object_bytes`; the scheduled sender
+requires that maximum to fit one source block. This is a buffer budget, not a
+whole-process allocator ceiling. Unsupported bounds fail during construction.
+
+Four pending CL boundaries and two pending keyframes accommodate independently
+ordered output workers. Under sustained skew, oldest pending entries are replaced
+and counted; the last complete bundle remains usable. Ordinary data expires after
+`max_latency_ms`, measured from encoded-record admission. Retained recovery stays
+useful after that deadline and is repeated until replaced or stopped.
+
+Pool exhaustion, packet-queue overflow, expiry, carrier backpressure, and shutdown
+shedding are counted. `SenderMonitor` exposes final counters and failure state;
+the worker also writes its shutdown statistics and failures to Copper structured
+logging. Dropping both sinks stops repetition and drains only until the configured
+latency deadline. An independent running RobotClock bounds teardown of a frozen
+test clock. Production real-time handoff is unchanged.
+
+`SenderCore` is available without `std`; callers provide `CuTime` from their
+RobotClock and drive `poll` themselves. The std driver owns thread wakeups.
+Immediate `ContinuousCopperListSink` and `KeyFrameAnchorSink` remain available
+for codec tests/custom integration and do not enforce pacing themselves.
+
+Run `just logstream-pacing-check` for scheduler, worker lifecycle, and UDP demo
+checks, including recovery after the entire initial bootstrap transmission is lost.

--- a/core/cu29_logstream/build.rs
+++ b/core/cu29_logstream/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    cu29_build::setup();
+}

--- a/core/cu29_logstream/src/lib.rs
+++ b/core/cu29_logstream/src/lib.rs
@@ -2,8 +2,9 @@
 
 //! Transport-independent Copper log framing and continuous-stream recovery.
 //!
-//! The crate deliberately stops at datagrams. Runtime ownership handoff,
-//! pacing, and concrete transports are composed outside this layer.
+//! The crate owns bounded FEC, pacing, and autonomous recovery repetition above
+//! packet transports. The host driver consumes encoded records from existing
+//! semantic output workers; runtime ownership handoff stays outside this layer.
 
 extern crate alloc;
 
@@ -18,6 +19,7 @@ mod copper;
 mod error;
 mod manifest;
 mod object;
+mod pacing;
 mod record;
 mod recovery;
 mod rlc;
@@ -25,6 +27,10 @@ mod router;
 mod sender;
 mod stream;
 mod wire;
+#[cfg(feature = "std")]
+mod worker;
+#[cfg(feature = "std")]
+pub use worker::{ScheduledCopperListSink, ScheduledKeyFrameSink, SenderMonitor, scheduled_sinks};
 
 /// Utilities for testing log streaming over unreliable datagram links.
 ///
@@ -46,6 +52,7 @@ pub use object::{
     FiniteObjectDecoder, FiniteObjectEncoder, FiniteObjectLimits, FiniteObjectRecoveryStats,
     FiniteObjectSenderConfig,
 };
+pub use pacing::{PacingConfig, RECOVERY_REPEAT_INTERVAL, SenderCore, SenderStats};
 pub use record::{DecodedRecord, RecordKind, decode_record, encode_record};
 pub use recovery::{
     Anchor, decode_anchor, decode_keyframe, encode_anchor, encode_keyframe,
@@ -62,7 +69,10 @@ pub use sender::{
     DEFAULT_MAX_SYMBOL_SIZE, DEFAULT_MAX_WINDOW_SYMBOLS, DefaultContinuousCopperListSink,
     KeyFrameAnchorSink, LogStreamSenderConfig, RecoverySenderConfig, RecoverySenderStats,
 };
-pub use stream::{CuStreamRx, CuStreamRxError, CuStreamTx, CuStreamTxError};
+pub use stream::{
+    CuFeedbackRx, CuFeedbackTx, CuStreamRx, CuStreamRxError, CuStreamTx, CuStreamTxError, OneWay,
+    SeparateFeedback,
+};
 pub use wire::{
     FecScheme, FecSymbolKind, Lane, PACKET_HEADER_LEN, WIRE_VERSION, WireHeader, WirePacket,
     encode_packet_into,

--- a/core/cu29_logstream/src/manifest.rs
+++ b/core/cu29_logstream/src/manifest.rs
@@ -281,6 +281,12 @@ impl LogStreamPlan {
             });
         }
         Ok(LogStreamSenderConfig {
+            pacing: crate::PacingConfig {
+                bitrate_bps: self.bitrate_bps,
+                burst_packets: self.burst_packets,
+                max_latency: cu29_clock::CuDuration::from_millis(u64::from(self.max_latency_ms)),
+                memory_budget_bytes: self.memory_budget_kib as usize * 1024,
+            },
             continuous: ContinuousSenderConfig {
                 identity,
                 first_packet_sequence: 0,

--- a/core/cu29_logstream/src/pacing.rs
+++ b/core/cu29_logstream/src/pacing.rs
@@ -1,0 +1,568 @@
+//! Bounded autonomous sender scheduling. All methods run off the real-time path.
+
+use crate::rlc::RepairSchedule;
+use crate::{
+    Anchor, ContinuousEncoder, CuStreamTx, CuStreamTxError, Error, FiniteObjectEncoder,
+    LogStreamSenderConfig, RecordKind, Result, decode_record, encode_anchor, encode_record,
+};
+use alloc::{boxed::Box, vec, vec::Vec};
+use cu29_clock::{CuDuration, CuTime};
+
+/// Autonomous repetition period, measured by the sender's local RobotClock.
+/// Repetition is coalesced while the previous transmission is still pending.
+pub const RECOVERY_REPEAT_INTERVAL: CuDuration = CuDuration(250_000_000);
+const MAX_SENDS_PER_POLL: usize = 64;
+const PENDING_BOUNDARIES: usize = 4;
+const PENDING_KEYFRAMES: usize = 2;
+
+/// Shared destination budget. Counts complete Copper packets, excluding carrier overhead.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PacingConfig {
+    pub bitrate_bps: u64,
+    pub burst_packets: u32,
+    pub max_latency: CuDuration,
+    /// Storage budget for sender buffers and the continuous encoder. Finite-object
+    /// codec scratch allocations and thread stacks are additional, bounded by object size.
+    pub memory_budget_bytes: usize,
+}
+
+/// Counters distinguish queue shedding from carrier backpressure.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SenderStats {
+    pub packets_sent: u64,
+    pub bytes_sent: u64,
+    pub queue_drops: u64,
+    pub expired_packets: u64,
+    pub transport_drops: u64,
+    pub recovery_rounds: u64,
+    pub recovery_superseded: u64,
+    pub shutdown_drops: u64,
+    pub queue_peak: usize,
+}
+
+/// Fixed-capacity packet storage; filling and replacing it never grows its allocation.
+struct Packets {
+    bytes: Vec<u8>,
+    lengths: Vec<usize>,
+    times: Vec<CuTime>,
+    ids: Vec<u64>,
+    mtu: usize,
+    head: usize,
+    len: usize,
+}
+
+impl Packets {
+    fn new(capacity: usize, mtu: usize) -> Self {
+        Self {
+            bytes: vec![0; capacity * mtu],
+            lengths: vec![0; capacity],
+            times: vec![CuTime::default(); capacity],
+            ids: vec![0; capacity],
+            mtu,
+            head: 0,
+            len: 0,
+        }
+    }
+
+    fn clear(&mut self) {
+        self.head = 0;
+        self.len = 0;
+    }
+
+    fn push(&mut self, bytes: &[u8], now: CuTime, id: u64) -> bool {
+        if self.len == self.lengths.len() || bytes.len() > self.mtu {
+            return false;
+        }
+        let slot = (self.head + self.len) % self.lengths.len();
+        self.bytes[slot * self.mtu..slot * self.mtu + bytes.len()].copy_from_slice(bytes);
+        self.lengths[slot] = bytes.len();
+        self.times[slot] = now;
+        self.ids[slot] = id;
+        self.len += 1;
+        true
+    }
+
+    fn get(&self, index: usize) -> &[u8] {
+        let slot = (self.head + index) % self.lengths.len();
+        &self.bytes[slot * self.mtu..slot * self.mtu + self.lengths[slot]]
+    }
+
+    fn pop(&mut self) {
+        self.head = (self.head + 1) % self.lengths.len();
+        self.len -= 1;
+    }
+}
+
+struct PendingPackets {
+    id: Option<u64>,
+    packets: Packets,
+}
+
+struct RecoveryPackets {
+    control: Packets,
+    boundary: Packets,
+}
+
+/// A destination's single packet scheduler and retained recovery state.
+///
+/// `now` always belongs to the same local RobotClock. The caller owns transport
+/// and wakeups; this core neither reads a global clock nor sleeps. Runtime objects
+/// are never retained here. Optional feedback can later request the same retained
+/// jobs through `request_recovery`, without bypassing this scheduler's budget.
+pub struct SenderCore {
+    config: LogStreamSenderConfig,
+    continuous: Box<ContinuousEncoder<1128, 64>>,
+    finite: FiniteObjectEncoder,
+    repairs: RepairSchedule,
+    scratch: Vec<u8>,
+    data: Packets,
+    manifest: Packets,
+    latest: RecoveryPackets,
+    pending_cl: Vec<PendingPackets>,
+    pending_kf: Vec<PendingPackets>,
+    latest_id: Option<u64>,
+    manifest_cursor: usize,
+    recovery_cursor: usize,
+    next_repeat: CuTime,
+    last_now: CuTime,
+    credit: u128,
+    capacity: u128,
+    // Byte deficit fairness: three MTUs of replay for one MTU of recovery.
+    deficit: [usize; 2],
+    lane: usize,
+    stopping: bool,
+    stats: SenderStats,
+}
+
+impl SenderCore {
+    /// Validate all storage arithmetic before allocating. `reserved_bytes` covers
+    /// the driver's owned-record pool, which shares the destination budget.
+    pub fn new(config: LogStreamSenderConfig, now: CuTime, reserved_bytes: usize) -> Result<Self> {
+        config.validate()?;
+        let policy = config.pacing;
+        if policy.bitrate_bps == 0
+            || policy.burst_packets == 0
+            || policy.max_latency.as_nanos() == 0
+        {
+            return Err(Error::InvalidConfig("pacing bounds must be nonzero"));
+        }
+        let mtu = crate::PACKET_HEADER_LEN + config.continuous.fec.symbol_size();
+        let object_bytes = usize::try_from(config.recovery.finite.max_object_bytes)
+            .map_err(|_| Error::InvalidConfig("object limit exceeds usize"))?;
+        let symbol = usize::from(config.recovery.finite.symbol_size);
+        if symbol != config.continuous.fec.symbol_size()
+            || symbol <= crate::rlc::FRAGMENT_HEADER_LEN
+            || config.continuous.repair_every_source_symbols == 0
+            || object_bytes < 256
+        {
+            return Err(Error::InvalidConfig(
+                "scheduled lanes require matching valid symbols and object bounds",
+            ));
+        }
+        // One source block keeps finite encoding and its retained packet bound explicit.
+        if object_bytes.div_ceil(symbol) > 56_403
+            || raptorq::ObjectTransmissionInformation::with_defaults(
+                object_bytes as u64,
+                symbol as u16,
+            )
+            .source_blocks()
+                != 1
+        {
+            return Err(Error::InvalidConfig(
+                "scheduled objects must fit one RaptorQ source block",
+            ));
+        }
+        let repairs_per_object = config.recovery.finite.repair_symbols_per_block as usize;
+        let finite_capacity = |bytes: usize| bytes.div_ceil(symbol).checked_add(repairs_per_object);
+        let manifest_capacity = finite_capacity(config.recovery.manifest_record.len())
+            .ok_or(Error::InvalidConfig("manifest packet bound overflow"))?;
+        let control_capacity = finite_capacity(object_bytes)
+            .and_then(|v| finite_capacity(256).and_then(|a| v.checked_add(a)))
+            .ok_or(Error::InvalidConfig("recovery packet bound overflow"))?;
+        let source_capacity = config
+            .continuous
+            .max_record_bytes
+            .div_ceil(symbol - crate::rlc::FRAGMENT_HEADER_LEN);
+        let boundary_capacity = source_capacity
+            .checked_mul(2)
+            .ok_or(Error::InvalidConfig("boundary packet bound overflow"))?;
+        let packet_bytes = mtu + size_of::<usize>() + size_of::<CuTime>() + size_of::<u64>();
+        let retained_packets = control_capacity
+            .checked_mul(PENDING_KEYFRAMES + 1)
+            .and_then(|v| {
+                boundary_capacity
+                    .checked_mul(PENDING_BOUNDARIES + 1)
+                    .and_then(|b| v.checked_add(b))
+            })
+            .and_then(|v| v.checked_add(manifest_capacity))
+            .ok_or(Error::InvalidConfig("retained packet bound overflow"))?;
+        let fixed = retained_packets
+            .checked_mul(packet_bytes)
+            .and_then(|v| v.checked_add(size_of::<ContinuousEncoder<1128, 64>>()))
+            .and_then(|v| v.checked_add(size_of::<Self>()))
+            .and_then(|v| {
+                v.checked_add(
+                    (PENDING_BOUNDARIES + PENDING_KEYFRAMES) * size_of::<PendingPackets>(),
+                )
+            })
+            .and_then(|v| v.checked_add(mtu))
+            .and_then(|v| v.checked_add(config.recovery.manifest_record.len()))
+            .and_then(|v| v.checked_add(reserved_bytes))
+            .ok_or(Error::InvalidConfig("sender storage bound overflow"))?;
+        let queue_capacity = policy
+            .memory_budget_bytes
+            .checked_sub(fixed)
+            .map(|remaining| remaining / packet_bytes)
+            .filter(|capacity| *capacity >= boundary_capacity.max(1))
+            .ok_or(Error::InvalidConfig(
+                "sender buffers exceed destination memory budget",
+            ))?;
+        let continuous = Box::new(ContinuousEncoder::new(
+            config.continuous.identity,
+            config.continuous.first_packet_sequence,
+            config.continuous.lane,
+            config.continuous.fec,
+            config.continuous.max_record_bytes,
+            config.continuous.initial_esi,
+        )?);
+        let mut finite = FiniteObjectEncoder::new(config.recovery.finite)?;
+        let mut manifest = Packets::new(manifest_capacity, mtu);
+        let manifest_id = decode_record(&config.recovery.manifest_record)?.object_id;
+        finite.push_record_with(&config.recovery.manifest_record, |packet| {
+            if !manifest.push(packet, now, manifest_id) {
+                return Err(Error::InvalidConfig("manifest packet capacity"));
+            }
+            Ok(())
+        })?;
+        let recovery = || RecoveryPackets {
+            control: Packets::new(control_capacity, mtu),
+            boundary: Packets::new(boundary_capacity, mtu),
+        };
+        let capacity = u128::from(policy.burst_packets) * mtu as u128 * 8 * 1_000_000_000;
+        Ok(Self {
+            repairs: RepairSchedule::new(
+                config.continuous.repair_every_source_symbols,
+                config.continuous.first_repair_key,
+                config.continuous.repair_density,
+            ),
+            config,
+            continuous,
+            finite,
+            scratch: vec![0; mtu],
+            data: Packets::new(queue_capacity, mtu),
+            manifest,
+            latest: recovery(),
+            pending_cl: (0..PENDING_BOUNDARIES)
+                .map(|_| PendingPackets {
+                    id: None,
+                    packets: Packets::new(boundary_capacity, mtu),
+                })
+                .collect(),
+            pending_kf: (0..PENDING_KEYFRAMES)
+                .map(|_| PendingPackets {
+                    id: None,
+                    packets: Packets::new(control_capacity, mtu),
+                })
+                .collect(),
+            latest_id: None,
+            manifest_cursor: 0,
+            recovery_cursor: 0,
+            next_repeat: now + RECOVERY_REPEAT_INTERVAL,
+            last_now: now,
+            credit: capacity,
+            capacity,
+            deficit: [0; 2],
+            lane: 0,
+            stopping: false,
+            stats: SenderStats::default(),
+        })
+    }
+
+    pub const fn stats(&self) -> SenderStats {
+        self.stats
+    }
+
+    /// Admit an already encoded record from a bounded worker buffer. No borrow
+    /// escapes this call. CL packets shed on overflow; retained recovery replaces
+    /// only a complete matching boundary/keyframe pair.
+    pub fn accept_record(&mut self, record: &[u8], now: CuTime) -> Result<()> {
+        let decoded = decode_record(record)?;
+        match decoded.kind {
+            RecordKind::CopperList => {
+                let retain = decoded
+                    .object_id
+                    .is_multiple_of(u64::from(self.config.recovery.anchor_interval));
+                let slot = if retain {
+                    Some(Self::reserve(
+                        &mut self.pending_cl,
+                        decoded.object_id,
+                        &mut self.stats,
+                    ))
+                } else {
+                    None
+                };
+                let stats = &mut self.stats;
+                let pending = &mut self.pending_cl;
+                let data = &mut self.data;
+                self.continuous.push_record_with_repairs(
+                    record,
+                    &mut self.scratch,
+                    &mut |packet| {
+                        if let Some(slot) = slot
+                            && !pending[slot].packets.push(packet, now, decoded.object_id)
+                        {
+                            return Err(Error::InvalidConfig("boundary packet capacity"));
+                        }
+                        if !data.push(packet, now, decoded.object_id) {
+                            stats.queue_drops = stats.queue_drops.saturating_add(1);
+                        }
+                        stats.queue_peak = stats.queue_peak.max(data.len);
+                        Ok(())
+                    },
+                    &mut self.repairs,
+                )?;
+            }
+            RecordKind::KeyFrame => {
+                if !decoded
+                    .object_id
+                    .is_multiple_of(u64::from(self.config.recovery.anchor_interval))
+                {
+                    return Ok(());
+                }
+                let manifest = decode_record(&self.config.recovery.manifest_record)?;
+                let anchor = encode_record(
+                    RecordKind::Anchor,
+                    decoded.object_id,
+                    &encode_anchor(&Anchor {
+                        manifest_object_id: manifest.object_id,
+                        manifest_record_digest: manifest.digest,
+                        copperlist_id: decoded.object_id,
+                        keyframe_object_id: decoded.object_id,
+                        keyframe_record_digest: decoded.digest,
+                    })?,
+                )?;
+                let slot = Self::reserve(&mut self.pending_kf, decoded.object_id, &mut self.stats);
+                for bytes in [record, anchor.as_slice()] {
+                    self.finite.push_record_with(bytes, |packet| {
+                        if !self.pending_kf[slot]
+                            .packets
+                            .push(packet, now, decoded.object_id)
+                        {
+                            return Err(Error::InvalidConfig("recovery packet capacity"));
+                        }
+                        Ok(())
+                    })?;
+                }
+            }
+            _ => {
+                return Err(Error::InvalidConfig(
+                    "sender inbox accepts CLs and keyframes",
+                ));
+            }
+        }
+        self.promote_recovery();
+        Ok(())
+    }
+
+    fn reserve(slots: &mut [PendingPackets], id: u64, stats: &mut SenderStats) -> usize {
+        let index = slots
+            .iter()
+            .position(|s| s.id.is_none() || s.id == Some(id))
+            .unwrap_or_else(|| {
+                slots
+                    .iter()
+                    .enumerate()
+                    .min_by_key(|(_, s)| s.id)
+                    .unwrap()
+                    .0
+            });
+        if slots[index].id.is_some() {
+            stats.recovery_superseded += 1;
+        }
+        slots[index].id = Some(id);
+        slots[index].packets.clear();
+        index
+    }
+
+    fn promote_recovery(&mut self) {
+        // Finish an in-flight bundle before replacing it; frequent captures must
+        // not continually restart a large transfer on a slow link.
+        if self.recovery_cursor < self.recovery_len() {
+            return;
+        }
+        let pair = self
+            .pending_cl
+            .iter()
+            .enumerate()
+            .filter_map(|(cl, entry)| {
+                let id = entry.id?;
+                // An anchor must not make the receiver skip older source packets
+                // still waiting in our own queue. Expiry releases this fence too.
+                if self.data.len > 0 && self.data.ids[self.data.head] < id {
+                    return None;
+                }
+                if self.latest_id.is_some_and(|latest| id <= latest) {
+                    return None;
+                }
+                self.pending_kf
+                    .iter()
+                    .position(|kf| kf.id == Some(id))
+                    .map(|kf| (id, cl, kf))
+            })
+            .min_by_key(|(id, _, _)| *id);
+        if let Some((id, cl, kf)) = pair {
+            core::mem::swap(&mut self.latest.boundary, &mut self.pending_cl[cl].packets);
+            core::mem::swap(&mut self.latest.control, &mut self.pending_kf[kf].packets);
+            self.pending_cl[cl].id = None;
+            self.pending_kf[kf].id = None;
+            self.latest_id = Some(id);
+            self.recovery_cursor = 0;
+            self.request_recovery();
+        }
+    }
+
+    /// Coalesced request for retained bootstrap data. Future advisory feedback
+    /// uses this same operation; it grants neither extra bandwidth nor retention.
+    pub fn request_recovery(&mut self) {
+        if self.stopping || self.control_packet().is_some() {
+            return;
+        }
+        if self.manifest_cursor >= self.manifest.len {
+            self.manifest_cursor = 0;
+        }
+        if self.recovery_cursor >= self.recovery_len() {
+            self.recovery_cursor = 0;
+        }
+    }
+
+    fn recovery_len(&self) -> usize {
+        self.latest.control.len + self.latest.boundary.len
+    }
+
+    fn control_packet(&self) -> Option<&[u8]> {
+        if self.manifest_cursor < self.manifest.len {
+            return Some(self.manifest.get(self.manifest_cursor));
+        }
+        if self.recovery_cursor < self.latest.control.len {
+            return Some(self.latest.control.get(self.recovery_cursor));
+        }
+        let boundary = self.recovery_cursor - self.latest.control.len;
+        (boundary < self.latest.boundary.len).then(|| self.latest.boundary.get(boundary))
+    }
+
+    /// Disable periodic work. The driver enforces the finite shutdown deadline.
+    pub fn begin_shutdown(&mut self) {
+        self.stopping = true;
+    }
+
+    /// Account for work abandoned at the driver's finite shutdown deadline.
+    pub fn discard_pending(&mut self) {
+        self.stats.shutdown_drops += (self.data.len
+            + self.manifest.len.saturating_sub(self.manifest_cursor)
+            + self.recovery_len().saturating_sub(self.recovery_cursor))
+            as u64;
+        self.data.clear();
+        self.manifest_cursor = self.manifest.len;
+        self.recovery_cursor = self.recovery_len();
+    }
+
+    pub fn is_idle(&self) -> bool {
+        self.data.len == 0 && self.control_packet().is_none()
+    }
+
+    /// Send a bounded amount of eligible work and return the next local deadline.
+    /// Carrier WouldBlock consumes the attempt's budget and drops the packet.
+    pub fn poll<T: CuStreamTx>(
+        &mut self,
+        now: CuTime,
+        transport: &mut T,
+    ) -> Result<Option<CuTime>> {
+        if now < self.last_now {
+            return Err(Error::InvalidConfig("sender clock moved backwards"));
+        }
+        let elapsed = (now - self.last_now).as_nanos();
+        self.credit = self.capacity.min(
+            self.credit
+                .saturating_add(u128::from(elapsed) * u128::from(self.config.pacing.bitrate_bps)),
+        );
+        self.last_now = now;
+        self.promote_recovery();
+        if !self.stopping && now >= self.next_repeat {
+            self.request_recovery();
+            self.stats.recovery_rounds = self.stats.recovery_rounds.saturating_add(1);
+            self.next_repeat = now + RECOVERY_REPEAT_INTERVAL;
+        }
+        let mut work = 0;
+        while self.data.len > 0
+            && now >= self.data.times[self.data.head] + self.config.pacing.max_latency
+            && work < MAX_SENDS_PER_POLL
+        {
+            self.data.pop();
+            self.stats.expired_packets += 1;
+            work += 1;
+        }
+        while work < MAX_SENDS_PER_POLL {
+            let has_data = self.data.len > 0;
+            let has_control = self.control_packet().is_some();
+            if !has_data && !has_control {
+                break;
+            }
+            if (self.lane == 0 && !has_data) || (self.lane == 1 && !has_control) {
+                self.deficit[self.lane] = 0;
+                self.lane ^= 1;
+            }
+            let packet = if self.lane == 0 {
+                self.data.get(0)
+            } else {
+                self.control_packet().unwrap()
+            };
+            let len = packet.len();
+            if self.deficit[self.lane] < len {
+                self.deficit[self.lane] += self.scratch.len() * if self.lane == 0 { 3 } else { 1 };
+                self.lane ^= 1;
+                continue;
+            }
+            let cost = len as u128 * 8 * 1_000_000_000;
+            if self.credit < cost {
+                let wait =
+                    (cost - self.credit).div_ceil(u128::from(self.config.pacing.bitrate_bps));
+                let mut deadline = now + CuDuration(wait.min(u128::from(u64::MAX)) as u64);
+                if self.data.len > 0 {
+                    deadline = deadline
+                        .min(self.data.times[self.data.head] + self.config.pacing.max_latency);
+                }
+                return Ok(Some(if self.stopping {
+                    deadline
+                } else {
+                    deadline.min(self.next_repeat)
+                }));
+            }
+            match transport.try_send(packet) {
+                Ok(()) => {
+                    self.stats.packets_sent += 1;
+                    self.stats.bytes_sent += len as u64;
+                }
+                Err(CuStreamTxError::WouldBlock) => self.stats.transport_drops += 1,
+                Err(CuStreamTxError::Failed(message)) => return Err(Error::Transport(message)),
+            }
+            self.credit -= cost;
+            self.deficit[self.lane] -= len;
+            if self.lane == 0 {
+                self.data.pop();
+            } else if self.manifest_cursor < self.manifest.len {
+                self.manifest_cursor += 1;
+            } else {
+                self.recovery_cursor += 1;
+            }
+            work += 1;
+            self.promote_recovery();
+        }
+        Ok(if !self.is_idle() {
+            Some(now)
+        } else if self.stopping {
+            None
+        } else {
+            Some(self.next_repeat)
+        })
+    }
+}

--- a/core/cu29_logstream/src/sender.rs
+++ b/core/cu29_logstream/src/sender.rs
@@ -46,6 +46,7 @@ pub struct RecoverySenderConfig {
 /// Complete sender configuration for continuous CopperLists and restart anchors.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LogStreamSenderConfig {
+    pub pacing: crate::PacingConfig,
     pub continuous: ContinuousSenderConfig,
     pub recovery: RecoverySenderConfig,
 }
@@ -94,7 +95,8 @@ pub struct RecoverySenderStats {
     pub datagrams_dropped: u64,
 }
 
-/// Runtime keyframe sink that sends a repeated manifest, keyframe, and binding anchor.
+/// Immediate, unpaced keyframe sink for codec tests and custom drivers.
+/// Generated applications use `scheduled_sinks` to share a destination budget.
 pub struct KeyFrameAnchorSink<T: CuStreamTx> {
     transport: T,
     encoder: FiniteObjectEncoder,
@@ -215,7 +217,8 @@ impl<T: CuStreamTx> WriteStream<KeyFrame> for KeyFrameAnchorSink<T> {
     }
 }
 
-/// CopperList semantic sink backed by continuous RLC and a nonblocking datagram transport.
+/// Immediate, unpaced CopperList sink backed by continuous RLC.
+/// Generated applications use `scheduled_sinks` for bounded packet scheduling.
 pub struct ContinuousCopperListSink<
     P,
     T,

--- a/core/cu29_logstream/src/stream.rs
+++ b/core/cu29_logstream/src/stream.rs
@@ -57,3 +57,67 @@ impl<T: CuStreamRx + ?Sized> CuStreamRx for alloc::boxed::Box<T> {
         (**self).try_recv(packet)
     }
 }
+
+/// Optional advisory receive direction. This logical interface may share the
+/// physical stream carrier. A shared endpoint must have one receive owner and
+/// route complete packet kinds; cloned competing readers cannot provide routing.
+/// Protocol decoding, capability negotiation, and feedback policy belong above it.
+pub trait CuFeedbackRx: Debug + Send + Sync {
+    fn try_recv_feedback(
+        &mut self,
+        packet: &mut [u8],
+    ) -> core::result::Result<Option<usize>, CuStreamRxError>;
+}
+
+/// Optional advisory transmit direction; same atomic, bounded contract as stream TX.
+pub trait CuFeedbackTx: Debug + Send + Sync {
+    fn try_send_feedback(&mut self, packet: &[u8]) -> core::result::Result<(), CuStreamTxError>;
+}
+
+/// Static autonomous wiring. There is no feedback polling or capability discovery.
+#[derive(Debug)]
+pub struct OneWay<T> {
+    tx: T,
+}
+impl<T> OneWay<T> {
+    pub const fn new(tx: T) -> Self {
+        Self { tx }
+    }
+    pub fn into_inner(self) -> T {
+        self.tx
+    }
+}
+impl<T: CuStreamTx> CuStreamTx for OneWay<T> {
+    fn try_send(&mut self, packet: &[u8]) -> core::result::Result<(), CuStreamTxError> {
+        self.tx.try_send(packet)
+    }
+}
+impl<T: CuStreamTx> CuFeedbackRx for OneWay<T> {
+    fn try_recv_feedback(
+        &mut self,
+        _packet: &mut [u8],
+    ) -> core::result::Result<Option<usize>, CuStreamRxError> {
+        Ok(None)
+    }
+}
+
+/// Explicit feedback wiring for separate logical endpoints. The endpoints may be
+/// resource handles backed by one carrier; physical out-of-band links are optional.
+#[derive(Debug)]
+pub struct SeparateFeedback<T, R> {
+    pub tx: T,
+    pub feedback_rx: R,
+}
+impl<T: CuStreamTx, R: CuFeedbackRx> CuStreamTx for SeparateFeedback<T, R> {
+    fn try_send(&mut self, packet: &[u8]) -> core::result::Result<(), CuStreamTxError> {
+        self.tx.try_send(packet)
+    }
+}
+impl<T: CuStreamTx, R: CuFeedbackRx> CuFeedbackRx for SeparateFeedback<T, R> {
+    fn try_recv_feedback(
+        &mut self,
+        packet: &mut [u8],
+    ) -> core::result::Result<Option<usize>, CuStreamRxError> {
+        self.feedback_rx.try_recv_feedback(packet)
+    }
+}

--- a/core/cu29_logstream/src/worker.rs
+++ b/core/cu29_logstream/src/worker.rs
@@ -1,0 +1,334 @@
+//! Host driver for the autonomous sender. Only semantic output workers call these sinks.
+
+use crate::{CuStreamTx, LogStreamSenderConfig, OneWay, SenderCore, SenderStats};
+use cu29_clock::{CuDuration, CuTime, RobotClock};
+#[allow(unused_imports)]
+use cu29_log::{ANONYMOUS, CuLogEntry, CuLogLevel};
+#[allow(unused_imports)]
+use cu29_log_runtime::log;
+#[cfg(debug_assertions)]
+#[allow(unused_imports)]
+use cu29_log_runtime::log_debug_mode;
+use cu29_runtime::{copperlist::CopperList, curuntime::KeyFrame};
+use cu29_traits::{CopperListTuple, CuError, CuResult, WriteStream};
+#[allow(unused_imports)]
+use cu29_value::to_value;
+use std::{
+    fmt::{Debug, Formatter},
+    marker::PhantomData,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        mpsc::{self, Receiver, SyncSender, TryRecvError},
+    },
+    thread::{JoinHandle, Thread},
+};
+
+const CL_BUFFERS: usize = 4;
+const KF_BUFFERS: usize = 2;
+
+struct Record {
+    bytes: Box<[u8]>,
+    len: usize,
+    keyframe: bool,
+    queued_at: CuTime,
+}
+
+/// Final counters remain readable after both output sinks have been dropped.
+#[derive(Clone, Debug)]
+pub struct SenderMonitor(Arc<Shared>);
+
+#[derive(Debug, Default)]
+struct Shared {
+    stop: AtomicBool,
+    failed: AtomicBool,
+    inbox_drops: AtomicU64,
+    final_stats: Mutex<Option<SenderStats>>,
+}
+
+impl SenderMonitor {
+    pub fn inbox_drops(&self) -> u64 {
+        self.0.inbox_drops.load(Ordering::Relaxed)
+    }
+    pub fn failed(&self) -> bool {
+        self.0.failed.load(Ordering::Acquire)
+    }
+    pub fn final_stats(&self) -> Option<SenderStats> {
+        *self.0.final_stats.lock().expect("sender stats poisoned")
+    }
+}
+
+#[derive(Debug)]
+struct Worker {
+    shared: Arc<Shared>,
+    thread: Thread,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for Worker {
+    fn drop(&mut self) {
+        self.shared.stop.store(true, Ordering::Release);
+        self.thread.unpark();
+        if self
+            .handle
+            .take()
+            .is_some_and(|handle| handle.join().is_err())
+        {
+            self.shared.failed.store(true, Ordering::Release);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Inbox {
+    clock: RobotClock,
+    worker: Arc<Worker>,
+    pending: SyncSender<Record>,
+    // Mutex supplies Sync for WriteStream; exclusive log() uses get_mut, never lock().
+    free: Mutex<Receiver<Box<[u8]>>>,
+    recycled: SyncSender<Box<[u8]>>,
+}
+
+impl Inbox {
+    fn submit(
+        &mut self,
+        keyframe: bool,
+        encode: impl FnOnce(&mut [u8]) -> CuResult<usize>,
+    ) -> CuResult<()> {
+        if self.worker.shared.failed.load(Ordering::Acquire) {
+            return Err(CuError::from("Logstream sender worker failed"));
+        }
+        let mut bytes = match self.free.get_mut().expect("exclusive inbox").try_recv() {
+            Ok(bytes) => bytes,
+            Err(TryRecvError::Empty) => {
+                self.worker
+                    .shared
+                    .inbox_drops
+                    .fetch_add(1, Ordering::Relaxed);
+                return Ok(());
+            }
+            Err(TryRecvError::Disconnected) => {
+                return Err(CuError::from("Logstream sender worker stopped"));
+            }
+        };
+        let queued_at = self.clock.now();
+        let len = match encode(&mut bytes) {
+            Ok(len) => len,
+            Err(error) => {
+                let _ = self.recycled.try_send(bytes);
+                return Err(error);
+            }
+        };
+        // Capacity equals the total buffer count, so an owned free buffer always
+        // has a corresponding inbox slot. Neither this nor pool exhaustion waits.
+        self.pending
+            .try_send(Record {
+                bytes,
+                len,
+                keyframe,
+                queued_at,
+            })
+            .map_err(|_| CuError::from("Logstream sender inbox disconnected"))?;
+        self.worker.thread.unpark();
+        Ok(())
+    }
+}
+
+/// Encodes directly into a sender-owned buffer on the existing CL output worker.
+pub struct ScheduledCopperListSink<P> {
+    inbox: Inbox,
+    _payload: PhantomData<fn() -> P>,
+}
+impl<P> Debug for ScheduledCopperListSink<P> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScheduledCopperListSink")
+            .finish_non_exhaustive()
+    }
+}
+impl<P: CopperListTuple + Send + Sync> WriteStream<CopperList<P>> for ScheduledCopperListSink<P> {
+    fn log(&mut self, record: &CopperList<P>) -> CuResult<()> {
+        self.inbox.submit(false, |bytes| {
+            crate::encode_copperlist_record_into(record, bytes)
+                .map_err(|error| CuError::from(error.to_string()))
+        })
+    }
+}
+
+/// Bounded keyframe encoding; capture objects are released before pacing begins.
+#[derive(Debug)]
+pub struct ScheduledKeyFrameSink {
+    inbox: Inbox,
+    interval: u32,
+}
+impl WriteStream<KeyFrame> for ScheduledKeyFrameSink {
+    fn log(&mut self, keyframe: &KeyFrame) -> CuResult<()> {
+        if !keyframe.culistid.is_multiple_of(u64::from(self.interval)) {
+            return Ok(());
+        }
+        self.inbox.submit(true, |bytes| {
+            if bytes.len() < crate::record::RECORD_HEADER_LEN {
+                return Err(CuError::from("Keyframe buffer too small"));
+            }
+            let (header, payload) = bytes.split_at_mut(crate::record::RECORD_HEADER_LEN);
+            let len = bincode::encode_into_slice(keyframe, payload, bincode::config::standard())
+                .map_err(|error| CuError::from(error.to_string()))?;
+            crate::record::encode_record_header(
+                crate::RecordKind::KeyFrame,
+                keyframe.culistid,
+                &payload[..len],
+                header,
+            )
+            .map_err(|error| CuError::from(error.to_string()))?;
+            Ok(header.len() + len)
+        })
+    }
+}
+
+/// Start one autonomous worker with an explicitly selected local RobotClock.
+/// A real carrier must use a running clock even when application time is mocked.
+/// Drops of both sinks stop repetition, then drain at most max_latency in local
+/// clock time. No application object, serialization, or wait is added to the RT path.
+pub fn scheduled_sinks<P, T>(
+    transport: T,
+    config: LogStreamSenderConfig,
+    clock: RobotClock,
+) -> CuResult<(
+    ScheduledCopperListSink<P>,
+    ScheduledKeyFrameSink,
+    SenderMonitor,
+)>
+where
+    P: CopperListTuple + Send + Sync,
+    T: CuStreamTx + 'static,
+{
+    let cl_bytes = config.continuous.max_record_bytes;
+    let kf_bytes = usize::try_from(config.recovery.finite.max_object_bytes)
+        .map_err(|_| CuError::from("Keyframe limit exceeds usize"))?;
+    let reserved = cl_bytes
+        .checked_mul(CL_BUFFERS)
+        .and_then(|v| {
+            kf_bytes
+                .checked_mul(KF_BUFFERS)
+                .and_then(|k| v.checked_add(k))
+        })
+        .ok_or_else(|| CuError::from("Sender pool size overflow"))?;
+    let shutdown_clock = if clock.is_mock() {
+        RobotClock::new()
+    } else {
+        clock.clone()
+    };
+    let interval = config.recovery.anchor_interval;
+    let drain_time = config.pacing.max_latency;
+    let mut core = SenderCore::new(config, clock.now(), reserved)
+        .map_err(|error| CuError::from(error.to_string()))?;
+    let (pending, records) = mpsc::sync_channel::<Record>(CL_BUFFERS + KF_BUFFERS);
+    let (cl_return, cl_free) = mpsc::sync_channel(CL_BUFFERS);
+    let (kf_return, kf_free) = mpsc::sync_channel(KF_BUFFERS);
+    for _ in 0..CL_BUFFERS {
+        cl_return
+            .try_send(vec![0; cl_bytes].into_boxed_slice())
+            .expect("new pool");
+    }
+    for _ in 0..KF_BUFFERS {
+        kf_return
+            .try_send(vec![0; kf_bytes].into_boxed_slice())
+            .expect("new pool");
+    }
+    let cl_clock = clock.clone();
+    let kf_clock = clock.clone();
+    let shared = Arc::new(Shared::default());
+    let status = shared.clone();
+    let cl_recycled = cl_return.clone();
+    let kf_recycled = kf_return.clone();
+    let handle = std::thread::Builder::new()
+        .name("cu-logstream".into())
+        .spawn(move || {
+            let mut transport = OneWay::new(transport);
+            let mut stop_at = None;
+            // Teardown remains finite even for deliberately frozen scheduler test clocks.
+            let result = (|| -> crate::Result<()> {
+                loop {
+                    if status.stop.load(Ordering::Acquire) && stop_at.is_none() {
+                        core.begin_shutdown();
+                        stop_at = Some(shutdown_clock.now() + drain_time);
+                    }
+                    let mut received = 0;
+                    for _ in 0..CL_BUFFERS + KF_BUFFERS {
+                        let Ok(record) = records.try_recv() else {
+                            break;
+                        };
+                        let result =
+                            core.accept_record(&record.bytes[..record.len], record.queued_at);
+                        let returned = if record.keyframe {
+                            &kf_return
+                        } else {
+                            &cl_return
+                        };
+                        let _ = returned.try_send(record.bytes);
+                        result?;
+                        received += 1;
+                    }
+                    let next = core.poll(clock.now(), &mut transport)?;
+                    if stop_at.is_some_and(|deadline| shutdown_clock.now() >= deadline)
+                        || (stop_at.is_some() && received == 0 && core.is_idle())
+                    {
+                        break;
+                    }
+                    if received > 0 {
+                        continue;
+                    }
+                    if let Some(deadline) = next {
+                        let now = clock.now();
+                        if deadline > now {
+                            let duration = (deadline - now).min(CuDuration::from_millis(50));
+                            std::thread::park_timeout(std::time::Duration::from_nanos(
+                                duration.as_nanos(),
+                            ));
+                        }
+                    } else {
+                        std::thread::park_timeout(std::time::Duration::from_millis(50));
+                    }
+                }
+                Ok(())
+            })();
+            core.discard_pending();
+            let stats = core.stats();
+            *status.final_stats.lock().expect("sender stats") = Some(stats);
+            cu29_log_derive::info!("Logstream sender stopped: sent={} bytes={} queue_drops={} expired={} transport_drops={} inbox_drops={} shutdown_drops={}",
+                stats.packets_sent, stats.bytes_sent, stats.queue_drops, stats.expired_packets, stats.transport_drops,
+                status.inbox_drops.load(Ordering::Relaxed), stats.shutdown_drops);
+            if let Err(error) = result {
+                status.failed.store(true, Ordering::Release);
+                cu29_log_derive::error!("Logstream sender failed: {}", error.to_string());
+            }
+        })
+        .map_err(|error| CuError::new_with_cause("Start logstream sender", error))?;
+    let worker = Arc::new(Worker {
+        shared: shared.clone(),
+        thread: handle.thread().clone(),
+        handle: Some(handle),
+    });
+    Ok((
+        ScheduledCopperListSink {
+            inbox: Inbox {
+                clock: cl_clock,
+                worker: worker.clone(),
+                pending: pending.clone(),
+                free: Mutex::new(cl_free),
+                recycled: cl_recycled,
+            },
+            _payload: PhantomData,
+        },
+        ScheduledKeyFrameSink {
+            inbox: Inbox {
+                clock: kf_clock,
+                worker,
+                pending,
+                free: Mutex::new(kf_free),
+                recycled: kf_recycled,
+            },
+            interval,
+        },
+        SenderMonitor(shared),
+    ))
+}

--- a/core/cu29_logstream/tests/pacing.rs
+++ b/core/cu29_logstream/tests/pacing.rs
@@ -1,0 +1,289 @@
+use cu29_clock::{CuDuration, CuTime, RobotClock};
+use cu29_logstream::*;
+use cu29_runtime::curuntime::KeyFrame;
+
+fn config() -> LogStreamSenderConfig {
+    let plan = LogStreamPlan {
+        destination_id: "ground".into(),
+        mtu_bytes: 1200,
+        symbol_size: 1128,
+        bitrate_bps: 1_000_000,
+        memory_budget_kib: 512,
+        max_latency_ms: 250,
+        burst_packets: 4,
+        continuous: ResolvedContinuousFec {
+            field: ResolvedRlcField::Gf256,
+            window_symbols: 64,
+            repair_every_source_symbols: 4,
+            repair_density: DensityThreshold::FULL.get(),
+        },
+        objects: ResolvedObjectFec {
+            max_object_bytes: 4096,
+            repair_symbols_per_block: 2,
+        },
+        content: ResolvedContentPolicy {
+            archive: true,
+            live_viz: false,
+            anchor_interval: 1,
+        },
+        max_record_bytes: 4096,
+    };
+    plan.sender_config(
+        StreamIdentity {
+            session_id: *b"paced-session001",
+            sender_id: 1,
+        },
+        ApplicationSchema { outputs: vec![] },
+    )
+    .unwrap()
+}
+
+fn cl(id: u64) -> Vec<u8> {
+    encode_record(RecordKind::CopperList, id, &[42; 100]).unwrap()
+}
+fn kf(id: u64) -> Vec<u8> {
+    encode_record(
+        RecordKind::KeyFrame,
+        id,
+        &encode_keyframe(&KeyFrame {
+            culistid: id,
+            timestamp: CuTime::default(),
+            serialized_tasks: vec![7; 100],
+        })
+        .unwrap(),
+    )
+    .unwrap()
+}
+
+#[derive(Debug, Default)]
+struct Capture {
+    now: CuTime,
+    packets: Vec<(CuTime, Vec<u8>)>,
+    block: bool,
+}
+impl CuStreamTx for Capture {
+    fn try_send(&mut self, packet: &[u8]) -> std::result::Result<(), CuStreamTxError> {
+        self.packets.push((self.now, packet.to_vec()));
+        if self.block {
+            Err(CuStreamTxError::WouldBlock)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn advance(
+    core: &mut SenderCore,
+    tx: &mut Capture,
+    clock: &RobotClock,
+    mock: &cu29_clock::RobotClockMock,
+    from: u64,
+    through: u64,
+) {
+    for ms in from..=through {
+        mock.set_value(ms * 1_000_000);
+        tx.now = clock.now();
+        core.poll(clock.now(), tx).unwrap();
+    }
+}
+
+#[test]
+fn shared_budget_burst_and_queue_pressure_are_bounded() {
+    let (clock, mock) = RobotClock::mock();
+    let config = config();
+    let mut core = SenderCore::new(config.clone(), clock.now(), 0).unwrap();
+    for id in 0..2000 {
+        core.accept_record(&cl(id), clock.now()).unwrap();
+    }
+    core.accept_record(&kf(1999), clock.now()).unwrap();
+    let mut tx = Capture::default();
+    advance(&mut core, &mut tx, &clock, &mock, 0, 1000);
+    assert!(core.stats().queue_drops > 0);
+    assert!(core.stats().expired_packets > 0);
+    assert!(core.stats().queue_peak * 1200 < config.pacing.memory_budget_bytes);
+    // Check every observed time interval, including same-timestamp bursts and
+    // mixed source, repair, manifest, and anchor packets.
+    for first in 0..tx.packets.len() {
+        let mut bytes = 0_u128;
+        for last in first..tx.packets.len() {
+            bytes += tx.packets[last].1.len() as u128;
+            let elapsed = (tx.packets[last].0 - tx.packets[first].0).as_nanos();
+            assert!(
+                bytes * 8 * 1_000_000_000
+                    <= u128::from(config.pacing.burst_packets) * 1200 * 8 * 1_000_000_000
+                        + u128::from(elapsed) * u128::from(config.pacing.bitrate_bps)
+            );
+        }
+    }
+    let before = tx.packets.len();
+    mock.set_value(60_000_000_000);
+    tx.now = clock.now();
+    core.poll(clock.now(), &mut tx).unwrap();
+    assert!(tx.packets.len() - before <= config.pacing.burst_packets as usize);
+}
+
+#[test]
+fn missed_bootstrap_recovers_during_idle_without_new_captures() {
+    let (clock, mock) = RobotClock::mock();
+    let mut core = SenderCore::new(config(), clock.now(), 0).unwrap();
+    core.accept_record(&kf(32), clock.now()).unwrap();
+    core.accept_record(&cl(32), clock.now()).unwrap();
+    let mut tx = Capture::default();
+    advance(&mut core, &mut tx, &clock, &mock, 0, 200);
+    tx.packets.clear(); // Lose the entire initial transmission, including CL32.
+    advance(&mut core, &mut tx, &clock, &mock, 201, 600);
+    let mut router = SessionRouter::<1128, 64, 64>::new(SessionRouterLimits {
+        max_sessions: 1,
+        max_startup_packets: 64,
+        max_recovery_records: 8,
+        max_pending_events: 32,
+        max_record_bytes: 4096,
+        max_buffered_records: 64,
+        equation_capacity: 64,
+        finite_objects: FiniteObjectLimits::new(4096, 1128, 4),
+    })
+    .unwrap();
+    let mut events = Vec::new();
+    for (_, packet) in tx.packets {
+        router
+            .receive_datagram(&packet, |event| {
+                events.push(event);
+                Ok::<_, ()>(())
+            })
+            .unwrap();
+    }
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, SessionEvent::Manifest(_)))
+    );
+    assert!(events.iter().any(
+        |e| matches!(e, SessionEvent::VerifiedAnchor { anchor, .. } if anchor.copperlist_id == 32)
+    ));
+    assert!(events.iter().any(
+        |e| matches!(e, SessionEvent::Gap { gap, .. } if gap.first_id == 0 && gap.last_id == 31)
+    ));
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| matches!(e, SessionEvent::ContinuousRecord { .. }))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn independently_ordered_workers_pair_bounded_recovery_records() {
+    for keyframes_first in [false, true] {
+        let (clock, mock) = RobotClock::mock();
+        let mut core = SenderCore::new(config(), clock.now(), 0).unwrap();
+        if keyframes_first {
+            for id in 0..2 {
+                core.accept_record(&kf(id), clock.now()).unwrap();
+            }
+            for id in 0..4 {
+                core.accept_record(&cl(id), clock.now()).unwrap();
+            }
+        } else {
+            for id in 0..4 {
+                core.accept_record(&cl(id), clock.now()).unwrap();
+            }
+            for id in 0..2 {
+                core.accept_record(&kf(id), clock.now()).unwrap();
+            }
+        }
+        let mut tx = Capture::default();
+        advance(&mut core, &mut tx, &clock, &mock, 0, 200);
+        for id in 0..2 {
+            assert!(tx.packets.iter().any(|(_, p)| {
+                let h = WirePacket::decode(p).unwrap().header;
+                h.record_kind == RecordKind::Anchor && h.object_id == id
+            }));
+        }
+    }
+}
+
+#[test]
+fn feedback_requests_coalesce_and_backpressure_does_not_retry() {
+    let (clock, mock) = RobotClock::mock();
+    let mut baseline = SenderCore::new(config(), clock.now(), 0).unwrap();
+    let mut requested = SenderCore::new(config(), clock.now(), 0).unwrap();
+    for core in [&mut baseline, &mut requested] {
+        core.accept_record(&cl(0), clock.now()).unwrap();
+        core.accept_record(&kf(0), clock.now()).unwrap();
+    }
+    let mut a = Capture {
+        block: true,
+        ..Capture::default()
+    };
+    let mut b = Capture {
+        block: true,
+        ..Capture::default()
+    };
+    for ms in 0..100 {
+        mock.set_value(ms * 1_000_000);
+        a.now = clock.now();
+        b.now = clock.now();
+        for _ in 0..100 {
+            requested.request_recovery();
+        }
+        baseline.poll(clock.now(), &mut a).unwrap();
+        requested.poll(clock.now(), &mut b).unwrap();
+        // While bootstrap remains in flight, requests must not reset its cursor.
+        if !baseline.is_idle() {
+            assert_eq!(a.packets, b.packets);
+        }
+    }
+    assert_eq!(requested.stats().packets_sent, 0);
+    assert_eq!(requested.stats().transport_drops as usize, b.packets.len());
+    requested.begin_shutdown();
+    advance(&mut requested, &mut b, &clock, &mock, 100, 300);
+    let count = b.packets.len();
+    requested.request_recovery();
+    advance(&mut requested, &mut b, &clock, &mock, 301, 1000);
+    assert_eq!(count, b.packets.len());
+}
+
+#[test]
+fn invalid_bounds_and_backward_clock_fail_explicitly() {
+    let mut invalid = config();
+    invalid.pacing.memory_budget_bytes = 1;
+    assert!(SenderCore::new(invalid, CuTime::default(), 0).is_err());
+    let mut core = SenderCore::new(config(), CuTime::from_millis(10), 0).unwrap();
+    assert!(
+        core.poll(CuTime::default(), &mut Capture::default())
+            .is_err()
+    );
+    let (clock, mock) = RobotClock::mock();
+    assert!(clock.is_mock());
+    mock.increment(CuDuration::from_millis(1));
+    assert_eq!(clock.clone().now(), clock.now());
+}
+
+#[test]
+fn recovery_never_overtakes_older_queued_source_records() {
+    let (clock, mock) = RobotClock::mock();
+    let mut cfg = config();
+    cfg.pacing.max_latency = CuDuration::from_millis(2000);
+    let mut core = SenderCore::new(cfg, clock.now(), 0).unwrap();
+    for id in 0..33 {
+        core.accept_record(&cl(id), clock.now()).unwrap();
+    }
+    core.accept_record(&kf(32), clock.now()).unwrap();
+    let mut tx = Capture::default();
+    advance(&mut core, &mut tx, &clock, &mock, 0, 600);
+    let anchor = tx
+        .packets
+        .iter()
+        .position(|(_, p)| WirePacket::decode(p).unwrap().header.record_kind == RecordKind::Anchor)
+        .unwrap();
+    for id in 0..32 {
+        assert!(tx.packets[..anchor].iter().any(|(_, p)| {
+            let h = WirePacket::decode(p).unwrap().header;
+            h.record_kind == RecordKind::CopperList
+                && h.symbol_kind == FecSymbolKind::Source
+                && h.object_id == id
+        }));
+    }
+    assert_eq!(core.stats().expired_packets, 0);
+}

--- a/examples/cu_logstream_demo/README.md
+++ b/examples/cu_logstream_demo/README.md
@@ -12,6 +12,7 @@ just run loss
 just run outage
 just run late
 just run restart
+just run idle
 ```
 
 `just` builds the tools, runs the clean scenario, compares the received archive
@@ -26,6 +27,7 @@ example's `logs/` and prints its path.
 | `loss` | Discard the source packets for CopperList 20; RLC repairs recover it with no semantic gap. |
 | `outage` | Discard a contiguous arrival interval beginning at CopperList 32 and ending before 160, including control traffic. Missing history remains explicit and a verified anchor enables recovery. |
 | `late` | Start the receiver after the sender is already running. Its archive contains a `LateJoin` prefix gap. |
+| `idle` | Drop all traffic for the first 300 ms, produce only CL0, and keep the sender alive with no new captures. Periodic recovery restores the complete one-record archive. |
 | `restart` | Close the first receiver after CopperList 64, leave it offline briefly, and launch a new process while the sender continues. The new archive reports unavailable history. |
 
 Loss injection runs at the receiver's packet boundary after real UDP reception,
@@ -85,14 +87,24 @@ native keyframe sections.
 ## Check the milestone
 
 From the repository root, run `just logstream-demo-check`. This checks Clippy,
-builds the opt-in binaries, and exercises all five scenarios. `just check` in this
+builds the opt-in binaries, and exercises all six scenarios. `just check` in this
 directory runs all scenarios. Normal workspace builds leave streaming disabled;
 `demo` enables it and `replay` also enables the remote-debug replay tools.
 
-This is a low-rate demonstrator. The configured bitrate, burst, and latency
-policy are not yet enforced by a pacer. Manifests and anchors are emitted on
-qualifying keyframe captures; independent retained-object repetition is deferred.
+The configured 2 Mbps budget includes Copper packet headers and FEC/recovery
+traffic, excluding UDP/IP overhead. A bounded background sender enforces the
+bitrate, eight-packet burst allowance, and 250 ms ordinary-data queue deadline.
+Manifest and complete recovery bundles repeat on a 250 ms local deadline while
+the sender remains alive, including when application time is paused. The demo's
+mock application timestamps stay deterministic; physical pacing uses a running
+RobotClock. Receiver time synchronization is not required.
+
+Run `just logstream-pacing-check` at the root for deterministic rate/burst,
+overload, and worker lifecycle checks alongside these scenarios. The sender
+buffer budget excludes thread stacks, channel/allocator bookkeeping, and bounded
+RaptorQ scratch allocations; see the [sender docs](../../core/cu29_logstream).
 Memory-bounded recovery cannot recover expired history, and receiver shutdown
 does not establish the sender's unobserved tail. Full-capture native archival
 requires the matching application schema. Feedback, hybrid reconstruction, the
-live twin API, and serial are later milestones.
+live twin API, and serial are later milestones. Feedback interfaces permit a
+shared bidirectional carrier or separate explicitly configured endpoints.

--- a/examples/cu_logstream_demo/copperconfig.ron
+++ b/examples/cu_logstream_demo/copperconfig.ron
@@ -29,7 +29,7 @@
                 ),
                 link: (
                     mtu_bytes: 1200,
-                    bitrate_bps: 1000000,
+                    bitrate_bps: 2000000,
                     memory_budget_kib: 512,
                     max_latency_ms: 250,
                     burst_packets: 8,

--- a/examples/cu_logstream_demo/justfile
+++ b/examples/cu_logstream_demo/justfile
@@ -6,7 +6,7 @@ default: (run "clean")
 build:
     cargo +stable build -p cu-logstream-demo --features replay --bins
 
-# Scenarios: clean, loss, outage, late, restart, all.
+# Scenarios: clean, loss, outage, late, restart, idle, all.
 run scenario="clean": build
     python3 run.py {{scenario}} --binary {{root}}/target/debug/cu-logstream-demo
 

--- a/examples/cu_logstream_demo/run.py
+++ b/examples/cu_logstream_demo/run.py
@@ -42,10 +42,15 @@ def run(binary, scenario):
 
     def verify(name, expectation):
         wait(spawn("verify", "--sender", directory / "sender.copper", "--received",
-                   directory / f"{name}.copper", "--expect", expectation))
+                   directory / f"{name}.copper", "--expect", expectation,
+                   "--iterations", "1" if scenario == "idle" else "256"))
 
     try:
-        if scenario == "late":
+        if scenario == "idle":
+            ground, address = receiver("received", impairment="bootstrap")
+            sender = spawn("sender", "--remote", address, "--log-base", directory / "sender.copper",
+                           "--iterations", "1", "--idle-ms", "1000")
+        elif scenario == "late":
             # Reserve an endpoint using the actual receiver, then close it before
             # starting the sender. This receiver receives no data or manifest.
             initial, address = receiver("reservation")
@@ -72,7 +77,7 @@ def run(binary, scenario):
         else:
             wait(sender)
             wait(ground)
-            verify("received", {"clean": "complete", "loss": "complete", "outage": "outage", "late": "late"}[scenario])
+            verify("received", {"idle": "complete", "clean": "complete", "loss": "complete", "outage": "outage", "late": "late"}[scenario])
             replay_names = ["received"]
 
         logreader = binary.with_name("cu-logstream-demo-logreader")
@@ -95,9 +100,9 @@ def run(binary, scenario):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("scenario", choices=["clean", "loss", "outage", "late", "restart", "all"], default="clean", nargs="?")
+    parser.add_argument("scenario", choices=["clean", "loss", "outage", "late", "restart", "idle", "all"], default="clean", nargs="?")
     parser.add_argument("--binary", type=pathlib.Path, required=True)
     args = parser.parse_args()
     binary = args.binary.resolve()
-    for scenario in (["clean", "loss", "outage", "late", "restart"] if args.scenario == "all" else [args.scenario]):
+    for scenario in (["clean", "loss", "outage", "late", "restart", "idle"] if args.scenario == "all" else [args.scenario]):
         run(binary, scenario)

--- a/examples/cu_logstream_demo/src/lib.rs
+++ b/examples/cu_logstream_demo/src/lib.rs
@@ -31,6 +31,7 @@ pub fn run_sender(
     remote: std::net::SocketAddr,
     path: &std::path::Path,
     iterations: u64,
+    idle_ms: u64,
 ) -> CuResult<()> {
     let mut config = CuConfig::deserialize_ron(include_str!("../copperconfig.ron"))?;
     config.resources[0]
@@ -52,6 +53,7 @@ pub fn run_sender(
         // Low-rate example driving, outside task execution. This is not link pacing.
         std::thread::sleep(std::time::Duration::from_nanos(TICK_NS));
     }
+    std::thread::sleep(std::time::Duration::from_millis(idle_ms));
     drop(running.stop()?);
     Ok(())
 }

--- a/examples/cu_logstream_demo/src/main.rs
+++ b/examples/cu_logstream_demo/src/main.rs
@@ -35,6 +35,9 @@ enum Command {
         log_base: PathBuf,
         #[arg(long, default_value_t = ITERATIONS, value_parser = clap::value_parser!(u64).range(1..))]
         iterations: u64,
+        /// Keep the sender alive without new captures to exercise autonomous repetition.
+        #[arg(long, default_value_t = 0)]
+        idle_ms: u64,
     },
     Receiver {
         #[arg(long, default_value = "127.0.0.1:7447")]
@@ -70,6 +73,7 @@ enum Impairment {
     Clean,
     Loss,
     Outage,
+    Bootstrap,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -95,9 +99,9 @@ fn prepare_log(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn sender(remote: SocketAddr, path: &Path, iterations: u64) -> Result<()> {
+fn sender(remote: SocketAddr, path: &Path, iterations: u64, idle_ms: u64) -> Result<()> {
     prepare_log(path)?;
-    cu_logstream_demo::run_sender(remote, path, iterations)?;
+    cu_logstream_demo::run_sender(remote, path, iterations, idle_ms)?;
     println!(
         "Sender finished {iterations} iterations: {}",
         path.display()
@@ -152,6 +156,7 @@ fn receiver(
     let mut last_packet = started;
     let mut last_status = started;
     let mut seen_packet = false;
+    let mut first_packet = None;
     let mut in_outage = false;
     let mut packet = [0; 1200];
     loop {
@@ -161,6 +166,7 @@ fn receiver(
         {
             last_packet = Instant::now();
             seen_packet = true;
+            let first = *first_packet.get_or_insert(last_packet);
             // Demo-only receive-side impairment. Production sender/resource code is unchanged.
             let wire = WirePacket::decode(&packet[..len])?;
             let header = wire.header;
@@ -177,6 +183,9 @@ fn receiver(
                         && header.object_id == 20
                 }
                 Impairment::Outage => in_outage,
+                Impairment::Bootstrap => {
+                    last_packet.duration_since(first) < Duration::from_millis(300)
+                }
             };
             if discard {
                 status.dropped += 1;
@@ -360,7 +369,8 @@ fn main() -> Result<()> {
             remote,
             log_base,
             iterations,
-        } => sender(remote, &log_base, iterations),
+            idle_ms,
+        } => sender(remote, &log_base, iterations, idle_ms),
         Command::Receiver {
             listen,
             log_base,

--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ pr-check:
 	just api-check
 	just test
 	just logstream-udp-check
-	just logstream-demo-check
+	just logstream-pacing-check
 
 # Reproduce the scheduled weekly audit and beta checks on the local host.
 weekly: weekly-audit
@@ -175,6 +175,15 @@ logstream-receiver-check:
 	cargo +stable check -p cu29-logstream --no-default-features
 	cargo +stable test -p cu29-runtime --test replay_primitives
 	just logstream-udp-check
+
+# Sender budget/retention, generated integration, and one-way UDP recovery.
+logstream-pacing-check:
+	cargo +stable clippy -p cu29-logstream --all-targets -- --deny warnings
+	cargo +stable test -p cu29-logstream
+	cargo +stable check -p cu29-logstream --no-default-features
+	cargo +stable clippy -p cu29 --features logstream --test logstream_runtime -- --deny warnings
+	cargo +stable test -p cu29 --features logstream --test logstream_runtime
+	just logstream-demo-check
 
 # Runnable two-process UDP scenarios, archive comparison, and recorded replay.
 logstream-demo-check:


### PR DESCRIPTION
## Summary

Generated logstream senders now enforce the configured destination bitrate and burst budget. A retained manifest and complete keyframe/anchor/CopperList-boundary bundle repeat without new captures, allowing a receiver to recover while task execution is idle.

Stacked on #1323 (`gbin/cu-logstream-demo`).

## Changes

- One background worker owns each carrier, continuous FEC window, bounded encoded-record pools, packet queues, and retained recovery data. Existing real-time ownership handoff is unchanged. Encoding writes directly into owned buffers; packet staging/retention copies happen only in the background.
- Byte-deficit scheduling shares the budget 3:1 between replay and recovery. Ordinary data expires from admission time; queue pressure and carrier WouldBlock are counted. An anchor waits for older queued source packets to be attempted or expired. Recovery requests coalesce, and new captures cannot continually restart an in-flight bundle.
- A local RobotClock drives pacing and 250 ms repetition. Physical links use a running clock when application time is mocked; no ground/robot time synchronization is required. Shutdown has a finite drain deadline, including frozen-clock tests.
- Add logical feedback packet traits plus OneWay and SeparateFeedback adapters. Feedback may share a duplex carrier. The protocol, negotiation, receive polling, and adaptation remain deferred; future requests use the same bounded scheduler/retention entry point.
- Add the two-process `just run idle` scenario: lose the complete initial transmission, capture only CL0, and recover its native archive through repetition. Existing clean/loss/outage/late/restart scenarios still compare payloads/timestamps, fsck, and replay exactly.

The memory budget covers explicit sender buffers and continuous state. Thread stacks, channel/allocator bookkeeping, and object-size-bounded RaptorQ scratch are additional; scheduled finite objects must fit one source block. Packet budgets exclude carrier framing overhead. Immediate low-level codec sinks remain unpaced for custom integration/tests.

## Validation

- `just logstream-pacing-check`: six scheduler tests, three runtime/worker regressions, no-default-features check, Clippy, replay tests, and all six UDP process scenarios.
- `just logstream-udp-check`: 11 carrier tests and actual-arrival-order native archive integration.
- `just nostd-ci`, `just api-check`, `just fmt`, and Git whitespace checks passed.
- Book build passed. Full `just pr-check` was not rerun; focused root targets cover the changed surfaces.
- Clean demo structured log: 525 packets / 630000 bytes, zero queue/expiry/transport/inbox/shutdown drops.

## Reminder

- [ ] I ran `just` from the repo root (focused verification above)
- [x] I have updated docs or examples where needed
