### PR TITLE
Add Copper-owned live twin sessions with opt-in verification

### DIFF
--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -638,9 +638,6 @@ pub enum cu29_runtime::continuity::StreamContinuityRecord
 pub cu29_runtime::continuity::StreamContinuityRecord::Anchor
 pub cu29_runtime::continuity::StreamContinuityRecord::Anchor::copperlist_id: u64
 pub cu29_runtime::continuity::StreamContinuityRecord::Anchor::record: alloc::vec::Vec<u8>
-pub cu29_runtime::continuity::StreamContinuityRecord::Capture
-pub cu29_runtime::continuity::StreamContinuityRecord::Capture::copperlist_id: u64
-pub cu29_runtime::continuity::StreamContinuityRecord::Capture::proof: alloc::vec::Vec<u8>
 pub cu29_runtime::continuity::StreamContinuityRecord::Finished
 pub cu29_runtime::continuity::StreamContinuityRecord::Finished::next_copperlist_id: u64
 pub cu29_runtime::continuity::StreamContinuityRecord::Gap

--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -211,6 +211,9 @@ pub cu29_runtime::config::SchedulingPolicy::Fifo::priority: u8
 pub cu29_runtime::config::SchedulingPolicy::Nice(i8)
 pub cu29_runtime::config::SchedulingPolicy::RoundRobin
 pub cu29_runtime::config::SchedulingPolicy::RoundRobin::priority: u8
+pub enum cu29_runtime::config::StreamReplay
+pub cu29_runtime::config::StreamReplay::Capture
+pub cu29_runtime::config::StreamReplay::Reconstruct
 pub enum cu29_runtime::config::TaskKind
 pub cu29_runtime::config::TaskKind::Regular
 pub cu29_runtime::config::TaskKind::Sink
@@ -452,6 +455,7 @@ pub fn cu29_runtime::config::Node::set_param<T: core::convert::Into<cu29_runtime
 pub fn cu29_runtime::config::Node::set_resources<I>(&mut self, resources: core::option::Option<I>) where I: core::iter::traits::collect::IntoIterator<Item = (alloc::string::String, alloc::string::String)>
 pub fn cu29_runtime::config::Node::set_task_kind(&mut self, kind: core::option::Option<cu29_runtime::config::TaskKind>)
 pub fn cu29_runtime::config::Node::set_type(self, name: core::option::Option<alloc::string::String>) -> Self
+pub fn cu29_runtime::config::Node::streaming(&self) -> cu29_runtime::config::NodeStreaming
 pub struct cu29_runtime::config::NodeLogging
 impl cu29_runtime::config::NodeLogging
 pub fn cu29_runtime::config::NodeLogging::codec(&self) -> core::option::Option<&str>
@@ -461,6 +465,9 @@ pub fn cu29_runtime::config::NodeLogging::enabled(&self) -> bool
 pub fn cu29_runtime::config::NodeLogging::handle_content(&self) -> cu29_runtime::config::HandleContent
 impl core::default::Default for cu29_runtime::config::NodeLogging
 pub fn cu29_runtime::config::NodeLogging::default() -> Self
+pub struct cu29_runtime::config::NodeStreaming
+pub cu29_runtime::config::NodeStreaming::replay: cu29_runtime::config::StreamReplay
+pub cu29_runtime::config::NodeStreaming::replay_abi: core::option::Option<u32>
 pub struct cu29_runtime::config::PlannerConfig
 impl cu29_runtime::config::PlannerConfig
 pub fn cu29_runtime::config::PlannerConfig::get_config(&self) -> core::option::Option<&cu29_runtime::config::ComponentConfig>
@@ -631,6 +638,9 @@ pub enum cu29_runtime::continuity::StreamContinuityRecord
 pub cu29_runtime::continuity::StreamContinuityRecord::Anchor
 pub cu29_runtime::continuity::StreamContinuityRecord::Anchor::copperlist_id: u64
 pub cu29_runtime::continuity::StreamContinuityRecord::Anchor::record: alloc::vec::Vec<u8>
+pub cu29_runtime::continuity::StreamContinuityRecord::Capture
+pub cu29_runtime::continuity::StreamContinuityRecord::Capture::copperlist_id: u64
+pub cu29_runtime::continuity::StreamContinuityRecord::Capture::proof: alloc::vec::Vec<u8>
 pub cu29_runtime::continuity::StreamContinuityRecord::Finished
 pub cu29_runtime::continuity::StreamContinuityRecord::Finished::next_copperlist_id: u64
 pub cu29_runtime::continuity::StreamContinuityRecord::Gap
