### PR TITLE
fix(runtime): key planner output ports on (msg_type, src_channel)

### DIFF
--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -323,6 +323,7 @@ pub fn cu29_runtime::config::CuGraph::get_node_mut(&mut self, node_id: cu29_runt
 pub fn cu29_runtime::config::CuGraph::get_node_output_msg_type(&self, node_id: &str) -> core::option::Option<alloc::string::String>
 pub fn cu29_runtime::config::CuGraph::get_node_output_msg_types(&self, node_id: &str) -> core::option::Option<alloc::vec::Vec<alloc::string::String>>
 pub fn cu29_runtime::config::CuGraph::get_node_output_msg_types_by_id(&self, node_id: cu29_runtime::config::NodeId) -> cu29_traits::CuResult<alloc::vec::Vec<alloc::string::String>>
+pub fn cu29_runtime::config::CuGraph::get_node_output_ports_by_id(&self, node_id: cu29_runtime::config::NodeId) -> cu29_traits::CuResult<alloc::vec::Vec<(alloc::string::String, core::option::Option<alloc::string::String>)>>
 pub fn cu29_runtime::config::CuGraph::get_node_weight(&self, index: cu29_runtime::config::NodeId) -> core::option::Option<&cu29_runtime::config::Node>
 pub fn cu29_runtime::config::CuGraph::get_src_edges(&self, node_id: cu29_runtime::config::NodeId) -> cu29_traits::CuResult<alloc::vec::Vec<usize>>
 pub fn cu29_runtime::config::CuGraph::incoming_neighbor_count(&self, node_id: cu29_runtime::config::NodeId) -> usize
@@ -910,6 +911,7 @@ pub cu29_runtime::curuntime::CuInputMsg::src_port: usize
 pub struct cu29_runtime::curuntime::CuOutputPack
 pub cu29_runtime::curuntime::CuOutputPack::culist_index: u32
 pub cu29_runtime::curuntime::CuOutputPack::msg_types: alloc::vec::Vec<alloc::string::String>
+pub cu29_runtime::curuntime::CuOutputPack::src_channels: alloc::vec::Vec<core::option::Option<alloc::string::String>>
 pub struct cu29_runtime::curuntime::CuRuntime<CT, CB, P: cu29_traits::CopperListTuple, M: cu29_runtime::monitoring::CuMonitor, const NBCL: usize>
 impl<CT, CB, P, M, const NBCL: usize> cu29_runtime::curuntime::CuRuntime<CT, CB, P, M, NBCL> where P: cu29_traits::CopperListTuple + cu29_runtime::copperlist::CuListZeroedInit + core::default::Default + 'static, M: cu29_runtime::monitoring::CuMonitor
 pub fn cu29_runtime::curuntime::CuRuntime<CT, CB, P, M, NBCL>::captures_keyframe(&self, culistid: u64) -> bool

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -2082,15 +2082,16 @@ impl CuGraph {
             record_port(msg.clone(), None, order);
         }
 
-        port_order.sort_by(
-            |(order_a, msg_a, ch_a), (order_b, msg_b, ch_b)| {
-                order_a
-                    .cmp(order_b)
-                    .then_with(|| msg_a.cmp(msg_b))
-                    .then_with(|| ch_a.cmp(ch_b))
-            },
-        );
-        Ok(port_order.into_iter().map(|(_, msg, ch)| (msg, ch)).collect())
+        port_order.sort_by(|(order_a, msg_a, ch_a), (order_b, msg_b, ch_b)| {
+            order_a
+                .cmp(order_b)
+                .then_with(|| msg_a.cmp(msg_b))
+                .then_with(|| ch_a.cmp(ch_b))
+        });
+        Ok(port_order
+            .into_iter()
+            .map(|(_, msg, ch)| (msg, ch))
+            .collect())
     }
 
     #[allow(dead_code)]

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -2033,6 +2033,66 @@ impl CuGraph {
         Ok(msg_order.into_iter().map(|(_, msg)| msg).collect())
     }
 
