### PR TITLE
Add Telemetry and a Ratatui ground-station example

### DIFF
--- a/components/res/cu29_logstream_udp/tests/configured_sender.rs
+++ b/components/res/cu29_logstream_udp/tests/configured_sender.rs
@@ -69,7 +69,7 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
         .set("remote_addr", rx.local_addr().unwrap().to_string());
 
     // The receiver knows hard capacity limits, but no sender identity or FEC plan.
-    let mut router = SessionRouter::<1128, 64, 64>::new(SessionRouterLimits {
+    let router_limits = SessionRouterLimits {
         max_startup_packets: 64,
         max_recovery_records: 8,
         max_sessions: 1,
@@ -79,8 +79,8 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
         max_buffered_records: 64,
         equation_capacity: 64,
         finite_objects: FiniteObjectLimits::new(65536, 1128, 4),
-    })
-    .unwrap();
+    };
+    let mut router = SessionRouter::<1128, 64, 64>::new(router_limits).unwrap();
     let logs = tempfile::tempdir().unwrap();
     let archive_path = logs.path().join("received.copper");
     let expected_schema = cu29_logstream::ApplicationSchema::from_output_specs(
@@ -178,21 +178,43 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
         // entirely in the test harness; the production sender remains one-way.
         let deadline = Instant::now() + Duration::from_secs(2);
         let mut source_received = false;
-        while !source_received && Instant::now() < deadline {
+        // At the late-join and outage boundaries, also wait for a fresh receiver
+        // to bootstrap. Manifest repetition is periodic, so source progress alone
+        // does not guarantee the impaired capture contains a recovery bundle.
+        let mut bootstrap = matches!(id, 64 | 96)
+            .then(|| SessionRouter::<1128, 64, 64>::new(router_limits).unwrap());
+        let mut recovery_received = bootstrap.is_none();
+        while !(source_received && recovery_received) && Instant::now() < deadline {
             if let Some(len) = rx.try_recv(&mut packet).unwrap() {
                 let header = cu29_logstream::WirePacket::decode(&packet[..len])
                     .unwrap()
                     .header;
-                source_received = header.record_kind == RecordKind::CopperList
+                source_received |= header.record_kind == RecordKind::CopperList
                     && header.symbol_kind == cu29_logstream::FecSymbolKind::Source
                     && header.object_id == id;
                 traffic.push(packet[..len].to_vec());
                 router.receive_datagram(&packet[..len], &mut emit).unwrap();
+                // The impaired capture starts at this source packet; earlier
+                // manifests must not satisfy its bootstrap requirement.
+                if source_received && let Some(bootstrap) = bootstrap.as_mut() {
+                    bootstrap
+                        .receive_datagram(&packet[..len], |event| {
+                            if let SessionEvent::VerifiedAnchor { anchor, .. } = event {
+                                recovery_received |= anchor.copperlist_id >= id;
+                            }
+                            Ok::<(), core::convert::Infallible>(())
+                        })
+                        .unwrap();
+                }
             } else {
                 std::thread::sleep(Duration::from_millis(1));
             }
         }
         assert!(source_received, "sender did not transmit CopperList {id}");
+        assert!(
+            recovery_received,
+            "sender did not repeat a complete recovery bundle at CopperList {id}"
+        );
     }
     drop(running.stop()?);
     let deadline = Instant::now() + Duration::from_millis(100);
@@ -325,7 +347,10 @@ fn validate_impaired_archive(
             })
             .unwrap();
     }