@@ -2233,6 +2243,7 @@ pub cu29_runtime::simulation::CuTaskCallbackState::New(core::option::Option<cu29
 pub cu29_runtime::simulation::CuTaskCallbackState::Postprocess
 pub cu29_runtime::simulation::CuTaskCallbackState::Preprocess
 pub cu29_runtime::simulation::CuTaskCallbackState::Process(I, O)
+pub cu29_runtime::simulation::CuTaskCallbackState::ProcessCompleted(O)
 pub cu29_runtime::simulation::CuTaskCallbackState::Start
 pub cu29_runtime::simulation::CuTaskCallbackState::Stop
 pub enum cu29_runtime::simulation::SimOverride

--- a/api/v1/cu29-traits.txt
+++ b/api/v1/cu29-traits.txt
@@ -140,6 +140,8 @@ pub fn cu29_traits::TaskOutputSpec::payload_type_path(&self) -> &'static str
 pub const cu29_traits::COMPACT_STRING_CAPACITY: usize
 pub trait cu29_traits::CopperListTuple: cu_bincode::enc::Encode + cu_bincode::de::Decode<()> + core::fmt::Debug + serde_core::ser::Serialize + cu29_traits::ErasedCuStampedDataSet + cu29_traits::MatchingTasks + core::default::Default
 impl<T> cu29_traits::CopperListTuple for T where T: cu_bincode::enc::Encode + cu_bincode::de::Decode<()> + core::fmt::Debug + serde_core::ser::Serialize + cu29_traits::ErasedCuStampedDataSet + cu29_traits::MatchingTasks + core::default::Default
+pub trait cu29_traits::CuCrossPlatformDeterministic
+pub const cu29_traits::CuCrossPlatformDeterministic::REPLAY_ABI: u32
 pub trait cu29_traits::CuMsgMetadataTrait
 pub fn cu29_traits::CuMsgMetadataTrait::origin(&self) -> core::option::Option<&cu29_traits::CuMsgOrigin>
 pub fn cu29_traits::CuMsgMetadataTrait::process_time(&self) -> cu29_clock::PartialCuTimeRange

--- a/api/v1/cu29.txt
+++ b/api/v1/cu29.txt
@@ -58,6 +58,7 @@ pub use cu29::prelude::<<cu29_unifiedlog::*>>
 pub use cu29::prelude::COMPACT_STRING_CAPACITY
 pub use cu29::prelude::CopperListTuple
 pub use cu29::prelude::CuCompactString
+pub use cu29::prelude::CuCrossPlatformDeterministic
 pub use cu29::prelude::CuError
 pub use cu29::prelude::CuMsgMetadataTrait
 pub use cu29::prelude::CuMsgOrigin

--- a/core/cu29/Cargo.toml
+++ b/core/cu29/Cargo.toml
@@ -51,6 +51,7 @@ rayon = { workspace = true, optional = true }
 ctrlc = { workspace = true, optional = true }
 
 [features]
+logstream-verify = ["logstream", "cu29-logstream/verify-reconstruction"]
 default = ["std", "signal-handler", "textlogs", "units"]
 defmt = [
   "dep:defmt",

--- a/core/cu29/src/lib.rs
+++ b/core/cu29/src/lib.rs
@@ -329,13 +329,13 @@ pub mod prelude {
     #[allow(deprecated)]
     pub use cu29_traits::PayloadSchemas;
     pub use cu29_traits::{
-        COMPACT_STRING_CAPACITY, CopperListTuple, CuCompactString, CuError, CuMsgMetadataTrait,
-        CuMsgOrigin, CuPayloadRawBytes, CuResult, DebugEnumVariantDescriptor, DebugEnumVariantKind,
-        DebugFieldDescriptor, DebugFieldKind, DebugFieldSemantics, DebugScalarKind,
-        DebugScalarRegistration, DebugScalarType, ErasedCuStampedData, ErasedCuStampedDataSet,
-        MatchingTasks, Metadata, ObservedWriter, ReflectSerializedPayloadSchema,
-        SerializedPayloadSchema, TaskOutputSpec, UnifiedLogType, WriteStream,
-        abort_observed_encode, begin_observed_encode, finish_observed_encode,
+        COMPACT_STRING_CAPACITY, CopperListTuple, CuCompactString, CuCrossPlatformDeterministic,
+        CuError, CuMsgMetadataTrait, CuMsgOrigin, CuPayloadRawBytes, CuResult,
+        DebugEnumVariantDescriptor, DebugEnumVariantKind, DebugFieldDescriptor, DebugFieldKind,
+        DebugFieldSemantics, DebugScalarKind, DebugScalarRegistration, DebugScalarType,
+        ErasedCuStampedData, ErasedCuStampedDataSet, MatchingTasks, Metadata, ObservedWriter,
+        ReflectSerializedPayloadSchema, SerializedPayloadSchema, TaskOutputSpec, UnifiedLogType,
+        WriteStream, abort_observed_encode, begin_observed_encode, finish_observed_encode,
         observed_encode_bytes, record_observed_encode_bytes, with_cause,
     };
     #[cfg(feature = "std")]

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -1,3 +1,4 @@
+mod live_twin;
 use proc_macro::TokenStream;
 use quote::{ToTokens, format_ident, quote};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -1121,6 +1122,7 @@ fn gen_culist_support(
                 &encode_helper_names,
                 &slot_handle_modes,
                 cumsg_count,
+                None,
             ),
             build_compressed_culist_tuple_decode(
                 &output_packs,
@@ -1450,8 +1452,22 @@ fn gen_culist_support(
         }
     }
 
+    let capture_support = if cfg!(feature = "logstream") {
+        live_twin::dataset_support(
+            runtime_plan,
+            &output_packs,
+            &encode_helper_names,
+            &slot_handle_modes,
+            cumsg_count,
+            &flat_codec_bindings,
+        )
+    } else {
+        quote! {}
+    };
+
     // This generates a way to get the metadata of every single message of a culist at low cost
     quote! {
+        #capture_support
         #collect_metadata_function
         #compute_payload_bytes_fn
         #default_config_ron_const
@@ -1636,6 +1652,9 @@ fn gen_sim_support(
         });
     }
 
+    if cfg!(feature = "logstream") {
+        variants.push(quote! { CopperListCompleted(&'a mut CopperList<CuStampedDataSet>) });
+    }
     variants.push(quote! { __Phantom(core::marker::PhantomData<&'a ()>) });
     quote! {
         // not used if sim is not generated but this is ok.
@@ -2258,13 +2277,17 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 };
             let bridge_resource_mappings =
                 build_bridge_resource_mappings(&resource_specs, &culist_bridge_specs, sim_mode);
-            let logstream_resource_specs = match build_logstream_resource_specs(
-                &copper_config,
-                mission.as_str(),
-                &resource_specs,
-            ) {
-                Ok(specs) => specs,
-                Err(e) => return return_error(e.to_string()),
+            let logstream_resource_specs = if sim_mode {
+                Vec::new()
+            } else {
+                match build_logstream_resource_specs(
+                    &copper_config,
+                    mission.as_str(),
+                    &resource_specs,
+                ) {
+                    Ok(specs) => specs,
+                    Err(e) => return return_error(e.to_string()),
+                }
             };
             (
                 resources_module,
@@ -4580,7 +4603,10 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 .logging
                 .as_ref()
                 .is_none_or(|logging| logging.enable_keyframe_logging && logging.enable_task_logging);
-            if configured_keyframe_logging != #local_keyframe_logging_enabled {
+            // A ground-side simulation may disable local output entirely while
+            // retaining the generated freeze/thaw plan for received anchors.
+            if configured_keyframe_logging != #local_keyframe_logging_enabled
+                && !(#sim_mode && #logstream_enabled && !configured_keyframe_logging) {
                 return Err(CuError::from(format!(
                     "Configured keyframe logging ({configured_keyframe_logging}) does not match the runtime compiled into this binary ({})",
                     #local_keyframe_logging_enabled
@@ -5246,6 +5272,21 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
             quote! { self.copper_runtime.keyframes_manager.finish_pending()?; }
         });
 
+        let live_completed = (sim_mode && logstream_enabled).then(|| {
+            quote! {
+                let _ = sim_callback(SimStep::CopperListCompleted(culist));
+            }
+        });
+        let live_replay_impl = if sim_mode && logstream_enabled {
+            live_twin::runtime_support(
+                application_name,
+                &mission_mod,
+                &culist_plan,
+                &culist_exec_entities,
+            )
+        } else {
+            quote! {}
+        };
         let run_methods: proc_macro2::TokenStream = quote! {
 
             #run_one_iteration {
@@ -5313,6 +5354,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 // here drop the payloads if we don't want them to be logged.
                 #(#preprocess_logging_calls)*
 
+                #live_completed
                 cl_manager.end_of_processing(clid)?;
                 monitor_result?;
 
@@ -5455,6 +5497,8 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 #[cfg(target_os = "none")]
                 ::cu29::prelude::info!("CuApp init: loading config");
                 #config_load_stmt
+                let mut config = config;
+                if #sim_mode { config.log_streaming = None; }
                 #constant_override_warning
                 #copperlist_count_check
                 #keyframe_logging_check
@@ -5579,9 +5623,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
         let configured_logstream_session = (!logstream_resource_specs.is_empty()).then(|| {
             quote! {
                 let logstream_session_id = ::cu29::logstream::new_session_id();
-                let logstream_schema = ::cu29::logstream::ApplicationSchema::from_output_specs(
-                    <#mission_mod::CuStampedDataSet as ::cu29::prelude::MatchingTasks>::get_output_specs(),
-                );
+                let logstream_schema = <#mission_mod::CuStampedDataSet as ::cu29::logstream::capture::CaptureDataSet>::stream_schema();
             }
         });
         let configured_logstream_initializers = logstream_resource_specs.iter().map(|spec| {
@@ -5624,6 +5666,11 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         #transport_ident, sender_config,
                         if clock.is_mock() { RobotClock::new() } else { clock.clone() },
                     )?;
+                let #continuous_ident = if logstream_schema.reconstruction.is_empty() {
+                    #continuous_ident
+                } else {
+                    #continuous_ident.with_encoder(::cu29::logstream::capture::encode_capture_record_into)
+                };
             }
         });
         let configured_logstream_fanouts = logstream_resource_specs.iter().map(|spec| {
@@ -5664,10 +5711,20 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                     .map(|(transport, mut sender_config)| {
                         sender_config.continuous.identity.sender_id = instance_id;
                         sender_config.recovery.finite.identity.sender_id = instance_id;
+                        let schema = <#mission_mod::CuStampedDataSet as ::cu29::logstream::capture::CaptureDataSet>::stream_schema();
+                        if !schema.reconstruction.is_empty() {
+                            let manifest = ::cu29::logstream::SessionManifest::decode_record(&sender_config.recovery.manifest_record)
+                                .map_err(|e| CuError::from(e.to_string()))?;
+                            if manifest.application_schema != schema {
+                                return Err(CuError::from("injected sender must use the generated reconstruction schema"));
+                            }
+                        }
                         let (copperlist, keyframe, _) = ::cu29::logstream::scheduled_sinks::<
                             #mission_mod::CuStampedDataSet, _
                         >(transport, sender_config,
                             if clock.is_mock() { RobotClock::new() } else { clock.clone() })?;
+                        let copperlist = if schema.reconstruction.is_empty() { copperlist }
+                            else { copperlist.with_encoder(::cu29::logstream::capture::encode_capture_record_into) };
                         Ok::<_, CuError>((copperlist, keyframe))
                     })
                     .transpose()?;
@@ -6800,6 +6857,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 #app_reflect_impl
                 #app_runtime_copperlist_impl
                 #application_impl
+                #live_replay_impl
                 #recorded_replay_app_impl
                 #distributed_replay_app_impl
 
@@ -8271,6 +8329,7 @@ fn build_compressed_culist_tuple_encode(
     encode_helper_names: &[Option<Ident>],
     slot_handle_modes: &[HandleContent],
     cumsg_count: usize,
+    capture_slots: Option<&[bool]>,
 ) -> ItemImpl {
     let mut flat_idx = 0usize;
     let mut metadata_refs = Vec::with_capacity(cumsg_count);
@@ -8304,7 +8363,9 @@ fn build_compressed_culist_tuple_encode(
             original_idents.push(original_ident.clone());
             captured_idents.push(captured_ident.clone());
 
-            let captured_value = if mode == HandleContent::default() {
+            let captured_value = if capture_slots.is_some_and(|slots| !slots[slot_idx]) {
+                quote! { false }
+            } else if mode == HandleContent::default() {
                 quote! { #original_ident }
             } else {
                 let mode_u8 = mode as u8;
@@ -8357,9 +8418,20 @@ fn build_compressed_culist_tuple_encode(
         }
     }
 
+    let (impl_header, method) = if capture_slots.is_some() {
+        (
+            quote! { impl CuStampedDataSet },
+            format_ident!("__encode_capture"),
+        )
+    } else {
+        (
+            quote! { impl Encode for CuStampedDataSet },
+            format_ident!("encode"),
+        )
+    };
     parse_quote! {
-        impl Encode for CuStampedDataSet {
-            fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        #impl_header {
+            fn #method<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
                 let __cu_capture = cu29::monitoring::start_copperlist_io_capture(&self.1);
                 #(#presence_initializers)*
                 let __cu_metadata = [#(#metadata_refs),*];
@@ -10857,6 +10929,9 @@ fn generate_task_execution_tokens(
                 "task",
                 &quote! { cu29::cutask::CuTask },
             );
+            let live_process_completed = (sim_mode && cfg!(feature = "logstream")).then(|| quote! {
+                let _ = sim_callback(SimStep::#enum_name(CuTaskCallbackState::ProcessCompleted(cumsg_output)));
+            });
             let regular_process_tokens = quote! {
                 #slot_cast_defs
 
@@ -10872,6 +10947,7 @@ fn generate_task_execution_tokens(
                     #task_instance.process(&ctx, cumsg_input, cumsg_output)
                 };
                 #output_end_time
+                #live_process_completed
                 #alloc_close
                 result
             };

--- a/core/cu29_derive/src/live_twin.rs
+++ b/core/cu29_derive/src/live_twin.rs
@@ -48,7 +48,7 @@ pub(super) fn dataset_support(
         return quote! { compile_error!("hybrid streaming currently requires the lossless native compressed codec and full handle capture"); };
     }
     let encode = build_compressed_culist_tuple_encode(packs, helpers, modes, count, Some(&capture));
-    let mut presence = Vec::new();
+    let mut validate = Vec::new();
     let mut digests = Vec::new();
     let mut flat_abis = Vec::new();
     let mut metadata = Vec::new();
@@ -61,10 +61,14 @@ pub(super) fn dataset_support(
             } else {
                 quote! { #slot }
             };
-            presence.push(quote! { self.0.#access.payload().is_some() });
-            digests.push(if capture[i] { quote! { None } } else {
-                quote! { ::cu29::logstream::capture::reconstruction_digest(&self.0.#access.payload())? }
-            });
+            if !capture[i] {
+                validate.push(quote! {
+                    if self.0.#access.payload().is_some() {
+                        return Err(::cu29::logstream::Error::InvalidConfig("reconstructed payload must be omitted"));
+                    }
+                });
+                digests.push(quote! { self.0.#access.payload().encode(encoder)?; });
+            }
             flat_abis.push(abis[i].clone());
             metadata.push(quote! {
                 self.0.#access.tov = captured.0.#access.tov;
@@ -78,7 +82,6 @@ pub(super) fn dataset_support(
         #encode
         impl ::cu29::logstream::capture::CaptureDataSet for CuStampedDataSet {
             const RECONSTRUCTION: &'static [Option<u32>] = &[#(#flat_abis),*];
-            fn original_presence(&self) -> Vec<bool> { vec![#(#presence),*] }
             fn stream_schema() -> ::cu29::logstream::ApplicationSchema {
                 #[allow(unused_mut)]
                 let mut schema = ::cu29::logstream::ApplicationSchema::from_output_specs(
@@ -89,12 +92,16 @@ pub(super) fn dataset_support(
             fn encode_capture<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
                 self.__encode_capture(encoder)
             }
-            fn capture_proof(&self) -> ::cu29::logstream::Result<::cu29::logstream::capture::CaptureProof> {
-                Ok(::cu29::logstream::capture::CaptureProof {
-                    version: 1,
-                    original_presence: self.original_presence(),
-                    reconstructed_digests: vec![#(#digests),*],
-                })
+            fn validate_capture(&self) -> ::cu29::logstream::Result<()> {
+                #(#validate)*
+                Ok(())
+            }
+            ::cu29::logstream::__with_reconstruction_verification! {
+                fn encode_reconstruction<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+                    let _ = &encoder;
+                    #(#digests)*
+                    Ok(())
+                }
             }
             fn restore_sender_metadata(&mut self, captured: &Self) { #(#metadata)* }
         }
@@ -150,21 +157,32 @@ pub(super) fn runtime_support(
             .push(quote! { #mission::SimStep::#variant(_) => SimOverride::ExecuteByRuntime, });
     }
     quote! {
+        impl #app {
+            /// Start a live twin from this graph; Copper owns receive, archive and replay workers.
+            pub fn twin<R: ::cu29::logstream::CuStreamRx + 'static>(rx: R)
+                -> ::cu29::logstream::CuTwinBuilder<Self, R> {
+                ::cu29::logstream::CuTwin::<Self>::builder(rx)
+            }
+        }
         impl ::cu29::logstream::twin::LiveReplay for #app {
             type DataSet = #mission::CuStampedDataSet;
             #[allow(deprecated)]
             fn build_twin() -> CuResult<(Self, RobotClockMock)> {
                 let (clock, mock) = RobotClock::mock();
                 let mut config = CuConfig::deserialize_ron(&Self::original_config())?;
-                if let Some(logging) = &mut config.logging {
-                    logging.enable_task_logging = false;
-                    logging.enable_keyframe_logging = false;
-                }
+                let logging = config.logging.get_or_insert_with(Default::default);
+                logging.enable_task_logging = false;
+                logging.enable_keyframe_logging = false;
                 let mut app = Self::builder().with_clock(clock).with_config(config)
                     .with_sim_callback(&mut |_| SimOverride::ExecutedBySim).build()?.into_inner();
                 <Self as CuSimApplication<NoopSectionStorage, NoopLogger>>::start_all_tasks(&mut app,
                     &mut |step| match step { #(#lifecycle_arms)* _ => SimOverride::ExecutedBySim })?;
                 Ok((app, mock))
+            }
+            #[allow(deprecated)]
+            fn stop_twin(&mut self) -> CuResult<()> {
+                <Self as CuSimApplication<NoopSectionStorage, NoopLogger>>::stop_all_tasks(self,
+                    &mut |step| match step { #(#lifecycle_arms)* _ => SimOverride::ExecutedBySim })
             }
             #[allow(deprecated)]
             fn replay_capture(&mut self, clock_mock: &RobotClockMock,

--- a/core/cu29_derive/src/live_twin.rs
+++ b/core/cu29_derive/src/live_twin.rs
@@ -1,0 +1,207 @@
+use super::*;
+
+pub(super) fn dataset_support(
+    plan: &CuExecutionLoop,
+    packs: &[OutputPack],
+    helpers: &[Option<Ident>],
+    modes: &[HandleContent],
+    count: usize,
+    codecs: &[Option<SlotCodecBinding>],
+) -> proc_macro2::TokenStream {
+    let mut capture = vec![true; packs.len()];
+    let mut abis = vec![quote! { None }; packs.len()];
+    let mut contracts = Vec::new();
+    for unit in &plan.steps {
+        let CuExecutionUnit::Step(step) = unit else {
+            continue;
+        };
+        let policy = step.node.streaming();
+        if policy.replay != cu29_runtime::config::StreamReplay::Reconstruct {
+            continue;
+        }
+        if step.task_type != CuTaskType::Regular
+            || step.node.get_flavor() != Flavor::Task
+            || step.node.is_background()
+            || step.node.is_anytime()
+            || !step.node.is_logging_enabled()
+        {
+            return quote! { compile_error!("reconstruct requires an ordinary, synchronous, logged deterministic task"); };
+        }
+        let Some(abi) = policy.replay_abi.filter(|abi| *abi != 0) else {
+            return quote! { compile_error!("reconstruct requires a nonzero replay_abi"); };
+        };
+        let task: Type = parse_str(step.node.get_type()).unwrap();
+        contracts.push(quote! {
+            const _: () = assert!(<#task as ::cu29::CuCrossPlatformDeterministic>::REPLAY_ABI == #abi,
+                "task deterministic replay ABI does not match RON");
+        });
+        let slot = step.output_msg_pack.as_ref().unwrap().culist_index as usize;
+        capture[slot] = false;
+        abis[slot] = quote! { Some(#abi) };
+    }
+    let hybrid = capture.contains(&false);
+    if hybrid
+        && (cfg!(feature = "flat-copperlist-encoding")
+            || codecs.iter().any(Option::is_some)
+            || modes.iter().any(|mode| *mode != HandleContent::default()))
+    {
+        return quote! { compile_error!("hybrid streaming currently requires the lossless native compressed codec and full handle capture"); };
+    }
+    let encode = build_compressed_culist_tuple_encode(packs, helpers, modes, count, Some(&capture));
+    let mut presence = Vec::new();
+    let mut digests = Vec::new();
+    let mut flat_abis = Vec::new();
+    let mut metadata = Vec::new();
+    for (i, pack) in packs.iter().enumerate() {
+        let slot = syn::Index::from(i);
+        for port in 0..pack.msg_types.len() {
+            let access = if pack.is_multi() {
+                let port = syn::Index::from(port);
+                quote! { #slot.#port }
+            } else {
+                quote! { #slot }
+            };
+            presence.push(quote! { self.0.#access.payload().is_some() });
+            digests.push(if capture[i] { quote! { None } } else {
+                quote! { ::cu29::logstream::capture::reconstruction_digest(&self.0.#access.payload())? }
+            });
+            flat_abis.push(abis[i].clone());
+            metadata.push(quote! {
+                self.0.#access.tov = captured.0.#access.tov;
+                self.0.#access.metadata = captured.0.#access.metadata.clone();
+            });
+        }
+    }
+    let schema = hybrid.then(|| quote! { schema.reconstruction = Self::RECONSTRUCTION.to_vec(); });
+    quote! {
+        #(#contracts)*
+        #encode
+        impl ::cu29::logstream::capture::CaptureDataSet for CuStampedDataSet {
+            const RECONSTRUCTION: &'static [Option<u32>] = &[#(#flat_abis),*];
+            fn original_presence(&self) -> Vec<bool> { vec![#(#presence),*] }
+            fn stream_schema() -> ::cu29::logstream::ApplicationSchema {
+                #[allow(unused_mut)]
+                let mut schema = ::cu29::logstream::ApplicationSchema::from_output_specs(
+                    <Self as MatchingTasks>::get_output_specs());
+                #schema
+                schema
+            }
+            fn encode_capture<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+                self.__encode_capture(encoder)
+            }
+            fn capture_proof(&self) -> ::cu29::logstream::Result<::cu29::logstream::capture::CaptureProof> {
+                Ok(::cu29::logstream::capture::CaptureProof {
+                    version: 1,
+                    original_presence: self.original_presence(),
+                    reconstructed_digests: vec![#(#digests),*],
+                })
+            }
+            fn restore_sender_metadata(&mut self, captured: &Self) { #(#metadata)* }
+        }
+    }
+}
+
+pub(super) fn runtime_support(
+    app: &Ident,
+    mission: &Ident,
+    plan: &CuExecutionLoop,
+    entities: &[ExecutionEntity],
+) -> proc_macro2::TokenStream {
+    let mut reconstruct_arms = Vec::new();
+    let mut lifecycle_arms = Vec::new();
+    for unit in &plan.steps {
+        let CuExecutionUnit::Step(step) = unit else {
+            continue;
+        };
+        if !matches!(
+            entities[step.node_id as usize].kind,
+            ExecutionEntityKind::Task { .. }
+        ) || step.node.streaming().replay != cu29_runtime::config::StreamReplay::Reconstruct
+        {
+            continue;
+        }
+        let variant = Ident::new(&config_id_to_enum(&step.node.get_id()), Span::call_site());
+        let slot = syn::Index::from(step.output_msg_pack.as_ref().unwrap().culist_index as usize);
+        let ports = step.output_msg_pack.as_ref().unwrap().msg_types.len();
+        let metadata: Vec<_> = (0..ports).map(|port| {
+            let (output, recorded) = if ports == 1 { (quote! { output }, quote! { captured.msgs.0.#slot }) }
+            else { let port = syn::Index::from(port); (quote! { output.#port }, quote! { captured.msgs.0.#slot.#port }) };
+            quote! { #output.tov = #recorded.tov; #output.metadata = #recorded.metadata.clone(); }
+        }).collect();
+        let recorded = if ports == 1 {
+            quote! { captured.msgs.0.#slot }
+        } else {
+            quote! { captured.msgs.0.#slot.0 }
+        };
+        reconstruct_arms.push(quote! {
+            #mission::SimStep::#variant(CuTaskCallbackState::Process(_, _)) => {
+                if let Some(start) = Option::<CuTime>::from(#recorded.metadata.process_time.start) {
+                    clock_mock.set_value(start.as_nanos());
+                }
+                SimOverride::ExecuteByRuntime
+            }
+            #mission::SimStep::#variant(CuTaskCallbackState::ProcessCompleted(output)) => {
+                #(#metadata)*
+                SimOverride::ExecutedBySim
+            }
+            #mission::SimStep::#variant(_) => SimOverride::ExecuteByRuntime,
+        });
+        lifecycle_arms
+            .push(quote! { #mission::SimStep::#variant(_) => SimOverride::ExecuteByRuntime, });
+    }
+    quote! {
+        impl ::cu29::logstream::twin::LiveReplay for #app {
+            type DataSet = #mission::CuStampedDataSet;
+            #[allow(deprecated)]
+            fn build_twin() -> CuResult<(Self, RobotClockMock)> {
+                let (clock, mock) = RobotClock::mock();
+                let mut config = CuConfig::deserialize_ron(&Self::original_config())?;
+                if let Some(logging) = &mut config.logging {
+                    logging.enable_task_logging = false;
+                    logging.enable_keyframe_logging = false;
+                }
+                let mut app = Self::builder().with_clock(clock).with_config(config)
+                    .with_sim_callback(&mut |_| SimOverride::ExecutedBySim).build()?.into_inner();
+                <Self as CuSimApplication<NoopSectionStorage, NoopLogger>>::start_all_tasks(&mut app,
+                    &mut |step| match step { #(#lifecycle_arms)* _ => SimOverride::ExecutedBySim })?;
+                Ok((app, mock))
+            }
+            #[allow(deprecated)]
+            fn replay_capture(&mut self, clock_mock: &RobotClockMock,
+                captured: &mut CopperList<Self::DataSet>, keyframe: Option<&KeyFrame>) -> CuResult<()> {
+                use ::cu29::logstream::capture::CaptureDataSet;
+                cu29::continuity::validate_replay_continuity(
+                    self.copper_runtime.copperlists_manager.next_cl_id(), captured.id,
+                    keyframe.map(|frame| frame.culistid))?;
+                let timestamp = keyframe.map(|frame| frame.timestamp)
+                    .or_else(|| cu29::simulation::recorded_copperlist_timestamp(captured))
+                    .ok_or_else(|| CuError::from("capture has no sender timestamp"))?;
+                self.copper_runtime.copperlists_manager.prepare_recorded_replay(captured.id)?;
+                self.copper_runtime.keyframes_manager.finish_pending()?;
+                if let Some(frame) = keyframe {
+                    <Self as CuSimApplication<NoopSectionStorage, NoopLogger>>::restore_keyframe(self, frame)?;
+                    self.copper_runtime.set_forced_keyframe_timestamp(timestamp);
+                    self.copper_runtime.lock_keyframe(frame);
+                }
+                clock_mock.set_value(timestamp.as_nanos());
+                let mut completed = false;
+                let mut callback = |step: #mission::SimStep<'_>| -> SimOverride { match step {
+                    #mission::SimStep::CopperListCompleted(list) => {
+                        list.msgs.restore_sender_metadata(&captured.msgs);
+                        core::mem::swap(&mut captured.msgs, &mut list.msgs);
+                        completed = true;
+                        SimOverride::ExecutedBySim
+                    }
+                    #(#reconstruct_arms)*
+                    other => {
+                        let result = #mission::recorded_replay_step(other, captured);
+                        if result == SimOverride::ExecuteByRuntime { SimOverride::ExecutedBySim } else { result }
+                    }
+                }};
+                <Self as CuSimApplication<NoopSectionStorage, NoopLogger>>::run_one_iteration(self, &mut callback)?;
+                if !completed { return Err(CuError::from("live replay aborted before completing the CopperList")); }
+                Ok(())
+            }
+        }
+    }
+}

--- a/core/cu29_logstream/Cargo.toml
+++ b/core/cu29_logstream/Cargo.toml
@@ -41,6 +41,8 @@ cu29-build = { workspace = true }
 serde = { workspace = true }
 
 [features]
+# Developer-only per-output divergence checks; all hashing stays off the RT path.
+verify-reconstruction = []
 default = ["std"]
 std = [
   "dep:atomic-waker",

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -159,45 +159,62 @@ Sources and bridge receives stay captured. Reconstruction currently supports
 ordinary synchronous tasks using the lossless native compressed codec; background,
 anytime, custom codec and selective handle policies are rejected for this path.
 
-A ground station declares `#[copper_runtime(config = "copperconfig.ron", sim_mode = true)]`
-and uses its generated `LiveReplay` implementation. Create `TwinWorker::spawn` with
-a bounded queue and the existing `TelemetryPublisher`, then process each ordered
-router event with:
+A ground station declares `#[copper_runtime(config = "copperconfig.ron", sim_mode = true)]`.
+The generated application exposes a twin builder:
 
 ```rust,ignore
-let capture = archive.accept(&event)?; // CaptureArchive<GeneratedDataSet>
-twin.accept(&event, capture)?;
+let (mut twin, mut frames) = Ground::twin(rx)
+    .with_log_path("logs/received.copper")
+    .spawn()?;
+
+// On the UI or analysis thread:
+frames.wait_timeout(std::time::Duration::from_millis(50));
+while let Some(update) = frames.try_read() {
+    render(&update.frame.copperlist);
+}
+let status = twin.stop()?;
 ```
 
-The archive writes the received native capture bytes, original-presence metadata,
-reconstruction policy and omission proofs before handing ownership to replay. It
-never stores synthesized outputs or waits for replay/UI consumption. `NativeArchive`
-remains the full-capture API; use `CaptureArchive` for this selective view. Existing
-native sections retain proofs in `StreamContinuity`; the container format is unchanged.
-Manifest version 2 binds the per-output replay ABI. Build matching robot and ground
-code; numeric mission dispatch remains separate work.
+`rx` is any `CuStreamRx`, such as the receive half of a UDP resource. Copper owns
+session routing, native recording, the bounded replay worker, status publication,
+and shutdown. The caller owns the frame reader and presentation. Pausing or dropping
+that reader never blocks recording. Dropping the twin stops and joins its workers;
+`stop()` also reports receiver errors and final counters. `archive_only()` records
+without running a twin. Each handle accepts one sender session and a fresh log path.
+The default receiver supports the 1200-byte-MTU, 64-symbol streaming profile, with
+4 KiB records and 64 KiB recovery objects. It retains 32 replay events, 32 pending
+captures, one anchor, one executing frame and 64 display frames; payload storage and
+thread/runtime allocations are additional. `with_frame_capacity` changes display retention.
 
-The worker joins independently arriving keyframes and captured boundaries, restores
-state, injects captured messages and executes only reconstructible tasks. It restores
-sender metadata before downstream tasks run. Generated simulation does not bind
-configured stream transmitters; the twin disables local logging and uses no log file.
-The worker retains at most the configured number of queued events and pending
-captures, one anchor and one executing frame, plus the presentation ring. Payload
-allocations and thread/runtime storage are additional. Source gaps and replay queue
-overflow require another matching anchor; UI overwrites only discard display samples.
+Production sends the existing native CopperList format with selected payloads omitted.
+The native codec already carries original/captured presence. There is no proof envelope,
+per-list verification allocation, or new continuity record. The archive writes the
+received native bytes before replay and never stores synthesized outputs. The unreleased
+session manifest stays at **version 1** and binds the reconstruction ABI to the graph.
+Packet framing, FEC and anchor recovery are unchanged.
 
-Per-output digest checking is **off by default**, including debug Rust builds.
-Enable `cu29/logstream-verify` (or the demo's `verify-reconstruction`) at development
-time to check reconstructed payloads. All digest encoding/hashing happens on the
-existing sender output worker and the ground replay worker. No task-path hashing,
-serialization, allocation or copying is added. Ordinary packet/anchor integrity
-checks remain; they do not independently prove behavioral determinism.
+Copper restores keyframes, injects captured inputs, executes reconstructible tasks and
+restores sender metadata before downstream tasks run. Existing source gaps and replay
+queue overflows require a matching recovery anchor. These continuity checks are separate
+from checking whether deterministic task code produced the right result. The generated
+ground runtime disables its own logging and transport transmitters; its archive is owned
+by the twin receiver.
 
-The UI reports Waiting/Recovering, Reconstructed, Verified (developer checks), or
-Diverged. Only checked frames are called Verified. With checks enabled, a mismatch
-withholds reconstructed frames until another matching anchor. Capture recording
-continues through divergence and UI pause. Use `just dashboard-verify` and
-`just sender-verify` in separate terminals to run the developer checks.
+Reconstruction correctness checks are **entirely opt-in**, even in debug Rust builds.
+Enable `cu29/logstream-verify` (the demo calls it `verify-reconstruction`) on both ends
+for development. Only this feature compiles in hashing and a fixed 32-byte digest trailer
+covering the omitted outputs and their payload presence. Hashing runs on the existing
+sender output worker and the ground replay worker, using borrowed payloads with no
+intermediate allocation. Production captures have no trailer or digest storage. A normal
+receiver rejects debug trailers explicitly; a verification receiver also accepts normal
+captures and labels them Reconstructed, never Verified.
 
-`just resim` reconstructs the capture archive offline into full native CopperLists.
-Run `just logstream-twin-check` at the repository root for the focused checks.
+Only debug captures that pass comparison are labeled Verified. A mismatch suppresses
+reconstructed frames until the next matching anchor; native recording continues. Debug
+digests are consumed live and do not add archive sections or change offline log readers.
+Use `just dashboard-verify` and `just sender-verify` to run the development checks.
+`just resim` reconstructs ordinary capture archives offline; the demo's verification
+command compares the result against the full onboard log.
+
+Run `just logstream-twin-check` for allocation/native-format checks, both verification
+modes, worker lifecycle, reader isolation, and the UDP loss/recovery/replay scenarios.

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -40,8 +40,8 @@ preserves the received payloads and timestamps.
 - Recovery uses bounded memory. Packet loss beyond those bounds leaves gaps.
 - A late receiver can resume from a verified keyframe, but cannot recover expired
   history. Replay refuses to cross a gap without a matching keyframe.
-- Native archival currently requires the matching application and full-capture
-  codec. Use a separate archive path for each sender session.
+- Native archival requires the matching application. `NativeArchive` handles
+  full captures; `CaptureArchive` retains selective captures for live/offline replay. Use a separate archive path for each sender session.
 - Generated senders enforce one bitrate/burst budget across continuous data,
   repairs, and recovery packets. The budget counts Copper packet bytes, excluding
   UDP/IP or other carrier overhead. Replay and recovery share byte-deficit
@@ -137,3 +137,67 @@ for codec tests/custom integration and do not enforce pacing themselves.
 
 Run `just logstream-pacing-check` for scheduler, worker lifecycle, and UDP demo
 checks, including recovery after the entire initial bootstrap transmission is lost.
+
+## Live Copper twin
+
+The demo graph is `counter -> sum -> derived`. The ordinary `Derived` Copper task
+computes `sum % 256` on the robot and in generated ground-side replay. Its payload
+is never transmitted, including repeated anchor boundaries and FEC repairs. The
+robot's onboard log contains the full output for comparison. Ratatui explicitly
+labels the derived value **reconstructed locally; payload not transmitted**.
+
+Declare the static contract in the same RON used by the robot and ground build:
+
+```ron
+(id: "derived", type: "tasks::Derived",
+ streaming: (replay: reconstruct, replay_abi: 1)),
+```
+
+The task implements `CuCrossPlatformDeterministic` with `REPLAY_ABI = 1`. This is
+an explicit promise of deterministic behavior and no external side effects.
+Sources and bridge receives stay captured. Reconstruction currently supports
+ordinary synchronous tasks using the lossless native compressed codec; background,
+anytime, custom codec and selective handle policies are rejected for this path.
+
+A ground station declares `#[copper_runtime(config = "copperconfig.ron", sim_mode = true)]`
+and uses its generated `LiveReplay` implementation. Create `TwinWorker::spawn` with
+a bounded queue and the existing `TelemetryPublisher`, then process each ordered
+router event with:
+
+```rust,ignore
+let capture = archive.accept(&event)?; // CaptureArchive<GeneratedDataSet>
+twin.accept(&event, capture)?;
+```
+
+The archive writes the received native capture bytes, original-presence metadata,
+reconstruction policy and omission proofs before handing ownership to replay. It
+never stores synthesized outputs or waits for replay/UI consumption. `NativeArchive`
+remains the full-capture API; use `CaptureArchive` for this selective view. Existing
+native sections retain proofs in `StreamContinuity`; the container format is unchanged.
+Manifest version 2 binds the per-output replay ABI. Build matching robot and ground
+code; numeric mission dispatch remains separate work.
+
+The worker joins independently arriving keyframes and captured boundaries, restores
+state, injects captured messages and executes only reconstructible tasks. It restores
+sender metadata before downstream tasks run. Generated simulation does not bind
+configured stream transmitters; the twin disables local logging and uses no log file.
+The worker retains at most the configured number of queued events and pending
+captures, one anchor and one executing frame, plus the presentation ring. Payload
+allocations and thread/runtime storage are additional. Source gaps and replay queue
+overflow require another matching anchor; UI overwrites only discard display samples.
+
+Per-output digest checking is **off by default**, including debug Rust builds.
+Enable `cu29/logstream-verify` (or the demo's `verify-reconstruction`) at development
+time to check reconstructed payloads. All digest encoding/hashing happens on the
+existing sender output worker and the ground replay worker. No task-path hashing,
+serialization, allocation or copying is added. Ordinary packet/anchor integrity
+checks remain; they do not independently prove behavioral determinism.
+
+The UI reports Waiting/Recovering, Reconstructed, Verified (developer checks), or
+Diverged. Only checked frames are called Verified. With checks enabled, a mismatch
+withholds reconstructed frames until another matching anchor. Capture recording
+continues through divergence and UI pause. Use `just dashboard-verify` and
+`just sender-verify` in separate terminals to run the developer checks.
+
+`just resim` reconstructs the capture archive offline into full native CopperLists.
+Run `just logstream-twin-check` at the repository root for the focused checks.

--- a/core/cu29_logstream/src/archive.rs
+++ b/core/cu29_logstream/src/archive.rs
@@ -22,6 +22,9 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+type ArchiveDecoder<P> =
+    fn(&[u8]) -> Result<(CopperList<P>, &[u8], Option<crate::capture::CaptureProof>)>;
+
 type NativeStream = LogStream<MmapSectionStorage, UnifiedLoggerWrite>;
 
 /// One application-typed archive per `(session id, sender id)`. Pass all ordered
@@ -38,6 +41,8 @@ pub struct NativeArchive<P: CopperListTuple> {
     next_id: u64,
     poisoned: bool,
     payload: PhantomData<P>,
+    decode: ArchiveDecoder<P>,
+    last_proof: Option<crate::capture::CaptureProof>,
 }
 
 struct CanonicalEntry<'a>(&'a [u8]);
@@ -56,11 +61,29 @@ impl<P: CopperListTuple> NativeArchive<P> {
         slab_bytes: usize,
         section_bytes: usize,
     ) -> Result<Self> {
+        let expected = ApplicationSchema::from_output_specs(P::get_output_specs());
+        Self::new_checked(
+            path,
+            manifest,
+            slab_bytes,
+            section_bytes,
+            expected,
+            |bytes| Ok((crate::decode_copperlist(bytes)?, bytes, None)),
+        )
+    }
+
+    fn new_checked(
+        path: &Path,
+        manifest: SessionManifest,
+        slab_bytes: usize,
+        section_bytes: usize,
+        expected_schema: ApplicationSchema,
+        decode: ArchiveDecoder<P>,
+    ) -> Result<Self> {
         manifest.plan.validate()?;
         if manifest.version != crate::SESSION_MANIFEST_VERSION {
             return Err(Error::UnsupportedManifestVersion(manifest.version));
         }
-        let expected_schema = ApplicationSchema::from_output_specs(P::get_output_specs());
         if manifest.application_schema != expected_schema || !manifest.plan.content.archive {
             return Err(Error::InvalidConfig(
                 "archive requires the matching application schema and archive content policy",
@@ -100,6 +123,8 @@ impl<P: CopperListTuple> NativeArchive<P> {
             next_id: 0,
             poisoned: false,
             payload: PhantomData,
+            decode,
+            last_proof: None,
         };
         archive
             .continuity
@@ -148,7 +173,7 @@ impl<P: CopperListTuple> NativeArchive<P> {
                 if decoded.kind != RecordKind::CopperList || decoded.object_id != self.next_id {
                     return Err(Error::InconsistentObject);
                 }
-                let copperlist: CopperList<P> = crate::decode_copperlist(decoded.payload)?;
+                let (copperlist, native, proof) = (self.decode)(decoded.payload)?;
                 if copperlist.id != decoded.object_id {
                     return Err(Error::InconsistentObject);
                 }
@@ -156,8 +181,18 @@ impl<P: CopperListTuple> NativeArchive<P> {
                     .next_id
                     .checked_add(1)
                     .ok_or(Error::InconsistentObject)?;
+                if let Some(proof) = &proof {
+                    self.continuity
+                        .log(&StreamContinuityRecord::Capture {
+                            copperlist_id: copperlist.id,
+                            proof: bincode::encode_to_vec(proof, bincode::config::standard())
+                                .map_err(io_error)?,
+                        })
+                        .map_err(io_error)?;
+                }
+                self.last_proof = proof;
                 self.copperlists
-                    .log(&CanonicalEntry(decoded.payload))
+                    .log(&CanonicalEntry(native))
                     .map_err(io_error)?;
                 self.next_id = next;
                 return Ok(Some(copperlist));
@@ -232,4 +267,48 @@ impl<P: CopperListTuple> NativeArchive<P> {
 
 fn io_error(error: impl core::fmt::Display) -> Error {
     Error::Codec(error.to_string())
+}
+
+/// Capture-aware native archive. Synthesized payloads never enter this writer.
+/// Native CopperList metadata retains both original and captured presence planes;
+/// StreamContinuity retains each proof and the complete reconstruction contract.
+pub struct CaptureArchive<P: crate::capture::CaptureDataSet>(NativeArchive<P>);
+impl<P: crate::capture::CaptureDataSet> CaptureArchive<P> {
+    pub fn new(
+        path: &Path,
+        manifest: SessionManifest,
+        slab_bytes: usize,
+        section_bytes: usize,
+    ) -> Result<Self> {
+        Ok(Self(NativeArchive::new_checked(
+            path,
+            manifest,
+            slab_bytes,
+            section_bytes,
+            P::stream_schema(),
+            |bytes| {
+                let (capture, native) = crate::capture::decode_capture(bytes)?;
+                Ok((capture.copperlist, native, Some(capture.proof)))
+            },
+        )?))
+    }
+    pub fn accept(
+        &mut self,
+        event: &SessionEvent,
+    ) -> Result<Option<crate::capture::CapturedList<P>>> {
+        Ok(self
+            .0
+            .accept(event)?
+            .map(|copperlist| crate::capture::CapturedList {
+                copperlist,
+                proof: self
+                    .0
+                    .last_proof
+                    .take()
+                    .expect("capture decoder supplies proof"),
+            }))
+    }
+    pub fn finish(self) -> Result<()> {
+        self.0.finish()
+    }
 }

--- a/core/cu29_logstream/src/archive.rs
+++ b/core/cu29_logstream/src/archive.rs
@@ -1,5 +1,6 @@
 //! Application-typed native archival. All work here is receiver-side.
 
+use crate::capture::CapturedList;
 use crate::{
     ApplicationSchema, Error, RecordKind, Result, SessionEvent, SessionManifest, StreamIdentity,
 };
@@ -22,15 +23,14 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-type ArchiveDecoder<P> =
-    fn(&[u8]) -> Result<(CopperList<P>, &[u8], Option<crate::capture::CaptureProof>)>;
+type ArchiveDecoder<P> = fn(&[u8]) -> Result<(CapturedList<P>, &[u8])>;
 
 type NativeStream = LogStream<MmapSectionStorage, UnifiedLoggerWrite>;
 
 /// One application-typed archive per `(session id, sender id)`. Pass all ordered
 /// router events for that sender to `accept`. The expected schema comes from
 /// `P`'s generated output specs, independently of the remote manifest.
-/// Only the full captured native codec view is supported; hybrid views are deferred.
+/// `CaptureArchive` applies the generated selective codec for a live twin.
 /// A write failure poisons the writer: do not retry a partially committed event.
 pub struct NativeArchive<P: CopperListTuple> {
     copperlists: NativeStream,
@@ -42,7 +42,6 @@ pub struct NativeArchive<P: CopperListTuple> {
     poisoned: bool,
     payload: PhantomData<P>,
     decode: ArchiveDecoder<P>,
-    last_proof: Option<crate::capture::CaptureProof>,
 }
 
 struct CanonicalEntry<'a>(&'a [u8]);
@@ -68,7 +67,7 @@ impl<P: CopperListTuple> NativeArchive<P> {
             slab_bytes,
             section_bytes,
             expected,
-            |bytes| Ok((crate::decode_copperlist(bytes)?, bytes, None)),
+            |bytes| Ok((CapturedList::new(crate::decode_copperlist(bytes)?), bytes)),
         )
     }
 
@@ -124,7 +123,6 @@ impl<P: CopperListTuple> NativeArchive<P> {
             poisoned: false,
             payload: PhantomData,
             decode,
-            last_proof: None,
         };
         archive
             .continuity
@@ -139,6 +137,11 @@ impl<P: CopperListTuple> NativeArchive<P> {
     /// and returns the typed value for an in-process consumer. Keyframes are
     /// archived only after the router has verified their anchor references.
     pub fn accept(&mut self, event: &SessionEvent) -> Result<Option<CopperList<P>>> {
+        self.accept_capture(event)
+            .map(|capture| capture.map(|c| c.copperlist))
+    }
+
+    fn accept_capture(&mut self, event: &SessionEvent) -> Result<Option<CapturedList<P>>> {
         if self.poisoned {
             return Err(Error::InvalidConfig(
                 "archive failed; close it before continuing",
@@ -151,7 +154,7 @@ impl<P: CopperListTuple> NativeArchive<P> {
         result
     }
 
-    fn accept_inner(&mut self, event: &SessionEvent) -> Result<Option<CopperList<P>>> {
+    fn accept_inner(&mut self, event: &SessionEvent) -> Result<Option<CapturedList<P>>> {
         let identity = match event {
             SessionEvent::Manifest(manifest) => manifest.identity,
             SessionEvent::ContinuousRecord { identity, .. }
@@ -173,7 +176,8 @@ impl<P: CopperListTuple> NativeArchive<P> {
                 if decoded.kind != RecordKind::CopperList || decoded.object_id != self.next_id {
                     return Err(Error::InconsistentObject);
                 }
-                let (copperlist, native, proof) = (self.decode)(decoded.payload)?;
+                let (capture, native) = (self.decode)(decoded.payload)?;
+                let copperlist = &capture.copperlist;
                 if copperlist.id != decoded.object_id {
                     return Err(Error::InconsistentObject);
                 }
@@ -181,21 +185,11 @@ impl<P: CopperListTuple> NativeArchive<P> {
                     .next_id
                     .checked_add(1)
                     .ok_or(Error::InconsistentObject)?;
-                if let Some(proof) = &proof {
-                    self.continuity
-                        .log(&StreamContinuityRecord::Capture {
-                            copperlist_id: copperlist.id,
-                            proof: bincode::encode_to_vec(proof, bincode::config::standard())
-                                .map_err(io_error)?,
-                        })
-                        .map_err(io_error)?;
-                }
-                self.last_proof = proof;
                 self.copperlists
                     .log(&CanonicalEntry(native))
                     .map_err(io_error)?;
                 self.next_id = next;
-                return Ok(Some(copperlist));
+                return Ok(Some(capture));
             }
             SessionEvent::Gap { gap, .. } => {
                 if gap.first_id != self.next_id || gap.last_id < gap.first_id {
@@ -271,7 +265,7 @@ fn io_error(error: impl core::fmt::Display) -> Error {
 
 /// Capture-aware native archive. Synthesized payloads never enter this writer.
 /// Native CopperList metadata retains both original and captured presence planes;
-/// StreamContinuity retains each proof and the complete reconstruction contract.
+/// StreamContinuity retains the reconstruction contract and source gaps.
 pub struct CaptureArchive<P: crate::capture::CaptureDataSet>(NativeArchive<P>);
 impl<P: crate::capture::CaptureDataSet> CaptureArchive<P> {
     pub fn new(
@@ -286,28 +280,16 @@ impl<P: crate::capture::CaptureDataSet> CaptureArchive<P> {
             slab_bytes,
             section_bytes,
             P::stream_schema(),
-            |bytes| {
-                let (capture, native) = crate::capture::decode_capture(bytes)?;
-                Ok((capture.copperlist, native, Some(capture.proof)))
-            },
+            crate::capture::decode_capture,
         )?))
     }
     pub fn accept(
         &mut self,
         event: &SessionEvent,
     ) -> Result<Option<crate::capture::CapturedList<P>>> {
-        Ok(self
-            .0
-            .accept(event)?
-            .map(|copperlist| crate::capture::CapturedList {
-                copperlist,
-                proof: self
-                    .0
-                    .last_proof
-                    .take()
-                    .expect("capture decoder supplies proof"),
-            }))
+        self.0.accept_capture(event)
     }
+
     pub fn finish(self) -> Result<()> {
         self.0.finish()
     }

--- a/core/cu29_logstream/src/capture.rs
+++ b/core/cu29_logstream/src/capture.rs
@@ -1,0 +1,150 @@
+//! Generated selective streaming codecs. Encoding and hashing run on output workers.
+
+use crate::{ApplicationSchema, Error, Result};
+use alloc::{string::ToString, vec::Vec};
+use bincode::{
+    Decode, Encode,
+    enc::{Encoder, EncoderImpl, write::Writer},
+    error::EncodeError,
+};
+use cu29_runtime::copperlist::CopperList;
+use cu29_traits::CopperListTuple;
+
+/// One proof per output slot, including intentionally absent messages.
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct CaptureProof {
+    pub version: u16,
+    pub original_presence: Vec<bool>,
+    pub reconstructed_digests: Vec<Option<[u8; 32]>>,
+}
+
+/// Generated from the application's RON. Users do not implement slot dispatch.
+pub trait CaptureDataSet: CopperListTuple {
+    const RECONSTRUCTION: &'static [Option<u32>];
+    fn original_presence(&self) -> Vec<bool>;
+    fn stream_schema() -> ApplicationSchema;
+    fn encode_capture<E: Encoder>(&self, encoder: &mut E) -> core::result::Result<(), EncodeError>;
+    fn capture_proof(&self) -> Result<CaptureProof>;
+    fn restore_sender_metadata(&mut self, captured: &Self);
+}
+
+pub struct CaptureView<'a, P>(pub &'a P);
+impl<P: CaptureDataSet> Encode for CaptureView<'_, P> {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> core::result::Result<(), EncodeError> {
+        self.0.encode_capture(encoder)
+    }
+}
+
+struct DigestWriter(blake3::Hasher);
+impl Writer for DigestWriter {
+    fn write(&mut self, bytes: &[u8]) -> core::result::Result<(), EncodeError> {
+        self.0.update(bytes);
+        Ok(())
+    }
+}
+
+/// Hash a canonical payload without allocating an encoded payload buffer.
+pub fn payload_digest(value: &impl Encode) -> Result<[u8; 32]> {
+    let mut writer = DigestWriter(blake3::Hasher::new());
+    value
+        .encode(&mut EncoderImpl::new(
+            &mut writer,
+            bincode::config::standard(),
+        ))
+        .map_err(|e| Error::Codec(e.to_string()))?;
+    Ok(*writer.0.finalize().as_bytes())
+}
+
+/// A captured native list and its explicit omission proof. Never a verified twin frame.
+pub struct CapturedList<P: CopperListTuple> {
+    pub copperlist: CopperList<P>,
+    pub proof: CaptureProof,
+}
+
+pub fn encode_capture_record_into<P: CaptureDataSet>(
+    list: &CopperList<P>,
+    output: &mut [u8],
+) -> Result<usize> {
+    let proof = list.msgs.capture_proof()?;
+    let header_len = crate::record::RECORD_HEADER_LEN;
+    if output.len() < header_len {
+        return Err(Error::BufferTooSmall {
+            needed: header_len,
+            available: output.len(),
+        });
+    }
+    let (header, payload) = output.split_at_mut(header_len);
+    let len = bincode::encode_into_slice(
+        (&proof, list.id, list.get_state(), CaptureView(&list.msgs)),
+        payload,
+        bincode::config::standard(),
+    )
+    .map_err(|e| Error::Codec(e.to_string()))?;
+    crate::record::encode_record_header(
+        crate::RecordKind::CopperList,
+        list.id,
+        &payload[..len],
+        header,
+    )?;
+    Ok(header_len + len)
+}
+
+/// Decode once; return the original native byte slice for capture archival.
+pub fn decode_capture<P: CaptureDataSet>(payload: &[u8]) -> Result<(CapturedList<P>, &[u8])> {
+    let (proof, offset): (CaptureProof, usize) =
+        bincode::decode_from_slice(payload, bincode::config::standard().with_limit::<1048576>())
+            .map_err(|e| Error::Codec(e.to_string()))?;
+    let output_count = P::get_output_specs().len();
+    if proof.version != 1
+        || proof.original_presence.len() != output_count
+        || proof.reconstructed_digests.len() != output_count
+    {
+        return Err(Error::InvalidConfig("invalid capture proof layout"));
+    }
+    let native = &payload[offset..];
+    let copperlist = crate::decode_copperlist::<P>(native)?;
+    let captured_presence = copperlist.msgs.original_presence();
+    for (i, present) in captured_presence.iter().enumerate() {
+        let reconstruct = P::RECONSTRUCTION.get(i).is_some_and(Option::is_some);
+        if *present != (proof.original_presence[i] && !reconstruct)
+            || (proof.reconstructed_digests[i].is_some() && !reconstruct)
+        {
+            return Err(Error::InvalidConfig(
+                "capture payload/presence policy mismatch",
+            ));
+        }
+    }
+    Ok((CapturedList { copperlist, proof }, native))
+}
+
+impl<P: CaptureDataSet> CapturedList<P> {
+    pub fn verify(&self) -> Result<()> {
+        let actual = self.copperlist.msgs.capture_proof()?;
+        if actual.original_presence != self.proof.original_presence
+            || self
+                .proof
+                .reconstructed_digests
+                .iter()
+                .zip(&actual.reconstructed_digests)
+                .any(|(expected, actual)| expected.is_some() && expected != actual)
+        {
+            return Err(Error::InvalidConfig(
+                "deterministic reconstruction diverged",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Optional developer checks. The production build does not encode or hash a reconstructed payload.
+pub fn reconstruction_digest(value: &impl Encode) -> Result<Option<[u8; 32]>> {
+    #[cfg(feature = "verify-reconstruction")]
+    {
+        payload_digest(value).map(Some)
+    }
+    #[cfg(not(feature = "verify-reconstruction"))]
+    {
+        let _ = value;
+        Ok(None)
+    }
+}

--- a/core/cu29_logstream/src/capture.rs
+++ b/core/cu29_logstream/src/capture.rs
@@ -1,31 +1,42 @@
-//! Generated selective streaming codecs. Encoding and hashing run on output workers.
+//! Generated selective native codecs. Optional verification runs on output workers.
 
 use crate::{ApplicationSchema, Error, Result};
-use alloc::{string::ToString, vec::Vec};
-use bincode::{
-    Decode, Encode,
-    enc::{Encoder, EncoderImpl, write::Writer},
-    error::EncodeError,
-};
+use alloc::string::ToString;
+use bincode::{Encode, enc::Encoder, error::EncodeError};
 use cu29_runtime::copperlist::CopperList;
 use cu29_traits::CopperListTuple;
 
-/// One proof per output slot, including intentionally absent messages.
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
-pub struct CaptureProof {
-    pub version: u16,
-    pub original_presence: Vec<bool>,
-    pub reconstructed_digests: Vec<Option<[u8; 32]>>,
+// Gate generated methods using this crate's feature, not a downstream app's
+// feature names or the proc-macro host's independently resolved features.
+#[doc(hidden)]
+#[cfg(feature = "verify-reconstruction")]
+#[macro_export]
+macro_rules! __with_reconstruction_verification {
+    ($($item:item)*) => { $($item)* };
+}
+#[doc(hidden)]
+#[cfg(not(feature = "verify-reconstruction"))]
+#[macro_export]
+macro_rules! __with_reconstruction_verification {
+    ($($item:item)*) => {};
 }
 
-/// Generated from the application's RON. Users do not implement slot dispatch.
+/// Generated from RON. Slot dispatch and storage are fixed at compile time.
 pub trait CaptureDataSet: CopperListTuple {
     const RECONSTRUCTION: &'static [Option<u32>];
-    fn original_presence(&self) -> Vec<bool>;
     fn stream_schema() -> ApplicationSchema;
     fn encode_capture<E: Encoder>(&self, encoder: &mut E) -> core::result::Result<(), EncodeError>;
-    fn capture_proof(&self) -> Result<CaptureProof>;
+    fn validate_capture(&self) -> Result<()>;
     fn restore_sender_metadata(&mut self, captured: &Self);
+    #[cfg(feature = "verify-reconstruction")]
+    fn encode_reconstruction<E: Encoder>(
+        &self,
+        encoder: &mut E,
+    ) -> core::result::Result<(), EncodeError>;
+    #[cfg(feature = "verify-reconstruction")]
+    fn reconstruction_digest(&self) -> Result<[u8; 32]> {
+        payload_digest(&ReconstructionView(self))
+    }
 }
 
 pub struct CaptureView<'a, P>(pub &'a P);
@@ -35,19 +46,32 @@ impl<P: CaptureDataSet> Encode for CaptureView<'_, P> {
     }
 }
 
+#[cfg(feature = "verify-reconstruction")]
+struct ReconstructionView<'a, P>(&'a P);
+#[cfg(feature = "verify-reconstruction")]
+impl<P: CaptureDataSet> Encode for ReconstructionView<'_, P> {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> core::result::Result<(), EncodeError> {
+        self.0.encode_reconstruction(encoder)
+    }
+}
+
+#[cfg(feature = "verify-reconstruction")]
 struct DigestWriter(blake3::Hasher);
-impl Writer for DigestWriter {
+#[cfg(feature = "verify-reconstruction")]
+impl bincode::enc::write::Writer for DigestWriter {
     fn write(&mut self, bytes: &[u8]) -> core::result::Result<(), EncodeError> {
         self.0.update(bytes);
         Ok(())
     }
 }
 
-/// Hash a canonical payload without allocating an encoded payload buffer.
+/// Debug-only digest of the reconstructed outputs, including payload presence.
+/// Hashes directly from borrowed payloads without an intermediate allocation.
+#[cfg(feature = "verify-reconstruction")]
 pub fn payload_digest(value: &impl Encode) -> Result<[u8; 32]> {
     let mut writer = DigestWriter(blake3::Hasher::new());
     value
-        .encode(&mut EncoderImpl::new(
+        .encode(&mut bincode::enc::EncoderImpl::new(
             &mut writer,
             bincode::config::standard(),
         ))
@@ -55,17 +79,28 @@ pub fn payload_digest(value: &impl Encode) -> Result<[u8; 32]> {
     Ok(*writer.0.finalize().as_bytes())
 }
 
-/// A captured native list and its explicit omission proof. Never a verified twin frame.
+/// A native capture. Production stores only the CopperList itself.
 pub struct CapturedList<P: CopperListTuple> {
     pub copperlist: CopperList<P>,
-    pub proof: CaptureProof,
+    #[cfg(feature = "verify-reconstruction")]
+    pub digest: Option<[u8; 32]>,
+}
+
+impl<P: CopperListTuple> CapturedList<P> {
+    /// Wrap an ordinary capture archive entry. Archives contain no debug digests.
+    pub fn new(copperlist: CopperList<P>) -> Self {
+        Self {
+            copperlist,
+            #[cfg(feature = "verify-reconstruction")]
+            digest: None,
+        }
+    }
 }
 
 pub fn encode_capture_record_into<P: CaptureDataSet>(
     list: &CopperList<P>,
     output: &mut [u8],
 ) -> Result<usize> {
-    let proof = list.msgs.capture_proof()?;
     let header_len = crate::record::RECORD_HEADER_LEN;
     if output.len() < header_len {
         return Err(Error::BufferTooSmall {
@@ -75,11 +110,25 @@ pub fn encode_capture_record_into<P: CaptureDataSet>(
     }
     let (header, payload) = output.split_at_mut(header_len);
     let len = bincode::encode_into_slice(
-        (&proof, list.id, list.get_state(), CaptureView(&list.msgs)),
+        (list.id, list.get_state(), CaptureView(&list.msgs)),
         payload,
         bincode::config::standard(),
     )
     .map_err(|e| Error::Codec(e.to_string()))?;
+    // A developer build appends one fixed-size digest. Production is exactly
+    // the existing native CopperList format, including its presence planes.
+    #[cfg(feature = "verify-reconstruction")]
+    let len = {
+        let available = payload.len();
+        let trailer = payload
+            .get_mut(len..len + 32)
+            .ok_or(Error::BufferTooSmall {
+                needed: header_len + len + 32,
+                available: header_len + available,
+            })?;
+        trailer.copy_from_slice(&list.msgs.reconstruction_digest()?);
+        len + 32
+    };
     crate::record::encode_record_header(
         crate::RecordKind::CopperList,
         list.id,
@@ -89,62 +138,48 @@ pub fn encode_capture_record_into<P: CaptureDataSet>(
     Ok(header_len + len)
 }
 
-/// Decode once; return the original native byte slice for capture archival.
+/// Decode once and borrow the native bytes for archival. Verification builds
+/// accept production captures too; production rejects debug trailers explicitly.
 pub fn decode_capture<P: CaptureDataSet>(payload: &[u8]) -> Result<(CapturedList<P>, &[u8])> {
-    let (proof, offset): (CaptureProof, usize) =
-        bincode::decode_from_slice(payload, bincode::config::standard().with_limit::<1048576>())
+    let (copperlist, consumed): (CopperList<P>, usize) =
+        bincode::decode_from_slice(payload, bincode::config::standard())
             .map_err(|e| Error::Codec(e.to_string()))?;
-    let output_count = P::get_output_specs().len();
-    if proof.version != 1
-        || proof.original_presence.len() != output_count
-        || proof.reconstructed_digests.len() != output_count
-    {
-        return Err(Error::InvalidConfig("invalid capture proof layout"));
+    copperlist.msgs.validate_capture()?;
+    #[cfg(feature = "verify-reconstruction")]
+    let digest = match &payload[consumed..] {
+        [] => None,
+        bytes => Some(
+            bytes
+                .try_into()
+                .map_err(|_| Error::InvalidConfig("invalid reconstruction digest trailer"))?,
+        ),
+    };
+    #[cfg(not(feature = "verify-reconstruction"))]
+    if consumed != payload.len() {
+        return Err(Error::InvalidConfig(
+            "capture has trailing bytes; debug captures require verify-reconstruction",
+        ));
     }
-    let native = &payload[offset..];
-    let copperlist = crate::decode_copperlist::<P>(native)?;
-    let captured_presence = copperlist.msgs.original_presence();
-    for (i, present) in captured_presence.iter().enumerate() {
-        let reconstruct = P::RECONSTRUCTION.get(i).is_some_and(Option::is_some);
-        if *present != (proof.original_presence[i] && !reconstruct)
-            || (proof.reconstructed_digests[i].is_some() && !reconstruct)
-        {
-            return Err(Error::InvalidConfig(
-                "capture payload/presence policy mismatch",
-            ));
-        }
-    }
-    Ok((CapturedList { copperlist, proof }, native))
+    Ok((
+        CapturedList {
+            copperlist,
+            #[cfg(feature = "verify-reconstruction")]
+            digest,
+        },
+        &payload[..consumed],
+    ))
 }
 
+#[cfg(feature = "verify-reconstruction")]
 impl<P: CaptureDataSet> CapturedList<P> {
     pub fn verify(&self) -> Result<()> {
-        let actual = self.copperlist.msgs.capture_proof()?;
-        if actual.original_presence != self.proof.original_presence
-            || self
-                .proof
-                .reconstructed_digests
-                .iter()
-                .zip(&actual.reconstructed_digests)
-                .any(|(expected, actual)| expected.is_some() && expected != actual)
+        if let Some(expected) = self.digest
+            && self.copperlist.msgs.reconstruction_digest()? != expected
         {
             return Err(Error::InvalidConfig(
                 "deterministic reconstruction diverged",
             ));
         }
         Ok(())
-    }
-}
-
-/// Optional developer checks. The production build does not encode or hash a reconstructed payload.
-pub fn reconstruction_digest(value: &impl Encode) -> Result<Option<[u8; 32]>> {
-    #[cfg(feature = "verify-reconstruction")]
-    {
-        payload_digest(value).map(Some)
-    }
-    #[cfg(not(feature = "verify-reconstruction"))]
-    {
-        let _ = value;
-        Ok(None)
     }
 }

--- a/core/cu29_logstream/src/lib.rs
+++ b/core/cu29_logstream/src/lib.rs
@@ -16,6 +16,10 @@ mod archive;
 pub use archive::{CaptureArchive, NativeArchive};
 #[cfg(feature = "std")]
 pub mod twin;
+#[cfg(feature = "std")]
+mod twin_session;
+#[cfg(feature = "std")]
+pub use twin_session::{CuTwin, CuTwinBuilder, CuTwinReader, CuTwinRecordingState, CuTwinStatus};
 
 /// Bounded ground-side delivery to caller-owned telemetry consumers.
 #[cfg(feature = "std")]

--- a/core/cu29_logstream/src/lib.rs
+++ b/core/cu29_logstream/src/lib.rs
@@ -13,12 +13,15 @@ pub use cu_fec::{DensityThreshold, EncodingSymbolId, Field, RlcConfig};
 #[cfg(feature = "std")]
 mod archive;
 #[cfg(feature = "std")]
-pub use archive::NativeArchive;
+pub use archive::{CaptureArchive, NativeArchive};
+#[cfg(feature = "std")]
+pub mod twin;
 
 /// Bounded ground-side delivery to caller-owned telemetry consumers.
 #[cfg(feature = "std")]
 pub mod telemetry;
 
+pub mod capture;
 mod copper;
 mod error;
 mod manifest;

--- a/core/cu29_logstream/src/manifest.rs
+++ b/core/cu29_logstream/src/manifest.rs
@@ -14,7 +14,7 @@ use bincode::{Decode, Encode};
 use cu29_runtime::config::{LogStreamDestinationConfig, LogStreamRepairDensity, LogStreamRlcField};
 use cu29_traits::TaskOutputSpec;
 
-pub const SESSION_MANIFEST_VERSION: u16 = 2;
+pub const SESSION_MANIFEST_VERSION: u16 = 1;
 
 /// Link and codec policy after RON validation and MTU resolution.
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]

--- a/core/cu29_logstream/src/manifest.rs
+++ b/core/cu29_logstream/src/manifest.rs
@@ -14,7 +14,7 @@ use bincode::{Decode, Encode};
 use cu29_runtime::config::{LogStreamDestinationConfig, LogStreamRepairDensity, LogStreamRlcField};
 use cu29_traits::TaskOutputSpec;
 
-pub const SESSION_MANIFEST_VERSION: u16 = 1;
+pub const SESSION_MANIFEST_VERSION: u16 = 2;
 
 /// Link and codec policy after RON validation and MTU resolution.
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
@@ -63,6 +63,8 @@ pub struct ResolvedContentPolicy {
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 pub struct ApplicationSchema {
     pub outputs: Vec<ApplicationOutputSchema>,
+    /// Per-output deterministic ABI; empty means full capture.
+    pub reconstruction: Vec<Option<u32>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
@@ -75,6 +77,7 @@ pub struct ApplicationOutputSchema {
 impl ApplicationSchema {
     pub fn from_output_specs(specs: &[TaskOutputSpec]) -> Self {
         Self {
+            reconstruction: Vec::new(),
             outputs: specs
                 .iter()
                 .map(|spec| ApplicationOutputSchema {

--- a/core/cu29_logstream/src/twin.rs
+++ b/core/cu29_logstream/src/twin.rs
@@ -1,0 +1,355 @@
+//! Ordered, bounded live replay, independent of archive writes and presentation loss.
+use crate::{
+    StreamIdentity,
+    capture::{CaptureDataSet, CapturedList},
+    telemetry::TelemetryPublisher,
+};
+use crossbeam_queue::ArrayQueue;
+use cu29_clock::RobotClockMock;
+use cu29_runtime::{copperlist::CopperList, curuntime::KeyFrame};
+use cu29_traits::{CopperListTuple, CuResult};
+use std::{
+    num::NonZeroUsize,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+        mpsc::{self, SyncSender, TrySendError},
+    },
+    thread::{self, JoinHandle},
+    time::{Duration, Instant},
+};
+
+/// Implemented by `#[copper_runtime(..., sim_mode = true)]` with logstream enabled.
+pub trait LiveReplay: Sized + 'static {
+    type DataSet: CaptureDataSet + Send + 'static;
+    fn build_twin() -> CuResult<(Self, RobotClockMock)>;
+    fn replay_capture(
+        &mut self,
+        clock: &RobotClockMock,
+        capture: &mut CopperList<Self::DataSet>,
+        keyframe: Option<&KeyFrame>,
+    ) -> CuResult<()>;
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ReconstructionState {
+    #[default]
+    Waiting,
+    Recovering,
+    Reconstructed,
+    Verified,
+    Diverged,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TwinStatus {
+    pub state: ReconstructionState,
+    pub reconstructed: u64,
+    pub verified: u64,
+    pub divergences: u64,
+    pub queue_overflows: u64,
+}
+
+/// Compose receiver/archive status with independently available reconstruction health.
+pub trait TwinReceiverStatus: Copy + PartialEq + Send + 'static {
+    fn with_twin(self, status: TwinStatus) -> Self;
+}
+
+pub struct TwinFrame<P: CopperListTuple> {
+    pub identity: StreamIdentity,
+    pub received_at: Instant,
+    pub copperlist: CopperList<P>,
+}
+
+/// Synchronous replay engine, also usable for ordinary offline capture replay.
+pub struct LiveTwin<A: LiveReplay> {
+    app: A,
+    clock: RobotClockMock,
+    next: Option<u64>,
+    pub status: TwinStatus,
+}
+impl<A: LiveReplay> LiveTwin<A> {
+    pub fn new() -> CuResult<Self> {
+        let (app, clock) = A::build_twin()?;
+        Ok(Self {
+            app,
+            clock,
+            next: None,
+            status: TwinStatus::default(),
+        })
+    }
+    pub fn recover(&mut self) {
+        self.next = None;
+        self.status.state = ReconstructionState::Recovering;
+    }
+    pub fn reconstruct(
+        &mut self,
+        mut capture: CapturedList<A::DataSet>,
+        keyframe: Option<&KeyFrame>,
+    ) -> CuResult<Option<CopperList<A::DataSet>>> {
+        let id = capture.copperlist.id;
+        if self.next != Some(id) && keyframe.is_none_or(|k| k.culistid != id) {
+            if self.status.state != ReconstructionState::Diverged {
+                self.recover();
+            }
+            return Ok(None);
+        }
+        if let Err(error) = self
+            .app
+            .replay_capture(&self.clock, &mut capture.copperlist, keyframe)
+            .and_then(|()| {
+                capture
+                    .verify()
+                    .map_err(|e| cu29_traits::CuError::from(e.to_string()))
+            })
+        {
+            self.next = None;
+            self.status.state = ReconstructionState::Diverged;
+            self.status.divergences += 1;
+            return Err(error);
+        }
+        self.next = id.checked_add(1);
+        self.status.state = if capture
+            .proof
+            .reconstructed_digests
+            .iter()
+            .any(Option::is_some)
+        {
+            ReconstructionState::Verified
+        } else {
+            ReconstructionState::Reconstructed
+        };
+        self.status.reconstructed += 1;
+        if self.status.state == ReconstructionState::Verified {
+            self.status.verified += 1;
+        }
+        Ok(Some(capture.copperlist))
+    }
+}
+
+enum Input<P: CopperListTuple> {
+    Capture {
+        capture: CapturedList<P>,
+        identity: StreamIdentity,
+        received_at: Instant,
+    },
+    Anchor(KeyFrame),
+}
+struct Work<P: CopperListTuple> {
+    input: Input<P>,
+    generation: u64,
+}
+struct Pending<P: CopperListTuple> {
+    capture: CapturedList<P>,
+    identity: StreamIdentity,
+    received_at: Instant,
+}
+
+/// Nonblocking archive-to-replay handoff. The worker consumes every admitted
+/// iteration; only successfully reconstructed results enter the UI ring.
+/// Payload verification is opt-in through `verify-reconstruction`.
+/// Storage bounds are `capacity` queued events, `capacity` pending captures,
+/// one pending anchor and one executing frame, in addition to the telemetry ring.
+/// Overflow invalidates replay until an admitted matching anchor, never archival.
+pub struct TwinWorker<P: CopperListTuple, S> {
+    sender: Option<SyncSender<Work<P>>>,
+    statuses: Arc<ArrayQueue<S>>,
+    generation: Arc<AtomicU64>,
+    overflows: Arc<AtomicU64>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl<P: CaptureDataSet + Send + 'static, S: TwinReceiverStatus> TwinWorker<P, S> {
+    pub fn spawn<A: LiveReplay<DataSet = P>>(
+        capacity: NonZeroUsize,
+        mut publisher: TelemetryPublisher<TwinFrame<P>, S>,
+    ) -> CuResult<Self> {
+        let (sender, receiver) = mpsc::sync_channel::<Work<P>>(capacity.get());
+        let statuses = Arc::new(ArrayQueue::new(1));
+        let pending_status = statuses.clone();
+        let generation = Arc::new(AtomicU64::new(0));
+        let epoch = generation.clone();
+        let overflows = Arc::new(AtomicU64::new(0));
+        let drops = overflows.clone();
+        let (ready_tx, ready_rx) = mpsc::sync_channel(1);
+        let worker = thread::Builder::new()
+            .name("copper-live-twin".into())
+            .spawn(move || {
+                let mut twin = match LiveTwin::<A>::new() {
+                    Ok(twin) => {
+                        let _ = ready_tx.send(Ok(()));
+                        twin
+                    }
+                    Err(e) => {
+                        let _ = ready_tx.send(Err(e));
+                        return;
+                    }
+                };
+                let mut current_generation = 0;
+                let mut pending: std::collections::VecDeque<Pending<P>> =
+                    std::collections::VecDeque::with_capacity(capacity.get());
+                let mut anchor: Option<KeyFrame> = None;
+                let mut receiver_status = publisher.status();
+                loop {
+                    if let Some(status) = pending_status.pop() {
+                        receiver_status = status;
+                    }
+                    let latest_generation = epoch.load(Ordering::Acquire);
+                    if current_generation != latest_generation {
+                        twin.recover();
+                        pending.clear();
+                        anchor = None;
+                        current_generation = latest_generation;
+                    }
+                    twin.status.queue_overflows = drops.load(Ordering::Relaxed);
+                    publisher.set_status(receiver_status.with_twin(twin.status));
+                    match receiver.recv_timeout(Duration::from_millis(10)) {
+                        Ok(work) => {
+                            let latest = epoch.load(Ordering::Acquire);
+                            if current_generation != latest {
+                                twin.recover();
+                                pending.clear();
+                                anchor = None;
+                                current_generation = latest;
+                            }
+                            if work.generation != current_generation {
+                                continue;
+                            }
+                            match work.input {
+                                Input::Capture {
+                                    capture,
+                                    identity,
+                                    received_at,
+                                } => {
+                                    if pending.len() == capacity.get() {
+                                        pending.pop_front();
+                                        drops.fetch_add(1, Ordering::Relaxed);
+                                        twin.recover();
+                                    }
+                                    pending.push_back(Pending {
+                                        capture,
+                                        identity,
+                                        received_at,
+                                    });
+                                }
+                                Input::Anchor(frame) => {
+                                    if anchor
+                                        .as_ref()
+                                        .is_none_or(|old| old.culistid < frame.culistid)
+                                    {
+                                        anchor = Some(frame);
+                                    }
+                                }
+                            }
+                            while let Some(first) = pending.front() {
+                                if twin.next != Some(first.capture.copperlist.id) {
+                                    let Some(frame) = &anchor else {
+                                        break;
+                                    };
+                                    let Some(position) = pending.iter().position(|item| {
+                                        item.capture.copperlist.id == frame.culistid
+                                    }) else {
+                                        break;
+                                    };
+                                    pending.drain(..position);
+                                }
+                                let item = pending.pop_front().unwrap();
+                                let keyframe = if anchor.as_ref().is_some_and(|frame| {
+                                    frame.culistid == item.capture.copperlist.id
+                                }) {
+                                    anchor.take()
+                                } else {
+                                    None
+                                };
+                                if let Ok(Some(copperlist)) =
+                                    twin.reconstruct(item.capture, keyframe.as_ref())
+                                    && epoch.load(Ordering::Acquire) == current_generation
+                                {
+                                    publisher.publish(TwinFrame {
+                                        identity: item.identity,
+                                        received_at: item.received_at,
+                                        copperlist,
+                                    });
+                                }
+                            }
+                        }
+                        Err(mpsc::RecvTimeoutError::Timeout) => {}
+                        Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                    }
+                }
+                if let Some(status) = pending_status.pop() {
+                    receiver_status = status;
+                }
+                publisher.set_status(receiver_status.with_twin(twin.status));
+            })
+            .map_err(|e| cu29_traits::CuError::new_with_cause("spawn live twin", e))?;
+        ready_rx
+            .recv()
+            .map_err(|_| cu29_traits::CuError::from("live twin initialization failed"))??;
+        Ok(Self {
+            sender: Some(sender),
+            statuses,
+            generation,
+            overflows,
+            worker: Some(worker),
+        })
+    }
+    /// Route an already archived event into live replay. This is the usual
+    /// ground-station integration: `twin.accept(event, archive.accept(event)?)`.
+    /// Archival must succeed first; replay never retries or delays that writer.
+    pub fn accept(
+        &self,
+        event: &crate::SessionEvent,
+        capture: Option<CapturedList<P>>,
+    ) -> crate::Result<()> {
+        match event {
+            crate::SessionEvent::Manifest(_) | crate::SessionEvent::Gap { .. } => self.recover(),
+            crate::SessionEvent::VerifiedAnchor { keyframe, .. } => {
+                self.anchor(crate::decode_keyframe(keyframe.decoded()?.payload)?)
+            }
+            crate::SessionEvent::ContinuousRecord { identity, .. } => {
+                if let Some(capture) = capture {
+                    self.submit(capture, *identity, Instant::now());
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+    pub fn set_status(&self, status: S) {
+        self.statuses.force_push(status);
+    }
+    pub fn recover(&self) {
+        self.generation.fetch_add(1, Ordering::AcqRel);
+    }
+    pub fn submit(&self, capture: CapturedList<P>, identity: StreamIdentity, received_at: Instant) {
+        self.send(Input::Capture {
+            capture,
+            identity,
+            received_at,
+        });
+    }
+    /// Accept only keyframes from the session router's VerifiedAnchor event.
+    /// Control objects may arrive before or after their captured boundary.
+    pub fn anchor(&self, frame: KeyFrame) {
+        self.send(Input::Anchor(frame));
+    }
+    fn send(&self, input: Input<P>) {
+        let work = Work {
+            input,
+            generation: self.generation.load(Ordering::Acquire),
+        };
+        if let Err(TrySendError::Full(_)) = self.sender.as_ref().unwrap().try_send(work) {
+            self.overflows.fetch_add(1, Ordering::Relaxed);
+            self.recover();
+        }
+    }
+}
+impl<P: CopperListTuple, S> Drop for TwinWorker<P, S> {
+    fn drop(&mut self) {
+        self.sender.take();
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}

--- a/core/cu29_logstream/src/twin.rs
+++ b/core/cu29_logstream/src/twin.rs
@@ -23,6 +23,9 @@ use std::{
 pub trait LiveReplay: Sized + 'static {
     type DataSet: CaptureDataSet + Send + 'static;
     fn build_twin() -> CuResult<(Self, RobotClockMock)>;
+    fn stop_twin(&mut self) -> CuResult<()> {
+        Ok(())
+    }
     fn replay_capture(
         &mut self,
         clock: &RobotClockMock,
@@ -94,36 +97,38 @@ impl<A: LiveReplay> LiveTwin<A> {
             }
             return Ok(None);
         }
-        if let Err(error) = self
+        let result = self
             .app
-            .replay_capture(&self.clock, &mut capture.copperlist, keyframe)
-            .and_then(|()| {
-                capture
-                    .verify()
-                    .map_err(|e| cu29_traits::CuError::from(e.to_string()))
-            })
-        {
+            .replay_capture(&self.clock, &mut capture.copperlist, keyframe);
+        #[cfg(feature = "verify-reconstruction")]
+        let result = result.and_then(|()| {
+            capture
+                .verify()
+                .map_err(|e| cu29_traits::CuError::from(e.to_string()))
+        });
+        if let Err(error) = result {
             self.next = None;
             self.status.state = ReconstructionState::Diverged;
             self.status.divergences += 1;
             return Err(error);
         }
         self.next = id.checked_add(1);
-        self.status.state = if capture
-            .proof
-            .reconstructed_digests
-            .iter()
-            .any(Option::is_some)
-        {
-            ReconstructionState::Verified
-        } else {
-            ReconstructionState::Reconstructed
-        };
+        self.status.state = ReconstructionState::Reconstructed;
+        #[cfg(feature = "verify-reconstruction")]
+        if capture.digest.is_some() {
+            self.status.state = ReconstructionState::Verified;
+        }
         self.status.reconstructed += 1;
         if self.status.state == ReconstructionState::Verified {
             self.status.verified += 1;
         }
         Ok(Some(capture.copperlist))
+    }
+}
+
+impl<A: LiveReplay> Drop for LiveTwin<A> {
+    fn drop(&mut self) {
+        let _ = self.app.stop_twin();
     }
 }
 
@@ -151,12 +156,13 @@ struct Pending<P: CopperListTuple> {
 /// Storage bounds are `capacity` queued events, `capacity` pending captures,
 /// one pending anchor and one executing frame, in addition to the telemetry ring.
 /// Overflow invalidates replay until an admitted matching anchor, never archival.
+#[doc(hidden)]
 pub struct TwinWorker<P: CopperListTuple, S> {
     sender: Option<SyncSender<Work<P>>>,
     statuses: Arc<ArrayQueue<S>>,
     generation: Arc<AtomicU64>,
     overflows: Arc<AtomicU64>,
-    worker: Option<JoinHandle<()>>,
+    worker: Option<JoinHandle<TwinStatus>>,
 }
 
 impl<P: CaptureDataSet + Send + 'static, S: TwinReceiverStatus> TwinWorker<P, S> {
@@ -182,7 +188,7 @@ impl<P: CaptureDataSet + Send + 'static, S: TwinReceiverStatus> TwinWorker<P, S>
                     }
                     Err(e) => {
                         let _ = ready_tx.send(Err(e));
-                        return;
+                        return TwinStatus::default();
                     }
                 };
                 let mut current_generation = 0;
@@ -281,6 +287,7 @@ impl<P: CaptureDataSet + Send + 'static, S: TwinReceiverStatus> TwinWorker<P, S>
                     receiver_status = status;
                 }
                 publisher.set_status(receiver_status.with_twin(twin.status));
+                twin.status
             })
             .map_err(|e| cu29_traits::CuError::new_with_cause("spawn live twin", e))?;
         ready_rx
@@ -294,6 +301,15 @@ impl<P: CaptureDataSet + Send + 'static, S: TwinReceiverStatus> TwinWorker<P, S>
             worker: Some(worker),
         })
     }
+    pub fn finish(mut self) -> CuResult<TwinStatus> {
+        self.sender.take();
+        self.worker
+            .take()
+            .ok_or_else(|| cu29_traits::CuError::from("Twin worker already joined"))?
+            .join()
+            .map_err(|_| cu29_traits::CuError::from("Twin replay worker panicked"))
+    }
+
     /// Route an already archived event into live replay. This is the usual
     /// ground-station integration: `twin.accept(event, archive.accept(event)?)`.
     /// Archival must succeed first; replay never retries or delays that writer.

--- a/core/cu29_logstream/src/twin_session.rs
+++ b/core/cu29_logstream/src/twin_session.rs
@@ -1,0 +1,285 @@
+//! Copper-owned receive, archive, and reconstruction lifecycle for one robot session.
+
+use crate::telemetry::{TelemetryReader, telemetry_channel};
+use crate::twin::{LiveReplay, TwinFrame, TwinReceiverStatus, TwinStatus, TwinWorker};
+use crate::{
+    CaptureArchive, CuStreamRx, FiniteObjectLimits, SessionEvent, SessionRouter,
+    SessionRouterLimits, StreamIdentity,
+};
+use cu29_traits::{CuError, CuResult};
+use std::marker::PhantomData;
+use std::num::NonZeroUsize;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+const REPLAY_CAPACITY: NonZeroUsize = NonZeroUsize::new(32).unwrap();
+const FRAME_CAPACITY: NonZeroUsize = NonZeroUsize::new(64).unwrap();
+const SLAB_BYTES: usize = 16 * 1024 * 1024;
+const SECTION_BYTES: usize = 65536;
+const POLL_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Recording state is independent of reconstruction and display consumption.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CuTwinRecordingState {
+    #[default]
+    Waiting,
+    Recording,
+    Closed,
+    Failed,
+}
+
+/// Receiver and reconstruction health, available even when the view is paused.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CuTwinStatus {
+    pub latest: Option<u64>,
+    pub anchor: Option<u64>,
+    pub gaps: usize,
+    pub packets: usize,
+    pub archived: u64,
+    pub identity: Option<StreamIdentity>,
+    pub last_packet: Option<Instant>,
+    pub state: CuTwinRecordingState,
+    pub twin: TwinStatus,
+}
+
+impl TwinReceiverStatus for CuTwinStatus {
+    fn with_twin(mut self, status: TwinStatus) -> Self {
+        self.twin = status;
+        self
+    }
+}
+
+/// Builder for a generated application's live twin. Copper owns all worker,
+/// routing, archive, and recovery plumbing; callers supply a packet transport.
+/// Receiver bounds match the default 1200-byte-MTU, 64-symbol streaming profile.
+/// One handle accepts one sender session, with a fresh archive path.
+pub struct CuTwinBuilder<A, R> {
+    rx: R,
+    log_base: Option<PathBuf>,
+    frame_capacity: NonZeroUsize,
+    reconstruct: bool,
+    app: PhantomData<fn() -> A>,
+}
+
+impl<A: LiveReplay, R: CuStreamRx + 'static> CuTwinBuilder<A, R> {
+    pub fn with_log_path(mut self, path: impl AsRef<Path>) -> Self {
+        self.log_base = Some(path.as_ref().to_path_buf());
+        self
+    }
+
+    /// Presentation retention only; slowing the reader never delays recording.
+    pub fn with_frame_capacity(mut self, capacity: NonZeroUsize) -> Self {
+        self.frame_capacity = capacity;
+        self
+    }
+
+    /// Record the native capture without starting task reconstruction.
+    pub fn archive_only(mut self) -> Self {
+        self.reconstruct = false;
+        self
+    }
+
+    pub fn spawn(self) -> CuResult<(CuTwin<A>, CuTwinReader<A>)> {
+        let path = self
+            .log_base
+            .ok_or_else(|| CuError::from("Copper twin requires a log path"))?;
+        if cu29_runtime::replay::first_slab_path(&path)?.exists() || path.exists() {
+            return Err(CuError::from(
+                "Copper twin archive already exists; choose a fresh log path",
+            ));
+        }
+        if let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| CuError::new_with_cause("Create twin log directory", e))?;
+        }
+        let (publisher, reader) = telemetry_channel(self.frame_capacity, CuTwinStatus::default());
+        let stop = Arc::new(AtomicBool::new(false));
+        let stopping = stop.clone();
+        let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
+        let worker = thread::Builder::new()
+            .name("copper-twin-receiver".into())
+            .spawn(move || {
+                let mut status = CuTwinStatus::default();
+                let (replay, mut publisher) = if self.reconstruct {
+                    match TwinWorker::spawn::<A>(REPLAY_CAPACITY, publisher) {
+                        Ok(replay) => (Some(replay), None),
+                        Err(error) => {
+                            let _ = ready_tx.send(Err(error.clone()));
+                            return Err(error);
+                        }
+                    }
+                } else {
+                    (None, Some(publisher))
+                };
+                let mut publish_status = |status| {
+                    if let Some(replay) = &replay {
+                        replay.set_status(status);
+                    }
+                    if let Some(publisher) = &mut publisher {
+                        publisher.set_status(status);
+                    }
+                };
+                let mut archive = None;
+                let result = (|| {
+                    let mut router = SessionRouter::<1128, 64, 64>::new(SessionRouterLimits {
+                        max_sessions: 1,
+                        max_startup_packets: 64,
+                        max_recovery_records: 8,
+                        max_pending_events: 64,
+                        max_record_bytes: 4096,
+                        max_buffered_records: 64,
+                        equation_capacity: 64,
+                        finite_objects: FiniteObjectLimits::new(65536, 1128, 4),
+                    })
+                    .map_err(stream_error)?;
+                    let _ = ready_tx.send(Ok(()));
+                    let mut rx = self.rx;
+                    let mut packet = [0; 1200];
+                    while !stopping.load(Ordering::Acquire) {
+                        if let Some(len) = rx
+                            .try_recv(&mut packet)
+                            .map_err(|e| CuError::from(format!("Twin receive: {e:?}")))?
+                        {
+                            let bytes = packet.get(..len).ok_or_else(|| {
+                                CuError::from("Transport returned an invalid packet length")
+                            })?;
+                            status.last_packet = Some(Instant::now());
+                            router
+                                .receive_datagram(bytes, |event| {
+                                    // Recovery objects can arrive before the manifest.
+                                    // The router retains them and emits VerifiedAnchor
+                                    // once their manifest/keyframe references agree.
+                                    if matches!(event, SessionEvent::Object { .. }) {
+                                        return Ok(());
+                                    }
+                                    if let SessionEvent::Manifest(manifest) = &event {
+                                        status.identity = Some(manifest.identity);
+                                        archive = Some(CaptureArchive::<A::DataSet>::new(
+                                            &path,
+                                            manifest.clone(),
+                                            SLAB_BYTES,
+                                            SECTION_BYTES,
+                                        )?);
+                                    }
+                                    let writer =
+                                        archive.as_mut().ok_or(crate::Error::InvalidConfig(
+                                            "capture arrived before its manifest",
+                                        ))?;
+                                    let capture = writer.accept(&event)?;
+                                    if let Some(capture) = &capture {
+                                        status.latest = Some(capture.copperlist.id);
+                                        status.archived += 1;
+                                        status.state = CuTwinRecordingState::Recording;
+                                    }
+                                    if let Some(replay) = &replay {
+                                        replay.accept(&event, capture)?;
+                                    }
+                                    match event {
+                                        SessionEvent::Gap { .. } => status.gaps += 1,
+                                        SessionEvent::VerifiedAnchor { anchor, .. } => {
+                                            status.anchor = Some(anchor.copperlist_id)
+                                        }
+                                        _ => {}
+                                    }
+                                    Ok::<(), crate::Error>(())
+                                })
+                                .map_err(|e| CuError::from(format!("Twin receive: {e:?}")))?;
+                            status.packets = router.stats().datagrams_seen;
+                            publish_status(status);
+                        } else {
+                            thread::park_timeout(POLL_INTERVAL);
+                        }
+                    }
+                    if let Some(archive) = archive.take() {
+                        archive.finish().map_err(stream_error)?;
+                    }
+                    Ok(())
+                })();
+                status.state = if result.is_ok() {
+                    CuTwinRecordingState::Closed
+                } else {
+                    CuTwinRecordingState::Failed
+                };
+                publish_status(status);
+                // Drain admitted replay before returning the final receiver status.
+                if let Some(replay) = replay {
+                    status.twin = replay.finish()?;
+                }
+                result.map(|()| status)
+            })
+            .map_err(|e| CuError::new_with_cause("Start Copper twin", e))?;
+        if let Err(error) = ready_rx
+            .recv()
+            .map_err(|_| CuError::from("Copper twin initialization failed"))
+            .and_then(|ready| ready)
+        {
+            stop.store(true, Ordering::Release);
+            let _ = worker.join();
+            return Err(error);
+        }
+        Ok((
+            CuTwin {
+                stop,
+                worker: Some(worker),
+                final_status: None,
+                app: PhantomData,
+            },
+            reader,
+        ))
+    }
+}
+
+fn stream_error(error: crate::Error) -> CuError {
+    CuError::from(error.to_string())
+}
+
+/// Reader for a generated graph's reconstructed frames and recording status.
+pub type CuTwinReader<A> = TelemetryReader<TwinFrame<<A as LiveReplay>::DataSet>, CuTwinStatus>;
+
+/// Running Copper twin. The separately owned reader can be paused or dropped
+/// without affecting recording. `stop()` closes the archive and drains admitted
+/// replay; dropping the handle also stops and joins Copper's workers.
+pub struct CuTwin<A: LiveReplay> {
+    stop: Arc<AtomicBool>,
+    worker: Option<JoinHandle<CuResult<CuTwinStatus>>>,
+    final_status: Option<CuTwinStatus>,
+    app: PhantomData<fn() -> A>,
+}
+
+impl<A: LiveReplay> CuTwin<A> {
+    pub fn builder<R: CuStreamRx + 'static>(rx: R) -> CuTwinBuilder<A, R> {
+        CuTwinBuilder {
+            rx,
+            log_base: None,
+            frame_capacity: FRAME_CAPACITY,
+            reconstruct: true,
+            app: PhantomData,
+        }
+    }
+
+    pub fn stop(&mut self) -> CuResult<CuTwinStatus> {
+        self.stop.store(true, Ordering::Release);
+        if let Some(worker) = self.worker.take() {
+            worker.thread().unpark();
+            self.final_status = Some(
+                worker
+                    .join()
+                    .map_err(|_| CuError::from("Copper twin receiver panicked"))??,
+            );
+        }
+        self.final_status
+            .ok_or_else(|| CuError::from("Copper twin stopped after a worker failure"))
+    }
+}
+
+impl<A: LiveReplay> Drop for CuTwin<A> {
+    fn drop(&mut self) {
+        let _ = self.stop();
+    }
+}

--- a/core/cu29_logstream/src/worker.rs
+++ b/core/cu29_logstream/src/worker.rs
@@ -135,11 +135,25 @@ impl Inbox {
 }
 
 /// Encodes directly into a sender-owned buffer on the existing CL output worker.
-pub struct ScheduledCopperListSink<P> {
+pub struct ScheduledCopperListSink<P: CopperListTuple> {
     inbox: Inbox,
+    encoder: fn(&CopperList<P>, &mut [u8]) -> crate::Result<usize>,
     _payload: PhantomData<fn() -> P>,
 }
-impl<P> Debug for ScheduledCopperListSink<P> {
+impl<P: CopperListTuple> ScheduledCopperListSink<P> {
+    /// Select the generated capture encoder before handing the sink to its output worker.
+    pub fn with_encoder(
+        mut self,
+        encoder: fn(&CopperList<P>, &mut [u8]) -> crate::Result<usize>,
+    ) -> Self
+    where
+        P: CopperListTuple,
+    {
+        self.encoder = encoder;
+        self
+    }
+}
+impl<P: CopperListTuple> Debug for ScheduledCopperListSink<P> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ScheduledCopperListSink")
             .finish_non_exhaustive()
@@ -148,8 +162,7 @@ impl<P> Debug for ScheduledCopperListSink<P> {
 impl<P: CopperListTuple + Send + Sync> WriteStream<CopperList<P>> for ScheduledCopperListSink<P> {
     fn log(&mut self, record: &CopperList<P>) -> CuResult<()> {
         self.inbox.submit(false, |bytes| {
-            crate::encode_copperlist_record_into(record, bytes)
-                .map_err(|error| CuError::from(error.to_string()))
+            (self.encoder)(record, bytes).map_err(|error| CuError::from(error.to_string()))
         })
     }
 }
@@ -310,6 +323,7 @@ where
     });
     Ok((
         ScheduledCopperListSink {
+            encoder: crate::encode_copperlist_record_into,
             inbox: Inbox {
                 clock: cl_clock,
                 worker: worker.clone(),

--- a/core/cu29_logstream/tests/manifest.rs
+++ b/core/cu29_logstream/tests/manifest.rs
@@ -69,6 +69,7 @@ fn config_resolves_to_sender_config_and_versioned_manifest() {
 
     let manifest = SessionManifest::decode_record(&sender.recovery.manifest_record).unwrap();
     assert_eq!(manifest.version, SESSION_MANIFEST_VERSION);
+    assert_eq!(manifest.version, 1, "the unreleased protocol remains v1");
     assert_eq!(manifest.identity, identity);
     assert_eq!(manifest.plan, plan);
     assert_eq!(manifest.application_schema, schema());

--- a/core/cu29_logstream/tests/manifest.rs
+++ b/core/cu29_logstream/tests/manifest.rs
@@ -45,6 +45,7 @@ fn destination() -> LogStreamDestinationConfig {
 
 fn schema() -> ApplicationSchema {
     ApplicationSchema {
+        reconstruction: vec![],
         outputs: vec![ApplicationOutputSchema {
             task_id: "camera".into(),
             message_type: "app::Image".into(),

--- a/core/cu29_logstream/tests/pacing.rs
+++ b/core/cu29_logstream/tests/pacing.rs
@@ -33,7 +33,10 @@ fn config() -> LogStreamSenderConfig {
             session_id: *b"paced-session001",
             sender_id: 1,
         },
-        ApplicationSchema { outputs: vec![] },
+        ApplicationSchema {
+            outputs: vec![],
+            reconstruction: vec![],
+        },
     )
     .unwrap()
 }

--- a/core/cu29_logstream/tests/session_router.rs
+++ b/core/cu29_logstream/tests/session_router.rs
@@ -52,7 +52,13 @@ fn manifest_bootstraps_continuous_decoder_without_out_of_band_fec_config() {
     };
     let plan = LogStreamPlan::resolve(&destination()).unwrap();
     let sender = plan
-        .sender_config(identity, ApplicationSchema { outputs: vec![] })
+        .sender_config(
+            identity,
+            ApplicationSchema {
+                outputs: vec![],
+                reconstruction: vec![],
+            },
+        )
         .unwrap();
 
     let mut finite = FiniteObjectEncoder::new(sender.recovery.finite).unwrap();
@@ -126,7 +132,13 @@ fn setup() -> (
     };
     let sender = LogStreamPlan::resolve(&destination())
         .unwrap()
-        .sender_config(identity, ApplicationSchema { outputs: vec![] })
+        .sender_config(
+            identity,
+            ApplicationSchema {
+                outputs: vec![],
+                reconstruction: vec![],
+            },
+        )
         .unwrap();
     let router = SessionRouter::new(SessionRouterLimits {
         max_sessions: 1,

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -1106,6 +1106,24 @@ impl AnytimeConfig {
     }
 }
 
+/// Whether a task output is transmitted or deterministically recomputed on the ground.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamReplay {
+    #[default]
+    Capture,
+    Reconstruct,
+}
+
+/// Static streaming contract for an ordinary deterministic task.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default)]
+#[serde(deny_unknown_fields)]
+pub struct NodeStreaming {
+    #[serde(default)]
+    pub replay: StreamReplay,
+    pub replay_abi: Option<u32>,
+}
+
 /// A node in the configuration graph.
 /// A node represents a Task in the system Graph.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -1161,6 +1179,9 @@ pub struct Node {
     #[serde(skip_serializing_if = "Option::is_none")]
     logging: Option<NodeLogging>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    streaming: Option<NodeStreaming>,
+
     /// Node role in the runtime graph (normal task or bridge endpoint).
     #[serde(skip, default)]
     flavor: Flavor,
@@ -1186,6 +1207,7 @@ impl Node {
             anytime: None,
             run_in_sim: None,
             logging: None,
+            streaming: None,
             flavor: Flavor::Task,
             nc_outputs: Vec::new(),
             nc_output_orders: Vec::new(),
@@ -1304,6 +1326,11 @@ impl Node {
             .as_ref()
             .map(NodeLogging::handle_content)
             .unwrap_or_default()
+    }
+
+    #[allow(dead_code)]
+    pub fn streaming(&self) -> NodeStreaming {
+        self.streaming.unwrap_or_default()
     }
 
     #[allow(dead_code)]

--- a/core/cu29_runtime/src/continuity.rs
+++ b/core/cu29_runtime/src/continuity.rs
@@ -26,9 +26,6 @@ pub enum StreamContinuityRecord {
     Anchor { copperlist_id: u64, record: Vec<u8> },
     /// Explicit receiver finalization, not a claim about an unobserved sender tail.
     Finished { next_copperlist_id: u64 },
-    /// Versioned capture proof for an intentionally partial native CopperList.
-    /// Retains original presence and reconstruction digests for offline replay.
-    Capture { copperlist_id: u64, proof: Vec<u8> },
 }
 
 /// Rejects replay across missing history unless state is restored at this boundary.

--- a/core/cu29_runtime/src/continuity.rs
+++ b/core/cu29_runtime/src/continuity.rs
@@ -26,6 +26,9 @@ pub enum StreamContinuityRecord {
     Anchor { copperlist_id: u64, record: Vec<u8> },
     /// Explicit receiver finalization, not a claim about an unobserved sender tail.
     Finished { next_copperlist_id: u64 },
+    /// Versioned capture proof for an intentionally partial native CopperList.
+    /// Retains original presence and reconstruction digests for offline replay.
+    Capture { copperlist_id: u64, proof: Vec<u8> },
 }
 
 /// Rejects replay across missing history unless state is restored at this boundary.

--- a/core/cu29_runtime/src/simulation.rs
+++ b/core/cu29_runtime/src/simulation.rs
@@ -166,6 +166,9 @@ pub enum CuTaskCallbackState<I, O> {
     /// if this is a source task, I will be CuMsg<()>
     /// if this is a sink task, O will be CuMsg<()>
     Process(I, O),
+    /// Simulation-only observation after the runtime executed a task's process.
+    /// Generated live replay restores sender metadata before downstream tasks run.
+    ProcessCompleted(O),
     /// Callbacked when a task is getting called on post-process.
     Postprocess,
     /// Callbacked when a task is stopped.

--- a/core/cu29_traits/src/lib.rs
+++ b/core/cu29_traits/src/lib.rs
@@ -1131,3 +1131,10 @@ mod std_tests {
         assert!(descriptor.children.is_empty());
     }
 }
+
+/// Explicit promise that a task has no external side effects and replays exactly
+/// across supported targets from its captured inputs, clock and frozen state.
+/// Change the nonzero ABI whenever its state encoding or deterministic behavior changes.
+pub trait CuCrossPlatformDeterministic {
+    const REPLAY_ABI: u32;
+}

--- a/examples/cu_logstream_demo/Cargo.toml
+++ b/examples/cu_logstream_demo/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 
 [features]
 default = []
+verify-reconstruction = ["demo", "cu29/logstream-verify"]
 # Keep async runtime features out of ordinary workspace builds.
 demo = ["cu29/logstream", "cu29/reflect"]
 replay = ["demo", "cu29/remote-debug"]

--- a/examples/cu_logstream_demo/README.md
+++ b/examples/cu_logstream_demo/README.md
@@ -168,45 +168,62 @@ Sources and bridge receives stay captured. Reconstruction currently supports
 ordinary synchronous tasks using the lossless native compressed codec; background,
 anytime, custom codec and selective handle policies are rejected for this path.
 
-A ground station declares `#[copper_runtime(config = "copperconfig.ron", sim_mode = true)]`
-and uses its generated `LiveReplay` implementation. Create `TwinWorker::spawn` with
-a bounded queue and the existing `TelemetryPublisher`, then process each ordered
-router event with:
+A ground station declares `#[copper_runtime(config = "copperconfig.ron", sim_mode = true)]`.
+The generated application exposes a twin builder:
 
 ```rust,ignore
-let capture = archive.accept(&event)?; // CaptureArchive<GeneratedDataSet>
-twin.accept(&event, capture)?;
+let (mut twin, mut frames) = Ground::twin(rx)
+    .with_log_path("logs/received.copper")
+    .spawn()?;
+
+// On the UI or analysis thread:
+frames.wait_timeout(std::time::Duration::from_millis(50));
+while let Some(update) = frames.try_read() {
+    render(&update.frame.copperlist);
+}
+let status = twin.stop()?;
 ```
 
-The archive writes the received native capture bytes, original-presence metadata,
-reconstruction policy and omission proofs before handing ownership to replay. It
-never stores synthesized outputs or waits for replay/UI consumption. `NativeArchive`
-remains the full-capture API; use `CaptureArchive` for this selective view. Existing
-native sections retain proofs in `StreamContinuity`; the container format is unchanged.
-Manifest version 2 binds the per-output replay ABI. Build matching robot and ground
-code; numeric mission dispatch remains separate work.
+`rx` is any `CuStreamRx`, such as the receive half of a UDP resource. Copper owns
+session routing, native recording, the bounded replay worker, status publication,
+and shutdown. The caller owns the frame reader and presentation. Pausing or dropping
+that reader never blocks recording. Dropping the twin stops and joins its workers;
+`stop()` also reports receiver errors and final counters. `archive_only()` records
+without running a twin. Each handle accepts one sender session and a fresh log path.
+The default receiver supports the 1200-byte-MTU, 64-symbol streaming profile, with
+4 KiB records and 64 KiB recovery objects. It retains 32 replay events, 32 pending
+captures, one anchor, one executing frame and 64 display frames; payload storage and
+thread/runtime allocations are additional. `with_frame_capacity` changes display retention.
 
-The worker joins independently arriving keyframes and captured boundaries, restores
-state, injects captured messages and executes only reconstructible tasks. It restores
-sender metadata before downstream tasks run. Generated simulation does not bind
-configured stream transmitters; the twin disables local logging and uses no log file.
-The worker retains at most the configured number of queued events and pending
-captures, one anchor and one executing frame, plus the presentation ring. Payload
-allocations and thread/runtime storage are additional. Source gaps and replay queue
-overflow require another matching anchor; UI overwrites only discard display samples.
+Production sends the existing native CopperList format with selected payloads omitted.
+The native codec already carries original/captured presence. There is no proof envelope,
+per-list verification allocation, or new continuity record. The archive writes the
+received native bytes before replay and never stores synthesized outputs. The unreleased
+session manifest stays at **version 1** and binds the reconstruction ABI to the graph.
+Packet framing, FEC and anchor recovery are unchanged.
 
-Per-output digest checking is **off by default**, including debug Rust builds.
-Enable `cu29/logstream-verify` (or the demo's `verify-reconstruction`) at development
-time to check reconstructed payloads. All digest encoding/hashing happens on the
-existing sender output worker and the ground replay worker. No task-path hashing,
-serialization, allocation or copying is added. Ordinary packet/anchor integrity
-checks remain; they do not independently prove behavioral determinism.
+Copper restores keyframes, injects captured inputs, executes reconstructible tasks and
+restores sender metadata before downstream tasks run. Existing source gaps and replay
+queue overflows require a matching recovery anchor. These continuity checks are separate
+from checking whether deterministic task code produced the right result. The generated
+ground runtime disables its own logging and transport transmitters; its archive is owned
+by the twin receiver.
 
-The UI reports Waiting/Recovering, Reconstructed, Verified (developer checks), or
-Diverged. Only checked frames are called Verified. With checks enabled, a mismatch
-withholds reconstructed frames until another matching anchor. Capture recording
-continues through divergence and UI pause. Use `just dashboard-verify` and
-`just sender-verify` in separate terminals to run the developer checks.
+Reconstruction correctness checks are **entirely opt-in**, even in debug Rust builds.
+Enable `cu29/logstream-verify` (the demo calls it `verify-reconstruction`) on both ends
+for development. Only this feature compiles in hashing and a fixed 32-byte digest trailer
+covering the omitted outputs and their payload presence. Hashing runs on the existing
+sender output worker and the ground replay worker, using borrowed payloads with no
+intermediate allocation. Production captures have no trailer or digest storage. A normal
+receiver rejects debug trailers explicitly; a verification receiver also accepts normal
+captures and labels them Reconstructed, never Verified.
 
-`just resim` reconstructs the capture archive offline into full native CopperLists.
-Run `just logstream-twin-check` at the repository root for the focused checks.
+Only debug captures that pass comparison are labeled Verified. A mismatch suppresses
+reconstructed frames until the next matching anchor; native recording continues. Debug
+digests are consumed live and do not add archive sections or change offline log readers.
+Use `just dashboard-verify` and `just sender-verify` to run the development checks.
+`just resim` reconstructs ordinary capture archives offline; the demo's verification
+command compares the result against the full onboard log.
+
+Run `just logstream-twin-check` for allocation/native-format checks, both verification
+modes, worker lifecycle, reader isolation, and the UDP loss/recovery/replay scenarios.

--- a/examples/cu_logstream_demo/README.md
+++ b/examples/cu_logstream_demo/README.md
@@ -1,8 +1,8 @@
 # UDP log streaming demo
 
 Run a deterministic Copper graph in one process and collect its native execution
-log in another over localhost UDP. The graph is `counter → accumulator`: both
-tasks freeze their state, and every output retains the sender's timestamps.
+log in another over localhost UDP. The graph is `counter → sum → derived`. Counter and sum are transmitted; derived
+is reconstructed live from the same Copper task implementation.
 
 From this directory:
 
@@ -107,14 +107,14 @@ Use the printed log base from an automated run with these recipes:
 just cl logs/received.copper
 just fsck logs/received.copper
 just resim logs/received.copper logs/replay.copper
-just resim-debug logs/received.copper logs/debug-replay.copper
+just resim-debug logs/replay.copper logs/debug-replay.copper
 ```
 
 The replay binary uses Copper's standard `--log-base`, `--replay-log-base`, and
 `--debug-base` contract. Remote debug creates separate replay outputs per session.
-Recorded replay preserves captured outputs and checks missing CopperList ranges
-against keyframes before advancing. It does not perform hybrid reconstruction.
-The replay output is compared with the received CopperLists byte for byte.
+Offline replay injects captured outputs and reconstructs the omitted derived output.
+The verification tool compares full reconstructed outputs and sender metadata against
+the onboard log.
 Offline replay drains pending output before each iteration and aligns generated
 CopperList IDs at recovery boundaries. Production task execution remains nonblocking.
 The sender/replay slabs are 16 MiB to accommodate the runtime's existing 10 MiB
@@ -141,10 +141,72 @@ buffer budget excludes thread stacks, channel/allocator bookkeeping, and bounded
 RaptorQ scratch allocations; see the [sender docs](../../core/cu29_logstream).
 Memory-bounded recovery cannot recover expired history, and receiver shutdown
 does not establish the sender's unobserved tail. Full-capture native archival
-requires the matching application schema. Feedback, live deterministic
-reconstruction, mission dispatch, and serial are later
-milestones. The host telemetry buffer and optional `tui` feature are available
+requires the matching application schema. Feedback, mission dispatch, and serial remain later milestones. The host telemetry buffer and optional `tui` feature are available
 now. Run `just logstream-telemetry-check` at the root for notification/overrun
 tests, archive comparisons with fast/stalled/disconnected readers, terminal
 rendering, and all existing loss/recovery/replay scenarios. Feedback interfaces
 permit a shared bidirectional carrier or separate explicitly configured endpoints.
+
+## Live Copper twin
+
+The demo graph is `counter -> sum -> derived`. The ordinary `Derived` Copper task
+computes `sum % 256` on the robot and in generated ground-side replay. Its payload
+is never transmitted, including repeated anchor boundaries and FEC repairs. The
+robot's onboard log contains the full output for comparison. Ratatui explicitly
+labels the derived value **reconstructed locally; payload not transmitted**.
+
+Declare the static contract in the same RON used by the robot and ground build:
+
+```ron
+(id: "derived", type: "tasks::Derived",
+ streaming: (replay: reconstruct, replay_abi: 1)),
+```
+
+The task implements `CuCrossPlatformDeterministic` with `REPLAY_ABI = 1`. This is
+an explicit promise of deterministic behavior and no external side effects.
+Sources and bridge receives stay captured. Reconstruction currently supports
+ordinary synchronous tasks using the lossless native compressed codec; background,
+anytime, custom codec and selective handle policies are rejected for this path.
+
+A ground station declares `#[copper_runtime(config = "copperconfig.ron", sim_mode = true)]`
+and uses its generated `LiveReplay` implementation. Create `TwinWorker::spawn` with
+a bounded queue and the existing `TelemetryPublisher`, then process each ordered
+router event with:
+
+```rust,ignore
+let capture = archive.accept(&event)?; // CaptureArchive<GeneratedDataSet>
+twin.accept(&event, capture)?;
+```
+
+The archive writes the received native capture bytes, original-presence metadata,
+reconstruction policy and omission proofs before handing ownership to replay. It
+never stores synthesized outputs or waits for replay/UI consumption. `NativeArchive`
+remains the full-capture API; use `CaptureArchive` for this selective view. Existing
+native sections retain proofs in `StreamContinuity`; the container format is unchanged.
+Manifest version 2 binds the per-output replay ABI. Build matching robot and ground
+code; numeric mission dispatch remains separate work.
+
+The worker joins independently arriving keyframes and captured boundaries, restores
+state, injects captured messages and executes only reconstructible tasks. It restores
+sender metadata before downstream tasks run. Generated simulation does not bind
+configured stream transmitters; the twin disables local logging and uses no log file.
+The worker retains at most the configured number of queued events and pending
+captures, one anchor and one executing frame, plus the presentation ring. Payload
+allocations and thread/runtime storage are additional. Source gaps and replay queue
+overflow require another matching anchor; UI overwrites only discard display samples.
+
+Per-output digest checking is **off by default**, including debug Rust builds.
+Enable `cu29/logstream-verify` (or the demo's `verify-reconstruction`) at development
+time to check reconstructed payloads. All digest encoding/hashing happens on the
+existing sender output worker and the ground replay worker. No task-path hashing,
+serialization, allocation or copying is added. Ordinary packet/anchor integrity
+checks remain; they do not independently prove behavioral determinism.
+
+The UI reports Waiting/Recovering, Reconstructed, Verified (developer checks), or
+Diverged. Only checked frames are called Verified. With checks enabled, a mismatch
+withholds reconstructed frames until another matching anchor. Capture recording
+continues through divergence and UI pause. Use `just dashboard-verify` and
+`just sender-verify` in separate terminals to run the developer checks.
+
+`just resim` reconstructs the capture archive offline into full native CopperLists.
+Run `just logstream-twin-check` at the repository root for the focused checks.

--- a/examples/cu_logstream_demo/copperconfig.ron
+++ b/examples/cu_logstream_demo/copperconfig.ron
@@ -64,6 +64,14 @@
             id: "sum",
             type: "cu_logstream_demo::tasks::Accumulator",
         ),
+        (
+            id: "derived",
+            type: "cu_logstream_demo::tasks::Derived",
+            streaming: (
+                replay: reconstruct,
+                replay_abi: 1,
+            ),
+        ),
     ],
     cnx: [
         (
@@ -73,6 +81,11 @@
         ),
         (
             src: "sum",
+            dst: "derived",
+            msg: "cu_logstream_demo::tasks::Sample",
+        ),
+        (
+            src: "derived",
             dst: "__nc__",
             msg: "cu_logstream_demo::tasks::Sample",
         ),

--- a/examples/cu_logstream_demo/justfile
+++ b/examples/cu_logstream_demo/justfile
@@ -35,5 +35,14 @@ fsck log="logs/received.copper": build
 resim log="logs/received.copper" output="logs/replay.copper": build
     {{root}}/target/debug/cu-logstream-demo-resim --log-base {{log}} --replay-log-base {{output}}
 
-resim-debug log="logs/received.copper" output="logs/replay.copper" debug_base="copper/cu-logstream-demo/debug/v1": build
+resim-debug log="logs/replay.copper" output="logs/replay.copper" debug_base="copper/cu-logstream-demo/debug/v1": build
     {{root}}/target/debug/cu-logstream-demo-resim --log-base {{log}} --replay-log-base {{output}} --debug-base {{debug_base}}
+
+# Developer-only per-output divergence checks; hashing stays on output workers.
+dashboard-verify listen="127.0.0.1:7447" log="logs/dashboard-verify.copper":
+    cargo +stable build -p cu-logstream-demo --features tui,verify-reconstruction --bin cu-logstream-demo
+    {{root}}/target/debug/cu-logstream-demo dashboard --listen {{listen}} --log-base {{log}}
+
+sender-verify remote="127.0.0.1:7447" log="logs/sender-verify.copper" iterations="6000":
+    cargo +stable build -p cu-logstream-demo --features tui,verify-reconstruction --bin cu-logstream-demo
+    {{root}}/target/debug/cu-logstream-demo sender --remote {{remote}} --log-base {{log}} --iterations {{iterations}}

--- a/examples/cu_logstream_demo/src/dashboard.rs
+++ b/examples/cu_logstream_demo/src/dashboard.rs
@@ -29,6 +29,7 @@ struct View {
     paused: bool,
     counter: Option<u64>,
     sum: Option<u64>,
+    derived: Option<u64>,
     displayed: Option<u64>,
     missed: u64,
     frame_age: Option<Instant>,
@@ -66,6 +67,12 @@ impl View {
                 .get_sum_output()
                 .payload()
                 .map(|sample| sample.0);
+            self.derived = frame
+                .copperlist
+                .msgs
+                .get_derived_output()
+                .payload()
+                .map(|sample| sample.0);
             // This history policy belongs to this widget, not the backend.
             if let Some(counter) = self.counter {
                 if self.history.len() == CHART_CAPACITY {
@@ -77,6 +84,22 @@ impl View {
     }
 
     fn draw(&self, frame: &mut ratatui::Frame<'_>, status: Status, overwritten: u64, path: &str) {
+        use cu29_logstream::twin::ReconstructionState;
+        let reconstruction = match status.twin.state {
+            ReconstructionState::Waiting => "Waiting for anchor",
+            ReconstructionState::Recovering => "Recovering",
+            ReconstructionState::Reconstructed => "Reconstructed locally",
+            ReconstructionState::Verified => "Verified (developer checks)",
+            ReconstructionState::Diverged => "DIVERGED",
+        };
+        let derived = if matches!(
+            status.twin.state,
+            ReconstructionState::Reconstructed | ReconstructionState::Verified
+        ) {
+            number(self.derived)
+        } else {
+            "—".into()
+        };
         if frame.area().height < 20 || frame.area().width < 50 {
             let [header, body] =
                 Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).areas(frame.area());
@@ -92,14 +115,14 @@ impl View {
             );
             frame.render_widget(Line::from(" 😼 ").right_aligned(), mascot);
             frame.render_widget(Paragraph::new(format!(
-                "Counter: {}   Sum: {}\nArchived: {}   Gaps: {}\nUI missed: {}\nSpace: pause/resume   q: quit",
+                "Counter: {}   Sum: {}\nDerived: {derived} (local)\nPayload NOT transmitted\n{reconstruction}\nArchived: {}   Gaps: {}\nUI missed: {}\nSpace: pause/resume   q: quit",
                 number(self.counter), number(self.sum), status.archived, status.gaps, self.missed,
             )), body);
             return;
         }
         let [header, values, chart, health, footer] = Layout::vertical([
             Constraint::Length(3),
-            Constraint::Length(4),
+            Constraint::Length(6),
             Constraint::Min(3),
             Constraint::Length(7),
             Constraint::Length(3),
@@ -134,13 +157,13 @@ impl View {
         );
         frame.render_widget(
             Paragraph::new(format!(
-                "Counter: {}     Sum: {}\nDisplayed CopperList: {}     Frame age: {}",
+                "Counter: {}     Sum: {}\nDerived: {derived} — reconstructed locally; payload not transmitted\n{reconstruction}\nDisplayed CopperList: {}     Frame age: {}",
                 number(self.counter),
                 number(self.sum),
                 number(self.displayed),
                 age(self.frame_age)
             ))
-            .block(Block::bordered().title("Typed robot outputs")),
+            .block(Block::bordered().title("Captured inputs + Copper twin output")),
             values,
         );
         let history: Vec<_> = self.history.iter().copied().collect();
@@ -165,8 +188,8 @@ impl View {
                     number(status.anchor)
                 )),
                 Line::from(format!(
-                    "Source gap ranges: {}    Demo packet drops: {}",
-                    status.gaps, status.dropped
+                    "Source gaps: {}    Demo drops: {}    Replay queue drops: {}",
+                    status.gaps, status.dropped, status.twin.queue_overflows
                 )),
                 Line::from(format!(
                     "UI missed: {}    Buffer overwrites: {}    Capacity: {BUFFER_CAPACITY}",
@@ -198,21 +221,12 @@ pub fn run(options: ReceiverOptions) -> Result<()> {
             "Dashboard needs a terminal; use the receiver command for headless recording".into(),
         );
     }
-    let (mut publisher, mut reader) =
+    let (publisher, mut reader) =
         telemetry_channel(BUFFER_CAPACITY.try_into().unwrap(), Status::default());
     let stop = AtomicBool::new(false);
     thread::scope(|scope| -> Result<()> {
         let worker = scope.spawn(|| {
-            let result = receiver::run(&options, Some(&mut publisher), &stop)
-                .map_err(|error| error.to_string());
-            if result.is_err() {
-                let mut status = publisher.status();
-                status.state = RecordingState::Failed;
-                publisher.set_status(status);
-            }
-            // Closure wakes the UI even if no CopperList was ever received.
-            drop(publisher);
-            result
+            receiver::run(&options, Some(publisher), &stop).map_err(|error| error.to_string())
         });
         let ui_result: std::io::Result<()> = ratatui::run(|terminal| {
             let mut view = View {
@@ -300,6 +314,11 @@ mod tests {
                 .map(|cell| cell.symbol())
                 .collect();
             assert!(screen.contains("VIEW PAUSED"));
+            assert!(screen.contains(if width == 100 {
+                "payload not transmitted"
+            } else {
+                "Payload NOT transmitted"
+            }));
             if width == 100 {
                 assert!(screen.contains("Archived: 200"));
                 assert!(screen.contains("UI missed: 73"));

--- a/examples/cu_logstream_demo/src/dashboard.rs
+++ b/examples/cu_logstream_demo/src/dashboard.rs
@@ -4,7 +4,7 @@ use crate::{
     receiver::{self, ReceiverOptions},
 };
 use cu_logstream_demo::telemetry::{Frame, RecordingState, Status};
-use cu29_logstream::telemetry::{TelemetryReader, telemetry_channel};
+use cu29_logstream::telemetry::TelemetryReader;
 use ratatui::{
     crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
     layout::{Constraint, Layout},
@@ -15,8 +15,6 @@ use ratatui::{
 use std::{
     collections::VecDeque,
     io::IsTerminal,
-    sync::atomic::{AtomicBool, Ordering},
-    thread,
     time::{Duration, Instant},
 };
 
@@ -188,8 +186,8 @@ impl View {
                     number(status.anchor)
                 )),
                 Line::from(format!(
-                    "Source gaps: {}    Demo drops: {}    Replay queue drops: {}",
-                    status.gaps, status.dropped, status.twin.queue_overflows
+                    "Source gaps: {}    Replay queue drops: {}",
+                    status.gaps, status.twin.queue_overflows
                 )),
                 Line::from(format!(
                     "UI missed: {}    Buffer overwrites: {}    Capacity: {BUFFER_CAPACITY}",
@@ -221,67 +219,60 @@ pub fn run(options: ReceiverOptions) -> Result<()> {
             "Dashboard needs a terminal; use the receiver command for headless recording".into(),
         );
     }
-    let (publisher, mut reader) =
-        telemetry_channel(BUFFER_CAPACITY.try_into().unwrap(), Status::default());
-    let stop = AtomicBool::new(false);
-    thread::scope(|scope| -> Result<()> {
-        let worker = scope.spawn(|| {
-            receiver::run(&options, Some(publisher), &stop).map_err(|error| error.to_string())
-        });
-        let ui_result: std::io::Result<()> = ratatui::run(|terminal| {
-            let mut view = View {
-                history: VecDeque::with_capacity(CHART_CAPACITY),
-                ..Default::default()
-            };
-            let mut redraw = Instant::now();
-            loop {
-                // Paused/closed views only service keyboard/age timers. Live views
-                // wait for backend notification, with the same keyboard deadline.
-                if view.paused || reader.is_closed() {
-                    event::poll(UI_TICK)?;
-                } else {
-                    reader.wait_timeout(UI_TICK);
-                }
-                while event::poll(Duration::ZERO)? {
-                    if let Event::Key(key) = event::read()?
-                        && key.kind == KeyEventKind::Press
-                    {
-                        match key.code {
-                            KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
-                            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                                return Ok(());
-                            }
-                            KeyCode::Char(' ') => {
-                                view.paused = !view.paused;
-                                redraw = Instant::now();
-                            }
-                            _ => {}
+    let (mut twin, mut reader, _) = receiver::start(&options)?;
+    let ui_result: std::io::Result<()> = ratatui::run(|terminal| {
+        let mut view = View {
+            history: VecDeque::with_capacity(CHART_CAPACITY),
+            ..Default::default()
+        };
+        let mut redraw = Instant::now();
+        loop {
+            // Paused/closed views only service keyboard/age timers. Live views
+            // wait for backend notification, with the same keyboard deadline.
+            if view.paused || reader.is_closed() {
+                event::poll(UI_TICK)?;
+            } else {
+                reader.wait_timeout(UI_TICK);
+            }
+            while event::poll(Duration::ZERO)? {
+                if let Event::Key(key) = event::read()?
+                    && key.kind == KeyEventKind::Press
+                {
+                    match key.code {
+                        KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            return Ok(());
                         }
+                        KeyCode::Char(' ') => {
+                            view.paused = !view.paused;
+                            redraw = Instant::now();
+                        }
+                        _ => {}
                     }
                 }
-                view.consume(&mut reader);
-                let status = reader.status();
-                if Instant::now() >= redraw {
-                    terminal.draw(|frame| {
-                        view.draw(
-                            frame,
-                            status,
-                            reader.overwritten(),
-                            &options.log_base.display().to_string(),
-                        )
-                    })?;
-                    redraw = Instant::now() + UI_TICK;
-                }
-                if reader.is_closed() && status.state == RecordingState::Failed {
-                    return Ok(());
-                }
             }
-        });
-        stop.store(true, Ordering::Release);
-        let receiver_result = worker.join().map_err(|_| "Receiver thread panicked")?;
-        ui_result?;
-        receiver_result.map_err(Into::into)
-    })
+            view.consume(&mut reader);
+            let status = reader.status();
+            if Instant::now() >= redraw {
+                terminal.draw(|frame| {
+                    view.draw(
+                        frame,
+                        status,
+                        reader.overwritten(),
+                        &options.log_base.display().to_string(),
+                    )
+                })?;
+                redraw = Instant::now() + UI_TICK;
+            }
+            if reader.is_closed() && status.state == RecordingState::Failed {
+                return Ok(());
+            }
+        }
+    });
+    let receiver_result = twin.stop();
+    ui_result?;
+    receiver_result?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/examples/cu_logstream_demo/src/lib.rs
+++ b/examples/cu_logstream_demo/src/lib.rs
@@ -4,7 +4,6 @@ extern crate self as cu_logstream_demo;
 pub mod tasks;
 pub mod telemetry;
 
-use cu29::bincode;
 use cu29::prelude::*;
 
 #[copper_runtime(config = "copperconfig.ron")]
@@ -67,37 +66,14 @@ pub fn run_sender(
     Ok(())
 }
 
-/// Read captured values and their explicit omission proofs for offline replay.
+/// Read native captures for offline reconstruction, with no debug side data.
 pub fn read_captures(
     path: &std::path::Path,
 ) -> CuResult<Vec<cu29_logstream::capture::CapturedList<DataSet>>> {
-    let reader = UnifiedLoggerIOReader::new(
-        UnifiedLoggerRead::new(path)
-            .map_err(|e| CuError::new_with_cause("Open capture proofs", e))?,
-        UnifiedLogType::StreamContinuity,
-    );
-    let mut proofs = std::collections::BTreeMap::new();
-    for record in cu29_export::stream_continuity_reader(reader) {
-        if let cu29::continuity::StreamContinuityRecord::Capture {
-            copperlist_id,
-            proof,
-        } = record
-        {
-            let (proof, _): (cu29_logstream::capture::CaptureProof, _) =
-                bincode::decode_from_slice(&proof, bincode::config::standard())
-                    .map_err(|e| CuError::new_with_cause("Decode capture proof", e))?;
-            proofs.insert(copperlist_id, proof);
-        }
-    }
-    read_lists(path)?
+    Ok(read_lists(path)?
         .into_iter()
-        .map(|copperlist| {
-            let proof = proofs
-                .remove(&copperlist.id)
-                .ok_or_else(|| CuError::from("Missing capture proof"))?;
-            Ok(cu29_logstream::capture::CapturedList { copperlist, proof })
-        })
-        .collect()
+        .map(cu29_logstream::capture::CapturedList::new)
+        .collect())
 }
 
 pub fn read_keyframes(path: &std::path::Path) -> CuResult<Vec<cu29::curuntime::KeyFrame>> {

--- a/examples/cu_logstream_demo/src/lib.rs
+++ b/examples/cu_logstream_demo/src/lib.rs
@@ -4,12 +4,20 @@ extern crate self as cu_logstream_demo;
 pub mod tasks;
 pub mod telemetry;
 
+use cu29::bincode;
 use cu29::prelude::*;
 
 #[copper_runtime(config = "copperconfig.ron")]
 struct Demo {}
 
-pub type DataSet = default::CuStampedDataSet;
+pub mod twin {
+    use cu29::prelude::*;
+    #[copper_runtime(config = "copperconfig.ron", sim_mode = true)]
+    struct Replay {}
+    pub type DataSet = default::CuStampedDataSet;
+    pub type Twin = default::Replay;
+}
+pub type DataSet = twin::DataSet;
 pub type List = CopperList<DataSet>;
 
 pub const ITERATIONS: u64 = 256;
@@ -57,4 +65,45 @@ pub fn run_sender(
     std::thread::sleep(std::time::Duration::from_millis(idle_ms));
     drop(running.stop()?);
     Ok(())
+}
+
+/// Read captured values and their explicit omission proofs for offline replay.
+pub fn read_captures(
+    path: &std::path::Path,
+) -> CuResult<Vec<cu29_logstream::capture::CapturedList<DataSet>>> {
+    let reader = UnifiedLoggerIOReader::new(
+        UnifiedLoggerRead::new(path)
+            .map_err(|e| CuError::new_with_cause("Open capture proofs", e))?,
+        UnifiedLogType::StreamContinuity,
+    );
+    let mut proofs = std::collections::BTreeMap::new();
+    for record in cu29_export::stream_continuity_reader(reader) {
+        if let cu29::continuity::StreamContinuityRecord::Capture {
+            copperlist_id,
+            proof,
+        } = record
+        {
+            let (proof, _): (cu29_logstream::capture::CaptureProof, _) =
+                bincode::decode_from_slice(&proof, bincode::config::standard())
+                    .map_err(|e| CuError::new_with_cause("Decode capture proof", e))?;
+            proofs.insert(copperlist_id, proof);
+        }
+    }
+    read_lists(path)?
+        .into_iter()
+        .map(|copperlist| {
+            let proof = proofs
+                .remove(&copperlist.id)
+                .ok_or_else(|| CuError::from("Missing capture proof"))?;
+            Ok(cu29_logstream::capture::CapturedList { copperlist, proof })
+        })
+        .collect()
+}
+
+pub fn read_keyframes(path: &std::path::Path) -> CuResult<Vec<cu29::curuntime::KeyFrame>> {
+    Ok(cu29_export::keyframes_reader(UnifiedLoggerIOReader::new(
+        UnifiedLoggerRead::new(path).map_err(|e| CuError::new_with_cause("Open keyframes", e))?,
+        UnifiedLogType::FrozenTasks,
+    ))
+    .collect())
 }

--- a/examples/cu_logstream_demo/src/main.rs
+++ b/examples/cu_logstream_demo/src/main.rs
@@ -227,7 +227,7 @@ fn main() -> Result<()> {
             iterations,
             idle_ms,
         } => sender(remote, &log_base, iterations, idle_ms),
-        Command::Receiver(options) => receiver::run(&options, None, &Default::default()),
+        Command::Receiver(options) => receiver::run(&options),
         #[cfg(feature = "tui")]
         Command::Dashboard(options) => dashboard::run(options),
         Command::Verify {

--- a/examples/cu_logstream_demo/src/main.rs
+++ b/examples/cu_logstream_demo/src/main.rs
@@ -151,15 +151,22 @@ fn verify(sender: &Path, received: &Path, expect: Expectation, iterations: u64) 
         {
             return Err("Archive marks a received record as missing".into());
         }
-        let encoding = bincode::config::standard();
-        if bincode::encode_to_vec(list, encoding)?
-            != bincode::encode_to_vec(&onboard[list.id as usize], encoding)?
-        {
-            return Err(format!(
-                "Payload or sender metadata mismatch at CopperList {}",
-                list.id
-            )
-            .into());
+        let expected = &onboard[list.id as usize];
+        if list.msgs.get_derived_output().payload().is_some() {
+            return Err("Derived payload was transmitted".into());
+        }
+        for (actual, expected) in [
+            (
+                list.msgs.get_counter_output(),
+                expected.msgs.get_counter_output(),
+            ),
+            (list.msgs.get_sum_output(), expected.msgs.get_sum_output()),
+        ] {
+            if bincode::encode_to_vec(actual, bincode::config::standard())?
+                != bincode::encode_to_vec(expected, bincode::config::standard())?
+            {
+                return Err(format!("Captured input or metadata mismatch at {}", list.id).into());
+            }
         }
         next = list.id + 1;
     }
@@ -169,6 +176,20 @@ fn verify(sender: &Path, received: &Path, expect: Expectation, iterations: u64) 
     ) || !matches!(continuity.last(), Some(StreamContinuityRecord::Finished { next_copperlist_id }) if *next_copperlist_id == next)
     {
         return Err("Missing archive provenance/finalization".into());
+    }
+    let mut twin = cu29_logstream::twin::LiveTwin::<cu_logstream_demo::twin::Twin>::new()?;
+    let keyframes = cu_logstream_demo::read_keyframes(received)?;
+    for capture in cu_logstream_demo::read_captures(received)? {
+        let id = capture.copperlist.id;
+        let keyframe = keyframes.iter().find(|k| k.culistid == id);
+        let reconstructed = twin
+            .reconstruct(capture, keyframe)?
+            .ok_or("Capture has no verified replay boundary")?;
+        if bincode::encode_to_vec(&reconstructed, bincode::config::standard())?
+            != bincode::encode_to_vec(&onboard[id as usize], bincode::config::standard())?
+        {
+            return Err(format!("Reconstructed output or sender metadata mismatch at {id}").into());
+        }
     }
     let valid = match expect {
         Expectation::Complete => ground.len() == onboard.len() && gaps.is_empty(),

--- a/examples/cu_logstream_demo/src/receiver.rs
+++ b/examples/cu_logstream_demo/src/receiver.rs
@@ -1,10 +1,10 @@
 use crate::{Impairment, Result, prepare_log};
 use cu_logstream_demo::{
     DataSet, SLAB_BYTES,
-    telemetry::{Frame, Publisher, RecordingState, Status},
+    telemetry::{Publisher, RecordingState, Status},
 };
 use cu29_logstream::{
-    CuStreamRx, FecSymbolKind, FiniteObjectLimits, NativeArchive, RecordKind, SessionEvent,
+    CaptureArchive, CuStreamRx, FecSymbolKind, FiniteObjectLimits, RecordKind, SessionEvent,
     SessionRouter, SessionRouterLimits, WirePacket,
 };
 use cu29_logstream_udp::CuUdpLogStreamConfig;
@@ -34,12 +34,69 @@ pub struct ReceiverOptions {
     /// Exit after this much silence; this does not prove the sender's tail is complete.
     #[arg(long, default_value_t = 1000, value_parser = clap::value_parser!(u64).range(1..))]
     pub idle_ms: u64,
+    /// Record captures without constructing a live twin.
+    #[arg(long)]
+    pub archive_only: bool,
 }
 
 pub fn run(
     options: &ReceiverOptions,
-    mut telemetry: Option<&mut Publisher>,
+    telemetry: Option<Publisher>,
     stop: &AtomicBool,
+) -> Result<()> {
+    let quiet = telemetry.is_some();
+    let mut headless_reader = None;
+    let telemetry = telemetry.or_else(|| {
+        if options.archive_only {
+            return None;
+        }
+        let (publisher, reader) =
+            cu29_logstream::telemetry::telemetry_channel(4.try_into().unwrap(), Status::default());
+        headless_reader = Some(reader);
+        Some(publisher)
+    });
+    let twin = telemetry
+        .map(|publisher| {
+            cu29_logstream::twin::TwinWorker::spawn::<cu_logstream_demo::twin::Twin>(
+                32.try_into().unwrap(),
+                publisher,
+            )
+        })
+        .transpose()?;
+    let result = run_inner(options, twin.as_ref(), stop, quiet);
+    if result.is_err()
+        && let Some(twin) = &twin
+    {
+        twin.set_status(Status {
+            state: RecordingState::Failed,
+            ..Default::default()
+        });
+    }
+    drop(twin);
+    if let Some(mut reader) = headless_reader {
+        let status = reader.status();
+        println!(
+            "Copper twin: {:?}, reconstructed={}, verified={}, replay_queue_drops={}",
+            status.twin.state,
+            status.twin.reconstructed,
+            status.twin.verified,
+            status.twin.queue_overflows
+        );
+        if result.is_ok() && status.archived > 0 && status.twin.reconstructed == 0 {
+            return Err("Live Copper twin produced no reconstructed frames".into());
+        }
+        if result.is_ok() && status.twin.divergences != 0 {
+            return Err("Live Copper twin diverged".into());
+        }
+    }
+    result
+}
+
+fn run_inner(
+    options: &ReceiverOptions,
+    twin: Option<&cu29_logstream::twin::TwinWorker<DataSet, Status>>,
+    stop: &AtomicBool,
+    quiet: bool,
 ) -> Result<()> {
     let ReceiverOptions {
         listen,
@@ -48,8 +105,8 @@ pub fn run(
         impairment,
         stop_at,
         idle_ms,
+        ..
     } = options;
-    let quiet = telemetry.is_some();
     prepare_log(path)?;
     let mut socket = CuUdpLogStreamConfig::new(*listen);
     socket.recv_buffer_bytes = Some(262144);
@@ -65,7 +122,7 @@ pub fn run(
         equation_capacity: 64,
         finite_objects: FiniteObjectLimits::new(65536, 1128, 4),
     })?;
-    let mut archive: Option<NativeArchive<DataSet>> = None;
+    let mut archive: Option<CaptureArchive<DataSet>> = None;
     let mut status = Status::default();
     if let Some(ready) = ready_file {
         // Coordination metadata only; the native archive contains all task data.
@@ -129,25 +186,22 @@ pub fn run(
                             );
                         }
                         status.identity = Some(manifest.identity);
-                        archive = Some(NativeArchive::new(
+                        archive = Some(CaptureArchive::new(
                             path,
                             manifest.clone(),
                             SLAB_BYTES,
                             65536,
                         )?);
                     }
-                    if let Some(writer) = archive.as_mut()
-                        && let Some(list) = writer.accept(&event)?
-                    {
-                        status.latest = Some(list.id);
-                        status.archived += 1;
-                        status.state = RecordingState::Recording;
-                        if let Some(publisher) = telemetry.as_deref_mut() {
-                            publisher.publish(Frame {
-                                identity: status.identity.expect("archived frame has a manifest"),
-                                received_at: Instant::now(),
-                                copperlist: list,
-                            });
+                    if let Some(writer) = archive.as_mut() {
+                        let capture = writer.accept(&event)?;
+                        if let Some(list) = &capture {
+                            status.latest = Some(list.copperlist.id);
+                            status.archived += 1;
+                            status.state = RecordingState::Recording;
+                        }
+                        if let Some(twin) = twin {
+                            twin.accept(&event, capture)?;
                         }
                     }
                     match event {
@@ -161,7 +215,7 @@ pub fn run(
                             }
                         }
                         SessionEvent::VerifiedAnchor { anchor, .. } => {
-                            status.anchor = Some(anchor.copperlist_id)
+                            status.anchor = Some(anchor.copperlist_id);
                         }
                         _ => {}
                     }
@@ -172,8 +226,8 @@ pub fn run(
             thread::sleep(Duration::from_millis(1));
         }
         status.packets = router.stats().datagrams_seen;
-        if let Some(publisher) = telemetry.as_deref_mut() {
-            publisher.set_status(status);
+        if let Some(twin) = &twin {
+            twin.set_status(status);
         }
         if !quiet && last_status.elapsed() >= Duration::from_millis(500) {
             print_status(&status, router.stats().datagrams_seen);
@@ -194,8 +248,8 @@ pub fn run(
         return Err("No session manifest received".into());
     }
     status.state = RecordingState::Closed;
-    if let Some(publisher) = telemetry {
-        publisher.set_status(status);
+    if let Some(twin) = &twin {
+        twin.set_status(status);
     }
     if !quiet {
         print_status(&status, router.stats().datagrams_seen);
@@ -222,6 +276,7 @@ fn print_status(status: &Status, packets: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cu_logstream_demo::telemetry::Frame;
     use cu29_logstream::telemetry::telemetry_channel;
 
     #[test]
@@ -244,20 +299,18 @@ mod tests {
                 impairment: Impairment::Clean,
                 stop_at: Some(COUNT - 1),
                 idle_ms: 2000,
+                archive_only: mode == "disabled",
             };
             let (publisher, reader) =
                 telemetry_channel::<Frame, Status>(4.try_into().unwrap(), Status::default());
-            let mut publisher = (mode != "disabled").then_some(publisher);
+            let publisher = (mode != "disabled").then_some(publisher);
             let mut reader = Some(reader);
             if mode == "disconnected" {
                 drop(reader.take());
             }
             thread::scope(|scope| {
                 let worker = scope.spawn(move || {
-                    let result = run(&options, publisher.as_mut(), &AtomicBool::new(false))
-                        .map_err(|e| e.to_string());
-                    drop(publisher);
-                    result
+                    run(&options, publisher, &AtomicBool::new(false)).map_err(|e| e.to_string())
                 });
                 let fast_reader = if mode == "fast" {
                     let mut reader = reader.take().unwrap();
@@ -267,10 +320,28 @@ mod tests {
                             assert!(reader.wait_timeout(Duration::from_secs(5)));
                             reader.status();
                             while let Some(update) = reader.try_read() {
+                                let list = &update.frame.copperlist;
+                                assert_eq!(
+                                    list.msgs.get_derived_output().payload().unwrap().0,
+                                    list.msgs.get_sum_output().payload().unwrap().0 % 256
+                                );
+                                assert_eq!(
+                                    list.msgs.get_derived_output().tov,
+                                    list.msgs.get_sum_output().tov
+                                );
                                 accounted += update.missed + 1;
                             }
                             if reader.is_closed() {
                                 while let Some(update) = reader.try_read() {
+                                    let list = &update.frame.copperlist;
+                                    assert_eq!(
+                                        list.msgs.get_derived_output().payload().unwrap().0,
+                                        list.msgs.get_sum_output().payload().unwrap().0 % 256
+                                    );
+                                    assert_eq!(
+                                        list.msgs.get_derived_output().tov,
+                                        list.msgs.get_sum_output().tov
+                                    );
                                     accounted += update.missed + 1;
                                 }
                                 return accounted;

--- a/examples/cu_logstream_demo/src/receiver.rs
+++ b/examples/cu_logstream_demo/src/receiver.rs
@@ -1,21 +1,16 @@
+//! Demo-only CLI and packet impairment. Copper owns the receiver and twin lifecycle.
 use crate::{Impairment, Result, prepare_log};
-use cu_logstream_demo::{
-    DataSet, SLAB_BYTES,
-    telemetry::{Publisher, RecordingState, Status},
-};
+use cu_logstream_demo::telemetry::Status;
+use cu_logstream_demo::twin::Twin;
 use cu29_logstream::{
-    CaptureArchive, CuStreamRx, FecSymbolKind, FiniteObjectLimits, RecordKind, SessionEvent,
-    SessionRouter, SessionRouterLimits, WirePacket,
+    CuStreamRx, CuStreamRxError, CuTwin, CuTwinReader, FecSymbolKind, RecordKind, WirePacket,
 };
 use cu29_logstream_udp::CuUdpLogStreamConfig;
-use std::{
-    fs,
-    net::SocketAddr,
-    path::PathBuf,
-    sync::atomic::{AtomicBool, Ordering},
-    thread,
-    time::{Duration, Instant},
-};
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 
 #[derive(clap::Args)]
 pub struct ReceiverOptions {
@@ -23,364 +18,238 @@ pub struct ReceiverOptions {
     pub listen: SocketAddr,
     #[arg(long)]
     pub log_base: PathBuf,
-    /// Write the bound endpoint after socket setup (used by the demo launcher).
+    /// Write the bound endpoint for the demo launcher.
     #[arg(long)]
     pub ready_file: Option<PathBuf>,
     #[arg(long, value_enum, default_value_t = Impairment::Clean)]
     pub impairment: Impairment,
-    /// Stop this receiver after archiving this CopperList, for the restart scenario.
     #[arg(long)]
     pub stop_at: Option<u64>,
-    /// Exit after this much silence; this does not prove the sender's tail is complete.
     #[arg(long, default_value_t = 1000, value_parser = clap::value_parser!(u64).range(1..))]
     pub idle_ms: u64,
-    /// Record captures without constructing a live twin.
     #[arg(long)]
     pub archive_only: bool,
 }
 
-pub fn run(
-    options: &ReceiverOptions,
-    telemetry: Option<Publisher>,
-    stop: &AtomicBool,
-) -> Result<()> {
-    let quiet = telemetry.is_some();
-    let mut headless_reader = None;
-    let telemetry = telemetry.or_else(|| {
-        if options.archive_only {
-            return None;
-        }
-        let (publisher, reader) =
-            cu29_logstream::telemetry::telemetry_channel(4.try_into().unwrap(), Status::default());
-        headless_reader = Some(reader);
-        Some(publisher)
-    });
-    let twin = telemetry
-        .map(|publisher| {
-            cu29_logstream::twin::TwinWorker::spawn::<cu_logstream_demo::twin::Twin>(
-                32.try_into().unwrap(),
-                publisher,
-            )
-        })
-        .transpose()?;
-    let result = run_inner(options, twin.as_ref(), stop, quiet);
-    if result.is_err()
-        && let Some(twin) = &twin
-    {
-        twin.set_status(Status {
-            state: RecordingState::Failed,
-            ..Default::default()
-        });
-    }
-    drop(twin);
-    if let Some(mut reader) = headless_reader {
-        let status = reader.status();
-        println!(
-            "Copper twin: {:?}, reconstructed={}, verified={}, replay_queue_drops={}",
-            status.twin.state,
-            status.twin.reconstructed,
-            status.twin.verified,
-            status.twin.queue_overflows
-        );
-        if result.is_ok() && status.archived > 0 && status.twin.reconstructed == 0 {
-            return Err("Live Copper twin produced no reconstructed frames".into());
-        }
-        if result.is_ok() && status.twin.divergences != 0 {
-            return Err("Live Copper twin diverged".into());
-        }
-    }
-    result
+#[derive(Debug)]
+pub struct ImpairmentStats {
+    started: Instant,
+    last_packet_ms: AtomicU64,
+    seen_packet: AtomicBool,
+    dropped: AtomicUsize,
 }
 
-fn run_inner(
+impl ImpairmentStats {
+    pub fn should_stop(&self, options: &ReceiverOptions, status: Status) -> Result<bool> {
+        if !self.seen_packet.load(Ordering::Acquire) {
+            if self.started.elapsed() >= Duration::from_secs(15) {
+                return Err("No UDP traffic arrived within 15 seconds".into());
+            }
+            return Ok(false);
+        }
+        let elapsed = self.started.elapsed().as_millis() as u64;
+        Ok(options
+            .stop_at
+            .is_some_and(|id| status.latest.is_some_and(|latest| latest >= id))
+            || elapsed.saturating_sub(self.last_packet_ms.load(Ordering::Relaxed))
+                >= options.idle_ms)
+    }
+}
+
+#[derive(Debug)]
+struct ImpairedRx<R> {
+    rx: R,
+    impairment: Impairment,
+    stats: Arc<ImpairmentStats>,
+    first_packet: Option<Instant>,
+    in_outage: bool,
+}
+
+impl<R: CuStreamRx> CuStreamRx for ImpairedRx<R> {
+    fn try_recv(
+        &mut self,
+        packet: &mut [u8],
+    ) -> std::result::Result<Option<usize>, CuStreamRxError> {
+        let Some(len) = self.rx.try_recv(packet)? else {
+            return Ok(None);
+        };
+        let now = Instant::now();
+        self.stats.last_packet_ms.store(
+            self.stats.started.elapsed().as_millis() as u64,
+            Ordering::Relaxed,
+        );
+        self.stats.seen_packet.store(true, Ordering::Release);
+        let first = *self.first_packet.get_or_insert(now);
+        let wire = WirePacket::decode(&packet[..len])
+            .map_err(|_| CuStreamRxError::Failed("Invalid demo packet"))?;
+        let header = wire.header;
+        if header.record_kind == RecordKind::CopperList
+            && header.symbol_kind == FecSymbolKind::Source
+        {
+            self.in_outage = (32..160).contains(&header.object_id);
+        }
+        let discard = match self.impairment {
+            Impairment::Clean => false,
+            Impairment::Loss => {
+                header.record_kind == RecordKind::CopperList
+                    && header.symbol_kind == FecSymbolKind::Source
+                    && header.object_id == 20
+            }
+            Impairment::Outage => self.in_outage,
+            Impairment::Bootstrap => now.duration_since(first) < Duration::from_millis(300),
+        };
+        if discard {
+            self.stats.dropped.fetch_add(1, Ordering::Relaxed);
+            return Ok(None);
+        }
+        Ok(Some(len))
+    }
+}
+
+pub fn start(
     options: &ReceiverOptions,
-    twin: Option<&cu29_logstream::twin::TwinWorker<DataSet, Status>>,
-    stop: &AtomicBool,
-    quiet: bool,
-) -> Result<()> {
-    let ReceiverOptions {
-        listen,
-        log_base: path,
-        ready_file,
-        impairment,
-        stop_at,
-        idle_ms,
-        ..
-    } = options;
-    prepare_log(path)?;
-    let mut socket = CuUdpLogStreamConfig::new(*listen);
+) -> Result<(CuTwin<Twin>, CuTwinReader<Twin>, Arc<ImpairmentStats>)> {
+    prepare_log(&options.log_base)?;
+    let mut socket = CuUdpLogStreamConfig::new(options.listen);
     socket.recv_buffer_bytes = Some(262144);
-    let (_, mut rx) = socket.open()?;
+    let (_, rx) = socket.open()?;
     let address = rx.local_addr()?;
-    let mut router = SessionRouter::<1128, 64, 64>::new(SessionRouterLimits {
-        max_sessions: 1,
-        max_startup_packets: 64,
-        max_recovery_records: 8,
-        max_pending_events: 64,
-        max_record_bytes: 4096,
-        max_buffered_records: 64,
-        equation_capacity: 64,
-        finite_objects: FiniteObjectLimits::new(65536, 1128, 4),
-    })?;
-    let mut archive: Option<CaptureArchive<DataSet>> = None;
-    let mut status = Status::default();
-    if let Some(ready) = ready_file {
-        // Coordination metadata only; the native archive contains all task data.
+    let stats = Arc::new(ImpairmentStats {
+        started: Instant::now(),
+        last_packet_ms: AtomicU64::new(0),
+        seen_packet: AtomicBool::new(false),
+        dropped: AtomicUsize::new(0),
+    });
+    let rx = ImpairedRx {
+        rx,
+        impairment: options.impairment,
+        stats: stats.clone(),
+        first_packet: None,
+        in_outage: false,
+    };
+    let builder = Twin::twin(rx).with_log_path(&options.log_base);
+    let builder = if options.archive_only {
+        builder.archive_only()
+    } else {
+        builder
+    };
+    let (twin, reader) = builder.spawn()?;
+    if let Some(ready) = &options.ready_file {
         use std::io::Write;
-        let mut file = fs::OpenOptions::new()
+        let mut file = std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
             .open(ready)?;
         writeln!(file, "{address}")?;
     }
-    if !quiet {
-        println!("Receiver listening at {address}: {}", path.display());
-    }
-    let started = Instant::now();
-    let mut last_packet = started;
-    let mut last_status = started;
-    let mut seen_packet = false;
-    let mut first_packet = None;
-    let mut in_outage = false;
-    let mut packet = [0; 1200];
-    while !stop.load(Ordering::Acquire) {
-        if let Some(len) = rx
-            .try_recv(&mut packet)
-            .map_err(|error| format!("UDP receive: {error:?}"))?
-        {
-            last_packet = Instant::now();
-            status.last_packet = Some(last_packet);
-            seen_packet = true;
-            let first = *first_packet.get_or_insert(last_packet);
-            // Demo-only receive-side impairment. Production sender/resource code is unchanged.
-            let wire = WirePacket::decode(&packet[..len])?;
-            let header = wire.header;
-            if header.record_kind == RecordKind::CopperList
-                && header.symbol_kind == FecSymbolKind::Source
-            {
-                in_outage = (32..160).contains(&header.object_id);
-            }
-            let discard = match impairment {
-                Impairment::Clean => false,
-                Impairment::Loss => {
-                    header.record_kind == RecordKind::CopperList
-                        && header.symbol_kind == FecSymbolKind::Source
-                        && header.object_id == 20
-                }
-                Impairment::Outage => in_outage,
-                Impairment::Bootstrap => {
-                    last_packet.duration_since(first) < Duration::from_millis(300)
-                }
-            };
-            if discard {
-                status.dropped += 1;
-                continue;
-            }
-            router
-                .receive_datagram(&packet[..len], |event| {
-                    if let SessionEvent::Manifest(manifest) = &event {
-                        if !quiet {
-                            println!(
-                                "Session sender={} id={:02x?}",
-                                manifest.identity.sender_id, manifest.identity.session_id
-                            );
-                        }
-                        status.identity = Some(manifest.identity);
-                        archive = Some(CaptureArchive::new(
-                            path,
-                            manifest.clone(),
-                            SLAB_BYTES,
-                            65536,
-                        )?);
-                    }
-                    if let Some(writer) = archive.as_mut() {
-                        let capture = writer.accept(&event)?;
-                        if let Some(list) = &capture {
-                            status.latest = Some(list.copperlist.id);
-                            status.archived += 1;
-                            status.state = RecordingState::Recording;
-                        }
-                        if let Some(twin) = twin {
-                            twin.accept(&event, capture)?;
-                        }
-                    }
-                    match event {
-                        SessionEvent::Gap { gap, .. } => {
-                            status.gaps += 1;
-                            if !quiet {
-                                println!(
-                                    "Missing CopperLists {}..={}: {:?}",
-                                    gap.first_id, gap.last_id, gap.reason
-                                );
-                            }
-                        }
-                        SessionEvent::VerifiedAnchor { anchor, .. } => {
-                            status.anchor = Some(anchor.copperlist_id);
-                        }
-                        _ => {}
-                    }
-                    Ok::<(), cu29_logstream::Error>(())
-                })
-                .map_err(|error| format!("Receiver consumer failed: {error:?}"))?;
-        } else {
-            thread::sleep(Duration::from_millis(1));
-        }
-        status.packets = router.stats().datagrams_seen;
-        if let Some(twin) = &twin {
-            twin.set_status(status);
-        }
-        if !quiet && last_status.elapsed() >= Duration::from_millis(500) {
-            print_status(&status, router.stats().datagrams_seen);
-            last_status = Instant::now();
-        }
-        if stop_at.is_some_and(|id| status.latest.is_some_and(|latest| latest >= id))
-            || (seen_packet && last_packet.elapsed() >= Duration::from_millis(*idle_ms))
-        {
+    Ok((twin, reader, stats))
+}
+
+pub fn run(options: &ReceiverOptions) -> Result<()> {
+    let (mut twin, mut reader, impairment) = start(options)?;
+    println!(
+        "Receiver listening at {}: {}",
+        options.listen,
+        options.log_base.display()
+    );
+    loop {
+        let status = reader.status();
+        while reader.try_read().is_some() {}
+        if reader.is_closed() || impairment.should_stop(options, status)? {
             break;
         }
-        if !seen_packet && started.elapsed() >= Duration::from_secs(15) {
-            return Err("No UDP traffic arrived within 15 seconds".into());
-        }
+        std::thread::sleep(Duration::from_millis(10));
     }
-    if let Some(archive) = archive {
-        archive.finish()?;
-    } else if !stop.load(Ordering::Acquire) {
+    let status = twin.stop()?;
+    if status.identity.is_none() {
         return Err("No session manifest received".into());
     }
-    status.state = RecordingState::Closed;
-    if let Some(twin) = &twin {
-        twin.set_status(status);
+    if !options.archive_only && status.archived > 0 && status.twin.reconstructed == 0 {
+        return Err("Live Copper twin produced no reconstructed frames".into());
     }
-    if !quiet {
-        print_status(&status, router.stats().datagrams_seen);
+    if status.twin.divergences != 0 {
+        return Err("Live Copper twin diverged".into());
     }
-    if !stop.load(Ordering::Acquire)
-        && !matches!(impairment, Impairment::Clean)
-        && status.dropped == 0
+    if !matches!(options.impairment, Impairment::Clean)
+        && impairment.dropped.load(Ordering::Relaxed) == 0
     {
         return Err("Impairment scenario did not discard any packets".into());
     }
-    if !quiet {
-        println!("Archive closed at receiver's known boundary; unobserved sender tail is unknown.");
-    }
-    Ok(())
-}
-
-fn print_status(status: &Status, packets: usize) {
     println!(
-        "packets={packets} archived={:?} verified_anchor={:?} gaps={} demo_drops={}",
-        status.latest, status.anchor, status.gaps, status.dropped
+        "packets={} archived={:?} verified_anchor={:?} gaps={} demo_drops={}",
+        status.packets,
+        status.latest,
+        status.anchor,
+        status.gaps,
+        impairment.dropped.load(Ordering::Relaxed)
     );
+    println!(
+        "Copper twin: {:?}, reconstructed={}, verified={}, replay_queue_drops={}",
+        status.twin.state,
+        status.twin.reconstructed,
+        status.twin.verified,
+        status.twin.queue_overflows
+    );
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cu_logstream_demo::telemetry::Frame;
-    use cu29_logstream::telemetry::telemetry_channel;
+    use cu_logstream_demo::telemetry::RecordingState;
+    use cu_logstream_demo::{ITERATIONS, run_sender};
 
     #[test]
     fn native_archive_is_identical_with_fast_stalled_or_disconnected_reader() {
         const COUNT: u64 = 96;
         let logs = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("logs");
-        fs::create_dir_all(&logs).unwrap();
-        let directory = tempfile::Builder::new()
-            .prefix("telemetry-test-")
-            .tempdir_in(logs)
-            .unwrap();
+        std::fs::create_dir_all(&logs).unwrap();
+        let directory = tempfile::tempdir_in(logs).unwrap();
         for mode in ["disabled", "fast", "stalled", "disconnected"] {
-            let ready = directory.path().join(format!("{mode}.endpoint"));
             let received = directory.path().join(format!("{mode}.copper"));
             let sender = directory.path().join(format!("{mode}-sender.copper"));
-            let options = ReceiverOptions {
-                listen: "127.0.0.1:0".parse().unwrap(),
-                log_base: received.clone(),
-                ready_file: Some(ready.clone()),
-                impairment: Impairment::Clean,
-                stop_at: Some(COUNT - 1),
-                idle_ms: 2000,
-                archive_only: mode == "disabled",
+            let mut socket = CuUdpLogStreamConfig::new("127.0.0.1:0".parse().unwrap());
+            socket.recv_buffer_bytes = Some(262144);
+            let (_, rx) = socket.open().unwrap();
+            let address = rx.local_addr().unwrap();
+            let builder = Twin::twin(rx)
+                .with_log_path(&received)
+                .with_frame_capacity(4.try_into().unwrap());
+            let builder = if mode == "disabled" {
+                builder.archive_only()
+            } else {
+                builder
             };
-            let (publisher, reader) =
-                telemetry_channel::<Frame, Status>(4.try_into().unwrap(), Status::default());
-            let publisher = (mode != "disabled").then_some(publisher);
+            let (mut twin, reader) = builder.spawn().unwrap();
             let mut reader = Some(reader);
             if mode == "disconnected" {
                 drop(reader.take());
             }
-            thread::scope(|scope| {
-                let worker = scope.spawn(move || {
-                    run(&options, publisher, &AtomicBool::new(false)).map_err(|e| e.to_string())
-                });
-                let fast_reader = if mode == "fast" {
-                    let mut reader = reader.take().unwrap();
-                    Some(scope.spawn(move || {
-                        let mut accounted = 0;
-                        loop {
-                            assert!(reader.wait_timeout(Duration::from_secs(5)));
-                            reader.status();
-                            while let Some(update) = reader.try_read() {
-                                let list = &update.frame.copperlist;
-                                assert_eq!(
-                                    list.msgs.get_derived_output().payload().unwrap().0,
-                                    list.msgs.get_sum_output().payload().unwrap().0 % 256
-                                );
-                                assert_eq!(
-                                    list.msgs.get_derived_output().tov,
-                                    list.msgs.get_sum_output().tov
-                                );
-                                accounted += update.missed + 1;
-                            }
-                            if reader.is_closed() {
-                                while let Some(update) = reader.try_read() {
-                                    let list = &update.frame.copperlist;
-                                    assert_eq!(
-                                        list.msgs.get_derived_output().payload().unwrap().0,
-                                        list.msgs.get_sum_output().payload().unwrap().0 % 256
-                                    );
-                                    assert_eq!(
-                                        list.msgs.get_derived_output().tov,
-                                        list.msgs.get_sum_output().tov
-                                    );
-                                    accounted += update.missed + 1;
-                                }
-                                return accounted;
-                            }
+            std::thread::scope(|scope| {
+                let producer = scope.spawn(|| run_sender(address, &sender, COUNT, 0).unwrap());
+                if mode == "fast" {
+                    let reader = reader.as_mut().unwrap();
+                    let deadline = Instant::now() + Duration::from_secs(10);
+                    while reader.status().archived < COUNT {
+                        assert!(Instant::now() < deadline);
+                        while let Some(update) = reader.try_read() {
+                            let list = &update.frame.copperlist;
+                            assert_eq!(
+                                list.msgs.get_derived_output().payload().unwrap().0,
+                                list.msgs.get_sum_output().payload().unwrap().0 % ITERATIONS
+                            );
                         }
-                    }))
-                } else {
-                    None
-                };
-                let started = Instant::now();
-                let address = loop {
-                    if let Ok(text) = fs::read_to_string(&ready)
-                        && let Ok(address) = text.trim().parse()
-                    {
-                        break address;
+                        std::thread::sleep(Duration::from_millis(1));
                     }
-                    if worker.is_finished() {
-                        panic!(
-                            "Receiver exited before binding: {:?}",
-                            worker.join().unwrap()
-                        );
-                    }
-                    assert!(
-                        started.elapsed() < Duration::from_secs(5),
-                        "receiver did not bind"
-                    );
-                    thread::sleep(Duration::from_millis(5));
-                };
-                cu_logstream_demo::run_sender(address, &sender, COUNT, 0).unwrap();
-                worker.join().unwrap().unwrap();
-                if let Some(worker) = fast_reader {
-                    assert_eq!(worker.join().unwrap(), COUNT);
                 }
+                producer.join().unwrap();
+                std::thread::sleep(Duration::from_millis(100));
             });
+            let status = twin.stop().unwrap();
+            assert_eq!(status.archived, COUNT);
+            assert_eq!(status.state, RecordingState::Closed);
             if mode == "stalled" {
                 let reader = reader.as_mut().unwrap();
-                let status = reader.status();
-                assert_eq!(status.archived, COUNT);
-                assert_eq!(status.state, RecordingState::Closed);
                 let update = reader.try_read().unwrap();
                 assert_eq!(update.missed, COUNT - 4);
                 assert_eq!(update.frame.copperlist.id, COUNT - 4);

--- a/examples/cu_logstream_demo/src/resim.rs
+++ b/examples/cu_logstream_demo/src/resim.rs
@@ -37,14 +37,6 @@ fn build(path: &Path) -> CuResult<(Replay, RobotClock, RobotClockMock)> {
     Ok((app, clock, mock))
 }
 
-fn reader(path: &Path, kind: UnifiedLogType) -> CuResult<UnifiedLoggerIOReader> {
-    Ok(UnifiedLoggerIOReader::new(
-        UnifiedLoggerRead::new(path)
-            .map_err(|error| CuError::new_with_cause("Open archive", error))?,
-        kind,
-    ))
-}
-
 fn main() -> CuResult<()> {
     let cli = ReplayCli::parse(ReplayDefaults::new(
         "logs/received.copper",
@@ -52,6 +44,14 @@ fn main() -> CuResult<()> {
     ));
     cu29::replay::ensure_log_family_exists(&cli.log_base)?;
     if let Some(debug_base) = cli.debug_base {
+        if cu_logstream_demo::read_lists(&cli.log_base)?
+            .iter()
+            .any(|list| list.msgs.get_derived_output().payload().is_none())
+        {
+            return Err(
+                "Run just resim first, then use resim-debug on the reconstructed full log".into(),
+            );
+        }
         let template = cli.replay_log_base;
         return serve_remote_debug::<
             Replay,
@@ -77,43 +77,61 @@ fn main() -> CuResult<()> {
     if cu29::replay::first_slab_path(&cli.replay_log_base)?.exists() {
         return Err("Replay output already exists; choose a new --replay-log-base".into());
     }
-    let (mut app, _, mock) = build(&cli.replay_log_base)?;
-    app.start_all_tasks(&mut |_| SimOverride::ExecuteByRuntime)?;
-    let keyframes: Vec<_> =
-        cu29_export::keyframes_reader(reader(&cli.log_base, UnifiedLogType::FrozenTasks)?)
-            .collect();
-    let mut count = 0;
-    for list in cu29_export::copperlists_reader::<default::CuStampedDataSet>(reader(
-        &cli.log_base,
+    let mut twin = cu29_logstream::twin::LiveTwin::<cu_logstream_demo::twin::Twin>::new()?;
+    let keyframes = cu_logstream_demo::read_keyframes(&cli.log_base)?;
+    let logger = UnifiedLoggerBuilder::new()
+        .file_base_name(&cli.replay_log_base)
+        .preallocated_size(SLAB_BYTES)
+        .write(true)
+        .create(true)
+        .build()
+        .map_err(|e| CuError::new_with_cause("Create replay output", e))?;
+    let UnifiedLogger::Write(logger) = logger else {
+        unreachable!()
+    };
+    let logger = std::sync::Arc::new(std::sync::Mutex::new(logger));
+    let mut output = cu29_unifiedlog::stream_write::<cu_logstream_demo::List, MmapSectionStorage>(
+        logger.clone(),
         UnifiedLogType::CopperList,
-    )?) {
-        let keyframe = keyframes.iter().find(|frame| frame.culistid == list.id);
-        if let Some(frame) = keyframe {
-            <Replay as cu29::prelude::app::CuSimApplication<
-                MmapSectionStorage,
-                MmapUnifiedLoggerWrite,
-            >>::restore_keyframe(&mut app, frame)?;
+        65536,
+    )?;
+    let mut states = cu29_unifiedlog::stream_write::<cu29::curuntime::KeyFrame, MmapSectionStorage>(
+        logger.clone(),
+        UnifiedLogType::FrozenTasks,
+        65536,
+    )?;
+    let mut provenance = cu29_unifiedlog::stream_write::<
+        cu29::continuity::StreamContinuityRecord,
+        MmapSectionStorage,
+    >(logger, UnifiedLogType::StreamContinuity, 65536)?;
+    let source = UnifiedLoggerIOReader::new(
+        UnifiedLoggerRead::new(&cli.log_base)
+            .map_err(|e| CuError::new_with_cause("Open capture provenance", e))?,
+        UnifiedLogType::StreamContinuity,
+    );
+    for record in cu29_export::stream_continuity_reader(source) {
+        if !matches!(
+            record,
+            cu29::continuity::StreamContinuityRecord::Capture { .. }
+        ) {
+            provenance.log(&record)?;
         }
-        // Generated replay checks continuity before touching the clock or tasks.
-        app.replay_recorded_copperlist(&mock, &list, keyframe)?;
+    }
+    let mut count = 0;
+    for capture in cu_logstream_demo::read_captures(&cli.log_base)? {
+        let keyframe = keyframes
+            .iter()
+            .find(|k| k.culistid == capture.copperlist.id);
+        let list = twin
+            .reconstruct(capture, keyframe)?
+            .ok_or_else(|| CuError::from("Missing replay anchor"))?;
+        if let Some(keyframe) = keyframe {
+            states.log(keyframe)?;
+        }
+        output.log(&list)?;
         count += 1;
     }
-    app.stop_all_tasks(&mut |_| SimOverride::ExecuteByRuntime)?;
-    drop(app);
-    let recorded = cu_logstream_demo::read_lists(&cli.log_base)?;
-    let replayed = cu_logstream_demo::read_lists(&cli.replay_log_base)?;
-    if recorded.len() != replayed.len() {
-        return Err("Recorded replay lost CopperLists".into());
-    }
-    for (expected, actual) in recorded.iter().zip(&replayed) {
-        let encode = |list| {
-            cu29::bincode::encode_to_vec(list, cu29::bincode::config::standard())
-                .map_err(|error| CuError::new_with_cause("Encode replay comparison", error))
-        };
-        if encode(expected)? != encode(actual)? {
-            return Err(format!("Recorded replay changed CopperList {}", expected.id).into());
-        }
-    }
-    println!("Replayed {count} captured CopperLists with verified keyframe boundaries.");
+    drop(output);
+    println!("Reconstructed {count} full CopperLists from captured inputs.");
     Ok(())
 }

--- a/examples/cu_logstream_demo/src/resim.rs
+++ b/examples/cu_logstream_demo/src/resim.rs
@@ -110,13 +110,9 @@ fn main() -> CuResult<()> {
         UnifiedLogType::StreamContinuity,
     );
     for record in cu29_export::stream_continuity_reader(source) {
-        if !matches!(
-            record,
-            cu29::continuity::StreamContinuityRecord::Capture { .. }
-        ) {
-            provenance.log(&record)?;
-        }
+        provenance.log(&record)?;
     }
+
     let mut count = 0;
     for capture in cu_logstream_demo::read_captures(&cli.log_base)? {
         let keyframe = keyframes

--- a/examples/cu_logstream_demo/src/tasks.rs
+++ b/examples/cu_logstream_demo/src/tasks.rs
@@ -57,6 +57,10 @@ impl Freezable for Accumulator {
     }
 }
 
+impl CuCrossPlatformDeterministic for Accumulator {
+    const REPLAY_ABI: u32 = 1;
+}
+
 impl CuTask for Accumulator {
     type Resources<'r> = ();
     type Input<'m> = input_msg!(Sample);
@@ -75,6 +79,35 @@ impl CuTask for Accumulator {
             .ok_or_else(|| CuError::from("Counter produced no sample"))?
             .0;
         output.set_payload(Sample(self.sum));
+        output.tov = input.tov;
+        Ok(())
+    }
+}
+
+/// This task runs on both the robot and the generated ground-side replay runtime.
+#[derive(Default, Reflect)]
+pub struct Derived;
+impl Freezable for Derived {}
+impl CuCrossPlatformDeterministic for Derived {
+    const REPLAY_ABI: u32 = 1;
+}
+impl CuTask for Derived {
+    type Resources<'r> = ();
+    type Input<'m> = input_msg!(Sample);
+    type Output<'m> = output_msg!(Sample);
+    fn new(_: Option<&ComponentConfig>, _: ()) -> CuResult<Self> {
+        Ok(Self)
+    }
+    fn process(
+        &mut self,
+        _: &CuContext,
+        input: &Self::Input<'_>,
+        output: &mut Self::Output<'_>,
+    ) -> CuResult<()> {
+        let sum = input
+            .payload()
+            .ok_or_else(|| CuError::from("Accumulator produced no sample"))?;
+        output.set_payload(Sample(sum.0 % 256));
         output.tov = input.tov;
         Ok(())
     }

--- a/examples/cu_logstream_demo/src/telemetry.rs
+++ b/examples/cu_logstream_demo/src/telemetry.rs
@@ -1,37 +1,3 @@
-//! Example-specific telemetry values shared by the receiver and native UI.
-use cu29_logstream::{StreamIdentity, telemetry::TelemetryPublisher};
-use std::time::Instant;
-
-/// A small current snapshot; frame delivery may be paused independently.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct Status {
-    pub latest: Option<u64>,
-    pub anchor: Option<u64>,
-    pub gaps: usize,
-    pub dropped: usize,
-    pub packets: usize,
-    pub archived: u64,
-    pub identity: Option<StreamIdentity>,
-    pub last_packet: Option<Instant>,
-    pub state: RecordingState,
-    pub twin: cu29_logstream::twin::TwinStatus,
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum RecordingState {
-    #[default]
-    Waiting,
-    Recording,
-    Closed,
-    Failed,
-}
-
+//! Typed views of Copper-owned twin frames and status.
+pub use cu29_logstream::{CuTwinRecordingState as RecordingState, CuTwinStatus as Status};
 pub type Frame = cu29_logstream::twin::TwinFrame<crate::DataSet>;
-impl cu29_logstream::twin::TwinReceiverStatus for Status {
-    fn with_twin(mut self, status: cu29_logstream::twin::TwinStatus) -> Self {
-        self.twin = status;
-        self
-    }
-}
-
-pub type Publisher = TelemetryPublisher<Frame, Status>;

--- a/examples/cu_logstream_demo/src/telemetry.rs
+++ b/examples/cu_logstream_demo/src/telemetry.rs
@@ -14,6 +14,7 @@ pub struct Status {
     pub identity: Option<StreamIdentity>,
     pub last_packet: Option<Instant>,
     pub state: RecordingState,
+    pub twin: cu29_logstream::twin::TwinStatus,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -25,10 +26,12 @@ pub enum RecordingState {
     Failed,
 }
 
-pub struct Frame {
-    pub identity: StreamIdentity,
-    pub received_at: Instant,
-    pub copperlist: crate::List,
+pub type Frame = cu29_logstream::twin::TwinFrame<crate::DataSet>;
+impl cu29_logstream::twin::TwinReceiverStatus for Status {
+    fn with_twin(mut self, status: cu29_logstream::twin::TwinStatus) -> Self {
+        self.twin = status;
+        self
+    }
 }
 
 pub type Publisher = TelemetryPublisher<Frame, Status>;

--- a/examples/cu_logstream_demo/tests/stateful.ron
+++ b/examples/cu_logstream_demo/tests/stateful.ron
@@ -1,0 +1,47 @@
+(
+    logging: (
+        enable_task_logging: true,
+        enable_keyframe_logging: true,
+        keyframe_interval: 16,
+        copperlist_count: 8,
+    ),
+    tasks: [
+        (
+            id: "counter",
+            type: "cu_logstream_demo::tasks::Counter",
+        ),
+        (
+            id: "sum",
+            type: "cu_logstream_demo::tasks::Accumulator",
+            streaming: (
+                replay: reconstruct,
+                replay_abi: 1,
+            ),
+        ),
+        (
+            id: "derived",
+            type: "cu_logstream_demo::tasks::Derived",
+            streaming: (
+                replay: reconstruct,
+                replay_abi: 1,
+            ),
+        ),
+    ],
+    cnx: [
+        (
+            src: "counter",
+            dst: "sum",
+            msg: "cu_logstream_demo::tasks::Sample",
+        ),
+        (
+            src: "sum",
+            dst: "derived",
+            msg: "cu_logstream_demo::tasks::Sample",
+        ),
+        (
+            src: "derived",
+            dst: "__nc__",
+            msg: "cu_logstream_demo::tasks::Sample",
+        ),
+    ],
+)

--- a/examples/cu_logstream_demo/tests/twin.rs
+++ b/examples/cu_logstream_demo/tests/twin.rs
@@ -6,6 +6,34 @@ use cu29_logstream::{
     twin::{LiveTwin, ReconstructionState},
 };
 
+struct CountingAllocator;
+thread_local! {
+    static ALLOCATIONS: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
+}
+unsafe impl std::alloc::GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
+        let _ = ALLOCATIONS.try_with(|count| {
+            if let Some(value) = count.get() {
+                count.set(Some(value + 1));
+            }
+        });
+        unsafe { std::alloc::System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
+        unsafe { std::alloc::System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: std::alloc::Layout, size: usize) -> *mut u8 {
+        let _ = ALLOCATIONS.try_with(|count| {
+            if let Some(value) = count.get() {
+                count.set(Some(value + 1));
+            }
+        });
+        unsafe { std::alloc::System.realloc(ptr, layout, size) }
+    }
+}
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
 static SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 fn fixture() -> (Vec<List>, Vec<cu29::curuntime::KeyFrame>) {
@@ -31,7 +59,6 @@ fn capture(list: &List) -> CapturedList<DataSet> {
             .payload()
             .is_none()
     );
-    assert_eq!(captured.proof.original_presence, [true, true, true]);
     captured
 }
 
@@ -85,27 +112,15 @@ fn generated_twin_recovers_gaps_and_preserves_every_sender_field() {
     } else {
         assert_eq!(twin.status.verified, 0);
         assert_eq!(twin.status.state, ReconstructionState::Reconstructed);
-        assert!(
-            capture(&lists[0])
-                .proof
-                .reconstructed_digests
-                .iter()
-                .all(Option::is_none)
-        );
     }
 }
 
 #[test]
 fn a_payload_hidden_in_a_capture_is_rejected() {
-    use cu29_logstream::capture::CaptureDataSet;
     let _serial = SERIAL.lock().unwrap();
     let (lists, _) = fixture();
     let list = &lists[0];
-    let bytes = cu29::bincode::encode_to_vec(
-        (list.msgs.capture_proof().unwrap(), list),
-        cu29::bincode::config::standard(),
-    )
-    .unwrap();
+    let bytes = cu29::bincode::encode_to_vec(list, cu29::bincode::config::standard()).unwrap();
     assert!(decode_capture::<DataSet>(&bytes).is_err());
 }
 
@@ -119,7 +134,7 @@ fn divergence_suppresses_frames_until_a_matching_anchor() {
         .unwrap()
         .unwrap();
     let mut corrupted = capture(&lists[1]);
-    corrupted.proof.reconstructed_digests[2] = Some([0; 32]);
+    corrupted.digest = Some([0; 32]);
     assert!(twin.reconstruct(corrupted, None).is_err());
     assert_eq!(twin.status.state, ReconstructionState::Diverged);
     assert!(
@@ -295,4 +310,92 @@ fn stateful_reconstruction_restores_keyframes_and_feeds_downstream_tasks() {
         );
     }
     assert_eq!(twin.status.reconstructed, 22);
+}
+
+#[test]
+fn capture_encoding_is_native_and_does_not_allocate() {
+    use cu29_logstream::capture::CaptureView;
+    let _serial = SERIAL.lock().unwrap();
+    let (lists, _) = fixture();
+    let list = &lists[0];
+    let mut bytes = [0; 4096];
+    encode_capture_record_into(list, &mut bytes).unwrap(); // Warm thread-local I/O instrumentation.
+    ALLOCATIONS.with(|count| count.set(Some(0)));
+    let encoded = encode_capture_record_into(list, &mut bytes);
+    let allocations = ALLOCATIONS.with(|count| count.replace(None).unwrap());
+    assert_eq!(allocations, 0, "capture encoding allocated after startup");
+    let record = cu29_logstream::decode_record(&bytes[..encoded.unwrap()]).unwrap();
+    let (capture, native) = decode_capture::<DataSet>(record.payload).unwrap();
+    let expected = cu29::bincode::encode_to_vec(
+        (list.id, list.get_state(), CaptureView(&list.msgs)),
+        cu29::bincode::config::standard(),
+    )
+    .unwrap();
+    assert_eq!(native, expected);
+    let decoded = cu29_logstream::decode_copperlist::<DataSet>(native).unwrap();
+    assert!(decoded.msgs.get_derived_output().payload().is_none());
+    if cfg!(feature = "verify-reconstruction") {
+        assert_eq!(record.payload.len(), native.len() + 32);
+    } else {
+        assert_eq!(
+            record.payload, native,
+            "production added a verification envelope"
+        );
+        assert_eq!(std::mem::size_of_val(&capture), std::mem::size_of::<List>());
+    }
+    // Any debug build can replay a normal capture without claiming verification.
+    let (native_capture, _) = decode_capture::<DataSet>(native).unwrap();
+    #[cfg(feature = "verify-reconstruction")]
+    assert!(native_capture.digest.is_none());
+    assert_eq!(native_capture.copperlist.id, list.id);
+    let mut malformed = native.to_vec();
+    malformed.push(0);
+    assert!(decode_capture::<DataSet>(&malformed).is_err());
+}
+
+#[test]
+fn twin_owns_shutdown_and_reports_transport_failure() {
+    use cu29_logstream::{CuStreamRx, CuStreamRxError, CuTwinRecordingState};
+    #[derive(Debug)]
+    struct Rx(bool);
+    impl CuStreamRx for Rx {
+        fn try_recv(&mut self, _: &mut [u8]) -> Result<Option<usize>, CuStreamRxError> {
+            if self.0 {
+                Err(CuStreamRxError::Failed("test transport failed"))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+    let _serial = SERIAL.lock().unwrap();
+    let logs = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("logs");
+    std::fs::create_dir_all(&logs).unwrap();
+    let dir = tempfile::tempdir_in(logs).unwrap();
+    let (twin, mut reader) = Twin::twin(Rx(false))
+        .with_log_path(dir.path().join("unused.copper"))
+        .spawn()
+        .unwrap();
+    drop(twin);
+    assert!(
+        reader.is_closed(),
+        "dropping the twin must join its workers"
+    );
+    assert_eq!(reader.status().state, CuTwinRecordingState::Closed);
+    let (mut twin, mut reader) = Twin::twin(Rx(true))
+        .with_log_path(dir.path().join("failed.copper"))
+        .spawn()
+        .unwrap();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !reader.is_closed() {
+        assert!(std::time::Instant::now() < deadline);
+        reader.status();
+        reader.wait_timeout(std::time::Duration::from_millis(10));
+    }
+    assert_eq!(reader.status().state, CuTwinRecordingState::Failed);
+    assert!(
+        twin.stop()
+            .unwrap_err()
+            .to_string()
+            .contains("test transport failed")
+    );
 }

--- a/examples/cu_logstream_demo/tests/twin.rs
+++ b/examples/cu_logstream_demo/tests/twin.rs
@@ -1,0 +1,298 @@
+#![cfg(feature = "demo")]
+
+use cu_logstream_demo::{DataSet, List, read_keyframes, read_lists, run_sender, twin::Twin};
+use cu29_logstream::{
+    capture::{CapturedList, decode_capture, encode_capture_record_into},
+    twin::{LiveTwin, ReconstructionState},
+};
+
+static SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn fixture() -> (Vec<List>, Vec<cu29::curuntime::KeyFrame>) {
+    let logs = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("logs");
+    std::fs::create_dir_all(&logs).unwrap();
+    let directory = tempfile::tempdir_in(logs).unwrap();
+    let path = directory.path().join("onboard.copper");
+    let socket = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    run_sender(socket.local_addr().unwrap(), &path, 34, 0).unwrap();
+    (read_lists(&path).unwrap(), read_keyframes(&path).unwrap())
+}
+
+fn capture(list: &List) -> CapturedList<DataSet> {
+    let mut bytes = [0; 4096];
+    let len = encode_capture_record_into(list, &mut bytes).unwrap();
+    let record = cu29_logstream::decode_record(&bytes[..len]).unwrap();
+    let (captured, _) = decode_capture::<DataSet>(record.payload).unwrap();
+    assert!(
+        captured
+            .copperlist
+            .msgs
+            .get_derived_output()
+            .payload()
+            .is_none()
+    );
+    assert_eq!(captured.proof.original_presence, [true, true, true]);
+    captured
+}
+
+fn assert_exact(expected: &List, actual: &List) {
+    let encode =
+        |list| cu29::bincode::encode_to_vec(list, cu29::bincode::config::standard()).unwrap();
+    assert_eq!(
+        encode(expected),
+        encode(actual),
+        "CopperList {} including sender metadata",
+        expected.id
+    );
+}
+
+#[test]
+fn generated_twin_recovers_gaps_and_preserves_every_sender_field() {
+    let _serial = SERIAL.lock().unwrap();
+    let (lists, keyframes) = fixture();
+    let mut twin = LiveTwin::<Twin>::new().unwrap();
+    for list in &lists[..4] {
+        let result = twin
+            .reconstruct(
+                capture(list),
+                keyframes.iter().find(|k| k.culistid == list.id),
+            )
+            .unwrap()
+            .unwrap();
+        assert_exact(list, &result);
+    }
+    // Missing required iterations cannot be healed by a complete later input alone.
+    assert!(
+        twin.reconstruct(capture(&lists[9]), None)
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(twin.status.state, ReconstructionState::Recovering);
+    for list in &lists[16..] {
+        let result = twin
+            .reconstruct(
+                capture(list),
+                keyframes.iter().find(|k| k.culistid == list.id),
+            )
+            .unwrap()
+            .unwrap();
+        assert_exact(list, &result);
+    }
+    assert_eq!(twin.status.reconstructed, 22);
+    if cfg!(feature = "verify-reconstruction") {
+        assert_eq!(twin.status.verified, 22);
+        assert_eq!(twin.status.state, ReconstructionState::Verified);
+    } else {
+        assert_eq!(twin.status.verified, 0);
+        assert_eq!(twin.status.state, ReconstructionState::Reconstructed);
+        assert!(
+            capture(&lists[0])
+                .proof
+                .reconstructed_digests
+                .iter()
+                .all(Option::is_none)
+        );
+    }
+}
+
+#[test]
+fn a_payload_hidden_in_a_capture_is_rejected() {
+    use cu29_logstream::capture::CaptureDataSet;
+    let _serial = SERIAL.lock().unwrap();
+    let (lists, _) = fixture();
+    let list = &lists[0];
+    let bytes = cu29::bincode::encode_to_vec(
+        (list.msgs.capture_proof().unwrap(), list),
+        cu29::bincode::config::standard(),
+    )
+    .unwrap();
+    assert!(decode_capture::<DataSet>(&bytes).is_err());
+}
+
+#[cfg(feature = "verify-reconstruction")]
+#[test]
+fn divergence_suppresses_frames_until_a_matching_anchor() {
+    let _serial = SERIAL.lock().unwrap();
+    let (lists, keyframes) = fixture();
+    let mut twin = LiveTwin::<Twin>::new().unwrap();
+    twin.reconstruct(capture(&lists[0]), Some(&keyframes[0]))
+        .unwrap()
+        .unwrap();
+    let mut corrupted = capture(&lists[1]);
+    corrupted.proof.reconstructed_digests[2] = Some([0; 32]);
+    assert!(twin.reconstruct(corrupted, None).is_err());
+    assert_eq!(twin.status.state, ReconstructionState::Diverged);
+    assert!(
+        twin.reconstruct(capture(&lists[2]), None)
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(twin.status.state, ReconstructionState::Diverged);
+    let boundary = &lists[16];
+    let recovered = twin
+        .reconstruct(
+            capture(boundary),
+            keyframes.iter().find(|k| k.culistid == 16),
+        )
+        .unwrap()
+        .unwrap();
+    assert_exact(boundary, &recovered);
+    assert_eq!(twin.status.state, ReconstructionState::Verified);
+    assert_eq!(twin.status.divergences, 1);
+}
+
+static ENTERED: std::sync::LazyLock<std::sync::Barrier> =
+    std::sync::LazyLock::new(|| std::sync::Barrier::new(2));
+static RELEASE: std::sync::LazyLock<std::sync::Barrier> =
+    std::sync::LazyLock::new(|| std::sync::Barrier::new(2));
+struct BlockedTwin(Twin);
+impl cu29_logstream::twin::LiveReplay for BlockedTwin {
+    type DataSet = DataSet;
+    fn build_twin() -> cu29::CuResult<(Self, cu29::clock::RobotClockMock)> {
+        let (app, clock) = Twin::build_twin()?;
+        Ok((Self(app), clock))
+    }
+    fn replay_capture(
+        &mut self,
+        clock: &cu29::clock::RobotClockMock,
+        captured: &mut List,
+        keyframe: Option<&cu29::curuntime::KeyFrame>,
+    ) -> cu29::CuResult<()> {
+        ENTERED.wait();
+        RELEASE.wait();
+        self.0.replay_capture(clock, captured, keyframe)
+    }
+}
+
+#[test]
+fn replay_queue_overflow_invalidates_in_flight_output_without_blocking_capture() {
+    let _serial = SERIAL.lock().unwrap();
+    let (lists, keyframes) = fixture();
+    let (publisher, mut reader) = cu29_logstream::telemetry::telemetry_channel(
+        4.try_into().unwrap(),
+        cu_logstream_demo::telemetry::Status::default(),
+    );
+    let worker =
+        cu29_logstream::twin::TwinWorker::spawn::<BlockedTwin>(2.try_into().unwrap(), publisher)
+            .unwrap();
+    let identity = cu29_logstream::StreamIdentity {
+        session_id: [1; 16],
+        sender_id: 41,
+    };
+    worker.submit(capture(&lists[0]), identity, std::time::Instant::now());
+    worker.anchor(keyframes[0].clone());
+    ENTERED.wait(); // The replay worker is blocked inside task execution.
+    for list in &lists[1..4] {
+        worker.submit(capture(list), identity, std::time::Instant::now());
+    }
+    RELEASE.wait();
+    drop(worker);
+    assert!(
+        reader.try_read().is_none(),
+        "invalidated in-flight output reached the UI"
+    );
+    let status = reader.status();
+    assert_eq!(status.twin.queue_overflows, 1);
+    assert_eq!(status.twin.state, ReconstructionState::Recovering);
+}
+
+#[test]
+fn recovery_discards_captures_waiting_for_an_old_anchor() {
+    let _serial = SERIAL.lock().unwrap();
+    let (lists, keyframes) = fixture();
+    let (publisher, mut reader) = cu29_logstream::telemetry::telemetry_channel(
+        4.try_into().unwrap(),
+        cu_logstream_demo::telemetry::Status::default(),
+    );
+    let worker =
+        cu29_logstream::twin::TwinWorker::spawn::<Twin>(4.try_into().unwrap(), publisher).unwrap();
+    let identity = cu29_logstream::StreamIdentity {
+        session_id: [1; 16],
+        sender_id: 41,
+    };
+    worker.submit(capture(&lists[0]), identity, std::time::Instant::now());
+    // Two acknowledged status updates ensure the worker has consumed the capture,
+    // even if the first update was observed before its blocking receive.
+    for archived in 1..=2 {
+        worker.set_status(cu_logstream_demo::telemetry::Status {
+            archived,
+            ..Default::default()
+        });
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while reader.status().archived != archived {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "worker did not acknowledge status"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+    }
+    worker.recover();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while reader.status().twin.state != ReconstructionState::Recovering {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "worker did not recover"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+    worker.anchor(keyframes[0].clone());
+    drop(worker);
+    assert!(reader.try_read().is_none(), "old capture survived recovery");
+    assert_eq!(reader.status().twin.reconstructed, 0);
+}
+
+mod stateful {
+    use cu29::prelude::*;
+    #[copper_runtime(config = "tests/stateful.ron", sim_mode = true)]
+    struct Replay {}
+    pub type Twin = default::Replay;
+    pub type DataSet = default::CuStampedDataSet;
+}
+
+#[test]
+fn stateful_reconstruction_restores_keyframes_and_feeds_downstream_tasks() {
+    let _serial = SERIAL.lock().unwrap();
+    let (lists, keyframes) = fixture();
+    let mut twin = LiveTwin::<stateful::Twin>::new().unwrap();
+    // The same onboard graph, but both the stateful sum and its downstream
+    // modulo task are omitted from the stream in this reconstruction contract.
+    for expected in lists[..4].iter().chain(&lists[16..]) {
+        let full =
+            cu29::bincode::encode_to_vec(expected, cu29::bincode::config::standard()).unwrap();
+        let (list, _): (cu29::copperlist::CopperList<stateful::DataSet>, _) =
+            cu29::bincode::decode_from_slice(&full, cu29::bincode::config::standard()).unwrap();
+        let mut bytes = [0; 4096];
+        let len = encode_capture_record_into(&list, &mut bytes).unwrap();
+        let record = cu29_logstream::decode_record(&bytes[..len]).unwrap();
+        let (captured, _) = decode_capture::<stateful::DataSet>(record.payload).unwrap();
+        assert!(
+            captured
+                .copperlist
+                .msgs
+                .get_sum_output()
+                .payload()
+                .is_none()
+        );
+        assert!(
+            captured
+                .copperlist
+                .msgs
+                .get_derived_output()
+                .payload()
+                .is_none()
+        );
+        let actual = twin
+            .reconstruct(
+                captured,
+                keyframes.iter().find(|k| k.culistid == expected.id),
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            full,
+            cu29::bincode::encode_to_vec(actual, cu29::bincode::config::standard()).unwrap()
+        );
+    }
+    assert_eq!(twin.status.reconstructed, 22);
+}

--- a/justfile
+++ b/justfile
@@ -544,3 +544,12 @@ wt branch:
     zellij action write-chars "cd ${dir};reset"
     zellij action write 13
   fi
+
+# Selective capture, generated live replay, opt-in divergence checks, and UI isolation.
+logstream-twin-check:
+    cargo +stable clippy -p cu29-logstream --all-targets --features verify-reconstruction -- --deny warnings
+    cargo +stable clippy -p cu-logstream-demo --all-targets --features replay,tui,verify-reconstruction -- --deny warnings
+    cargo +stable test -p cu-logstream-demo --features demo,tui,verify-reconstruction
+    cargo +stable test -p cu-logstream-demo --features demo --test twin
+    just logstream-receiver-check
+    just --justfile examples/cu_logstream_demo/justfile check


### PR DESCRIPTION
## Summary

Reconstruct selected task outputs on the ground through Copper's generated runtime. A ground station starts with `Ground::twin(rx).with_log_path(...).spawn()`; Copper owns reception, session routing, native archival, bounded replay, status, and worker shutdown. The caller receives a typed frame reader.

## Related issues

Stacked on #1328 (`gbin/ratatui-mascot`).

## Changes

- Declare reconstruction in RON and implement `CuCrossPlatformDeterministic`. Generated replay restores keyframes, injects captured inputs, runs selected synchronous tasks, and preserves sender metadata.
- Keep production streaming in the existing native CopperList format. Remove the proof envelope, per-list proof vectors, and additional continuity record. The unreleased manifest remains v1, with the reconstruction ABI in its application schema; packet framing and FEC are unchanged.
- Compile reconstruction correctness checks only with `cu29/logstream-verify`. This adds one fixed 32-byte digest covering omitted outputs. Hashing and comparison stay on output/replay workers, without per-list verification buffers. Regression tests assert allocation-free demo capture encoding in both modes. Debug digests are consumed live and excluded from native archives.
- Let Copper manage the twin lifecycle, including archive-only operation, source-gap recovery, replay overflow, transport errors, and shutdown. Slow or disconnected readers do not affect recording. The demo uses this API without application-owned workers or event-routing glue.
- Keep offline captures directly readable by ordinary log tools and reconstruct them with the same replay engine. Update the demo and companion docs.

## Validation

- `just logstream-twin-check`: Clippy, both verification modes, allocation/native-format checks, lifecycle/error tests, reader isolation, and all six UDP recovery/replay scenarios passed.
- `just nostd-ci`: 530 tests passed (one skipped), embedded Clippy/builds, and RP2350 firmware/host checks passed. The existing non-fatal RP2350 `.text` alignment warning remains.
- `just api-check`, `just fmt`, Git whitespace checks, and the companion book build passed.

Checks ran in the reserved worktree. Temporary build-only copies corrected existing cu-vitfly/ZED dependencies that otherwise resolve Copper from the main checkout; those dependency-path changes are not included in the PR.

## Reminder

- [ ] I ran the full default `just` pipeline (focused root checks listed above were used).
- [x] I have updated docs and examples where needed.

## Additional context

Companion book PR: https://github.com/copper-project/copper-rs-book/pull/49.
Wiki updates are committed locally on `gbin/copper-twin-docs` at `a5d156c`; GitHub wikis do not support PRs.
