### PR TITLE
Reuse logstream receiver buffers and borrow archive records

### DIFF
--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -630,7 +630,7 @@ impl<'__de, __Context> cu_bincode::de::BorrowDecode<'__de, __Context> for cu29_r
 pub fn cu29_runtime::continuity::SourceGapReason::borrow_decode<__D: cu_bincode::de::BorrowDecoder<'__de, Context = __Context>>(decoder: &mut __D) -> core::result::Result<Self, cu_bincode::error::DecodeError>
 impl<__Context> cu_bincode::de::Decode<__Context> for cu29_runtime::continuity::SourceGapReason
 pub fn cu29_runtime::continuity::SourceGapReason::decode<__D: cu_bincode::de::Decoder<Context = __Context>>(decoder: &mut __D) -> core::result::Result<Self, cu_bincode::error::DecodeError>
-pub enum cu29_runtime::continuity::StreamContinuityRecord
+pub enum cu29_runtime::continuity::StreamContinuityRecord<B>
 pub cu29_runtime::continuity::StreamContinuityRecord::Finished
 pub cu29_runtime::continuity::StreamContinuityRecord::Finished::next_copperlist_id: u64
 pub cu29_runtime::continuity::StreamContinuityRecord::Gap
@@ -638,16 +638,16 @@ pub cu29_runtime::continuity::StreamContinuityRecord::Gap::first_id: u64
 pub cu29_runtime::continuity::StreamContinuityRecord::Gap::last_id: u64
 pub cu29_runtime::continuity::StreamContinuityRecord::Gap::reason: cu29_runtime::continuity::SourceGapReason
 pub cu29_runtime::continuity::StreamContinuityRecord::Manifest
-pub cu29_runtime::continuity::StreamContinuityRecord::Manifest::record: alloc::vec::Vec<u8>
+pub cu29_runtime::continuity::StreamContinuityRecord::Manifest::record: B
 pub cu29_runtime::continuity::StreamContinuityRecord::RecoveryPoint
 pub cu29_runtime::continuity::StreamContinuityRecord::RecoveryPoint::copperlist_id: u64
-pub cu29_runtime::continuity::StreamContinuityRecord::RecoveryPoint::record: alloc::vec::Vec<u8>
-impl cu_bincode::enc::Encode for cu29_runtime::continuity::StreamContinuityRecord
-pub fn cu29_runtime::continuity::StreamContinuityRecord::encode<__E: cu_bincode::enc::Encoder>(&self, encoder: &mut __E) -> core::result::Result<(), cu_bincode::error::EncodeError>
-impl<'__de, __Context> cu_bincode::de::BorrowDecode<'__de, __Context> for cu29_runtime::continuity::StreamContinuityRecord
-pub fn cu29_runtime::continuity::StreamContinuityRecord::borrow_decode<__D: cu_bincode::de::BorrowDecoder<'__de, Context = __Context>>(decoder: &mut __D) -> core::result::Result<Self, cu_bincode::error::DecodeError>
-impl<__Context> cu_bincode::de::Decode<__Context> for cu29_runtime::continuity::StreamContinuityRecord
-pub fn cu29_runtime::continuity::StreamContinuityRecord::decode<__D: cu_bincode::de::Decoder<Context = __Context>>(decoder: &mut __D) -> core::result::Result<Self, cu_bincode::error::DecodeError>
+pub cu29_runtime::continuity::StreamContinuityRecord::RecoveryPoint::record: B
+impl<'__de, B, __Context> cu_bincode::de::BorrowDecode<'__de, __Context> for cu29_runtime::continuity::StreamContinuityRecord<B> where B: cu_bincode::de::BorrowDecode<'__de, __Context>
+pub fn cu29_runtime::continuity::StreamContinuityRecord<B>::borrow_decode<__D: cu_bincode::de::BorrowDecoder<'__de, Context = __Context>>(decoder: &mut __D) -> core::result::Result<Self, cu_bincode::error::DecodeError>
+impl<B, __Context> cu_bincode::de::Decode<__Context> for cu29_runtime::continuity::StreamContinuityRecord<B> where B: cu_bincode::de::Decode<__Context>
+pub fn cu29_runtime::continuity::StreamContinuityRecord<B>::decode<__D: cu_bincode::de::Decoder<Context = __Context>>(decoder: &mut __D) -> core::result::Result<Self, cu_bincode::error::DecodeError>
+impl<B> cu_bincode::enc::Encode for cu29_runtime::continuity::StreamContinuityRecord<B> where B: cu_bincode::enc::Encode
+pub fn cu29_runtime::continuity::StreamContinuityRecord<B>::encode<__E: cu_bincode::enc::Encoder>(&self, encoder: &mut __E) -> core::result::Result<(), cu_bincode::error::EncodeError>
 pub fn cu29_runtime::continuity::validate_replay_continuity(expected: u64, actual: u64, keyframe: core::option::Option<u64>) -> cu29_traits::CuResult<()>
 pub mod cu29_runtime::copperlist
 pub enum cu29_runtime::copperlist::CopperListState

--- a/components/res/cu29_logstream_udp/tests/configured_sender.rs
+++ b/components/res/cu29_logstream_udp/tests/configured_sender.rs
@@ -94,9 +94,9 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
     let mut keyframe_seen = false;
     let mut recovery_point_seen = false;
     let mut gaps = Vec::new();