+    /// Channel-aware variant of [`CuGraph::get_node_output_msg_types_by_id`].
+    ///
+    /// Returns each distinct output port as `(msg_type, src_channel)`, where
+    /// `src_channel` is `None` for ordinary task ports and `Some(id)` for
+    /// bridge-channel ports. Unlike the msg-only variant, two ports sharing the
+    /// same message type but living on different bridge channels are kept as
+    /// separate entries, preserving their relative ordering (see #791).
+    #[allow(dead_code)]
+    pub fn get_node_output_ports_by_id(
+        &self,
+        node_id: NodeId,
+    ) -> CuResult<Vec<(String, Option<String>)>> {
+        let mut edge_ids = self.get_src_edges(node_id)?;
+        edge_ids.sort();
+
+        let node = self
+            .get_node(node_id)
+            .ok_or_else(|| CuError::from(format!("Node id {node_id} not found")))?;
+
+        let mut port_order: Vec<(usize, String, Option<String>)> = Vec::new();
+        let mut record_port = |msg: String, channel: Option<String>, order: usize| {
+            if let Some((existing_order, _, _)) = port_order
+                .iter_mut()
+                .find(|(_, m, c)| *m == msg && *c == channel)
+            {
+                if order < *existing_order {
+                    *existing_order = order;
+                }
+                return;
+            }
+            port_order.push((order, msg, channel));
+        };
+
+        for edge_id in edge_ids {
+            let Some(edge) = self.edge(edge_id) else {
+                continue;
+            };
+            let order = if edge.order == usize::MAX {
+                edge_id
+            } else {
+                edge.order
+            };
+            record_port(edge.msg.clone(), edge.src_channel.clone(), order);
+        }
+
+        for (msg, order) in node.nc_outputs_with_order() {
+            record_port(msg.clone(), None, order);
+        }
+
+        port_order.sort_by(
+            |(order_a, msg_a, ch_a), (order_b, msg_b, ch_b)| {
+                order_a
+                    .cmp(order_b)
+                    .then_with(|| msg_a.cmp(msg_b))
+                    .then_with(|| ch_a.cmp(ch_b))
+            },
+        );
+        Ok(port_order.into_iter().map(|(_, msg, ch)| (msg, ch)).collect())
+    }
+
     #[allow(dead_code)]
     pub fn get_node_input_msg_type(&self, node_id: &str) -> Option<String> {
         self.get_node_input_msg_types(node_id)

--- a/core/cu29_runtime/src/curuntime.rs
+++ b/core/cu29_runtime/src/curuntime.rs
@@ -2323,6 +2323,14 @@ impl From<TaskKind> for CuTaskType {
 pub struct CuOutputPack {
     pub culist_index: u32,
     pub msg_types: Vec<String>,
+    /// Per-port source channel, parallel to `msg_types`.
+    ///
+    /// `None` for ports that are not a bridge channel. A node may expose
+    /// several ports sharing the same `msg_type` distinguished only by their
+    /// bridge channel (e.g. a stereo driver publishing `Image` on `left` and
+    /// `right`); keying routing on `msg_type` alone would collapse those ports
+    /// (see #791).
+    pub src_channels: Vec<Option<String>>,
 }
 
 #[derive(Debug, Clone)]
@@ -3756,6 +3764,72 @@ mod tests {
     }
 
     #[test]
+    fn test_runtime_plan_distinguishes_channel_distinct_outputs() {
+        let mut config = CuConfig::default();
+        let graph = config.get_graph_mut(None).unwrap();
+        let src_id = graph.add_node(Node::new("cam", "Cam")).unwrap();
+        let sink_id = graph.add_node(Node::new("sink", "Sink")).unwrap();
+
+        // Two outputs sharing the same message type, distinguished only by
+        // their bridge channel (e.g. a stereo camera publishing `Image` on
+        // `left` and `right`). Regression test for #791.
+        graph
+            .connect_ext(
+                src_id,
+                sink_id,
+                "msg::Image",
+                None,
+                Some("left".to_string()),
+                None,
+            )
+            .unwrap();
+        graph
+            .connect_ext(
+                src_id,
+                sink_id,
+                "msg::Image",
+                None,
+                Some("right".to_string()),
+                None,
+            )
+            .unwrap();
+
+        let runtime = compute_runtime_plan(graph).unwrap();
+
+        let src_step = runtime
+            .steps
+            .iter()
+            .find_map(|step| match step {
+                CuExecutionUnit::Step(step) if step.node_id == src_id => Some(step),
+                _ => None,
+            })
+            .unwrap();
+        let output_pack = src_step.output_msg_pack.as_ref().unwrap();
+        assert_eq!(output_pack.msg_types, vec!["msg::Image", "msg::Image"]);
+        assert_eq!(
+            output_pack.src_channels,
+            vec![Some("left".to_string()), Some("right".to_string())]
+        );
+
+        let sink_step = runtime
+            .steps
+            .iter()
+            .find_map(|step| match step {
+                CuExecutionUnit::Step(step) if step.node_id == sink_id => Some(step),
+                _ => None,
+            })
+            .unwrap();
+
+        assert_eq!(sink_step.input_msg_indices_types.len(), 2);
+        let ports: Vec<usize> = sink_step
+            .input_msg_indices_types
+            .iter()
+            .map(|input| input.src_port)
+            .collect();
+        assert_eq!(ports, vec![0, 1]);
+    }
+
+    #[test]
     fn test_runtime_output_ports_fanout_single() {
         let mut config = CuConfig::default();
         let graph = config.get_graph_mut(None).unwrap();
@@ -4087,6 +4161,7 @@ mod tests {
             output_msg_pack: Some(CuOutputPack {
                 culist_index: output,
                 msg_types: vec!["msg::A".to_string()],
+                src_channels: vec![None],
             }),
         }))
     }