-    archive.unwrap().finish().unwrap();
+    archive
+        .expect("impaired capture must include a decodable session manifest")
+        .finish()
+        .unwrap();
     let lists: Vec<_> =
         cu29_export::copperlists_reader::<default::CuStampedDataSet>(UnifiedLoggerIOReader::new(
             UnifiedLoggerRead::new(path).unwrap(),

--- a/core/cu29_logstream/Cargo.toml
+++ b/core/cu29_logstream/Cargo.toml
@@ -18,6 +18,8 @@ domains = ["logging/streaming"]
 environments = ["host", "embedded"]
 
 [dependencies]
+atomic-waker = { version = "1.1", optional = true }
+crossbeam-queue = { version = "0.3", optional = true }
 bincode = { workspace = true }
 blake3 = { workspace = true }
 crc = { workspace = true }
@@ -41,6 +43,8 @@ serde = { workspace = true }
 [features]
 default = ["std"]
 std = [
+  "dep:atomic-waker",
+  "dep:crossbeam-queue",
   "dep:cu29-log-derive",
   "dep:cu29-log",
   "cu29-log/std",

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -61,6 +61,46 @@ Run `just logstream-receiver-check` from the repository root to test reception,
 archival, and replay continuity. See the Rust API docs for receiver limits and
 event handling.
 
+## Ground-side telemetry
+
+The std-only `telemetry` module provides a single-publisher, single-reader
+circular buffer with overwrite-oldest behavior. Feed it the typed value returned
+after `NativeArchive::accept()` succeeds; do not decode again or clone payloads.
+The transport and archive remain owned by the receiving worker.
+
+```rust,ignore
+let (mut publisher, mut reader) = telemetry_channel(capacity, initial_status);
+// Receiving worker, after successful archival:
+publisher.publish(frame); // Include the frame's session identity in its type.
+publisher.set_status(current_status);
+
+// User-owned thread/task:
+reader.ready().await; // Or wait_timeout(duration) / register_waker(&waker).
+let status = reader.status();
+while let Some(update) = reader.try_read() {
+    my_widgets.consume(update.frame, update.missed);
+}
+```
+
+Status uses an independent coalesced slot and a small `Copy` value. Reading it
+does not consume frames. Notifications cover unread frames, changed status, and
+publisher closure; consume/acknowledge these before waiting again. A registered
+waker only schedules work or unparks a thread, never blocks or processes data.
+
+The ring allocates at construction and holds at most its capacity plus one
+reader-owned in-flight frame. A borrowed frame stays valid while publication
+continues. Payload-owned allocations are additional. Crossbeam queue operations
+use atomics and never wait for user processing or free capacity; this host
+exchange is not an RT wait-free primitive. Consumer loss is independent of
+network/archive gaps. A disconnected reader cannot backpressure recording.
+Both still share a process failure boundary.
+
+The [Ratatui demo](../../examples/cu_logstream_demo#native-telemetry-screen)
+shows typed robot outputs and a pause control. Live deterministic task
+reconstruction and generated mission dispatch are subsequent steps; displaying
+captured payloads alone does not recover task state. Run
+`just logstream-telemetry-check` for the integration and regression checks.
+
 ## Sender storage and lifecycle
 
 `scheduled_sinks` creates one worker owning the transport and FEC state, a pool

--- a/core/cu29_logstream/src/lib.rs
+++ b/core/cu29_logstream/src/lib.rs
@@ -15,6 +15,10 @@ mod archive;
 #[cfg(feature = "std")]
 pub use archive::NativeArchive;
 
+/// Bounded ground-side delivery to caller-owned telemetry consumers.
+#[cfg(feature = "std")]
+pub mod telemetry;
+
 mod copper;
 mod error;
 mod manifest;

--- a/core/cu29_logstream/src/telemetry.rs
+++ b/core/cu29_logstream/src/telemetry.rs
@@ -1,0 +1,251 @@
+//! Pull-based delivery after native archival, independent of UI processing.
+//!
+//! One publisher owns reception; one reader owns consumption. Unread frames are
+//! overwritten oldest first. Status is coalesced separately, so a paused reader
+//! can still inspect recording health. This host-only exchange adds no robot
+//! task-path work. Publish only after a successful `NativeArchive::accept`.
+//!
+//! Storage is allocated at construction: a ring, a status slot, and one reader
+//! frame. Frames move without cloning. Payload-owned allocations and user-owned
+//! projections are outside this bound. Queue operations use Crossbeam atomics;
+//! they do not wait for capacity or for user processing, but are not an RT
+//! wait-free primitive. Frame destructors and registered wakers must not block.
+
+use atomic_waker::AtomicWaker;
+use crossbeam_queue::ArrayQueue;
+use std::{
+    future::poll_fn,
+    num::NonZeroUsize,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    task::{Poll, Wake, Waker},
+    thread::{self, Thread, ThreadId},
+    time::{Duration, Instant},
+};
+
+struct Sequenced<T> {
+    sequence: u64,
+    frame: T,
+}
+
+struct Shared<T, S> {
+    frames: ArrayQueue<Sequenced<T>>,
+    status: ArrayQueue<S>,
+    waker: AtomicWaker,
+    closed: AtomicBool,
+    connected: AtomicBool,
+    overwritten: AtomicU64,
+}
+
+/// The sole producer of archived frames and current receiver status.
+pub struct TelemetryPublisher<T, S> {
+    shared: Arc<Shared<T, S>>,
+    next_sequence: u64,
+    status: S,
+}
+
+/// A single consumer cursor. User code chooses when to read and what to retain.
+pub struct TelemetryReader<T, S> {
+    shared: Arc<Shared<T, S>>,
+    next_sequence: u64,
+    current: Option<Sequenced<T>>,
+    status: S,
+    thread_waker: Option<(ThreadId, Waker)>,
+}
+
+/// A stable borrow of one frame, valid until the next mutable reader operation.
+///
+/// Holding this borrow never pins a ring slot or prevents overwrite. `missed`
+/// counts locally overwritten unread frames, not missing source CopperLists.
+pub struct TelemetryRead<'a, T> {
+    pub frame: &'a T,
+    pub missed: u64,
+}
+
+/// Creates a preallocated circular delivery buffer and independent status slot.
+///
+/// The publisher and reader are deliberately not cloneable. Use `T` for your
+/// typed frame (including its session identity) and a small `Copy` type for
+/// receiver status. An initial status notification is available immediately.
+pub fn telemetry_channel<T, S: Copy + PartialEq>(
+    capacity: NonZeroUsize,
+    status: S,
+) -> (TelemetryPublisher<T, S>, TelemetryReader<T, S>) {
+    let shared = Arc::new(Shared {
+        frames: ArrayQueue::new(capacity.get()),
+        status: ArrayQueue::new(1),
+        waker: AtomicWaker::new(),
+        closed: AtomicBool::new(false),
+        connected: AtomicBool::new(true),
+        overwritten: AtomicU64::new(0),
+    });
+    shared.status.force_push(status);
+    (
+        TelemetryPublisher {
+            shared: shared.clone(),
+            next_sequence: 0,
+            status,
+        },
+        TelemetryReader {
+            shared,
+            next_sequence: 0,
+            current: None,
+            status,
+            thread_waker: None,
+        },
+    )
+}
+
+impl<T, S: Copy + PartialEq> TelemetryPublisher<T, S> {
+    /// Moves an already archived frame into the ring. A full ring replaces its
+    /// oldest unread frame. A disconnected reader causes immediate discard.
+    pub fn publish(&mut self, frame: T) {
+        if !self.is_connected() {
+            return;
+        }
+        let entry = Sequenced {
+            sequence: self.next_sequence,
+            frame,
+        };
+        self.next_sequence = self.next_sequence.wrapping_add(1);
+        if self.shared.frames.force_push(entry).is_some() {
+            self.shared.overwritten.fetch_add(1, Ordering::Relaxed);
+        }
+        self.shared.waker.wake();
+    }
+
+    /// Replaces current status and notifies even when no frame is arriving.
+    pub fn set_status(&mut self, status: S) {
+        if self.status != status {
+            self.status = status;
+            self.shared.status.force_push(status);
+            self.shared.waker.wake();
+        }
+    }
+
+    pub fn status(&self) -> S {
+        self.status
+    }
+
+    pub fn is_connected(&self) -> bool {
+        self.shared.connected.load(Ordering::Acquire)
+    }
+
+    /// Cumulative presentation loss; independent of source/archive gaps.
+    pub fn overwritten(&self) -> u64 {
+        self.shared.overwritten.load(Ordering::Relaxed)
+    }
+}
+
+impl<T, S> Drop for TelemetryPublisher<T, S> {
+    fn drop(&mut self) {
+        self.shared.closed.store(true, Ordering::Release);
+        self.shared.waker.wake();
+    }
+}
+
+impl<T, S: Copy> TelemetryReader<T, S> {
+    /// Pulls the oldest retained frame without waiting. At most one borrowed
+    /// frame can be held through this reader. Frame sequence wraps modulo u64;
+    /// fewer than 2^64 publications may separate consecutive reads.
+    pub fn try_read(&mut self) -> Option<TelemetryRead<'_, T>> {
+        let entry = self.shared.frames.pop()?;
+        let missed = entry.sequence.wrapping_sub(self.next_sequence);
+        self.next_sequence = entry.sequence.wrapping_add(1);
+        self.current = Some(entry);
+        Some(TelemetryRead {
+            frame: &self.current.as_ref().unwrap().frame,
+            missed,
+        })
+    }
+
+    /// Observes/acknowledges coalesced current status independently of frames.
+    /// A buffered frame may belong to an older session than this status.
+    pub fn status(&mut self) -> S {
+        if let Some(status) = self.shared.status.pop() {
+            self.status = status;
+        }
+        self.status
+    }
+
+    /// True after publisher shutdown; any retained frames can still be read.
+    pub fn is_closed(&self) -> bool {
+        self.shared.closed.load(Ordering::Acquire)
+    }
+
+    pub fn overwritten(&self) -> u64 {
+        self.shared.overwritten.load(Ordering::Relaxed)
+    }
+
+    fn is_ready(&self) -> bool {
+        !self.shared.frames.is_empty() || !self.shared.status.is_empty() || self.is_closed()
+    }
+
+    /// Registers a one-shot payload-free wake. Re-arm before checking data and
+    /// status. The waker must only schedule/unpark, never process user data.
+    /// The post-registration readiness check prevents lost wakeups.
+    pub fn register_waker(&self, waker: &Waker) {
+        self.shared.waker.register(waker);
+        if self.is_ready() {
+            self.shared.waker.wake();
+        }
+    }
+
+    /// Waits asynchronously for unread data, changed status, or closure. This
+    /// is level-triggered: drain data and observe status before waiting again.
+    pub async fn ready(&mut self) {
+        poll_fn(|cx| {
+            self.register_waker(cx.waker());
+            if self.is_ready() {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })
+        .await;
+    }
+
+    /// Synchronous counterpart of `ready`, with a timeout for UI/input timers.
+    /// Returns false only on timeout. The first call on a thread allocates its
+    /// reusable thread waker; publication itself never allocates a notification.
+    pub fn wait_timeout(&mut self, timeout: Duration) -> bool {
+        let current = thread::current();
+        if self.thread_waker.as_ref().map(|(id, _)| *id) != Some(current.id()) {
+            self.thread_waker = Some((current.id(), Waker::from(Arc::new(ThreadWake(current)))));
+        }
+        let waker = &self.thread_waker.as_ref().unwrap().1;
+        let start = Instant::now();
+        loop {
+            self.register_waker(waker);
+            if self.is_ready() {
+                return true;
+            }
+            let remaining = timeout.saturating_sub(start.elapsed());
+            if remaining.is_zero() {
+                return false;
+            }
+            thread::park_timeout(remaining);
+        }
+    }
+}
+
+impl<T, S> Drop for TelemetryReader<T, S> {
+    fn drop(&mut self) {
+        self.shared.connected.store(false, Ordering::Release);
+        self.shared.waker.take();
+    }
+}
+
+struct ThreadWake(Thread);
+
+impl Wake for ThreadWake {
+    fn wake(self: Arc<Self>) {
+        self.0.unpark();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.0.unpark();
+    }
+}

--- a/core/cu29_logstream/tests/telemetry.rs
+++ b/core/cu29_logstream/tests/telemetry.rs
@@ -1,0 +1,142 @@
+#![cfg(feature = "std")]
+
+use cu29_logstream::telemetry::telemetry_channel;
+use std::{
+    future::Future,
+    pin::pin,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    task::{Context, Poll, Wake, Waker},
+    thread,
+    time::Duration,
+};
+
+#[test]
+fn overwrite_reports_local_loss_and_preserves_the_oldest_retained_frame() {
+    let (mut publisher, mut reader) = telemetry_channel(3.try_into().unwrap(), 0);
+    // Source IDs have a gap and restart; they are not the delivery sequence.
+    for source_id in [100, 105, 0, 1, 2] {
+        publisher.publish(source_id);
+    }
+    let read = reader.try_read().unwrap();
+    assert_eq!((*read.frame, read.missed), (0, 2));
+    assert_eq!(*reader.try_read().unwrap().frame, 1);
+    assert_eq!(*reader.try_read().unwrap().frame, 2);
+    assert!(reader.try_read().is_none());
+    assert_eq!(reader.overwritten(), 2);
+}
+
+#[test]
+fn borrowed_frame_survives_producer_overwrite_on_another_thread() {
+    let (mut publisher, mut reader) = telemetry_channel(1.try_into().unwrap(), 0);
+    publisher.publish(String::from("borrowed"));
+    let read = reader.try_read().unwrap();
+    thread::spawn(move || {
+        for _ in 0..1000 {
+            publisher.publish(String::from("new"));
+        }
+        publisher.set_status(7);
+    })
+    .join()
+    .unwrap();
+    assert_eq!(read.frame, "borrowed");
+    let read = reader.try_read().unwrap();
+    assert_eq!(read.frame, "new");
+    assert_eq!(read.missed, 999);
+    assert_eq!(reader.status(), 7);
+    assert!(reader.is_closed());
+}
+
+#[test]
+fn paused_reader_can_observe_status_without_consuming_frames() {
+    let (mut publisher, mut reader) = telemetry_channel(2.try_into().unwrap(), 0);
+    reader.status();
+    assert!(!reader.wait_timeout(Duration::ZERO));
+    for i in 0..8 {
+        publisher.publish(i);
+        publisher.set_status(i);
+    }
+    assert_eq!(reader.status(), 7);
+    assert_eq!(reader.try_read().unwrap().missed, 6);
+    assert_eq!(reader.status(), 7);
+}
+
+#[derive(Default)]
+struct WakeCount(AtomicUsize);
+impl Wake for WakeCount {
+    fn wake(self: Arc<Self>) {
+        self.0.fetch_add(1, Ordering::Relaxed);
+    }
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.0.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[test]
+fn readiness_handles_preexisting_data_status_closure_and_cancelled_waits() {
+    let (mut publisher, mut reader) = telemetry_channel(2.try_into().unwrap(), 0);
+    let count = Arc::new(WakeCount::default());
+    let waker = Waker::from(count.clone());
+    let mut cx = Context::from_waker(&waker);
+    reader.status();
+    {
+        let mut ready = pin!(reader.ready());
+        assert_eq!(ready.as_mut().poll(&mut cx), Poll::Pending);
+        publisher.set_status(1);
+        assert!(count.0.load(Ordering::Relaxed) > 0);
+        assert_eq!(ready.as_mut().poll(&mut cx), Poll::Ready(()));
+    }
+    assert_eq!(reader.status(), 1);
+    {
+        let mut cancelled = pin!(reader.ready());
+        assert_eq!(cancelled.as_mut().poll(&mut cx), Poll::Pending);
+    }
+    publisher.publish(42);
+    assert_eq!(pin!(reader.ready()).as_mut().poll(&mut cx), Poll::Ready(()));
+    assert_eq!(*reader.try_read().unwrap().frame, 42);
+    drop(publisher);
+    assert!(reader.wait_timeout(Duration::ZERO));
+    assert!(reader.is_closed());
+    assert!(reader.try_read().is_none());
+}
+
+#[test]
+fn no_wakeup_is_lost_when_registration_races_publication() {
+    let (mut publisher, mut reader) = telemetry_channel(1.try_into().unwrap(), 0);
+    reader.status();
+    let producer = thread::spawn(move || {
+        for i in 0..100_000 {
+            publisher.publish(i);
+        }
+    });
+    let mut total = 0;
+    loop {
+        assert!(reader.wait_timeout(Duration::from_secs(5)));
+        while let Some(read) = reader.try_read() {
+            total += read.missed + 1;
+        }
+        if reader.is_closed() {
+            // Closure can race the last empty read. Drain again after Acquire.
+            while let Some(read) = reader.try_read() {
+                total += read.missed + 1;
+            }
+            break;
+        }
+    }
+    producer.join().unwrap();
+    assert_eq!(total, 100_000);
+}
+
+#[test]
+fn disconnect_discards_without_growing_or_blocking() {
+    let (mut publisher, reader) = telemetry_channel(2.try_into().unwrap(), 0);
+    publisher.publish(1);
+    drop(reader);
+    assert!(!publisher.is_connected());
+    for i in 0..100_000 {
+        publisher.publish(i);
+    }
+    assert_eq!(publisher.overwritten(), 0);
+}

--- a/examples/cu_logstream_demo/Cargo.toml
+++ b/examples/cu_logstream_demo/Cargo.toml
@@ -13,6 +13,7 @@ default = []
 # Keep async runtime features out of ordinary workspace builds.
 demo = ["cu29/logstream", "cu29/reflect"]
 replay = ["demo", "cu29/remote-debug"]
+tui = ["demo", "dep:ratatui"]
 
 [[bin]]
 name = "cu-logstream-demo"
@@ -37,6 +38,10 @@ cu29-export = { workspace = true }
 cu29-unifiedlog = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true }
+ratatui = { version = "0.30", optional = true }
 
 [build-dependencies]
 cu29-build = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/examples/cu_logstream_demo/README.md
+++ b/examples/cu_logstream_demo/README.md
@@ -26,16 +26,17 @@ example's `logs/` and prints its path.
 | `clean` | All 256 CopperLists match the onboard payloads and metadata. |
 | `loss` | Discard the source packets for CopperList 20; RLC repairs recover it with no semantic gap. |
 | `outage` | Discard a contiguous arrival interval beginning at CopperList 32 and ending before 160, including control traffic. Missing history remains explicit and a verified anchor enables recovery. |
-| `late` | Start the receiver after the sender is already running. Its archive contains a `LateJoin` prefix gap. |
+| `late` | A separate probe receiver archives through CopperList 64 and exits; a fresh receiver then starts with no prior session state. Its archive contains a `LateJoin` prefix gap. |
 | `idle` | Drop all traffic for the first 300 ms, produce only CL0, and keep the sender alive with no new captures. Periodic recovery restores the complete one-record archive. |
 | `restart` | Close the first receiver after CopperList 64, leave it offline briefly, and launch a new process while the sender continues. The new archive reports unavailable history. |
 
 Loss injection runs at the receiver's packet boundary after real UDP reception,
 before FEC decoding. It preserves arrival order and adds no sender task work.
 The source-loss and outage intervals are selected by wire record IDs. Late start
-and restart use real process lifetimes, so their exact recovery IDs depend on
-host scheduling. Verification checks the resulting continuity rather than
-assuming those IDs.
+and restart use real process lifetimes. Late start waits for observed stream
+progress instead of a launch-time sleep, which could join while CopperList 0
+is still recoverable from retained history. Exact recovery IDs still depend on
+host scheduling; verification checks the resulting continuity.
 
 The headless status display reports received packets, the latest archived
 CopperList, latest verified anchor, gap count, and demo packet drops. Received

--- a/examples/cu_logstream_demo/README.md
+++ b/examples/cu_logstream_demo/README.md
@@ -37,9 +37,43 @@ and restart use real process lifetimes, so their exact recovery IDs depend on
 host scheduling. Verification checks the resulting continuity rather than
 assuming those IDs.
 
-The status display reports received packets, the latest archived CopperList,
-latest verified anchor, gap count, and demo packet drops. Task data stays in the
-native log. Received files have separate paths for each receiver lifetime.
+The headless status display reports received packets, the latest archived
+CopperList, latest verified anchor, gap count, and demo packet drops. Received
+files have separate paths for each receiver lifetime.
+
+## Native telemetry screen
+
+From this directory, start `just dashboard`, then `just sender` in another
+terminal. The manual sender runs for about a minute; automated scenarios keep
+256 iterations. Choose fresh log paths when repeating a run:
+
+```sh
+just dashboard 127.0.0.1:7447 logs/dashboard-2.copper
+# In another terminal:
+just sender 127.0.0.1:7447 logs/sender-2.copper
+```
+
+The Ratatui screen shows counter/sum values, a counter chart, packet and frame
+age, archive progress, verified anchors, source gap ranges, and reader overwrites.
+**Space** pauses consumption; wait a second and resume to see missed samples
+while the archive count keeps advancing. **q**, Escape, or Ctrl-C closes the
+receiver and finalizes its archive. The sender is a separate process. After the
+sender finishes, the screen remains open until you quit.
+
+The receiver moves the already decoded, successfully archived CopperList into a
+64-frame circular buffer. The UI pulls on its own thread through
+`cu29_logstream::telemetry::telemetry_channel`. It waits for a payload-free wake
+with a 50 ms keyboard/age timer; no UI callback runs on the receiving thread.
+On overrun it resumes at the oldest retained frame with an exact local missed
+count. Source gaps and reader misses are distinct. Status stays available while
+the UI is paused. The UI owns its bounded chart history and uses generated
+`get_counter_output()` / `get_sum_output()` accessors.
+
+This step displays captured outputs; it does **not** yet execute a live
+Copper runtime on the ground to deterministically reconstruct omitted outputs
+or task state. That next step must feed this same archive/pull boundary after
+keyframe restore, ordered execution, and verification. This demo has one mission;
+numeric mission dispatch remains a separate protocol/codegen milestone.
 
 ## Run the processes yourself
 
@@ -58,7 +92,8 @@ just receiver 127.0.0.1:7447 logs/received-2.copper
 just sender 127.0.0.1:7447 logs/sender-2.copper
 ```
 
-The sender runs 256 iterations at roughly 100 Hz. The receiver exits after one
+The manual sender runs 6000 iterations at roughly 100 Hz; the final `just sender`
+argument selects another count. The receiver exits after one
 second without a datagram, or fails if no traffic arrives within 15 seconds.
 Socket addresses are explicit CLI arguments; stream policy and static sender
 resource binding are in `copperconfig.ron`.
@@ -105,6 +140,10 @@ buffer budget excludes thread stacks, channel/allocator bookkeeping, and bounded
 RaptorQ scratch allocations; see the [sender docs](../../core/cu29_logstream).
 Memory-bounded recovery cannot recover expired history, and receiver shutdown
 does not establish the sender's unobserved tail. Full-capture native archival
-requires the matching application schema. Feedback, hybrid reconstruction, the
-live twin API, and serial are later milestones. Feedback interfaces permit a
-shared bidirectional carrier or separate explicitly configured endpoints.
+requires the matching application schema. Feedback, live deterministic
+reconstruction, mission dispatch, and serial are later
+milestones. The host telemetry buffer and optional `tui` feature are available
+now. Run `just logstream-telemetry-check` at the root for notification/overrun
+tests, archive comparisons with fast/stalled/disconnected readers, terminal
+rendering, and all existing loss/recovery/replay scenarios. Feedback interfaces
+permit a shared bidirectional carrier or separate explicitly configured endpoints.

--- a/examples/cu_logstream_demo/justfile
+++ b/examples/cu_logstream_demo/justfile
@@ -6,6 +6,13 @@ default: (run "clean")
 build:
     cargo +stable build -p cu-logstream-demo --features replay --bins
 
+build-tui:
+    cargo +stable build -p cu-logstream-demo --features tui --bin cu-logstream-demo
+
+# Start this first, then `just sender` in another terminal. Space pauses only the view.
+dashboard listen="127.0.0.1:7447" log="logs/dashboard.copper": build-tui
+    {{root}}/target/debug/cu-logstream-demo dashboard --listen {{listen}} --log-base {{log}}
+
 # Scenarios: clean, loss, outage, late, restart, idle, all.
 run scenario="clean": build
     python3 run.py {{scenario}} --binary {{root}}/target/debug/cu-logstream-demo
@@ -13,8 +20,8 @@ run scenario="clean": build
 check: (run "all")
 
 # Start these in separate terminals, choosing fresh output paths for each run.
-sender remote="127.0.0.1:7447" log="logs/sender.copper": build
-    {{root}}/target/debug/cu-logstream-demo sender --remote {{remote}} --log-base {{log}}
+sender remote="127.0.0.1:7447" log="logs/sender.copper" iterations="6000": build
+    {{root}}/target/debug/cu-logstream-demo sender --remote {{remote}} --log-base {{log}} --iterations {{iterations}}
 
 receiver listen="127.0.0.1:7447" log="logs/received.copper": build
     {{root}}/target/debug/cu-logstream-demo receiver --listen {{listen}} --log-base {{log}}

--- a/examples/cu_logstream_demo/run.py
+++ b/examples/cu_logstream_demo/run.py
@@ -51,13 +51,15 @@ def run(binary, scenario):
             sender = spawn("sender", "--remote", address, "--log-base", directory / "sender.copper",
                            "--iterations", "1", "--idle-ms", "1000")
         elif scenario == "late":
-            # Reserve an endpoint using the actual receiver, then close it before
-            # starting the sender. This receiver receives no data or manifest.
-            initial, address = receiver("reservation")
-            initial.terminate()
-            initial.wait(timeout=5)
+            # Observe a real prefix with a separate receiver. A launch-time sleep
+            # can join while CL0 is still retained and recover it, so it does not
+            # establish the missing history required by this scenario.
+            initial, address = receiver("reservation", stop=True)
             sender = spawn("sender", "--remote", address, "--log-base", directory / "sender.copper")
-            time.sleep(0.6)
+            wait(initial)
+            if sender.poll() is not None:
+                raise RuntimeError("Sender finished before late receiver startup")
+            # This fresh process gets no archive or decoder state from the probe.
             ground, _ = receiver("received", address)
         else:
             ground, address = receiver("received", impairment=scenario if scenario in ("loss", "outage") else "clean",

--- a/examples/cu_logstream_demo/src/dashboard.rs
+++ b/examples/cu_logstream_demo/src/dashboard.rs
@@ -1,0 +1,293 @@
+//! A caller-owned UI: the receiver only publishes frames and wakes the reader.
+use crate::{
+    Result,
+    receiver::{self, ReceiverOptions},
+};
+use cu_logstream_demo::telemetry::{Frame, RecordingState, Status};
+use cu29_logstream::telemetry::{TelemetryReader, telemetry_channel};
+use ratatui::{
+    crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
+    layout::{Constraint, Layout},
+    style::{Color, Style},
+    text::Line,
+    widgets::{Block, Paragraph, Sparkline},
+};
+use std::{
+    collections::VecDeque,
+    io::IsTerminal,
+    sync::atomic::{AtomicBool, Ordering},
+    thread,
+    time::{Duration, Instant},
+};
+
+const BUFFER_CAPACITY: usize = 64;
+const CHART_CAPACITY: usize = 120;
+const UI_TICK: Duration = Duration::from_millis(50);
+
+#[derive(Default)]
+struct View {
+    paused: bool,
+    counter: Option<u64>,
+    sum: Option<u64>,
+    displayed: Option<u64>,
+    missed: u64,
+    frame_age: Option<Instant>,
+    session: Option<cu29_logstream::StreamIdentity>,
+    history: VecDeque<u64>,
+}
+
+impl View {
+    fn consume(&mut self, reader: &mut TelemetryReader<Frame, Status>) {
+        if self.paused {
+            return;
+        }
+        // Bound work per redraw even while the publisher is active.
+        for _ in 0..BUFFER_CAPACITY {
+            let Some(update) = reader.try_read() else {
+                break;
+            };
+            let frame = update.frame;
+            self.missed += update.missed;
+            if self.session != Some(frame.identity) {
+                self.history.clear();
+                self.session = Some(frame.identity);
+            }
+            self.displayed = Some(frame.copperlist.id);
+            self.frame_age = Some(frame.received_at);
+            self.counter = frame
+                .copperlist
+                .msgs
+                .get_counter_output()
+                .payload()
+                .map(|sample| sample.0);
+            self.sum = frame
+                .copperlist
+                .msgs
+                .get_sum_output()
+                .payload()
+                .map(|sample| sample.0);
+            // This history policy belongs to this widget, not the backend.
+            if let Some(counter) = self.counter {
+                if self.history.len() == CHART_CAPACITY {
+                    self.history.pop_front();
+                }
+                self.history.push_back(counter);
+            }
+        }
+    }
+
+    fn draw(&self, frame: &mut ratatui::Frame<'_>, status: Status, overwritten: u64, path: &str) {
+        if frame.area().height < 20 || frame.area().width < 50 {
+            frame.render_widget(Paragraph::new(format!(
+                "{}\nCounter: {}   Sum: {}\nArchived: {}   Gaps: {}\nUI missed: {}\nSpace: pause/resume   q: quit",
+                if self.paused { "VIEW PAUSED" } else { "LIVE VIEW" },
+                number(self.counter), number(self.sum), status.archived, status.gaps, self.missed,
+            )), frame.area());
+            return;
+        }
+        let [header, values, chart, health, footer] = Layout::vertical([
+            Constraint::Length(3),
+            Constraint::Length(4),
+            Constraint::Min(3),
+            Constraint::Length(7),
+            Constraint::Length(3),
+        ])
+        .areas(frame.area());
+        let recording = match status.state {
+            RecordingState::Waiting => "Waiting for robot",
+            RecordingState::Recording => "Recording",
+            RecordingState::Closed => "Archive closed",
+            RecordingState::Failed => "RECEIVER ERROR",
+        };
+        frame.render_widget(
+            Paragraph::new(format!(
+                "{recording}  |  {}",
+                if self.paused {
+                    "VIEW PAUSED"
+                } else {
+                    "LIVE VIEW"
+                }
+            ))
+            .block(Block::bordered().title("Copper · UDP ground station"))
+            .style(Style::default().fg(if self.paused {
+                Color::Yellow
+            } else {
+                Color::Cyan
+            })),
+            header,
+        );
+        frame.render_widget(
+            Paragraph::new(format!(
+                "Counter: {}     Sum: {}\nDisplayed CopperList: {}     Frame age: {}",
+                number(self.counter),
+                number(self.sum),
+                number(self.displayed),
+                age(self.frame_age)
+            ))
+            .block(Block::bordered().title("Typed robot outputs")),
+            values,
+        );
+        let history: Vec<_> = self.history.iter().copied().collect();
+        frame.render_widget(
+            Sparkline::default()
+                .data(&history)
+                .block(Block::bordered().title("Counter · last 120 consumed samples"))
+                .style(Style::default().fg(Color::Green)),
+            chart,
+        );
+        frame.render_widget(
+            Paragraph::new(vec![
+                Line::from(format!(
+                    "Packets: {}    Last packet: {}",
+                    status.packets,
+                    age(status.last_packet)
+                )),
+                Line::from(format!(
+                    "Archived: {}    Latest CL: {}    Verified anchor: {}",
+                    status.archived,
+                    number(status.latest),
+                    number(status.anchor)
+                )),
+                Line::from(format!(
+                    "Source gap ranges: {}    Demo packet drops: {}",
+                    status.gaps, status.dropped
+                )),
+                Line::from(format!(
+                    "UI missed: {}    Buffer overwrites: {}    Capacity: {BUFFER_CAPACITY}",
+                    self.missed, overwritten
+                )),
+                Line::from(format!("Archive: {path}")),
+            ])
+            .block(Block::bordered().title("Recording continues while the view is paused")),
+            health,
+        );
+        frame.render_widget(Paragraph::new("Space: pause/resume view   q: close receiver\nReceived history may have gaps; an unobserved sender tail is unknown.")
+            .block(Block::bordered()), footer);
+    }
+}
+
+fn number(value: Option<u64>) -> String {
+    value.map_or_else(|| "—".into(), |v| v.to_string())
+}
+fn age(value: Option<Instant>) -> String {
+    value.map_or_else(
+        || "—".into(),
+        |v| format!("{:.1}s", v.elapsed().as_secs_f32()),
+    )
+}
+
+pub fn run(options: ReceiverOptions) -> Result<()> {
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        return Err(
+            "Dashboard needs a terminal; use the receiver command for headless recording".into(),
+        );
+    }
+    let (mut publisher, mut reader) =
+        telemetry_channel(BUFFER_CAPACITY.try_into().unwrap(), Status::default());
+    let stop = AtomicBool::new(false);
+    thread::scope(|scope| -> Result<()> {
+        let worker = scope.spawn(|| {
+            let result = receiver::run(&options, Some(&mut publisher), &stop)
+                .map_err(|error| error.to_string());
+            if result.is_err() {
+                let mut status = publisher.status();
+                status.state = RecordingState::Failed;
+                publisher.set_status(status);
+            }
+            // Closure wakes the UI even if no CopperList was ever received.
+            drop(publisher);
+            result
+        });
+        let ui_result: std::io::Result<()> = ratatui::run(|terminal| {
+            let mut view = View {
+                history: VecDeque::with_capacity(CHART_CAPACITY),
+                ..Default::default()
+            };
+            let mut redraw = Instant::now();
+            loop {
+                // Paused/closed views only service keyboard/age timers. Live views
+                // wait for backend notification, with the same keyboard deadline.
+                if view.paused || reader.is_closed() {
+                    event::poll(UI_TICK)?;
+                } else {
+                    reader.wait_timeout(UI_TICK);
+                }
+                while event::poll(Duration::ZERO)? {
+                    if let Event::Key(key) = event::read()?
+                        && key.kind == KeyEventKind::Press
+                    {
+                        match key.code {
+                            KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                                return Ok(());
+                            }
+                            KeyCode::Char(' ') => {
+                                view.paused = !view.paused;
+                                redraw = Instant::now();
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                view.consume(&mut reader);
+                let status = reader.status();
+                if Instant::now() >= redraw {
+                    terminal.draw(|frame| {
+                        view.draw(
+                            frame,
+                            status,
+                            reader.overwritten(),
+                            &options.log_base.display().to_string(),
+                        )
+                    })?;
+                    redraw = Instant::now() + UI_TICK;
+                }
+                if reader.is_closed() && status.state == RecordingState::Failed {
+                    return Ok(());
+                }
+            }
+        });
+        stop.store(true, Ordering::Release);
+        let receiver_result = worker.join().map_err(|_| "Receiver thread panicked")?;
+        ui_result?;
+        receiver_result.map_err(Into::into)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{Terminal, backend::TestBackend};
+
+    #[test]
+    fn pause_and_recording_status_are_visible_even_on_small_terminals() {
+        for (width, height) in [(100, 26), (30, 8)] {
+            let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+            let view = View {
+                paused: true,
+                missed: 73,
+                ..Default::default()
+            };
+            let status = Status {
+                state: RecordingState::Recording,
+                archived: 200,
+                ..Default::default()
+            };
+            terminal
+                .draw(|frame| view.draw(frame, status, 73, "logs/test.copper"))
+                .unwrap();
+            let screen: String = terminal
+                .backend()
+                .buffer()
+                .content
+                .iter()
+                .map(|cell| cell.symbol())
+                .collect();
+            assert!(screen.contains("VIEW PAUSED"));
+            if width == 100 {
+                assert!(screen.contains("Archived: 200"));
+                assert!(screen.contains("UI missed: 73"));
+            }
+        }
+    }
+}

--- a/examples/cu_logstream_demo/src/lib.rs
+++ b/examples/cu_logstream_demo/src/lib.rs
@@ -2,6 +2,7 @@
 
 extern crate self as cu_logstream_demo;
 pub mod tasks;
+pub mod telemetry;
 
 use cu29::prelude::*;
 

--- a/examples/cu_logstream_demo/src/main.rs
+++ b/examples/cu_logstream_demo/src/main.rs
@@ -1,20 +1,17 @@
+#[cfg(feature = "tui")]
+mod dashboard;
+mod receiver;
+
 use clap::{Parser, Subcommand, ValueEnum};
-use cu_logstream_demo::{DataSet, ITERATIONS, SLAB_BYTES, read_lists, tasks::Sample};
+use cu_logstream_demo::{ITERATIONS, read_lists, tasks::Sample};
 use cu29::bincode;
 use cu29::continuity::{SourceGapReason, StreamContinuityRecord};
 use cu29::prelude::*;
-use cu29_logstream::{
-    CuStreamRx, FecSymbolKind, FiniteObjectLimits, NativeArchive, RecordKind, SessionEvent,
-    SessionRouter, SessionRouterLimits, WirePacket,
-};
-use cu29_logstream_udp::CuUdpLogStreamConfig;
 use std::{
     error::Error,
     fs,
     net::SocketAddr,
     path::{Path, PathBuf},
-    thread,
-    time::{Duration, Instant},
 };
 
 type Result<T> = std::result::Result<T, Box<dyn Error>>;
@@ -39,23 +36,10 @@ enum Command {
         #[arg(long, default_value_t = 0)]
         idle_ms: u64,
     },
-    Receiver {
-        #[arg(long, default_value = "127.0.0.1:7447")]
-        listen: SocketAddr,
-        #[arg(long)]
-        log_base: PathBuf,
-        /// Write the bound endpoint after socket setup (used by the demo launcher).
-        #[arg(long)]
-        ready_file: Option<PathBuf>,
-        #[arg(long, value_enum, default_value_t = Impairment::Clean)]
-        impairment: Impairment,
-        /// Stop this receiver after archiving this CopperList, for the restart scenario.
-        #[arg(long)]
-        stop_at: Option<u64>,
-        /// Exit after this much silence; this does not prove the sender's tail is complete.
-        #[arg(long, default_value_t = 1000, value_parser = clap::value_parser!(u64).range(1..))]
-        idle_ms: u64,
-    },
+    Receiver(receiver::ReceiverOptions),
+    /// Native telemetry screen; Space pauses only the reader, q closes recording.
+    #[cfg(feature = "tui")]
+    Dashboard(receiver::ReceiverOptions),
     Verify {
         #[arg(long)]
         sender: PathBuf,
@@ -107,155 +91,6 @@ fn sender(remote: SocketAddr, path: &Path, iterations: u64, idle_ms: u64) -> Res
         path.display()
     );
     Ok(())
-}
-
-#[derive(Default)]
-struct Status {
-    latest: Option<u64>,
-    anchor: Option<u64>,
-    gaps: usize,
-    dropped: usize,
-}
-
-fn receiver(
-    listen: SocketAddr,
-    path: &Path,
-    ready_file: Option<&Path>,
-    impairment: Impairment,
-    stop_at: Option<u64>,
-    idle_ms: u64,
-) -> Result<()> {
-    prepare_log(path)?;
-    let mut socket = CuUdpLogStreamConfig::new(listen);
-    socket.recv_buffer_bytes = Some(262144);
-    let (_, mut rx) = socket.open()?;
-    let address = rx.local_addr()?;
-    let mut router = SessionRouter::<1128, 64, 64>::new(SessionRouterLimits {
-        max_sessions: 1,
-        max_startup_packets: 64,
-        max_recovery_records: 8,
-        max_pending_events: 64,
-        max_record_bytes: 4096,
-        max_buffered_records: 64,
-        equation_capacity: 64,
-        finite_objects: FiniteObjectLimits::new(65536, 1128, 4),
-    })?;
-    let mut archive: Option<NativeArchive<DataSet>> = None;
-    let mut status = Status::default();
-    if let Some(ready) = ready_file {
-        // Coordination metadata only; the native archive contains all task data.
-        use std::io::Write;
-        let mut file = fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(ready)?;
-        writeln!(file, "{address}")?;
-    }
-    println!("Receiver listening at {address}: {}", path.display());
-    let started = Instant::now();
-    let mut last_packet = started;
-    let mut last_status = started;
-    let mut seen_packet = false;
-    let mut first_packet = None;
-    let mut in_outage = false;
-    let mut packet = [0; 1200];
-    loop {
-        if let Some(len) = rx
-            .try_recv(&mut packet)
-            .map_err(|error| format!("UDP receive: {error:?}"))?
-        {
-            last_packet = Instant::now();
-            seen_packet = true;
-            let first = *first_packet.get_or_insert(last_packet);
-            // Demo-only receive-side impairment. Production sender/resource code is unchanged.
-            let wire = WirePacket::decode(&packet[..len])?;
-            let header = wire.header;
-            if header.record_kind == RecordKind::CopperList
-                && header.symbol_kind == FecSymbolKind::Source
-            {
-                in_outage = (32..160).contains(&header.object_id);
-            }
-            let discard = match impairment {
-                Impairment::Clean => false,
-                Impairment::Loss => {
-                    header.record_kind == RecordKind::CopperList
-                        && header.symbol_kind == FecSymbolKind::Source
-                        && header.object_id == 20
-                }
-                Impairment::Outage => in_outage,
-                Impairment::Bootstrap => {
-                    last_packet.duration_since(first) < Duration::from_millis(300)
-                }
-            };
-            if discard {
-                status.dropped += 1;
-                continue;
-            }
-            router
-                .receive_datagram(&packet[..len], |event| {
-                    if let SessionEvent::Manifest(manifest) = &event {
-                        println!(
-                            "Session sender={} id={:02x?}",
-                            manifest.identity.sender_id, manifest.identity.session_id
-                        );
-                        archive = Some(NativeArchive::new(
-                            path,
-                            manifest.clone(),
-                            SLAB_BYTES,
-                            65536,
-                        )?);
-                    }
-                    if let Some(writer) = archive.as_mut()
-                        && let Some(list) = writer.accept(&event)?
-                    {
-                        status.latest = Some(list.id);
-                    }
-                    match event {
-                        SessionEvent::Gap { gap, .. } => {
-                            status.gaps += 1;
-                            println!(
-                                "Missing CopperLists {}..={}: {:?}",
-                                gap.first_id, gap.last_id, gap.reason
-                            );
-                        }
-                        SessionEvent::VerifiedAnchor { anchor, .. } => {
-                            status.anchor = Some(anchor.copperlist_id)
-                        }
-                        _ => {}
-                    }
-                    Ok::<(), cu29_logstream::Error>(())
-                })
-                .map_err(|error| format!("Receiver consumer failed: {error:?}"))?;
-        } else {
-            thread::sleep(Duration::from_millis(1));
-        }
-        if last_status.elapsed() >= Duration::from_millis(500) {
-            print_status(&status, router.stats().datagrams_seen);
-            last_status = Instant::now();
-        }
-        if stop_at.is_some_and(|id| status.latest.is_some_and(|latest| latest >= id))
-            || (seen_packet && last_packet.elapsed() >= Duration::from_millis(idle_ms))
-        {
-            break;
-        }
-        if !seen_packet && started.elapsed() >= Duration::from_secs(15) {
-            return Err("No UDP traffic arrived within 15 seconds".into());
-        }
-    }
-    archive.ok_or("No session manifest received")?.finish()?;
-    print_status(&status, router.stats().datagrams_seen);
-    if !matches!(impairment, Impairment::Clean) && status.dropped == 0 {
-        return Err("Impairment scenario did not discard any packets".into());
-    }
-    println!("Archive closed at receiver's known boundary; unobserved sender tail is unknown.");
-    Ok(())
-}
-
-fn print_status(status: &Status, packets: usize) {
-    println!(
-        "packets={packets} archived={:?} verified_anchor={:?} gaps={} demo_drops={}",
-        status.latest, status.anchor, status.gaps, status.dropped
-    );
 }
 
 fn verify(sender: &Path, received: &Path, expect: Expectation, iterations: u64) -> Result<()> {
@@ -371,21 +206,9 @@ fn main() -> Result<()> {
             iterations,
             idle_ms,
         } => sender(remote, &log_base, iterations, idle_ms),
-        Command::Receiver {
-            listen,
-            log_base,
-            ready_file,
-            impairment,
-            stop_at,
-            idle_ms,
-        } => receiver(
-            listen,
-            &log_base,
-            ready_file.as_deref(),
-            impairment,
-            stop_at,
-            idle_ms,
-        ),
+        Command::Receiver(options) => receiver::run(&options, None, &Default::default()),
+        #[cfg(feature = "tui")]
+        Command::Dashboard(options) => dashboard::run(options),
         Command::Verify {
             sender,
             received,

--- a/examples/cu_logstream_demo/src/receiver.rs
+++ b/examples/cu_logstream_demo/src/receiver.rs
@@ -1,0 +1,320 @@
+use crate::{Impairment, Result, prepare_log};
+use cu_logstream_demo::{
+    DataSet, SLAB_BYTES,
+    telemetry::{Frame, Publisher, RecordingState, Status},
+};
+use cu29_logstream::{
+    CuStreamRx, FecSymbolKind, FiniteObjectLimits, NativeArchive, RecordKind, SessionEvent,
+    SessionRouter, SessionRouterLimits, WirePacket,
+};
+use cu29_logstream_udp::CuUdpLogStreamConfig;
+use std::{
+    fs,
+    net::SocketAddr,
+    path::PathBuf,
+    sync::atomic::{AtomicBool, Ordering},
+    thread,
+    time::{Duration, Instant},
+};
+
+#[derive(clap::Args)]
+pub struct ReceiverOptions {
+    #[arg(long, default_value = "127.0.0.1:7447")]
+    pub listen: SocketAddr,
+    #[arg(long)]
+    pub log_base: PathBuf,
+    /// Write the bound endpoint after socket setup (used by the demo launcher).
+    #[arg(long)]
+    pub ready_file: Option<PathBuf>,
+    #[arg(long, value_enum, default_value_t = Impairment::Clean)]
+    pub impairment: Impairment,
+    /// Stop this receiver after archiving this CopperList, for the restart scenario.
+    #[arg(long)]
+    pub stop_at: Option<u64>,
+    /// Exit after this much silence; this does not prove the sender's tail is complete.
+    #[arg(long, default_value_t = 1000, value_parser = clap::value_parser!(u64).range(1..))]
+    pub idle_ms: u64,
+}
+
+pub fn run(
+    options: &ReceiverOptions,
+    mut telemetry: Option<&mut Publisher>,
+    stop: &AtomicBool,
+) -> Result<()> {
+    let ReceiverOptions {
+        listen,
+        log_base: path,
+        ready_file,
+        impairment,
+        stop_at,
+        idle_ms,
+    } = options;
+    let quiet = telemetry.is_some();
+    prepare_log(path)?;
+    let mut socket = CuUdpLogStreamConfig::new(*listen);
+    socket.recv_buffer_bytes = Some(262144);
+    let (_, mut rx) = socket.open()?;
+    let address = rx.local_addr()?;
+    let mut router = SessionRouter::<1128, 64, 64>::new(SessionRouterLimits {
+        max_sessions: 1,
+        max_startup_packets: 64,
+        max_recovery_records: 8,
+        max_pending_events: 64,
+        max_record_bytes: 4096,
+        max_buffered_records: 64,
+        equation_capacity: 64,
+        finite_objects: FiniteObjectLimits::new(65536, 1128, 4),
+    })?;
+    let mut archive: Option<NativeArchive<DataSet>> = None;
+    let mut status = Status::default();
+    if let Some(ready) = ready_file {
+        // Coordination metadata only; the native archive contains all task data.
+        use std::io::Write;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(ready)?;
+        writeln!(file, "{address}")?;
+    }
+    if !quiet {
+        println!("Receiver listening at {address}: {}", path.display());
+    }
+    let started = Instant::now();
+    let mut last_packet = started;
+    let mut last_status = started;
+    let mut seen_packet = false;
+    let mut first_packet = None;
+    let mut in_outage = false;
+    let mut packet = [0; 1200];
+    while !stop.load(Ordering::Acquire) {
+        if let Some(len) = rx
+            .try_recv(&mut packet)
+            .map_err(|error| format!("UDP receive: {error:?}"))?
+        {
+            last_packet = Instant::now();
+            status.last_packet = Some(last_packet);
+            seen_packet = true;
+            let first = *first_packet.get_or_insert(last_packet);
+            // Demo-only receive-side impairment. Production sender/resource code is unchanged.
+            let wire = WirePacket::decode(&packet[..len])?;
+            let header = wire.header;
+            if header.record_kind == RecordKind::CopperList
+                && header.symbol_kind == FecSymbolKind::Source
+            {
+                in_outage = (32..160).contains(&header.object_id);
+            }
+            let discard = match impairment {
+                Impairment::Clean => false,
+                Impairment::Loss => {
+                    header.record_kind == RecordKind::CopperList
+                        && header.symbol_kind == FecSymbolKind::Source
+                        && header.object_id == 20
+                }
+                Impairment::Outage => in_outage,
+                Impairment::Bootstrap => {
+                    last_packet.duration_since(first) < Duration::from_millis(300)
+                }
+            };
+            if discard {
+                status.dropped += 1;
+                continue;
+            }
+            router
+                .receive_datagram(&packet[..len], |event| {
+                    if let SessionEvent::Manifest(manifest) = &event {
+                        if !quiet {
+                            println!(
+                                "Session sender={} id={:02x?}",
+                                manifest.identity.sender_id, manifest.identity.session_id
+                            );
+                        }
+                        status.identity = Some(manifest.identity);
+                        archive = Some(NativeArchive::new(
+                            path,
+                            manifest.clone(),
+                            SLAB_BYTES,
+                            65536,
+                        )?);
+                    }
+                    if let Some(writer) = archive.as_mut()
+                        && let Some(list) = writer.accept(&event)?
+                    {
+                        status.latest = Some(list.id);
+                        status.archived += 1;
+                        status.state = RecordingState::Recording;
+                        if let Some(publisher) = telemetry.as_deref_mut() {
+                            publisher.publish(Frame {
+                                identity: status.identity.expect("archived frame has a manifest"),
+                                received_at: Instant::now(),
+                                copperlist: list,
+                            });
+                        }
+                    }
+                    match event {
+                        SessionEvent::Gap { gap, .. } => {
+                            status.gaps += 1;
+                            if !quiet {
+                                println!(
+                                    "Missing CopperLists {}..={}: {:?}",
+                                    gap.first_id, gap.last_id, gap.reason
+                                );
+                            }
+                        }
+                        SessionEvent::VerifiedAnchor { anchor, .. } => {
+                            status.anchor = Some(anchor.copperlist_id)
+                        }
+                        _ => {}
+                    }
+                    Ok::<(), cu29_logstream::Error>(())
+                })
+                .map_err(|error| format!("Receiver consumer failed: {error:?}"))?;
+        } else {
+            thread::sleep(Duration::from_millis(1));
+        }
+        status.packets = router.stats().datagrams_seen;
+        if let Some(publisher) = telemetry.as_deref_mut() {
+            publisher.set_status(status);
+        }
+        if !quiet && last_status.elapsed() >= Duration::from_millis(500) {
+            print_status(&status, router.stats().datagrams_seen);
+            last_status = Instant::now();
+        }
+        if stop_at.is_some_and(|id| status.latest.is_some_and(|latest| latest >= id))
+            || (seen_packet && last_packet.elapsed() >= Duration::from_millis(*idle_ms))
+        {
+            break;
+        }
+        if !seen_packet && started.elapsed() >= Duration::from_secs(15) {
+            return Err("No UDP traffic arrived within 15 seconds".into());
+        }
+    }
+    if let Some(archive) = archive {
+        archive.finish()?;
+    } else if !stop.load(Ordering::Acquire) {
+        return Err("No session manifest received".into());
+    }
+    status.state = RecordingState::Closed;
+    if let Some(publisher) = telemetry {
+        publisher.set_status(status);
+    }
+    if !quiet {
+        print_status(&status, router.stats().datagrams_seen);
+    }
+    if !stop.load(Ordering::Acquire)
+        && !matches!(impairment, Impairment::Clean)
+        && status.dropped == 0
+    {
+        return Err("Impairment scenario did not discard any packets".into());
+    }
+    if !quiet {
+        println!("Archive closed at receiver's known boundary; unobserved sender tail is unknown.");
+    }
+    Ok(())
+}
+
+fn print_status(status: &Status, packets: usize) {
+    println!(
+        "packets={packets} archived={:?} verified_anchor={:?} gaps={} demo_drops={}",
+        status.latest, status.anchor, status.gaps, status.dropped
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cu29_logstream::telemetry::telemetry_channel;
+
+    #[test]
+    fn native_archive_is_identical_with_fast_stalled_or_disconnected_reader() {
+        const COUNT: u64 = 96;
+        let logs = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("logs");
+        fs::create_dir_all(&logs).unwrap();
+        let directory = tempfile::Builder::new()
+            .prefix("telemetry-test-")
+            .tempdir_in(logs)
+            .unwrap();
+        for mode in ["disabled", "fast", "stalled", "disconnected"] {
+            let ready = directory.path().join(format!("{mode}.endpoint"));
+            let received = directory.path().join(format!("{mode}.copper"));
+            let sender = directory.path().join(format!("{mode}-sender.copper"));
+            let options = ReceiverOptions {
+                listen: "127.0.0.1:0".parse().unwrap(),
+                log_base: received.clone(),
+                ready_file: Some(ready.clone()),
+                impairment: Impairment::Clean,
+                stop_at: Some(COUNT - 1),
+                idle_ms: 2000,
+            };
+            let (publisher, reader) =
+                telemetry_channel::<Frame, Status>(4.try_into().unwrap(), Status::default());
+            let mut publisher = (mode != "disabled").then_some(publisher);
+            let mut reader = Some(reader);
+            if mode == "disconnected" {
+                drop(reader.take());
+            }
+            thread::scope(|scope| {
+                let worker = scope.spawn(move || {
+                    let result = run(&options, publisher.as_mut(), &AtomicBool::new(false))
+                        .map_err(|e| e.to_string());
+                    drop(publisher);
+                    result
+                });
+                let fast_reader = if mode == "fast" {
+                    let mut reader = reader.take().unwrap();
+                    Some(scope.spawn(move || {
+                        let mut accounted = 0;
+                        loop {
+                            assert!(reader.wait_timeout(Duration::from_secs(5)));
+                            reader.status();
+                            while let Some(update) = reader.try_read() {
+                                accounted += update.missed + 1;
+                            }
+                            if reader.is_closed() {
+                                while let Some(update) = reader.try_read() {
+                                    accounted += update.missed + 1;
+                                }
+                                return accounted;
+                            }
+                        }
+                    }))
+                } else {
+                    None
+                };
+                let started = Instant::now();
+                let address = loop {
+                    if let Ok(text) = fs::read_to_string(&ready)
+                        && let Ok(address) = text.trim().parse()
+                    {
+                        break address;
+                    }
+                    if worker.is_finished() {
+                        panic!(
+                            "Receiver exited before binding: {:?}",
+                            worker.join().unwrap()
+                        );
+                    }
+                    assert!(
+                        started.elapsed() < Duration::from_secs(5),
+                        "receiver did not bind"
+                    );
+                    thread::sleep(Duration::from_millis(5));
+                };
+                cu_logstream_demo::run_sender(address, &sender, COUNT, 0).unwrap();
+                worker.join().unwrap().unwrap();
+                if let Some(worker) = fast_reader {
+                    assert_eq!(worker.join().unwrap(), COUNT);
+                }
+            });
+            if mode == "stalled" {
+                let reader = reader.as_mut().unwrap();
+                let status = reader.status();
+                assert_eq!(status.archived, COUNT);
+                assert_eq!(status.state, RecordingState::Closed);
+                let update = reader.try_read().unwrap();
+                assert_eq!(update.missed, COUNT - 4);
+                assert_eq!(update.frame.copperlist.id, COUNT - 4);
+            }
+            crate::verify(&sender, &received, crate::Expectation::Complete, COUNT).unwrap();
+        }
+    }
+}

--- a/examples/cu_logstream_demo/src/telemetry.rs
+++ b/examples/cu_logstream_demo/src/telemetry.rs
@@ -1,0 +1,34 @@
+//! Example-specific telemetry values shared by the receiver and native UI.
+use cu29_logstream::{StreamIdentity, telemetry::TelemetryPublisher};
+use std::time::Instant;
+
+/// A small current snapshot; frame delivery may be paused independently.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Status {
+    pub latest: Option<u64>,
+    pub anchor: Option<u64>,
+    pub gaps: usize,
+    pub dropped: usize,
+    pub packets: usize,
+    pub archived: u64,
+    pub identity: Option<StreamIdentity>,
+    pub last_packet: Option<Instant>,
+    pub state: RecordingState,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum RecordingState {
+    #[default]
+    Waiting,
+    Recording,
+    Closed,
+    Failed,
+}
+
+pub struct Frame {
+    pub identity: StreamIdentity,
+    pub received_at: Instant,
+    pub copperlist: crate::List,
+}
+
+pub type Publisher = TelemetryPublisher<Frame, Status>;

--- a/justfile
+++ b/justfile
@@ -191,6 +191,15 @@ logstream-demo-check:
 	cargo +stable test -p cu29-runtime --test replay_primitives --features cu29/async-cl-io
 	just --justfile examples/cu_logstream_demo/justfile check
 
+# Pull telemetry, reader overruns, archive isolation, and the native terminal UI.
+logstream-telemetry-check:
+	cargo +stable clippy -p cu29-logstream --all-targets -- --deny warnings
+	cargo +stable test -p cu29-logstream
+	cargo +stable check -p cu29-logstream --no-default-features
+	cargo +stable clippy -p cu-logstream-demo --all-targets --features replay,tui -- --deny warnings
+	cargo +stable test -p cu-logstream-demo --features demo,tui --bin cu-logstream-demo
+	just logstream-demo-check
+
 # Check the large examples from the former extra-examples repo.
 check-extra-examples: check-extra-examples-host check-extra-examples-embedded
 


### PR DESCRIPTION
## Summary

A ground-station UI can now consume typed, already archived CopperLists without controlling reception or recording. The std-only telemetry API provides a preallocated overwrite-oldest ring, stable frame borrows, exact reader-overrun counts, independent coalesced status, and async/thread/waker notifications.

<img width="3140" height="2120" alt="image" src="https://github.com/user-attachments/assets/df6edacd-5d7b-4259-b170-638c3b05e412" />


The UDP demo adds an optional Ratatui dashboard showing counter/sum values, a small chart, packet freshness, archive/recovery progress, and separate source-gap and UI-overwrite counters. Space pauses the reader while recording continues; q closes the receiver and archive. Run `just dashboard` and `just sender` in separate terminals under `examples/cu_logstream_demo`.

## Changes

- Keep decode/append on the receiving worker and user processing on the reader's thread; no robot task-path changes or full-payload cloning.
- Preserve headless receiver scenarios and gate the terminal dependency behind `tui`.
- Add `just logstream-telemetry-check`, concurrency/notification tests, archive comparisons with fast/stalled/disconnected readers, and responsive terminal-rendering tests.
- Document the API and its bounds. This step displays captured outputs; live generated deterministic reconstruction and numeric mission dispatch remain subsequent milestones. The next demo will reconstruct a third task whose output is never transmitted.

## Validation

- `just logstream-telemetry-check`: passed, including Clippy, no-default-features, all six UDP impairment scenarios, native archive verification, and recorded replay.
- `just api-check` and `just fmt`: passed.
- Real PTY smoke test: render, pause/resume, q, terminal restoration, and all 256 received CopperLists matching the onboard archive passed.
- No-default-features dependency inspection excludes the new host telemetry dependencies and Ratatui.

Full `just pr-check` / `just nostd-ci` were not rerun; changes are confined to the std-only receiver API and opt-in example, with the focused no-default-features check above.

## Documentation

The crate/example documentation is included. Matching book documentation: https://github.com/copper-project/copper-rs-book/pull/48 (stacked on the existing pacing-docs PR); the book build passed. Wiki documentation is committed on a separate local branch.