-    let mut emit = |event| {
+    let mut emit = |event: cu29_logstream::SessionEventRef<'_>| {
         if let SessionEvent::Manifest(manifest) = &event {
-            let mut wrong_schema = manifest.clone();
+            let mut wrong_schema = manifest.manifest().clone();
             wrong_schema.application_schema.outputs[0]
                 .payload_type
                 .push_str("::Wrong");
@@ -104,7 +104,10 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
             assert!(
                 cu29_logstream::NativeArchive::<default::CuStampedDataSet>::new(
                     &rejected_path,
-                    wrong_schema,
+                    &cu29_logstream::ReceivedManifest::decode_record(
+                        wrong_schema.encode_record().unwrap()
+                    )
+                    .unwrap(),
                     1024 * 1024,
                     4096
                 )
@@ -112,13 +115,8 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
             );
             assert!(!rejected_path.exists());
             archive = Some(
-                cu29_logstream::NativeArchive::new(
-                    &archive_path,
-                    manifest.clone(),
-                    1024 * 1024,
-                    4096,
-                )
-                .unwrap(),
+                cu29_logstream::NativeArchive::new(&archive_path, manifest, 1024 * 1024, 4096)
+                    .unwrap(),
             );
         }
         if let Some(writer) = archive.as_mut() {
@@ -126,13 +124,13 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
         }
         match event {
             SessionEvent::Manifest(manifest) => {
-                assert_eq!(manifest.identity.sender_id, 41);
-                assert_eq!(manifest.plan.destination_id, "ground");
-                assert_eq!(manifest.plan.symbol_size, 1128);
-                assert_eq!(manifest.application_schema, expected_schema);
-                assert_eq!(manifest.application_schema.outputs.len(), 1);
+                assert_eq!(manifest.manifest().identity.sender_id, 41);
+                assert_eq!(manifest.manifest().plan.destination_id, "ground");
+                assert_eq!(manifest.manifest().plan.symbol_size, 1128);
+                assert_eq!(manifest.manifest().application_schema, expected_schema);
+                assert_eq!(manifest.manifest().application_schema.outputs.len(), 1);
                 assert_eq!(
-                    manifest.application_schema.outputs[0].payload_type,
+                    manifest.manifest().application_schema.outputs[0].payload_type,
                     core::any::type_name::<UdpMessage>()
                 );
                 manifest_seen = true;
@@ -140,7 +138,7 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
             SessionEvent::ContinuousRecord { identity, record } => {
                 assert!(manifest_seen);
                 assert_eq!(identity.sender_id, 41);
-                let record = record.decoded().unwrap();
+                let record = record.decoded();
                 expected_payloads.push(record.payload.to_vec());
                 let copperlist: default::CuList = decode_copperlist(record.payload).unwrap();
                 assert_eq!(record.object_id, copperlist.id);
@@ -151,7 +149,7 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
                 assert!(ids.last().is_none_or(|&id| copperlist.id > id));
                 ids.push(copperlist.id);
             }
-            SessionEvent::Object { record, .. } => match record.decoded().unwrap().kind {
+            SessionEvent::Object { record, .. } => match record.decoded().kind {
                 RecordKind::KeyFrame => keyframe_seen = true,
                 RecordKind::RecoveryPoint => recovery_point_seen = true,
                 _ => {}
@@ -333,13 +331,8 @@ fn validate_impaired_archive(
             .receive_datagram(packet, |event| {
                 if let SessionEvent::Manifest(manifest) = &event {
                     archive = Some(
-                        cu29_logstream::NativeArchive::new(
-                            path,
-                            manifest.clone(),
-                            1024 * 1024,
-                            4096,
-                        )
-                        .unwrap(),
+                        cu29_logstream::NativeArchive::new(path, manifest, 1024 * 1024, 4096)
+                            .unwrap(),
                     );
                 }
                 if let Some(archive) = archive.as_mut() {

--- a/core/cu29/tests/logstream_configured_runtime.rs
+++ b/core/cu29/tests/logstream_configured_runtime.rs
@@ -137,7 +137,7 @@ fn generated_runtime_binds_configured_transport_and_emits_manifest() -> CuResult
     for packet in control_packets.into_iter().chain(continuous_packets) {
         router
             .receive_datagram(&packet, |event| {
-                events.push(event);
+                events.push(event.to_owned());
                 Ok::<(), core::convert::Infallible>(())
             })
             .map_err(|error| CuError::from(format!("{error:?}")))?;

--- a/core/cu29/tests/logstream_runtime.rs
+++ b/core/cu29/tests/logstream_runtime.rs
@@ -178,14 +178,9 @@ fn generated_runtime_streams_without_local_copperlist_logging() -> CuResult<()> 
     for expected_id in 0..ITERATIONS {
         let record = records
             .iter()
-            .find(|record| {
-                record
-                    .decoded()
-                    .is_ok_and(|record| record.object_id == expected_id as u64)
-            })
+            .find(|record| record.decoded().object_id == expected_id as u64)
             .expect("every generated CopperList should be recovered")
-            .decoded()
-            .map_err(|error| CuError::from(error.to_string()))?;
+            .decoded();
         let copperlist: default::CuList =
             decode_copperlist(record.payload).map_err(|error| CuError::from(error.to_string()))?;
         assert_eq!(copperlist.id, expected_id as u64);

--- a/core/cu29_logstream/src/archive.rs
+++ b/core/cu29_logstream/src/archive.rs
@@ -2,7 +2,8 @@
 
 use crate::capture::CapturedList;
 use crate::{
-    ApplicationSchema, Error, RecordKind, Result, SessionEvent, SessionManifest, StreamIdentity,
+    ApplicationSchema, Error, ReceivedManifest, RecordKind, Result, SessionEvent, SessionEventRef,
+    StreamIdentity,
 };
 use bincode::{
     Encode,
@@ -37,7 +38,8 @@ pub struct NativeArchive<P: CopperListTuple> {
     keyframes: NativeStream,
     continuity: NativeStream,
     identity: StreamIdentity,
-    manifest: SessionManifest,
+    manifest_digest: [u8; 32],
+    manifest_object_id: u64,
     next_id: u64,
     poisoned: bool,
     payload: PhantomData<P>,
@@ -56,14 +58,14 @@ impl<P: CopperListTuple> NativeArchive<P> {
     /// The section size must fit the largest accepted canonical entry.
     pub fn new(
         path: &Path,
-        manifest: SessionManifest,
+        received: &ReceivedManifest,
         slab_bytes: usize,
         section_bytes: usize,
     ) -> Result<Self> {
         let expected = ApplicationSchema::from_output_specs(P::get_output_specs());
         Self::new_checked(
             path,
-            manifest,
+            received,
             slab_bytes,
             section_bytes,
             expected,
@@ -73,12 +75,13 @@ impl<P: CopperListTuple> NativeArchive<P> {
 
     fn new_checked(
         path: &Path,
-        manifest: SessionManifest,
+        received: &ReceivedManifest,
         slab_bytes: usize,
         section_bytes: usize,
         expected_schema: ApplicationSchema,
         decode: ArchiveDecoder<P>,
     ) -> Result<Self> {
+        let manifest = received.manifest();
         manifest.plan.validate()?;
         if manifest.version != crate::SESSION_MANIFEST_VERSION {
             return Err(Error::UnsupportedManifestVersion(manifest.version));
@@ -118,7 +121,8 @@ impl<P: CopperListTuple> NativeArchive<P> {
             continuity: NativeStream::new(UnifiedLogType::StreamContinuity, logger, section_bytes)
                 .map_err(io_error)?,
             identity: manifest.identity,
-            manifest,
+            manifest_digest: received.record().decoded().digest,
+            manifest_object_id: received.record().decoded().object_id,
             next_id: 0,
             poisoned: false,
             payload: PhantomData,
@@ -127,7 +131,7 @@ impl<P: CopperListTuple> NativeArchive<P> {
         archive
             .continuity
             .log(&StreamContinuityRecord::Manifest {
-                record: archive.manifest.encode_record()?,
+                record: received.record().bytes(),
             })
             .map_err(io_error)?;
         Ok(archive)
@@ -136,12 +140,12 @@ impl<P: CopperListTuple> NativeArchive<P> {
     /// Validates a typed CopperList once, appends its original canonical bytes,
     /// and returns the typed value for an in-process consumer. Keyframes are
     /// archived only after the router has verified their recovery point references.
-    pub fn accept(&mut self, event: &SessionEvent) -> Result<Option<CopperList<P>>> {
+    pub fn accept(&mut self, event: &SessionEventRef<'_>) -> Result<Option<CopperList<P>>> {
         self.accept_capture(event)
             .map(|capture| capture.map(|c| c.copperlist))
     }
 
-    fn accept_capture(&mut self, event: &SessionEvent) -> Result<Option<CapturedList<P>>> {
+    fn accept_capture(&mut self, event: &SessionEventRef<'_>) -> Result<Option<CapturedList<P>>> {
         if self.poisoned {
             return Err(Error::InvalidConfig(
                 "archive failed; close it before continuing",
@@ -154,9 +158,9 @@ impl<P: CopperListTuple> NativeArchive<P> {
         result
     }
 
-    fn accept_inner(&mut self, event: &SessionEvent) -> Result<Option<CapturedList<P>>> {
+    fn accept_inner(&mut self, event: &SessionEventRef<'_>) -> Result<Option<CapturedList<P>>> {
         let identity = match event {
-            SessionEvent::Manifest(manifest) => manifest.identity,
+            SessionEvent::Manifest(manifest) => manifest.manifest().identity,
             SessionEvent::ContinuousRecord { identity, .. }
             | SessionEvent::Gap { identity, .. }
             | SessionEvent::Object { identity, .. }
@@ -167,12 +171,14 @@ impl<P: CopperListTuple> NativeArchive<P> {
         }
         match event {
             SessionEvent::Manifest(manifest) => {
-                if manifest != &self.manifest {
+                if manifest.record().decoded().digest != self.manifest_digest
+                    || manifest.record().decoded().object_id != self.manifest_object_id
+                {
                     return Err(Error::InconsistentObject);
                 }
             }
             SessionEvent::ContinuousRecord { record, .. } => {
-                let decoded = record.decoded()?;
+                let decoded = record.decoded();
                 if decoded.kind != RecordKind::CopperList || decoded.object_id != self.next_id {
                     return Err(Error::InconsistentObject);
                 }
@@ -206,7 +212,7 @@ impl<P: CopperListTuple> NativeArchive<P> {
                     crate::GapReason::RecoveryPoint => SourceGapReason::RecoveryPoint,
                 };
                 self.continuity
-                    .log(&StreamContinuityRecord::Gap {
+                    .log(&StreamContinuityRecord::<&[u8]>::Gap {
                         first_id: gap.first_id,
                         last_id: gap.last_id,
                         reason,
@@ -216,30 +222,29 @@ impl<P: CopperListTuple> NativeArchive<P> {
             }
             SessionEvent::VerifiedRecoveryPoint {
                 recovery_point,
+                recovery_record,
                 keyframe,
                 ..
             } => {
-                let decoded = keyframe.decoded()?;
-                let manifest_record = self.manifest.encode_record()?;
-                if !recovery_point.references_manifest(crate::decode_record(&manifest_record)?)
+                let decoded = keyframe.decoded();
+                if recovery_point.manifest_record_digest != self.manifest_digest
+                    || recovery_point.manifest_object_id != self.manifest_object_id
                     || !recovery_point.references_keyframe(decoded)
-                    || crate::decode_keyframe(decoded.payload)?.culistid
-                        != recovery_point.copperlist_id
+                    || keyframe.keyframe_id() != Some(recovery_point.copperlist_id)
+                    || recovery_record.decoded().kind != RecordKind::RecoveryPoint
+                    || recovery_record.decoded().object_id != recovery_point.copperlist_id
+                    || crate::decode_recovery_point(recovery_record.decoded().payload)?
+                        != *recovery_point
                 {
                     return Err(Error::InconsistentObject);
                 }
                 self.keyframes
                     .log(&CanonicalEntry(decoded.payload))
                     .map_err(io_error)?;
-                let record = crate::encode_record(
-                    RecordKind::RecoveryPoint,
-                    recovery_point.copperlist_id,
-                    &crate::encode_recovery_point(recovery_point)?,
-                )?;
                 self.continuity
                     .log(&StreamContinuityRecord::RecoveryPoint {
                         copperlist_id: recovery_point.copperlist_id,
-                        record,
+                        record: recovery_record.bytes(),
                     })
                     .map_err(io_error)?;
             }
@@ -255,7 +260,7 @@ impl<P: CopperListTuple> NativeArchive<P> {
             return Err(Error::InvalidConfig("archive failed before finalization"));
         }
         self.continuity
-            .log(&StreamContinuityRecord::Finished {
+            .log(&StreamContinuityRecord::<&[u8]>::Finished {
                 next_copperlist_id: self.next_id,
             })
             .map_err(io_error)
@@ -273,13 +278,13 @@ pub struct CaptureArchive<P: crate::capture::CaptureDataSet>(NativeArchive<P>);
 impl<P: crate::capture::CaptureDataSet> CaptureArchive<P> {
     pub fn new(
         path: &Path,
-        manifest: SessionManifest,
+        received: &ReceivedManifest,
         slab_bytes: usize,
         section_bytes: usize,
     ) -> Result<Self> {
         Ok(Self(NativeArchive::new_checked(
             path,
-            manifest,
+            received,
             slab_bytes,
             section_bytes,
             P::stream_schema(),
@@ -288,7 +293,7 @@ impl<P: crate::capture::CaptureDataSet> CaptureArchive<P> {
     }
     pub fn accept(
         &mut self,
-        event: &SessionEvent,
+        event: &SessionEventRef<'_>,
     ) -> Result<Option<crate::capture::CapturedList<P>>> {
         self.0.accept_capture(event)
     }

--- a/core/cu29_logstream/src/lib.rs
+++ b/core/cu29_logstream/src/lib.rs
@@ -73,7 +73,10 @@ pub use rlc::{
     CopperListGap, GapReason, ReceiveError, ReceiverLimits, ReceiverOccupancy, RecoveredRecord,
     StreamIdentity,
 };
-pub use router::{SessionEvent, SessionRouter, SessionRouterLimits, SessionRouterStats};
+pub use router::{
+    ReceivedManifest, SessionEvent, SessionEventRef, SessionRouter, SessionRouterLimits,
+    SessionRouterStats,
+};
 pub use sender::{
     ContinuousCopperListSink, ContinuousSenderConfig, ContinuousSenderStats,
     DEFAULT_MAX_SYMBOL_SIZE, DEFAULT_MAX_WINDOW_SYMBOLS, DefaultContinuousCopperListSink,
@@ -85,5 +88,5 @@ pub use stream::{
 };
 pub use wire::{
     FecScheme, FecSymbolKind, Lane, PACKET_HEADER_LEN, WIRE_VERSION, WireHeader, WirePacket,
-    encode_packet_into,
+    WirePacketRef, encode_packet_into,
 };

--- a/core/cu29_logstream/src/manifest.rs
+++ b/core/cu29_logstream/src/manifest.rs
@@ -115,6 +115,10 @@ impl SessionManifest {
 
     pub fn decode_record(record: &[u8]) -> Result<Self> {
         let record = decode_semantic_record(record)?;
+        Self::from_decoded(record)
+    }
+
+    pub(crate) fn from_decoded(record: crate::DecodedRecord<'_>) -> Result<Self> {
         if record.kind != RecordKind::Manifest {
             return Err(Error::InvalidConfig("record is not a session manifest"));
         }

--- a/core/cu29_logstream/src/object.rs
+++ b/core/cu29_logstream/src/object.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Error, FecScheme, FecSymbolKind, Lane, PACKET_HEADER_LEN, ReceiveError, RecordKind,
-    RecoveredRecord, Result, StreamIdentity, WireHeader, WirePacket, decode_record,
+    RecoveredRecord, Result, StreamIdentity, WireHeader, WirePacketRef, decode_record,
     encode_packet_into,
 };
 use alloc::{vec, vec::Vec};
@@ -212,14 +212,20 @@ impl FiniteObjectDecoder {
         mut emit: impl FnMut(&RecoveredRecord) -> core::result::Result<(), E>,
     ) -> core::result::Result<(), ReceiveError<E>> {
         self.drain_records(&mut emit)?;
-        self.stats.datagrams_seen = self.stats.datagrams_seen.saturating_add(1);
-        let packet = match WirePacket::decode(datagram) {
+        let packet = match WirePacketRef::decode(datagram) {
             Ok(packet) => packet,
             Err(_) => {
+                self.stats.datagrams_seen = self.stats.datagrams_seen.saturating_add(1);
                 self.stats.invalid_datagrams = self.stats.invalid_datagrams.saturating_add(1);
                 return Ok(());
             }
         };
+        self.receive_packet(packet)?;
+        self.drain_records(&mut emit)
+    }
+
+    pub(crate) fn receive_packet(&mut self, packet: WirePacketRef<'_>) -> Result<()> {
+        self.stats.datagrams_seen = self.stats.datagrams_seen.saturating_add(1);
         if packet.header.session_id != self.identity.session_id
             || packet.header.sender_id != self.identity.sender_id
             || packet.header.lane != self.lane
@@ -291,8 +297,7 @@ impl FiniteObjectDecoder {
                     return Err(Error::TooManyRecords {
                         actual,
                         maximum: self.limits.max_concurrent_objects,
-                    }
-                    .into());
+                    });
                 }
                 self.objects.push(ObjectDecoder {
                     kind: packet.header.record_kind,
@@ -319,24 +324,25 @@ impl FiniteObjectDecoder {
         self.stats.valid_datagrams = self.stats.valid_datagrams.saturating_add(1);
         let completed = self.objects[object_index]
             .decoder
-            .decode(EncodingPacket::new(payload_id, packet.payload));
+            .decode(EncodingPacket::new(payload_id, packet.payload.to_vec()));
         let Some(bytes) = completed else {
             return Ok(());
         };
 
         let object = self.objects.swap_remove(object_index);
-        let decoded = decode_record(&bytes)?;
+        let record = RecoveredRecord::from_bytes(bytes)?;
+        let decoded = record.decoded();
         if decoded.kind != object.kind || decoded.object_id != object.object_id {
-            return Err(Error::InconsistentObject.into());
+            return Err(Error::InconsistentObject);
         }
         self.ready.push(ReadyObject {
             kind: object.kind,
             object_id: object.object_id,
             oti: object.oti,
-            record: RecoveredRecord::from_bytes(bytes),
+            record,
         });
         self.stats.objects_recovered = self.stats.objects_recovered.saturating_add(1);
-        self.drain_records(&mut emit)
+        Ok(())
     }
 
     /// Retries delivery of records retained after a consumer failure.
@@ -344,19 +350,27 @@ impl FiniteObjectDecoder {
         &mut self,
         mut emit: impl FnMut(&RecoveredRecord) -> core::result::Result<(), E>,
     ) -> core::result::Result<(), ReceiveError<E>> {
-        while !self.ready.is_empty() {
-            emit(&self.ready[0].record).map_err(ReceiveError::Consumer)?;
-            let delivered = self.ready.remove(0);
-            if self.completed.len() == self.limits.max_concurrent_objects {
-                self.completed.remove(0);
-            }
-            self.completed.push(CompletedObject {
-                kind: delivered.kind,
-                object_id: delivered.object_id,
-                oti: delivered.oti,
-            });
+        while let Some(ready) = self.ready.first() {
+            emit(&ready.record).map_err(ReceiveError::Consumer)?;
+            self.pop_record();
         }
         Ok(())
+    }
+
+    pub(crate) fn pop_record(&mut self) -> Option<RecoveredRecord> {
+        if self.ready.is_empty() {
+            return None;
+        }
+        let delivered = self.ready.remove(0);
+        if self.completed.len() == self.limits.max_concurrent_objects {
+            self.completed.remove(0);
+        }
+        self.completed.push(CompletedObject {
+            kind: delivered.kind,
+            object_id: delivered.object_id,
+            oti: delivered.oti,
+        });
+        Some(delivered.record)
     }
 }
 

--- a/core/cu29_logstream/src/recovery.rs
+++ b/core/cu29_logstream/src/recovery.rs
@@ -93,3 +93,20 @@ fn decode_exact<T: Decode<()>>(payload: &[u8], name: &'static str) -> Result<T> 
     }
     Ok(value)
 }
+
+/// Reads keyframe metadata while borrowing its task-state bytes.
+pub(crate) fn keyframe_id(payload: &[u8]) -> Result<u64> {
+    #[derive(bincode::BorrowDecode)]
+    struct View<'a> {
+        culistid: u64,
+        _timestamp: cu29_clock::CuTime,
+        _tasks: &'a [u8],
+    }
+    let (view, used): (View<'_>, usize) =
+        bincode::borrow_decode_from_slice(payload, bincode::config::standard())
+            .map_err(|e| Error::Codec(e.to_string()))?;
+    if used != payload.len() {
+        return Err(Error::Codec("keyframe has trailing bytes".into()));
+    }
+    Ok(view.culistid)
+}

--- a/core/cu29_logstream/src/rlc.rs
+++ b/core/cu29_logstream/src/rlc.rs
@@ -1,6 +1,6 @@
 use crate::{
-    DecodedRecord, Error, FecScheme, FecSymbolKind, Lane, PACKET_HEADER_LEN, RecordKind, Result,
-    WireHeader, WirePacket, decode_record, encode_packet_into,
+    Error, FecScheme, FecSymbolKind, Lane, PACKET_HEADER_LEN, RecordKind, Result, WireHeader,
+    WirePacketRef, decode_record, encode_packet_into,
 };
 use alloc::{boxed::Box, vec, vec::Vec};
 use bincode::{Decode, Encode};
@@ -175,19 +175,47 @@ impl ContinuousRecoveryStats {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RecoveredRecord {
     bytes: Vec<u8>,
+    kind: RecordKind,
+    object_id: u64,
+    digest: [u8; 32],
+    keyframe_id: Option<u64>,
 }
 
 impl RecoveredRecord {
-    pub(crate) fn from_bytes(bytes: Vec<u8>) -> Self {
-        Self { bytes }
+    pub(crate) fn from_bytes(bytes: Vec<u8>) -> Result<Self> {
+        let decoded = decode_record(&bytes)?;
+        let keyframe_id = None;
+        Ok(Self {
+            kind: decoded.kind,
+            object_id: decoded.object_id,
+            digest: decoded.digest,
+            keyframe_id,
+            bytes,
+        })
     }
 
     pub fn bytes(&self) -> &[u8] {
         &self.bytes
     }
 
-    pub fn decoded(&self) -> Result<DecodedRecord<'_>> {
-        decode_record(&self.bytes)
+    /// Borrows metadata verified on assembly; immutable records are never re-hashed.
+    pub fn decoded(&self) -> crate::DecodedRecord<'_> {
+        crate::DecodedRecord {
+            kind: self.kind,
+            object_id: self.object_id,
+            digest: self.digest,
+            payload: &self.bytes[crate::record::RECORD_HEADER_LEN..],
+        }
+    }
+
+    pub(crate) fn validate_keyframe(&mut self) -> Result<()> {
+        self.keyframe_id = Some(crate::recovery::keyframe_id(self.decoded().payload)?);
+        Ok(())
+    }
+
+    /// CopperList ID decoded without copying the serialized task state.
+    pub fn keyframe_id(&self) -> Option<u64> {
+        self.keyframe_id
     }
 }
 
@@ -423,7 +451,9 @@ impl RepairSchedule {
 /// Recovered records are delivered to the caller immediately and are never
 /// retained in an ever-growing history. Exact gap reporting assumes the sender
 /// serializes CopperLists in increasing identifier order, as generated Copper
-/// runtimes do.
+/// runtimes do. Assembly buffers grow on demand up to receiver limits and are
+/// recycled after delivery or expiry. Once buffer sizes and concurrency have
+/// warmed up, record assembly and borrowed delivery need no heap allocations.
 pub struct ContinuousDecoder<
     const MAX_SYMBOL_SIZE: usize,
     const MAX_WINDOW_SYMBOLS: usize,
@@ -434,8 +464,10 @@ pub struct ContinuousDecoder<
     limits: ReceiverLimits,
     fec: Box<RlcDecoder<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS, MAX_EQUATIONS>>,
     processed_symbols: Vec<EncodingSymbolId>,
+    symbols_pending: bool,
     assemblies: Vec<RecordAssembly>,
     ready: Vec<ReadyRecord>,
+    spares: Vec<RecordBuffers>,
     next_object_id: u64,
     observed_window_base: Option<EncodingSymbolId>,
     retention_floor: Option<EncodingSymbolId>,
@@ -465,8 +497,10 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
             limits,
             fec: Box::new(RlcDecoder::new(config, equation_capacity)?),
             processed_symbols: Vec::with_capacity(config.window_symbols()),
+            symbols_pending: false,
             assemblies: Vec::with_capacity(limits.max_buffered_records),
             ready: Vec::with_capacity(limits.max_buffered_records),
+            spares: Vec::with_capacity(limits.max_buffered_records),
             next_object_id: first_object_id,
             observed_window_base: None,
             retention_floor: None,
@@ -482,8 +516,8 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
     /// window and already assembled records at or beyond that boundary.
     pub(crate) fn resume_at(&mut self, boundary: u64) {
         self.next_object_id = self.next_object_id.max(boundary);
-        self.assemblies
-            .retain(|record| record.object_id >= self.next_object_id);
+        let next = self.next_object_id;
+        self.discard_assemblies(|id| id < next);
         self.discard_stale_ready();
     }
 
@@ -508,7 +542,12 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
         &mut self,
         mut emit: impl FnMut(ContinuousReceiveEvent<'_>) -> core::result::Result<(), E>,
     ) -> core::result::Result<(), ReceiveError<E>> {
-        self.expire_and_emit(&mut emit)
+        self.expire_and_emit(&mut emit)?;
+        if self.symbols_pending {
+            self.process_new_symbols()?;
+            self.expire_and_emit(&mut emit)?;
+        }
+        Ok(())
     }
 
     /// Finalizes ordered delivery through an inclusive CopperList identifier.
@@ -528,8 +567,7 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
             .iter()
             .filter(|assembly| assembly.object_id <= last_object_id)
             .count();
-        self.assemblies
-            .retain(|assembly| assembly.object_id > last_object_id);
+        self.discard_assemblies(|id| id <= last_object_id);
         self.stats.records_expired = self.stats.records_expired.saturating_add(unresolved);
         self.discard_stale_ready();
         Ok(())
@@ -541,16 +579,25 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
     pub fn receive_datagram<E>(
         &mut self,
         datagram: &[u8],
-        mut emit: impl FnMut(ContinuousReceiveEvent<'_>) -> core::result::Result<(), E>,
+        emit: impl FnMut(ContinuousReceiveEvent<'_>) -> core::result::Result<(), E>,
     ) -> core::result::Result<(), ReceiveError<E>> {
-        self.stats.datagrams_seen = self.stats.datagrams_seen.saturating_add(1);
-        let packet = match WirePacket::decode(datagram) {
+        let packet = match WirePacketRef::decode(datagram) {
             Ok(packet) => packet,
             Err(_) => {
+                self.stats.datagrams_seen = self.stats.datagrams_seen.saturating_add(1);
                 self.stats.invalid_datagrams = self.stats.invalid_datagrams.saturating_add(1);
                 return Ok(());
             }
         };
+        self.receive_packet(packet, emit)
+    }
+
+    pub(crate) fn receive_packet<E>(
+        &mut self,
+        packet: WirePacketRef<'_>,
+        mut emit: impl FnMut(ContinuousReceiveEvent<'_>) -> core::result::Result<(), E>,
+    ) -> core::result::Result<(), ReceiveError<E>> {
+        self.stats.datagrams_seen = self.stats.datagrams_seen.saturating_add(1);
         if packet.header.session_id != self.identity.session_id
             || packet.header.sender_id != self.identity.sender_id
             || packet.header.lane != self.lane
@@ -574,12 +621,11 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
         }
         self.stats.valid_datagrams = self.stats.valid_datagrams.saturating_add(1);
         self.update_retention_floor();
-        self.expire_and_emit(&mut emit)?;
-        self.process_new_symbols()?;
-        self.expire_and_emit(&mut emit)
+        self.symbols_pending = true;
+        self.drain_events(&mut emit)
     }
 
-    fn receive_source_packet(&mut self, packet: &WirePacket) -> Result<bool> {
+    fn receive_source_packet(&mut self, packet: &WirePacketRef<'_>) -> Result<bool> {
         if packet.header.fec_metadata[4..]
             .iter()
             .any(|byte| *byte != 0)
@@ -588,7 +634,7 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
             return Ok(false);
         }
         let id = SourcePayloadId::from_bytes(packet.header.fec_metadata[..4].try_into().unwrap());
-        let fragment = match decode_fragment(&packet.payload, fragment_capacity(self.fec.config())?)
+        let fragment = match decode_fragment(packet.payload, fragment_capacity(self.fec.config())?)
         {
             Ok(fragment) => fragment,
             Err(_) => {
@@ -602,7 +648,7 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
             self.stats.inconsistent_datagrams = self.stats.inconsistent_datagrams.saturating_add(1);
             return Ok(false);
         }
-        let report = match self.fec.receive_source(id.esi(), &packet.payload) {
+        let report = match self.fec.receive_source(id.esi(), packet.payload) {
             Ok(report) => report,
             Err(cu_fec::Error::WindowExpired) => {
                 self.stats.expired_datagrams = self.stats.expired_datagrams.saturating_add(1);
@@ -622,7 +668,7 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
         Ok(true)
     }
 
-    fn receive_repair_packet(&mut self, packet: &WirePacket) -> Result<bool> {
+    fn receive_repair_packet(&mut self, packet: &WirePacketRef<'_>) -> Result<bool> {
         if packet.header.object_id != 0
             || packet.header.fragment_count != 0
             || packet.header.fec_metadata[8..]
@@ -634,7 +680,7 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
         }
         let raw_id: [u8; 8] = packet.header.fec_metadata[..8].try_into().unwrap();
         let id = RepairPayloadId::from_bytes(raw_id)?;
-        let report = match self.fec.receive_repair(id, &packet.payload) {
+        let report = match self.fec.receive_repair(id, packet.payload) {
             Ok(report) => report,
             Err(cu_fec::Error::WindowExpired) => {
                 self.stats.expired_datagrams = self.stats.expired_datagrams.saturating_add(1);
@@ -656,6 +702,9 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
     }
 
     fn process_new_symbols(&mut self) -> Result<()> {
+        if !self.symbols_pending {
+            return Ok(());
+        }
         while let Some(esi) = self
             .fec
             .known_symbols()
@@ -665,60 +714,84 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
             let symbol = self
                 .fec
                 .symbol(esi)
-                .expect("known symbol disappeared from the retained RLC window")
-                .to_vec();
-            self.process_fragment(esi, &symbol)?;
+                .expect("known symbol disappeared from retained RLC window");
+            Self::process_fragment(
+                self.limits,
+                &mut self.assemblies,
+                &mut self.ready,
+                &mut self.spares,
+                &mut self.stats,
+                esi,
+                decode_fragment(symbol, fragment_capacity(self.fec.config())?)?,
+            )?;
             self.processed_symbols.push(esi);
         }
+        self.symbols_pending = false;
         Ok(())
     }
 
-    fn process_fragment(&mut self, esi: EncodingSymbolId, symbol: &[u8]) -> Result<()> {
-        let fragment = decode_fragment(symbol, fragment_capacity(self.fec.config())?)?;
-        if fragment.record_len > self.limits.max_record_bytes {
+    fn process_fragment(
+        limits: ReceiverLimits,
+        assemblies: &mut Vec<RecordAssembly>,
+        ready: &mut Vec<ReadyRecord>,
+        spares: &mut Vec<RecordBuffers>,
+        stats: &mut ContinuousRecoveryStats,
+        esi: EncodingSymbolId,
+        fragment: Fragment<'_>,
+    ) -> Result<()> {
+        if fragment.record_len > limits.max_record_bytes {
             return Err(Error::ObjectTooLarge {
                 actual: fragment.record_len as u64,
-                maximum: self.limits.max_record_bytes as u64,
+                maximum: limits.max_record_bytes as u64,
             });
         }
-        let assembly_index = match self.assemblies.iter().position(|assembly| {
+        let assembly_index = match assemblies.iter().position(|assembly| {
             assembly.kind == fragment.kind && assembly.object_id == fragment.object_id
         }) {
             Some(index) => index,
             None => {
-                let count = self
-                    .assemblies
+                let count = assemblies
                     .len()
-                    .saturating_add(self.ready.len())
+                    .saturating_add(ready.len())
                     .saturating_add(1);
-                if count > self.limits.max_buffered_records {
+                if count > limits.max_buffered_records {
                     return Err(Error::TooManyRecords {
                         actual: count,
-                        maximum: self.limits.max_buffered_records,
+                        maximum: limits.max_buffered_records,
                     });
                 }
-                self.assemblies.push(RecordAssembly::new(esi, &fragment));
-                self.observe_peak_buffered_records();
-                self.assemblies.len() - 1
+                assemblies.push(RecordAssembly::new(
+                    esi,
+                    &fragment,
+                    spares.pop().unwrap_or_default(),
+                ));
+                stats.peak_buffered_records = stats
+                    .peak_buffered_records
+                    .max(assemblies.len() + ready.len());
+                assemblies.len() - 1
             }
         };
-        let complete = self.assemblies[assembly_index].insert(esi, &fragment)?;
+        let complete = assemblies[assembly_index].insert(esi, &fragment)?;
         if !complete {
             return Ok(());
         }
 
-        let assembly = self.assemblies.swap_remove(assembly_index);
-        let decoded = decode_record(&assembly.bytes)?;
+        let assembly = assemblies.swap_remove(assembly_index);
+        let record = RecoveredRecord::from_bytes(assembly.bytes)?;
+        let decoded = record.decoded();
         if decoded.kind != assembly.kind || decoded.object_id != assembly.object_id {
             return Err(Error::InconsistentObject);
         }
-        self.ready.push(ReadyRecord {
+        ready.push(ReadyRecord {
             object_id: assembly.object_id,
             first_esi: assembly.first_esi,
-            record: RecoveredRecord::from_bytes(assembly.bytes),
+            record,
+            received: assembly.received,
         });
-        self.stats.records_recovered = self.stats.records_recovered.saturating_add(1);
-        self.observe_peak_buffered_records();
+        stats.records_recovered = stats.records_recovered.saturating_add(1);
+        stats.peak_buffered_records = stats
+            .peak_buffered_records
+            .max(assemblies.len() + ready.len());
         Ok(())
     }
 
@@ -746,7 +819,11 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
                 };
                 let object_id = self.assemblies[index].object_id;
                 self.emit_through(object_id, GapReason::RlcWindowExpired, emit)?;
-                self.assemblies.swap_remove(index);
+                let assembly = self.assemblies.swap_remove(index);
+                self.spares.push(RecordBuffers {
+                    bytes: assembly.bytes,
+                    received: assembly.received,
+                });
                 self.stats.records_expired = self.stats.records_expired.saturating_add(1);
             }
         }
@@ -820,7 +897,11 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
         };
         emit(ContinuousReceiveEvent::Record(&self.ready[index].record))
             .map_err(ReceiveError::Consumer)?;
-        self.ready.swap_remove(index);
+        let ready = self.ready.swap_remove(index);
+        self.spares.push(RecordBuffers {
+            bytes: ready.record.bytes,
+            received: ready.received,
+        });
         self.stats.records_emitted = self.stats.records_emitted.saturating_add(1);
         self.next_object_id = self.next_object_id.wrapping_add(1);
         Ok(true)
@@ -852,15 +933,33 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
     }
 
     fn discard_stale_ready(&mut self) {
-        self.ready
-            .retain(|record| record.object_id >= self.next_object_id);
+        let mut index = 0;
+        while index < self.ready.len() {
+            if self.ready[index].object_id < self.next_object_id {
+                let ready = self.ready.swap_remove(index);
+                self.spares.push(RecordBuffers {
+                    bytes: ready.record.bytes,
+                    received: ready.received,
+                });
+            } else {
+                index += 1;
+            }
+        }
     }
 
-    fn observe_peak_buffered_records(&mut self) {
-        self.stats.peak_buffered_records = self
-            .stats
-            .peak_buffered_records
-            .max(self.assemblies.len().saturating_add(self.ready.len()));
+    fn discard_assemblies(&mut self, discard: impl Fn(u64) -> bool) {
+        let mut index = 0;
+        while index < self.assemblies.len() {
+            if discard(self.assemblies[index].object_id) {
+                let assembly = self.assemblies.swap_remove(index);
+                self.spares.push(RecordBuffers {
+                    bytes: assembly.bytes,
+                    received: assembly.received,
+                });
+            } else {
+                index += 1;
+            }
+        }
     }
 
     fn update_retention_floor(&mut self) {
@@ -882,6 +981,7 @@ struct ReadyRecord {
     object_id: u64,
     first_esi: EncodingSymbolId,
     record: RecoveredRecord,
+    received: Vec<bool>,
 }
 
 #[derive(Debug)]
@@ -895,6 +995,12 @@ struct Fragment<'a> {
     payload: &'a [u8],
 }
 
+#[derive(Default)]
+struct RecordBuffers {
+    bytes: Vec<u8>,
+    received: Vec<bool>,
+}
+
 struct RecordAssembly {
     kind: RecordKind,
     object_id: u64,
@@ -906,13 +1012,16 @@ struct RecordAssembly {
 }
 
 impl RecordAssembly {
-    fn new(esi: EncodingSymbolId, fragment: &Fragment<'_>) -> Self {
+    fn new(esi: EncodingSymbolId, fragment: &Fragment<'_>, mut buffers: RecordBuffers) -> Self {
+        buffers.bytes.resize(fragment.record_len, 0);
+        buffers.received.resize(fragment.fragment_count, false);
+        buffers.received.fill(false);
         Self {
             kind: fragment.kind,
             object_id: fragment.object_id,
             first_esi: esi.wrapping_sub(fragment.fragment_index as u32),
-            bytes: vec![0; fragment.record_len],
-            received: vec![false; fragment.fragment_count],
+            bytes: buffers.bytes,
+            received: buffers.received,
             received_count: 0,
             fragment_capacity: fragment.fragment_capacity,
         }

--- a/core/cu29_logstream/src/router.rs
+++ b/core/cu29_logstream/src/router.rs
@@ -3,9 +3,9 @@
 use crate::{
     ContinuousDecoder, ContinuousReceiveEvent, CuStreamRx, CuStreamRxError, Error, FecScheme,
     FiniteObjectDecoder, FiniteObjectLimits, Lane, ReceiveError, ReceiverLimits, RecoveredRecord,
-    Result, SessionManifest, StreamIdentity, WirePacket,
+    Result, SessionManifest, StreamIdentity, WirePacketRef,
 };
-use alloc::vec::Vec;
+use alloc::{collections::VecDeque, vec::Vec};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SessionRouterLimits {
@@ -31,18 +31,48 @@ pub struct SessionRouterStats {
     pub startup_packets_dropped: usize,
 }
 
+/// A decoded manifest bound to its verified, immutable wire record.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum SessionEvent {
-    Manifest(SessionManifest),
+pub struct ReceivedManifest {
+    manifest: SessionManifest,
+    record: RecoveredRecord,
+}
+
+impl ReceivedManifest {
+    /// Takes ownership of canonical bytes and verifies their manifest envelope.
+    pub fn decode_record(bytes: Vec<u8>) -> Result<Self> {
+        Self::from_record(RecoveredRecord::from_bytes(bytes)?)
+    }
+
+    fn from_record(record: RecoveredRecord) -> Result<Self> {
+        let manifest = SessionManifest::from_decoded(record.decoded())?;
+        Ok(Self { manifest, record })
+    }
+
+    pub fn manifest(&self) -> &SessionManifest {
+        &self.manifest
+    }
+
+    pub fn record(&self) -> &RecoveredRecord {
+        &self.record
+    }
+}
+
+/// Session events borrow receiver storage during delivery. Use `to_owned` only
+/// when an application deliberately needs to retain encoded history.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SessionEvent<R = RecoveredRecord, M = ReceivedManifest> {
+    Manifest(M),
     /// Emitted only after the recovery point, manifest and keyframe agree by digest and id.
     VerifiedRecoveryPoint {
         identity: StreamIdentity,
         recovery_point: crate::RecoveryPoint,
-        keyframe: RecoveredRecord,
+        recovery_record: R,
+        keyframe: R,
     },
     ContinuousRecord {
         identity: StreamIdentity,
-        record: RecoveredRecord,
+        record: R,
     },
     Gap {
         identity: StreamIdentity,
@@ -50,12 +80,44 @@ pub enum SessionEvent {
     },
     Object {
         identity: StreamIdentity,
-        record: RecoveredRecord,
+        record: R,
     },
 }
+/// A callback-scoped view; retaining it requires an explicit allocating `to_owned` call.
+pub type SessionEventRef<'a> = SessionEvent<&'a RecoveredRecord, &'a ReceivedManifest>;
+impl SessionEventRef<'_> {
+    pub fn to_owned(&self) -> SessionEvent {
+        match self {
+            Self::Manifest(manifest) => SessionEvent::Manifest((*manifest).clone()),
+            Self::VerifiedRecoveryPoint {
+                identity,
+                recovery_point,
+                recovery_record,
+                keyframe,
+            } => SessionEvent::VerifiedRecoveryPoint {
+                identity: *identity,
+                recovery_point: recovery_point.clone(),
+                recovery_record: (*recovery_record).clone(),
+                keyframe: (*keyframe).clone(),
+            },
+            Self::ContinuousRecord { identity, record } => SessionEvent::ContinuousRecord {
+                identity: *identity,
+                record: (*record).clone(),
+            },
+            Self::Gap { identity, gap } => SessionEvent::Gap {
+                identity: *identity,
+                gap: *gap,
+            },
+            Self::Object { identity, record } => SessionEvent::Object {
+                identity: *identity,
+                record: (*record).clone(),
+            },
+        }
+    }
+}
 
-/// Discovers sender identities from RaptorQ control packets and routes all
-/// subsequent packets using the decoder parameters in the recovered manifest.
+/// Discovers sender identities and routes packets using the recovered manifest.
+/// Event payloads remain in receiver storage until the callback succeeds.
 pub struct SessionRouter<
     const MAX_SYMBOL_SIZE: usize,
     const MAX_WINDOW_SYMBOLS: usize,
@@ -63,24 +125,47 @@ pub struct SessionRouter<
 > {
     limits: SessionRouterLimits,
     sessions: Vec<RoutedSession<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS, MAX_EQUATIONS>>,
-    pending: Vec<SessionEvent>,
+    pending: VecDeque<PendingEvent>,
     stats: SessionRouterStats,
 }
 
-struct RoutedSession<
-    const MAX_SYMBOL_SIZE: usize,
-    const MAX_WINDOW_SYMBOLS: usize,
-    const MAX_EQUATIONS: usize,
-> {
+struct RecoveryRecord {
+    record: RecoveredRecord,
+    point: Option<crate::RecoveryPoint>,
+}
+// Cache indices remain stable: pending delivery completes before another control
+// packet can mutate a session'session cache. A finite packet completes at most one object.
+enum PendingEvent {
+    Manifest(usize),
+    CachedObject {
+        session: usize,
+        slot: usize,
+    },
+    Object {
+        identity: StreamIdentity,
+        record: RecoveredRecord,
+    },
+    RecoveryPoint {
+        session: usize,
+        point: usize,
+        keyframe: usize,
+    },
+    Gap {
+        identity: StreamIdentity,
+        gap: crate::CopperListGap,
+    },
+}
+
+struct RoutedSession<const S: usize, const W: usize, const E: usize> {
     identity: StreamIdentity,
     finite: FiniteObjectDecoder,
-    manifest: Option<SessionManifest>,
-    manifest_record: Option<RecoveredRecord>,
-    startup: Vec<Vec<u8>>,
-    recovery: Vec<RecoveredRecord>,
+    manifest: Option<ReceivedManifest>,
+    startup: VecDeque<Vec<u8>>,
+    recovery: Vec<RecoveryRecord>,
+    recovery_dirty: bool,
     last_recovery_point: Option<u64>,
     delivered_record: bool,
-    continuous: Option<ContinuousDecoder<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS, MAX_EQUATIONS>>,
+    continuous: Option<ContinuousDecoder<S, W, E>>,
 }
 
 impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQUATIONS: usize>
@@ -99,7 +184,7 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
         Ok(Self {
             limits,
             sessions: Vec::with_capacity(limits.max_sessions),
-            pending: Vec::with_capacity(limits.max_pending_events),
+            pending: VecDeque::with_capacity(limits.max_pending_events),
             stats: SessionRouterStats::default(),
         })
     }
@@ -113,18 +198,15 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
             .iter()
             .find(|session| session.identity == identity)
             .and_then(|session| session.manifest.as_ref())
+            .map(ReceivedManifest::manifest)
     }
 
-    /// Pulls at most one complete packet from a nonblocking Copper resource.
-    pub fn try_receive<T, E>(
+    pub fn try_receive<T: CuStreamRx, E>(
         &mut self,
         transport: &mut T,
         packet: &mut [u8],
-        emit: impl FnMut(SessionEvent) -> core::result::Result<(), E>,
-    ) -> core::result::Result<bool, ReceiveError<E>>
-    where
-        T: CuStreamRx,
-    {
+        emit: impl FnMut(SessionEventRef<'_>) -> core::result::Result<(), E>,
+    ) -> core::result::Result<bool, ReceiveError<E>> {
         let len = match transport.try_recv(packet) {
             Ok(Some(len)) => len,
             Ok(None) => return Ok(false),
@@ -135,9 +217,7 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
                 }
                 .into());
             }
-            Err(CuStreamRxError::Failed(message)) => {
-                return Err(Error::Transport(message).into());
-            }
+            Err(CuStreamRxError::Failed(message)) => return Err(Error::Transport(message).into()),
         };
         if len > packet.len() {
             return Err(Error::BufferTooSmall {
@@ -153,14 +233,14 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
     pub fn receive_datagram<E>(
         &mut self,
         datagram: &[u8],
-        mut emit: impl FnMut(SessionEvent) -> core::result::Result<(), E>,
+        mut emit: impl FnMut(SessionEventRef<'_>) -> core::result::Result<(), E>,
     ) -> core::result::Result<(), ReceiveError<E>> {
         self.drain_events(&mut emit)?;
-        self.stats.datagrams_seen = self.stats.datagrams_seen.saturating_add(1);
-        let packet = match WirePacket::decode(datagram) {
-            Ok(packet) => packet,
+        self.stats.datagrams_seen += 1;
+        let packet = match WirePacketRef::decode(datagram) {
+            Ok(p) => p,
             Err(_) => {
-                self.stats.malformed_datagrams = self.stats.malformed_datagrams.saturating_add(1);
+                self.stats.malformed_datagrams += 1;
                 return Ok(());
             }
         };
@@ -168,13 +248,12 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
             session_id: packet.header.session_id,
             sender_id: packet.header.sender_id,
         };
-
-        let session_index = match self
+        let index = match self
             .sessions
             .iter()
             .position(|session| session.identity == identity)
         {
-            Some(index) => index,
+            Some(i) => i,
             None if (packet.header.fec_scheme == FecScheme::RaptorQ
                 && packet.header.lane == Lane::Control)
                 || (packet.header.lane == Lane::ReplayCritical
@@ -194,258 +273,266 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
                         self.limits.finite_objects,
                     )?,
                     manifest: None,
-                    manifest_record: None,
-                    startup: Vec::with_capacity(self.limits.max_startup_packets),
+                    startup: VecDeque::with_capacity(self.limits.max_startup_packets),
                     recovery: Vec::with_capacity(self.limits.max_recovery_records),
+                    recovery_dirty: false,
                     last_recovery_point: None,
                     delivered_record: false,
                     continuous: None,
                 });
-                self.stats.sessions_discovered = self.stats.sessions_discovered.saturating_add(1);
+                self.stats.sessions_discovered += 1;
                 self.sessions.len() - 1
             }
             None => {
-                self.stats.datagrams_before_manifest =
-                    self.stats.datagrams_before_manifest.saturating_add(1);
+                self.stats.datagrams_before_manifest += 1;
                 return Ok(());
             }
         };
-
         if packet.header.fec_scheme == FecScheme::RaptorQ {
-            self.receive_finite(session_index, datagram)?;
-        } else if self.sessions[session_index].continuous.is_some() {
-            self.receive_continuous(session_index, datagram)?;
+            self.sessions[index].finite.receive_packet(packet)?;
+            if let Some(record) = self.sessions[index].finite.pop_record() {
+                self.receive_object(index, record)?;
+            }
+        } else if self.sessions[index].continuous.is_some() {
+            Self::receive_continuous(&mut self.sessions[index], packet, &mut emit)?;
         } else {
-            self.stats.datagrams_before_manifest =
-                self.stats.datagrams_before_manifest.saturating_add(1);
-            let startup = &mut self.sessions[session_index].startup;
+            self.stats.datagrams_before_manifest += 1;
+            let startup = &mut self.sessions[index].startup;
             if datagram.len() <= MAX_SYMBOL_SIZE + crate::PACKET_HEADER_LEN
                 && startup.len() < self.limits.max_startup_packets
             {
-                startup.push(datagram.to_vec());
+                startup.push_back(datagram.to_vec());
             } else {
-                self.stats.startup_packets_dropped =
-                    self.stats.startup_packets_dropped.saturating_add(1);
+                self.stats.startup_packets_dropped += 1;
             }
         }
         self.drain_events(&mut emit)
     }
-
+    /// Retries pending delivery without cloning encoded records. A consumer error
+    /// retains the same bytes until a later call succeeds.
     pub fn drain_events<E>(
         &mut self,
-        emit: &mut impl FnMut(SessionEvent) -> core::result::Result<(), E>,
+        emit: &mut impl FnMut(SessionEventRef<'_>) -> core::result::Result<(), E>,
     ) -> core::result::Result<(), ReceiveError<E>> {
         loop {
-            while let Some(event) = self.pending.first().cloned() {
+            while let Some(pending) = self.pending.front() {
+                let event = match pending {
+                    PendingEvent::Manifest(i) => {
+                        SessionEvent::Manifest(self.sessions[*i].manifest.as_ref().unwrap())
+                    }
+                    PendingEvent::CachedObject { session, slot } => SessionEvent::Object {
+                        identity: self.sessions[*session].identity,
+                        record: &self.sessions[*session].recovery[*slot].record,
+                    },
+                    PendingEvent::Object { identity, record } => SessionEvent::Object {
+                        identity: *identity,
+                        record,
+                    },
+                    PendingEvent::Gap { identity, gap } => SessionEvent::Gap {
+                        identity: *identity,
+                        gap: *gap,
+                    },
+                    PendingEvent::RecoveryPoint {
+                        session,
+                        point,
+                        keyframe,
+                    } => {
+                        let session = &self.sessions[*session];
+                        SessionEvent::VerifiedRecoveryPoint {
+                            identity: session.identity,
+                            recovery_point: session.recovery[*point]
+                                .point
+                                .as_ref()
+                                .unwrap()
+                                .clone(),
+                            recovery_record: &session.recovery[*point].record,
+                            keyframe: &session.recovery[*keyframe].record,
+                        }
+                    }
+                };
                 emit(event).map_err(ReceiveError::Consumer)?;
-                self.pending.remove(0);
+                self.pending.pop_front();
             }
             for session in &mut self.sessions {
-                if let Some(decoder) = session.continuous.as_mut() {
-                    decoder.drain_events(|event| {
-                        let event = match event {
-                            ContinuousReceiveEvent::Record(record) => {
-                                SessionEvent::ContinuousRecord {
-                                    identity: session.identity,
-                                    record: record.clone(),
-                                }
-                            }
-                            ContinuousReceiveEvent::Gap(mut gap) => {
-                                if !session.delivered_record
-                                    && session.last_recovery_point.is_none()
-                                {
-                                    gap.reason = crate::GapReason::LateJoin;
-                                }
-                                SessionEvent::Gap {
-                                    identity: session.identity,
-                                    gap,
-                                }
-                            }
-                        };
-                        let delivered = matches!(event, SessionEvent::ContinuousRecord { .. });
-                        emit(event)?;
-                        session.delivered_record |= delivered;
-                        Ok(())
+                if let Some(decoder) = &mut session.continuous {
+                    decoder.drain_events(|e| {
+                        Self::deliver_continuous(
+                            session.identity,
+                            session.last_recovery_point,
+                            &mut session.delivered_record,
+                            e,
+                            emit,
+                        )
                     })?;
                 }
             }
-            let startup = self
+            if let Some(index) = self
                 .sessions
                 .iter()
-                .position(|session| session.continuous.is_some() && !session.startup.is_empty());
-            if let Some(index) = startup {
-                let packet = self.sessions[index].startup.remove(0);
-                self.receive_continuous(index, &packet)?;
+                .position(|session| session.continuous.is_some() && !session.startup.is_empty())
+            {
+                let packet = self.sessions[index].startup.pop_front().unwrap();
+                Self::receive_continuous(
+                    &mut self.sessions[index],
+                    WirePacketRef::decode(&packet)?,
+                    emit,
+                )?;
                 continue;
             }
             for index in 0..self.sessions.len() {
-                self.verify_recovery(index)?;
+                if self.sessions[index].recovery_dirty {
+                    self.verify_recovery(index)?;
+                }
                 if !self.pending.is_empty() {
                     break;
                 }
             }
             if self.pending.is_empty() {
-                break;
+                return Ok(());
+            }
+        }
+    }
+
+    fn deliver_continuous<E>(
+        identity: StreamIdentity,
+        last_recovery_point: Option<u64>,
+        delivered: &mut bool,
+        event: ContinuousReceiveEvent<'_>,
+        emit: &mut impl FnMut(SessionEventRef<'_>) -> core::result::Result<(), E>,
+    ) -> core::result::Result<(), E> {
+        match event {
+            ContinuousReceiveEvent::Record(record) => {
+                emit(SessionEvent::ContinuousRecord { identity, record })?;
+                *delivered = true;
+            }
+            ContinuousReceiveEvent::Gap(mut gap) => {
+                if !*delivered && last_recovery_point.is_none() {
+                    gap.reason = crate::GapReason::LateJoin;
+                }
+                emit(SessionEvent::Gap { identity, gap })?;
             }
         }
         Ok(())
     }
 
-    fn receive_finite(&mut self, session_index: usize, datagram: &[u8]) -> Result<()> {
-        let mut recovered = Vec::new();
-        self.sessions[session_index]
-            .finite
-            .receive_datagram(datagram, |record| {
-                recovered.push(record.clone());
-                Ok::<(), core::convert::Infallible>(())
-            })
-            .map_err(|error| match error {
-                ReceiveError::Stream(error) => error,
-                ReceiveError::Consumer(never) => match never {},
-            })?;
-
-        for record in recovered {
-            if record.decoded()?.kind == crate::RecordKind::Manifest {
-                let manifest = SessionManifest::decode_record(record.bytes())?;
-                if manifest.identity != self.sessions[session_index].identity {
-                    return Err(Error::InconsistentObject);
-                }
-                if let Some(existing) = &self.sessions[session_index].manifest {
-                    if existing != &manifest {
-                        return Err(Error::InconsistentObject);
-                    }
-                    continue;
-                }
-                let continuous = self.decoder_from_manifest(&manifest)?;
-                self.sessions[session_index].continuous = Some(continuous);
-                self.sessions[session_index].manifest = Some(manifest.clone());
-                self.sessions[session_index].manifest_record = Some(record);
-                self.stats.manifests_accepted = self.stats.manifests_accepted.saturating_add(1);
-                self.push_event(SessionEvent::Manifest(manifest))?;
-            } else {
-                let session = &mut self.sessions[session_index];
-                let decoded = record.decoded()?;
-                match decoded.kind {
-                    crate::RecordKind::KeyFrame => {
-                        crate::decode_keyframe(decoded.payload)?;
-                    }
-                    crate::RecordKind::RecoveryPoint => {
-                        crate::decode_recovery_point(decoded.payload)?;
-                    }
-                    _ => {}
-                }
-                if matches!(
-                    decoded.kind,
-                    crate::RecordKind::KeyFrame | crate::RecordKind::RecoveryPoint
-                ) {
-                    if session.recovery.len() == self.limits.max_recovery_records {
-                        session.recovery.remove(0);
-                    }
-                    session.recovery.push(record.clone());
-                }
-                self.push_event(SessionEvent::Object {
-                    identity: self.sessions[session_index].identity,
-                    record,
-                })?;
-            }
-        }
-        Ok(())
-    }
-
-    fn receive_continuous(&mut self, index: usize, datagram: &[u8]) -> Result<()> {
-        let session = &mut self.sessions[index];
-        let pending = &mut self.pending;
-        let maximum = self.limits.max_pending_events;
-        let delivered = &mut session.delivered_record;
-        match session
+    fn receive_continuous<E>(
+        session: &mut RoutedSession<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS, MAX_EQUATIONS>,
+        packet: WirePacketRef<'_>,
+        emit: &mut impl FnMut(SessionEventRef<'_>) -> core::result::Result<(), E>,
+    ) -> core::result::Result<(), ReceiveError<E>> {
+        session
             .continuous
             .as_mut()
-            .expect("manifest accepted")
-            .receive_datagram(datagram, |event| {
-                if pending.len() == maximum {
-                    return Err(Error::TooManyRecords {
-                        actual: maximum + 1,
-                        maximum,
+            .unwrap()
+            .receive_packet(packet, |e| {
+                Self::deliver_continuous(
+                    session.identity,
+                    session.last_recovery_point,
+                    &mut session.delivered_record,
+                    e,
+                    emit,
+                )
+            })
+    }
+
+    fn receive_object(&mut self, index: usize, mut record: RecoveredRecord) -> Result<()> {
+        if record.decoded().kind == crate::RecordKind::Manifest {
+            if let Some(existing) = &self.sessions[index].manifest {
+                if existing.record.decoded().digest != record.decoded().digest {
+                    return Err(Error::InconsistentObject);
+                }
+                return Ok(());
+            }
+            let manifest = ReceivedManifest::from_record(record)?;
+            if manifest.manifest.identity != self.sessions[index].identity {
+                return Err(Error::InconsistentObject);
+            }
+            self.sessions[index].continuous = Some(Self::decoder_from_manifest(
+                self.limits,
+                &manifest.manifest,
+            )?);
+            self.sessions[index].manifest = Some(manifest);
+            self.sessions[index].recovery_dirty = true;
+            self.stats.manifests_accepted += 1;
+            self.push_event(PendingEvent::Manifest(index))?;
+        } else {
+            let point = match record.decoded().kind {
+                crate::RecordKind::KeyFrame => {
+                    record.validate_keyframe()?;
+                    None
+                }
+                crate::RecordKind::RecoveryPoint => {
+                    Some(crate::decode_recovery_point(record.decoded().payload)?)
+                }
+                _ => {
+                    return self.push_event(PendingEvent::Object {
+                        identity: self.sessions[index].identity,
+                        record,
                     });
                 }
-                pending.push(match event {
-                    ContinuousReceiveEvent::Record(record) => {
-                        *delivered = true;
-                        SessionEvent::ContinuousRecord {
-                            identity: session.identity,
-                            record: record.clone(),
-                        }
-                    }
-                    ContinuousReceiveEvent::Gap(mut gap) => {
-                        if !*delivered && session.last_recovery_point.is_none() {
-                            gap.reason = crate::GapReason::LateJoin;
-                        }
-                        SessionEvent::Gap {
-                            identity: session.identity,
-                            gap,
-                        }
-                    }
-                });
-                Ok(())
-            }) {
-            Ok(()) | Err(ReceiveError::Consumer(_)) => Ok(()),
-            Err(ReceiveError::Stream(error)) => Err(error),
+            };
+            let session = &mut self.sessions[index];
+            if session.recovery.len() == self.limits.max_recovery_records {
+                session.recovery.remove(0);
+            }
+            let slot = session.recovery.len();
+            session.recovery.push(RecoveryRecord { record, point });
+            session.recovery_dirty = true;
+            self.push_event(PendingEvent::CachedObject {
+                session: index,
+                slot,
+            })?;
         }
+        Ok(())
     }
 
     fn verify_recovery(&mut self, index: usize) -> Result<()> {
         let session = &mut self.sessions[index];
-        let Some(manifest) = session.manifest_record.as_ref() else {
+        let Some(manifest) = &session.manifest else {
             return Ok(());
         };
         let mut candidate = None;
-        for record in &session.recovery {
-            let decoded = record.decoded()?;
-            if decoded.kind != crate::RecordKind::RecoveryPoint {
+        for (point_index, entry) in session.recovery.iter().enumerate() {
+            let Some(point) = &entry.point else {
                 continue;
-            }
-            let recovery_point = crate::decode_recovery_point(decoded.payload)?;
-            if recovery_point.copperlist_id != decoded.object_id
-                || !recovery_point.references_manifest(manifest.decoded()?)
+            };
+            if point.copperlist_id != entry.record.decoded().object_id
+                || !point.references_manifest(manifest.record.decoded())
                 || session
                     .last_recovery_point
-                    .is_some_and(|last| recovery_point.copperlist_id <= last)
+                    .is_some_and(|id| point.copperlist_id <= id)
             {
                 continue;
             }
-            for keyframe in &session.recovery {
-                let decoded = keyframe.decoded()?;
-                if recovery_point.references_keyframe(decoded)
-                    && crate::decode_keyframe(decoded.payload)?.culistid
-                        == recovery_point.copperlist_id
-                    && candidate.as_ref().is_none_or(
-                        |(previous, _): &(crate::RecoveryPoint, RecoveredRecord)| {
-                            previous.copperlist_id < recovery_point.copperlist_id
-                        },
-                    )
+            for (kf_index, kf) in session.recovery.iter().enumerate() {
+                if point.references_keyframe(kf.record.decoded())
+                    && kf.record.keyframe_id() == Some(point.copperlist_id)
+                    && candidate.is_none_or(|(_, _, id)| point.copperlist_id > id)
                 {
-                    candidate = Some((recovery_point.clone(), keyframe.clone()));
+                    candidate = Some((point_index, kf_index, point.copperlist_id));
                 }
             }
         }
-        let Some((recovery_point, keyframe)) = candidate else {
+        session.recovery_dirty = false;
+        let Some((point, keyframe, id)) = candidate else {
             return Ok(());
         };
-        let decoder = session.continuous.as_mut().expect("manifest accepted");
+        let decoder = session.continuous.as_mut().unwrap();
         let next = decoder.next_object_id();
-        let needed = 1 + usize::from(recovery_point.copperlist_id > next);
+        let needed = 1 + usize::from(id > next);
         if self.pending.len() + needed > self.limits.max_pending_events {
+            session.recovery_dirty = true;
             return Err(Error::TooManyRecords {
                 actual: self.pending.len() + needed,
                 maximum: self.limits.max_pending_events,
             });
         }
-        if recovery_point.copperlist_id > next {
-            self.pending.push(SessionEvent::Gap {
+        if id > next {
+            self.pending.push_back(PendingEvent::Gap {
                 identity: session.identity,
                 gap: crate::CopperListGap {
                     first_id: next,
-                    last_id: recovery_point.copperlist_id - 1,
+                    last_id: id - 1,
                     reason: if session.delivered_record {
                         crate::GapReason::RecoveryPoint
                     } else {
@@ -453,23 +540,22 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
                     },
                 },
             });
-            decoder.resume_at(recovery_point.copperlist_id);
+            decoder.resume_at(id);
         }
-        session.last_recovery_point = Some(recovery_point.copperlist_id);
-        self.pending.push(SessionEvent::VerifiedRecoveryPoint {
-            identity: session.identity,
-            recovery_point,
+        session.last_recovery_point = Some(id);
+        self.pending.push_back(PendingEvent::RecoveryPoint {
+            session: index,
+            point,
             keyframe,
         });
         Ok(())
     }
 
-    /// Finalize a known sender boundary; an unknown tail is never invented.
     pub fn finish_through<E>(
         &mut self,
         identity: StreamIdentity,
         last_id: u64,
-        mut emit: impl FnMut(SessionEvent) -> core::result::Result<(), E>,
+        mut emit: impl FnMut(SessionEventRef<'_>) -> core::result::Result<(), E>,
     ) -> core::result::Result<(), ReceiveError<E>> {
         self.drain_events(&mut emit)?;
         let session = self
@@ -477,30 +563,26 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
             .iter_mut()
             .find(|session| session.identity == identity)
             .ok_or(Error::InvalidConfig("unknown session"))?;
-        let decoder = session
+        session
             .continuous
             .as_mut()
-            .ok_or(Error::InvalidConfig("session has no manifest"))?;
-        decoder.finish_through(last_id, |event| {
-            emit(match event {
-                ContinuousReceiveEvent::Record(record) => SessionEvent::ContinuousRecord {
-                    identity,
-                    record: record.clone(),
-                },
-                ContinuousReceiveEvent::Gap(gap) => SessionEvent::Gap { identity, gap },
+            .ok_or(Error::InvalidConfig("session has no manifest"))?
+            .finish_through(last_id, |event| match event {
+                ContinuousReceiveEvent::Record(record) => {
+                    emit(SessionEvent::ContinuousRecord { identity, record })
+                }
+                ContinuousReceiveEvent::Gap(gap) => emit(SessionEvent::Gap { identity, gap }),
             })
-        })
     }
 
     fn decoder_from_manifest(
-        &self,
+        limits: SessionRouterLimits,
         manifest: &SessionManifest,
     ) -> Result<ContinuousDecoder<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS, MAX_EQUATIONS>> {
         if usize::from(manifest.plan.symbol_size) > MAX_SYMBOL_SIZE
             || usize::from(manifest.plan.continuous.window_symbols) > MAX_WINDOW_SYMBOLS
-            || manifest.plan.max_record_bytes > self.limits.max_record_bytes as u64
-            || usize::from(manifest.plan.continuous.window_symbols)
-                > self.limits.max_buffered_records
+            || manifest.plan.max_record_bytes > limits.max_record_bytes as u64
+            || usize::from(manifest.plan.continuous.window_symbols) > limits.max_buffered_records
         {
             return Err(Error::InvalidConfig(
                 "session manifest exceeds receiver-local limits",
@@ -510,23 +592,23 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
             manifest.identity,
             Lane::ReplayCritical,
             manifest.plan.rlc_config()?,
-            self.limits.equation_capacity,
+            limits.equation_capacity,
             0,
             ReceiverLimits::new(
                 manifest.plan.max_record_bytes as usize,
-                self.limits.max_buffered_records,
+                limits.max_buffered_records,
             ),
         )
     }
 
-    fn push_event(&mut self, event: SessionEvent) -> Result<()> {
+    fn push_event(&mut self, event: PendingEvent) -> Result<()> {
         if self.pending.len() == self.limits.max_pending_events {
             return Err(Error::TooManyRecords {
-                actual: self.pending.len().saturating_add(1),
+                actual: self.pending.len() + 1,
                 maximum: self.limits.max_pending_events,
             });
         }
-        self.pending.push(event);
+        self.pending.push_back(event);
         Ok(())
     }
 }

--- a/core/cu29_logstream/src/twin.rs
+++ b/core/cu29_logstream/src/twin.rs
@@ -315,13 +315,13 @@ impl<P: CaptureDataSet + Send + 'static, S: TwinReceiverStatus> TwinWorker<P, S>
     /// Archival must succeed first; replay never retries or delays that writer.
     pub fn accept(
         &self,
-        event: &crate::SessionEvent,
+        event: &crate::SessionEventRef<'_>,
         capture: Option<CapturedList<P>>,
     ) -> crate::Result<()> {
         match event {
             crate::SessionEvent::Manifest(_) | crate::SessionEvent::Gap { .. } => self.recover(),
             crate::SessionEvent::VerifiedRecoveryPoint { keyframe, .. } => {
-                self.recovery_point(crate::decode_keyframe(keyframe.decoded()?.payload)?)
+                self.recovery_point(crate::decode_keyframe(keyframe.decoded().payload)?)
             }
             crate::SessionEvent::ContinuousRecord { identity, .. } => {
                 if let Some(capture) = capture {

--- a/core/cu29_logstream/src/twin_session.rs
+++ b/core/cu29_logstream/src/twin_session.rs
@@ -159,10 +159,10 @@ impl<A: LiveReplay, R: CuStreamRx + 'static> CuTwinBuilder<A, R> {
                                         return Ok(());
                                     }
                                     if let SessionEvent::Manifest(manifest) = &event {
-                                        status.identity = Some(manifest.identity);
+                                        status.identity = Some(manifest.manifest().identity);
                                         archive = Some(CaptureArchive::<A::DataSet>::new(
                                             &path,
-                                            manifest.clone(),
+                                            manifest,
                                             SLAB_BYTES,
                                             SECTION_BYTES,
                                         )?);

--- a/core/cu29_logstream/src/wire.rs
+++ b/core/cu29_logstream/src/wire.rs
@@ -91,7 +91,8 @@ pub struct WireHeader {
     pub fragment_count: u32,
 }
 
-/// One validated wire symbol and its FEC payload.
+/// Owned packet for callers that retain or edit payloads.
+/// Receiver parsing uses [`WirePacketRef`] to borrow the datagram instead.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WirePacket {
     pub header: WireHeader,
@@ -107,6 +108,23 @@ impl WirePacket {
     }
 
     pub fn decode(bytes: &[u8]) -> Result<Self> {
+        let packet = WirePacketRef::decode(bytes)?;
+        Ok(Self {
+            header: packet.header,
+            payload: packet.payload.to_vec(),
+        })
+    }
+}
+
+/// Validated packet view borrowing the transport's receive buffer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WirePacketRef<'a> {
+    pub header: WireHeader,
+    pub payload: &'a [u8],
+}
+
+impl<'a> WirePacketRef<'a> {
+    pub fn decode(bytes: &'a [u8]) -> Result<Self> {
         if bytes.len() < PACKET_HEADER_LEN {
             return Err(Error::TruncatedPacket);
         }
@@ -153,7 +171,7 @@ impl WirePacket {
                 fec_metadata,
                 fragment_count: u32::from_be_bytes(bytes[60..64].try_into().unwrap()),
             },
-            payload: bytes[PACKET_HEADER_LEN..].to_vec(),
+            payload: &bytes[PACKET_HEADER_LEN..],
         })
     }
 }

--- a/core/cu29_logstream/tests/continuous_copperlist.rs
+++ b/core/cu29_logstream/tests/continuous_copperlist.rs
@@ -25,9 +25,7 @@ enum ObservedEvent {
 
 fn observe_event(event: ContinuousReceiveEvent<'_>) -> ObservedEvent {
     match event {
-        ContinuousReceiveEvent::Record(record) => {
-            ObservedEvent::Record(record.decoded().unwrap().object_id)
-        }
+        ContinuousReceiveEvent::Record(record) => ObservedEvent::Record(record.decoded().object_id),
         ContinuousReceiveEvent::Gap(gap) => ObservedEvent::Gap(gap),
     }
 }
@@ -177,9 +175,9 @@ fn partial_copperlists_survive_a_deterministically_simulated_bad_link() {
     for expected in &source {
         let recovered = recovered_records
             .iter()
-            .find(|record| record.decoded().unwrap().object_id == expected.id)
+            .find(|record| record.decoded().object_id == expected.id)
             .expect("every partial CopperList should be recovered");
-        let decoded_record = recovered.decoded().unwrap();
+        let decoded_record = recovered.decoded();
         let decoded: CopperList<PartialDataSet> =
             decode_copperlist(decoded_record.payload).unwrap();
         assert_eq!(decoded.id, expected.id);
@@ -431,7 +429,7 @@ fn receiver_runs_past_many_windows_with_bounded_state_and_wrapping_sequences() {
                 .receive_datagram(datagram, |event| {
                     match event {
                         ContinuousReceiveEvent::Record(record) => {
-                            record_ids.push(record.decoded().unwrap().object_id);
+                            record_ids.push(record.decoded().object_id);
                         }
                         ContinuousReceiveEvent::Gap(gap) => panic!("unexpected gap: {gap:?}"),
                     }
@@ -582,7 +580,7 @@ fn consumer_failure_leaves_the_record_available_for_retry() {
     decoder
         .drain_events(|event| {
             if let ContinuousReceiveEvent::Record(record) = event {
-                retried_id = Some(record.decoded().unwrap().object_id);
+                retried_id = Some(record.decoded().object_id);
             }
             Ok::<(), core::convert::Infallible>(())
         })

--- a/core/cu29_logstream/tests/finite_objects.rs
+++ b/core/cu29_logstream/tests/finite_objects.rs
@@ -262,7 +262,7 @@ fn a_late_receiver_restarts_the_continuous_stream_at_the_recovery_point() {
             .receive_datagram(datagram, |event| {
                 match event {
                     ContinuousReceiveEvent::Record(record) => {
-                        recovered_ids.push(record.decoded().unwrap().object_id);
+                        recovered_ids.push(record.decoded().object_id);
                     }
                     ContinuousReceiveEvent::Gap(gap) => gaps.push(gap),
                 }

--- a/core/cu29_logstream/tests/pacing.rs
+++ b/core/cu29_logstream/tests/pacing.rs
@@ -146,7 +146,7 @@ fn missed_bootstrap_recovers_during_idle_without_new_captures() {
     for (_, packet) in tx.packets {
         router
             .receive_datagram(&packet, |event| {
-                events.push(event);
+                events.push(event.to_owned());
                 Ok::<_, ()>(())
             })
             .unwrap();

--- a/core/cu29_logstream/tests/session_router.rs
+++ b/core/cu29_logstream/tests/session_router.rs
@@ -93,7 +93,7 @@ fn manifest_bootstraps_continuous_decoder_without_out_of_band_fec_config() {
     for packet in manifest_packets {
         router
             .receive_datagram(&packet, |event| {
-                events.push(event);
+                events.push(event.to_owned());
                 Ok::<(), ()>(())
             })
             .unwrap();
@@ -104,7 +104,7 @@ fn manifest_bootstraps_continuous_decoder_without_out_of_band_fec_config() {
     for packet in continuous_packets {
         router
             .receive_datagram(&packet, |event| {
-                events.push(event);
+                events.push(event.to_owned());
                 Ok::<(), ()>(())
             })
             .unwrap();
@@ -207,7 +207,7 @@ fn receive(
     for packet in packets {
         router
             .receive_datagram(packet, |event| {
-                events.push(event);
+                events.push(event.to_owned());
                 Ok::<(), ()>(())
             })
             .unwrap();
@@ -218,9 +218,7 @@ fn ids(events: &[SessionEvent]) -> Vec<u64> {
     events
         .iter()
         .filter_map(|event| match event {
-            SessionEvent::ContinuousRecord { record, .. } => {
-                Some(record.decoded().unwrap().object_id)
-            }
+            SessionEvent::ContinuousRecord { record, .. } => Some(record.decoded().object_id),
             _ => None,
         })
         .collect()
@@ -359,7 +357,7 @@ fn outage_recovery_and_terminal_gap_are_explicit_and_consumer_failure_is_retryab
             if matches!(event, SessionEvent::VerifiedRecoveryPoint { .. }) {
                 return Err("archive unavailable");
             }
-            events.push(event);
+            events.push(event.to_owned());
             Ok(())
         });
         if result.is_err() {
@@ -370,14 +368,14 @@ fn outage_recovery_and_terminal_gap_are_explicit_and_consumer_failure_is_retryab
     assert!(failed);
     router
         .drain_events(&mut |event| {
-            events.push(event);
+            events.push(event.to_owned());
             Ok::<(), ()>(())
         })
         .unwrap();
     assert!(events.iter().any(|event| matches!(event, SessionEvent::Gap { gap, .. } if gap.first_id == 1 && gap.last_id == 99 && gap.reason == cu29_logstream::GapReason::RecoveryPoint)));
     router
         .finish_through(sender.continuous.identity, 102, |event| {
-            events.push(event);
+            events.push(event.to_owned());
             Ok::<(), ()>(())
         })
         .unwrap();
@@ -396,11 +394,292 @@ fn startup_overflow_is_bounded_and_never_claims_a_complete_session() {
     assert_eq!(ids(&events), (0..8).collect::<Vec<_>>());
     router
         .finish_through(sender.continuous.identity, 11, |event| {
-            events.push(event);
+            events.push(event.to_owned());
             Ok::<(), ()>(())
         })
         .unwrap();
     assert!(
         matches!(events.last(), Some(SessionEvent::Gap { gap, .. }) if gap.first_id == 8 && gap.last_id == 11)
     );
+}
+
+struct CountingAllocator;
+thread_local! {
+    static ALLOCATIONS: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
+}
+unsafe impl std::alloc::GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
+        let _ = ALLOCATIONS.try_with(|count| {
+            if let Some(value) = count.get() {
+                count.set(Some(value + 1));
+            }
+        });
+        unsafe { std::alloc::System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
+        unsafe { std::alloc::System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: std::alloc::Layout, size: usize) -> *mut u8 {
+        let _ = ALLOCATIONS.try_with(|count| {
+            if let Some(value) = count.get() {
+                count.set(Some(value + 1));
+            }
+        });
+        unsafe { std::alloc::System.realloc(ptr, layout, size) }
+    }
+}
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+fn count_allocations(run: impl FnOnce()) -> usize {
+    ALLOCATIONS.with(|count| count.set(Some(0)));
+    run();
+    ALLOCATIONS.with(|count| count.replace(None).unwrap())
+}
+
+#[test]
+fn warmed_router_reuses_record_buffers_with_reordering_and_consumer_retries() {
+    let (sender, mut router) = setup();
+    receive(&mut router, &objects(&sender, 0)[0], &mut Vec::new());
+    let mut encoder = ContinuousEncoder::<1128, 64>::new(
+        sender.continuous.identity,
+        0,
+        sender.continuous.lane,
+        sender.continuous.fec,
+        sender.continuous.max_record_bytes,
+        EncodingSymbolId::new(0),
+    )
+    .unwrap();
+    let packets: Vec<Vec<Vec<u8>>> = (0..200)
+        .map(|id| {
+            // Warm both buffers at the maximum size, then vary lengths and fragment counts.
+            let size = if id < 2 {
+                4096
+            } else {
+                [80, 2048, 4096][id as usize % 3]
+            };
+            let record = encode_record(RecordKind::CopperList, id, &vec![id as u8; size]).unwrap();
+            let mut packets = Vec::new();
+            encoder.push_record(&record, &mut packets).unwrap();
+            packets
+        })
+        .collect();
+    let mut next = 0;
+    let mut retry_pointer = None;
+    let mut deliver_pair = |pair: &[Vec<Vec<u8>>]| {
+        // Complete the later record first, forcing two concurrent assembly buffers.
+        for packet in pair[1].iter().chain(&pair[0]) {
+            let result = router.receive_datagram(packet, |event| {
+                if let SessionEvent::ContinuousRecord { record, .. } = event {
+                    assert_eq!(record.decoded().object_id, next);
+                    retry_pointer = Some(record.bytes().as_ptr());
+                    return Err("retry");
+                }
+                Ok(())
+            });
+            if let Err(cu29_logstream::ReceiveError::Consumer("retry")) = result {
+                router
+                    .drain_events(&mut |event| {
+                        if let SessionEvent::ContinuousRecord { record, .. } = event {
+                            if let Some(pointer) = retry_pointer.take() {
+                                assert_eq!(record.bytes().as_ptr(), pointer);
+                            }
+                            let decoded = record.decoded();
+                            assert_eq!(decoded.object_id, next);
+                            assert!(decoded.payload.iter().all(|byte| *byte == next as u8));
+                            next += 1;
+                        }
+                        Ok::<(), ()>(())
+                    })
+                    .unwrap();
+            } else {
+                result.unwrap();
+            }
+        }
+    };
+    deliver_pair(&packets[..2]);
+    let allocations = count_allocations(|| {
+        for pair in packets[2..].as_chunks::<2>().0 {
+            deliver_pair(pair);
+        }
+    });
+    assert_eq!(next, 200);
+    assert_eq!(allocations, 0, "steady-state receive and retry allocated");
+}
+
+#[test]
+fn recovery_delivery_retries_borrow_the_same_verified_control_records() {
+    let (sender, mut router) = setup();
+    let control = objects(&sender, 100);
+    receive(&mut router, &control[0], &mut Vec::new());
+    receive(&mut router, &control[1], &mut Vec::new());
+    let mut pointers = None;
+    for packet in &control[2] {
+        let result = router.receive_datagram(packet, |event| {
+            if let SessionEvent::VerifiedRecoveryPoint {
+                recovery_record,
+                keyframe,
+                ..
+            } = event
+            {
+                pointers = Some((recovery_record.bytes().as_ptr(), keyframe.bytes().as_ptr()));
+                return Err("retry");
+            }
+            Ok(())
+        });
+        if result.is_err() {
+            break;
+        }
+    }
+    let pointers = pointers.expect("recovery event");
+    let mut delivered = false;
+    let allocations = count_allocations(|| {
+        router
+            .drain_events(&mut |event| {
+                if let SessionEvent::VerifiedRecoveryPoint {
+                    recovery_record,
+                    keyframe,
+                    ..
+                } = event
+                {
+                    assert_eq!(
+                        (recovery_record.bytes().as_ptr(), keyframe.bytes().as_ptr()),
+                        pointers
+                    );
+                    assert_eq!(keyframe.keyframe_id(), Some(100));
+                    delivered = true;
+                }
+                Ok::<(), ()>(())
+            })
+            .unwrap();
+    });
+    assert!(delivered);
+    assert_eq!(allocations, 0);
+}
+
+#[derive(Debug, Default, bincode::Encode, bincode::Decode, serde::Serialize)]
+struct EmptyDataSet;
+impl cu29_traits::ErasedCuStampedDataSet for EmptyDataSet {
+    fn cumsgs(&self) -> Vec<&dyn cu29_traits::ErasedCuStampedData> {
+        Vec::new()
+    }
+}
+impl cu29_traits::MatchingTasks for EmptyDataSet {
+    fn get_all_task_ids() -> &'static [&'static str] {
+        &[]
+    }
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn archive_writes_recovery_bytes_without_allocating() {
+    let (sender, mut router) = setup();
+    let logs = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/cu_logstream_demo/logs");
+    std::fs::create_dir_all(&logs).unwrap();
+    let path = logs.join(format!("receiver-buffers-{}.copper", std::process::id()));
+    let mut archive = None;
+    let mut recovery_written = false;
+    for packets in objects(&sender, 0) {
+        for packet in packets {
+            router
+                .receive_datagram(&packet, |event| {
+                    if let SessionEvent::Manifest(manifest) = &event {
+                        archive = Some(
+                            cu29_logstream::NativeArchive::<EmptyDataSet>::new(
+                                &path,
+                                manifest,
+                                1024 * 1024,
+                                64 * 1024,
+                            )
+                            .unwrap(),
+                        );
+                    }
+                    if matches!(event, SessionEvent::VerifiedRecoveryPoint { .. }) {
+                        let allocations = count_allocations(|| {
+                            archive.as_mut().unwrap().accept(&event).unwrap();
+                        });
+                        assert_eq!(
+                            allocations, 0,
+                            "archive re-encoded recovery bytes or copied task state"
+                        );
+                        recovery_written = true;
+                    }
+                    Ok::<(), ()>(())
+                })
+                .unwrap();
+        }
+    }
+    assert!(recovery_written);
+    archive.unwrap().finish().unwrap();
+}
+
+#[test]
+fn continuity_records_support_borrowed_writes_and_owned_reads() {
+    use cu29_runtime::continuity::StreamContinuityRecord;
+    let payload = [42; 400];
+    let records = [
+        StreamContinuityRecord::Manifest {
+            record: payload.as_slice(),
+        },
+        StreamContinuityRecord::RecoveryPoint {
+            copperlist_id: 100,
+            record: payload.as_slice(),
+        },
+    ];
+    for record in records {
+        let mut bytes = [0; 512];
+        let mut len = 0;
+        let allocations = count_allocations(|| {
+            len = bincode::encode_into_slice(&record, &mut bytes, bincode::config::standard())
+                .unwrap();
+            let (decoded, used): (StreamContinuityRecord<&[u8]>, _) =
+                bincode::borrow_decode_from_slice(&bytes[..len], bincode::config::standard())
+                    .unwrap();
+            assert_eq!(used, len);
+            assert_eq!(decoded, record);
+        });
+        assert_eq!(allocations, 0);
+        let (owned, used): (StreamContinuityRecord, _) =
+            bincode::decode_from_slice(&bytes[..len], bincode::config::standard()).unwrap();
+        assert_eq!(used, len);
+        let owned_bytes = bincode::encode_to_vec(owned, bincode::config::standard()).unwrap();
+        assert_eq!(owned_bytes, bytes[..len]);
+    }
+}
+
+#[test]
+fn drain_processes_symbols_accepted_before_a_consumer_failure() {
+    use cu29_logstream::{ContinuousDecoder, ContinuousReceiveEvent, ReceiveError, ReceiverLimits};
+    let (sender, _) = setup();
+    let packets = continuous(&sender, 0..2);
+    let mut decoder = ContinuousDecoder::<1128, 64, 64>::new(
+        sender.continuous.identity,
+        sender.continuous.lane,
+        sender.continuous.fec,
+        64,
+        0,
+        ReceiverLimits::new(65_536, 64),
+    )
+    .unwrap();
+    for packet in packets {
+        assert_eq!(
+            decoder.receive_datagram(&packet, |_| Err("retry")),
+            Err(ReceiveError::Consumer("retry"))
+        );
+    }
+    // The second packet reached FEC, but delivery of record 0 interrupted its assembly.
+    // No further datagram is needed to assemble and deliver record 1.
+    let mut next = 0;
+    decoder
+        .drain_events(|event| {
+            let ContinuousReceiveEvent::Record(record) = event else {
+                panic!("unexpected gap")
+            };
+            assert_eq!(record.decoded().object_id, next);
+            next += 1;
+            Ok::<(), ()>(())
+        })
+        .unwrap();
+    assert_eq!(next, 2);
 }

--- a/core/cu29_runtime/src/continuity.rs
+++ b/core/cu29_runtime/src/continuity.rs
@@ -13,18 +13,19 @@ pub enum SourceGapReason {
 }
 
 /// Stored in `UnifiedLogType::StreamContinuity`. Ranges are inclusive.
+/// Writers use borrowed byte slices; readers choose owned storage when required.
 /// Gaps remain missing history even when a later keyframe permits state replay.
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
-pub enum StreamContinuityRecord {
+pub enum StreamContinuityRecord<B = Vec<u8>> {
     /// Canonical, versioned semantic manifest bytes bind identity, plan and schema.
-    Manifest { record: Vec<u8> },
+    Manifest { record: B },
     Gap {
         first_id: u64,
         last_id: u64,
         reason: SourceGapReason,
     },
     /// Verified keyframe/manifest references, retained as canonical recovery point bytes.
-    RecoveryPoint { copperlist_id: u64, record: Vec<u8> },
+    RecoveryPoint { copperlist_id: u64, record: B },
     /// Explicit receiver finalization, not a claim about an unobserved sender tail.
     Finished { next_copperlist_id: u64 },
 }


### PR DESCRIPTION
## Summary

The receiver copied packet payloads, cloned completed records for delivery and retries, allocated new continuous assembly buffers for each record, and re-encoded manifest/recovery records when archiving. It now borrows receiver-owned bytes through delivery and archival, caches verified metadata, and recycles assembly buffers.

## Related issues

Stacked on #1331, with `gbin/remove-logstream-content-flags` as the base. Sender serialization work is separate.

## Changes

- Parse borrowed `WirePacketRef` views and pass validated packets directly to FEC decoders, avoiding a second CRC pass.
- Deliver `SessionEventRef` callbacks from retained receiver storage. Consumer failures preserve the same buffers; `to_owned()` explicitly opts into retaining a copy. Draining also processes symbols accepted just before a consumer failure.
- Recycle continuous payload/fragment-map buffers after delivery, expiry, and recovery. Cache record digests and inspect keyframe IDs without copying serialized task state; only rescan recovery bindings when control state changes.
- Bind decoded manifests to their original records with `ReceivedManifest`. Archive original manifest/recovery bytes through `StreamContinuityRecord<&[u8]>`; offline readers can use owned storage. Adapt the twin, UDP integration, and runtime tests, and refresh the API snapshot.

## Reminder

- [x] I ran the relevant root `just` checks listed below.
- [x] I updated the book and wiki sources on matching stacked branches.

## Additional context

Validation: `just fmt`, `just logstream-twin-check` (including all six capture/fsck/replay scenarios), `just nostd-ci` (534 tests passed, one skipped, plus embedded builds), and `just api-check`. The generated-runtime logstream test also passes its focused clippy and three tests. Book `just build` passes.

Allocation regressions assert zero allocations after warming two buffers across 198 reordered, variable-size records with consumer retries; zero-allocation recovery retries and archive writes; and borrowed continuity encoding/decoding. Pointer checks prove retries retain the same storage.

Receiver buffers grow on demand within configured limits. Session discovery, RaptorQ's owned symbols/decoder storage, replay task-state ownership, and application payload decoding may still allocate. No sender real-time work is added.

Documentation: https://github.com/copper-project/copper-rs-book/pull/51 (stacked on book #50). The matching wiki update is pushed on `gbin/logstream-receiver-buffers` at `35f1a94`; GitHub wikis do not support PRs.