--- a/core/cu29_runtime/src/planner.rs
+++ b/core/cu29_runtime/src/planner.rs
@@ -478,16 +478,18 @@ pub(crate) fn plan_from_order(graph: &CuGraph, order: &StepOrder) -> CuResult<Cu
 
         match task_type {
             CuTaskType::Source => {
-                let msg_types = graph.get_node_output_msg_types_by_id(id)?;
-                if msg_types.is_empty() {
+                let ports = graph.get_node_output_ports_by_id(id)?;
+                if ports.is_empty() {
                     return Err(CuError::from(format!(
                         "Source node '{}' has no declared outputs",
                         node_ref.get_id()
                     )));
                 }
+                let (msg_types, src_channels) = ports.into_iter().unzip();
                 output_msg_pack = Some(CuOutputPack {
                     culist_index: next_culist_output_index,
                     msg_types,
+                    src_channels,
                 });
                 next_culist_output_index += 1;
             }
@@ -495,20 +497,23 @@ pub(crate) fn plan_from_order(graph: &CuGraph, order: &StepOrder) -> CuResult<Cu
                 output_msg_pack = Some(CuOutputPack {
                     culist_index: next_culist_output_index,
                     msg_types: Vec::from(["()".to_string()]),
+                    src_channels: vec![None],
                 });
                 next_culist_output_index += 1;
             }
             CuTaskType::Regular => {
-                let msg_types = graph.get_node_output_msg_types_by_id(id)?;
-                if msg_types.is_empty() {
+                let ports = graph.get_node_output_ports_by_id(id)?;
+                if ports.is_empty() {
                     return Err(CuError::from(format!(
                         "Regular node '{}' has no declared outputs",
                         node_ref.get_id()
                     )));
                 }
+                let (msg_types, src_channels) = ports.into_iter().unzip();
                 output_msg_pack = Some(CuOutputPack {
                     culist_index: next_culist_output_index,
                     msg_types,
+                    src_channels,
                 });
                 next_culist_output_index += 1;
             }
@@ -556,10 +561,12 @@ fn collect_step_inputs(
             ))
         })?;
         let msg_type = edge.msg.as_str();
+        let src_channel = edge.src_channel.as_deref();
         let src_port = output_pack
             .msg_types
             .iter()
-            .position(|msg| msg == msg_type)
+            .zip(output_pack.src_channels.iter())
+            .position(|(msg, ch)| msg == msg_type && ch.as_deref() == src_channel)
             .unwrap_or_else(|| {
                 panic!("Missing output port for message type '{msg_type}' on node {pid}")
             });
@@ -1697,6 +1704,7 @@ mod tests {
                     }
                     output_msg_pack = Some(CuOutputPack {
                         culist_index: next_culist_output_index,
+                        src_channels: vec![None; msg_types.len()],
                         msg_types,
                     });
                     next_culist_output_index += 1;
@@ -1740,6 +1748,7 @@ mod tests {
                     output_msg_pack = Some(CuOutputPack {
                         culist_index: next_culist_output_index,
                         msg_types: Vec::from(["()".to_string()]),
+                        src_channels: vec![None],
                     });
                     next_culist_output_index += 1;
                 }
@@ -1788,6 +1797,7 @@ mod tests {
                     }
                     output_msg_pack = Some(CuOutputPack {
                         culist_index: next_culist_output_index,
+                        src_channels: vec![None; msg_types.len()],
                         msg_types,
                     });
                     next_culist_output_index += 1;


### PR DESCRIPTION
## Summary

Runtime planning resolved a source's output ports by `msg_type` only. A source exposing several outputs with the same message type on different bridge channels (e.g. a stereo driver publishing `Image` on `left` and `right`) collapsed them onto a single planner port, so downstream inputs were routed to the wrong (first) port.

Fixes #791.

## Changes

- Add `CuGraph::get_node_output_ports_by_id`, a channel-aware variant of `get_node_output_msg_types_by_id` that keeps channel-distinct ports `(msg_type, src_channel)` and preserves their relative ordering.
- Carry a parallel `src_channels: Vec<Option<String>>` in `CuOutputPack`.
- Resolve `src_port` in `collect_step_inputs` by matching both `msg_type` and `src_channel`.

The derive path (`cu29_derive`) is unaffected: it already normalizes bridge channels into synthetic per-channel nodes before planning.

## Testing

- New regression test `test_runtime_plan_distinguishes_channel_distinct_outputs` verifies a source with two same-typed channel outputs produces two distinct ports and the sink resolves `src_port` 0 and 1.
- `cargo test -p cu29-runtime --lib`: 246 passed, 0 failed.
- `cargo check -p cu29-export -p cu29-derive`: clean.