### PR TITLE
fix: use cu-bincode in RP2350 skeleton

### DIFF
--- a/examples/cu_rp2350_skeleton/Cargo.toml
+++ b/examples/cu_rp2350_skeleton/Cargo.toml
@@ -28,7 +28,9 @@ cu-sdlogger = { path = "../../components/libs/cu_sdlogger", default-features = f
   "eh1",
 ], optional = true, version = "1.2.0-dev" }
 cu29-export = { path = "../../core/cu29_export", version = "1.2.0-dev", optional = true, default-features = false }
-bincode = { version = "2.0", default-features = false, features = ["derive"] }
+bincode = { package = "cu-bincode", version = "2.0", default-features = false, features = [
+  "derive",
+] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 # embedded stuff


### PR DESCRIPTION
## Summary

The standalone RP2350 skeleton still depended on public `bincode` 2.0 while Copper's runtime uses `cu-bincode`. Alias its dependency to `cu-bincode` so payload derives and runtime serialization use the same traits. Preserve the version requirement and existing no_std/feature settings.

## Changes

- Update the skeleton's dependency to `package = "cu-bincode"`.
- Audited all 141 tracked Cargo manifests (72 bincode dependency declarations) and project templates: all direct dependencies now use the fork or inherit it from the workspace.
- Public bincode 1.3.3 remains transitively through `zenoh-ext` 1.10.0; the skeleton's resolved dependencies contain only `cu-bincode` and `cu-bincode-derive`.

## Validation

- Passed `just fmt` and `just lint` from the repo root, including embedded and host clippy checks.
- Passed `cargo +stable build-arm` and `cargo +stable build-logreader` in the skeleton. Firmware linking emits a section-alignment warning but completes successfully.
- Passed `git diff --check`.
- `cargo shear` could not run because it is not installed.

## Reminder

- [ ] I ran `just` from the repo root (ran `just fmt` and `just lint`, plus focused builds)
- [x] I have updated docs or examples where needed
