### PR TITLE
Reconstruct a robot arm from streamed encoder angles

### DIFF
--- a/examples/cu_logstream_demo/Cargo.toml
+++ b/examples/cu_logstream_demo/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 default = []
 verify-reconstruction = ["demo", "cu29/logstream-verify"]
 # Keep async runtime features out of ordinary workspace builds.
-demo = ["cu29/logstream", "cu29/reflect"]
+demo = ["cu29/logstream", "cu29/reflect", "dep:cu-transform"]
 replay = ["demo", "cu29/remote-debug"]
 tui = ["demo", "dep:ratatui"]
 
@@ -33,6 +33,7 @@ required-features = ["replay"]
 
 [dependencies]
 cu29 = { workspace = true }
+cu-transform = { path = "../../components/libs/cu_transform", optional = true }
 cu29-logstream = { workspace = true, features = ["std"] }
 cu29-logstream-udp = { workspace = true }
 cu29-export = { workspace = true }

--- a/examples/cu_logstream_demo/README.md
+++ b/examples/cu_logstream_demo/README.md
@@ -73,8 +73,10 @@ come exclusively from reconstructed Copper task outputs.
 The screen follows `cu_tuimon` with numbered tabs and command badges. **1** selects
 Live, **2** selects Health, and **Tab** cycles between them. In Health, **hjkl**
 or the arrow keys scroll the details, including the archive path and recovery counters.
-Received values are green, reconstructed values cyan, warnings amber, and failures
-red, on an explicit dark background independent of the terminal palette.
+A warm graphite background and ivory text anchor the palette: received values use
+muted sage, reconstructed values and trails use copper, warnings use amber, and
+failures use soft red. Tabs and command badges share the same warm neutral colors,
+independent of the terminal palette.
 **Space** pauses consumption; wait a second and resume to see missed samples
 while the archive count keeps advancing. **q**, Escape, or Ctrl-C closes the
 receiver and finalizes its archive. The sender is a separate process. After the

--- a/examples/cu_logstream_demo/README.md
+++ b/examples/cu_logstream_demo/README.md
@@ -67,7 +67,8 @@ The Ratatui screen shows received shoulder/elbow angle traces on the left and a
 Braille-canvas robot arm on the right. Two rotating links draw a four-lobed loop
 every 12 seconds. The fingertip trail fades over one loop and clears on missing
 frames or a new session; the display never invents positions across a gap.
-The caption is the demo: **Only joint angles transmitted.** The arm positions
+The arm panel is labeled **Kinematics → output pose**, with the caption
+**Task re-executed on ground · pose not transmitted**. The arm positions
 come exclusively from reconstructed Copper task outputs.
 The screen follows `cu_tuimon` with numbered tabs and command badges. **1** selects
 Live, **2** selects Health, and **Tab** cycles between them. In Health, **hjkl**

--- a/examples/cu_logstream_demo/README.md
+++ b/examples/cu_logstream_demo/README.md
@@ -15,6 +15,7 @@ disables task reconstruction.
 From this directory:
 
 ```sh
+just dag
 just
 just run loss
 just run outage

--- a/examples/cu_logstream_demo/README.md
+++ b/examples/cu_logstream_demo/README.md
@@ -74,8 +74,10 @@ The screen follows `cu_tuimon` with numbered tabs and command badges. **1** sele
 Live, **2** selects Health, and **Tab** cycles between them. In Health, **hjkl**
 or the arrow keys scroll the details, including the archive path and recovery counters.
 The dashboard uses the official [Catppuccin Mocha palette](https://github.com/catppuccin/palette):
-green for received values, mauve for reconstruction, yellow for warnings, and red
-for failures. Text, tabs, and trails use Mocha's named colors; the main background
+green for received values and healthy status, mauve for reconstructed pose data,
+blue for headings and transport metrics, neutral text for explanations, yellow for
+warnings, and red for failures. Packet and frame ages get a red background as soon
+as the displayed age reaches 0.1 seconds; fresh data clears the highlight. Text, tabs, and trails use Mocha's named colors; the main background
 preserves the terminal's default black or transparency.
 Teal, sky, and sapphire accents are omitted.
 **Space** pauses consumption; wait a second and resume to see missed samples

--- a/examples/cu_logstream_demo/README.md
+++ b/examples/cu_logstream_demo/README.md
@@ -1,8 +1,9 @@
 # UDP log streaming demo
 
 Run a deterministic Copper graph in one process and collect its native execution
-log in another over localhost UDP. The graph is `counter → sum → derived`. Counter and sum are transmitted; derived
-is reconstructed live from the same Copper task implementation.
+log in another over localhost UDP. The graph is `encoders → kinematics`. Only shoulder and elbow encoder angles
+are transmitted; elbow and fingertip positions are reconstructed live by the same
+Copper task that runs on the robot.
 
 Each `log_streaming.destinations` entry sets `recovery_interval` directly alongside
 `transport`, `link`, `fec`, and `max_record_bytes`. The interval counts CopperLists
@@ -62,9 +63,12 @@ just dashboard
 just sender
 ```
 
-The Ratatui screen shows counter/sum values, a received counter chart on the left,
-and a live `sum % 256` chart on the right with its local reconstruction status.
-The modulo chart uses reconstructed task outputs and a fixed 0–255 scale.
+The Ratatui screen shows received shoulder/elbow angle traces on the left and a
+Braille-canvas robot arm on the right. Two rotating links draw a four-lobed loop
+every 12 seconds. The fingertip trail fades over one loop and clears on missing
+frames or a new session; the display never invents positions across a gap.
+The caption is the demo: **Only joint angles transmitted.** The arm positions
+come exclusively from reconstructed Copper task outputs.
 The screen follows `cu_tuimon` with numbered tabs and command badges. **1** selects
 Live, **2** selects Health, and **Tab** cycles between them. In Health, **hjkl**
 or the arrow keys scroll the details, including the archive path and recovery counters.
@@ -82,7 +86,7 @@ with a 50 ms keyboard/age timer; no UI callback runs on the receiving thread.
 On overrun it resumes at the oldest retained frame with an exact local missed
 count. Source gaps and reader misses are distinct. Status stays available while
 the UI is paused. The UI owns its bounded chart history and uses generated
-`get_counter_output()` / `get_sum_output()` accessors.
+`get_encoders_output()` / `get_kinematics_output()` accessors.
 
 This step displays captured outputs; it does **not** yet execute a live
 Copper runtime on the ground to deterministically reconstruct omitted outputs
@@ -126,7 +130,7 @@ just resim-debug logs/replay.copper logs/debug-replay.copper
 
 The replay binary uses Copper's standard `--log-base`, `--replay-log-base`, and
 `--debug-base` contract. Remote debug creates separate replay outputs per session.
-Offline replay injects captured outputs and reconstructs the omitted derived output.
+Offline replay injects captured outputs and reconstructs the omitted arm pose.
 The verification tool compares full reconstructed outputs and sender metadata against
 the onboard log.
 Offline replay drains pending output before each iteration and aligns generated
@@ -163,16 +167,34 @@ permit a shared bidirectional carrier or separate explicitly configured endpoint
 
 ## Live Copper twin
 
-The demo graph is `counter -> sum -> derived`. The ordinary `Derived` Copper task
-computes `sum % 256` on the robot and in generated ground-side replay. Its payload
-is never transmitted, including repeated recovery point boundaries and FEC repairs. The
-robot's onboard log contains the full output for comparison. Ratatui explicitly
-labels the derived value **reconstructed locally; payload not transmitted**.
+The demo graph is `encoders -> kinematics`. The `Encoders` source simulates two
+integer encoder readings in hundredths of a degree. Shoulder turns at 30 degrees
+per second and elbow turns four times as fast in the opposite direction, relative
+to the upper arm. `Kinematics` uses `cu_transform::TypedTransform3D` to compose:
+
+`Base -> Shoulder -> Elbow -> Forearm -> Tip`
+
+The one-meter upper arm and 0.65-meter forearm are constant, unit-typed transforms;
+received angles supply the joint rotations. The same task computes elbow and tip
+positions on the robot and in generated ground-side replay. Its pose payload is
+never transmitted, including recovery points and FEC repairs. The robot's onboard
+log contains the full output for byte-for-byte comparison.
+
+The reconstruction ABI uses bounded integer inputs and the transform library's
+scalar `f64` const-capable constructors and composition, avoiding platform libm
+trigonometry and SIMD matrix multiplication. Tests check known arm configurations,
+runtime-versus-const bit equality, allocation-free kinematics, and exact replay
+including sender metadata. This checkout validates the native host; it does not
+claim a tested architecture matrix. Changes to that arithmetic require reviewing
+the task's cross-platform determinism contract and replay ABI.
+
+The original stateful counter/sum/modulo graph remains a test-only replay fixture.
+Existing counter-demo archives have a different schema; use newly recorded arm logs.
 
 Declare the static contract in the same RON used by the robot and ground build:
 
 ```ron
-(id: "derived", type: "tasks::Derived",
+(id: "kinematics", type: "tasks::Kinematics",
  streaming: (replay: reconstruct, replay_abi: 1)),
 ```
 

--- a/examples/cu_logstream_demo/README.md
+++ b/examples/cu_logstream_demo/README.md
@@ -73,10 +73,11 @@ come exclusively from reconstructed Copper task outputs.
 The screen follows `cu_tuimon` with numbered tabs and command badges. **1** selects
 Live, **2** selects Health, and **Tab** cycles between them. In Health, **hjkl**
 or the arrow keys scroll the details, including the archive path and recovery counters.
-A warm graphite background and ivory text anchor the palette: received values use
-muted sage, reconstructed values and trails use copper, warnings use amber, and
-failures use soft red. Tabs and command badges share the same warm neutral colors,
-independent of the terminal palette.
+The dashboard uses the official [Catppuccin Mocha palette](https://github.com/catppuccin/palette):
+green for received values, mauve for reconstruction, yellow for warnings, and red
+for failures. Text, tabs, and trails use Mocha's named colors; the main background
+preserves the terminal's default black or transparency.
+Teal, sky, and sapphire accents are omitted.
 **Space** pauses consumption; wait a second and resume to see missed samples
 while the archive count keeps advancing. **q**, Escape, or Ctrl-C closes the
 receiver and finalizes its archive. The sender is a separate process. After the

--- a/examples/cu_logstream_demo/copperconfig.ron
+++ b/examples/cu_logstream_demo/copperconfig.ron
@@ -53,16 +53,12 @@
     ),
     tasks: [
         (
-            id: "counter",
-            type: "cu_logstream_demo::tasks::Counter",
+            id: "encoders",
+            type: "cu_logstream_demo::tasks::Encoders",
         ),
         (
-            id: "sum",
-            type: "cu_logstream_demo::tasks::Accumulator",
-        ),
-        (
-            id: "derived",
-            type: "cu_logstream_demo::tasks::Derived",
+            id: "kinematics",
+            type: "cu_logstream_demo::tasks::Kinematics",
             streaming: (
                 replay: reconstruct,
                 replay_abi: 1,
@@ -71,19 +67,14 @@
     ],
     cnx: [
         (
-            src: "counter",
-            dst: "sum",
-            msg: "cu_logstream_demo::tasks::Sample",
+            src: "encoders",
+            dst: "kinematics",
+            msg: "cu_logstream_demo::tasks::JointAngles",
         ),
         (
-            src: "sum",
-            dst: "derived",
-            msg: "cu_logstream_demo::tasks::Sample",
-        ),
-        (
-            src: "derived",
+            src: "kinematics",
             dst: "__nc__",
-            msg: "cu_logstream_demo::tasks::Sample",
+            msg: "cu_logstream_demo::tasks::ArmPose",
         ),
     ],
 )

--- a/examples/cu_logstream_demo/justfile
+++ b/examples/cu_logstream_demo/justfile
@@ -3,6 +3,10 @@ root := "../.."
 # Run the clean two-process demo and verify both native logs.
 default: (run "clean")
 
+# Render and open the encoder-to-kinematics task graph.
+dag:
+    cargo +stable run -p cu29-runtime --bin cu29-rendercfg -- --open copperconfig.ron
+
 build:
     cargo +stable build -p cu-logstream-demo --features replay --bins
 

--- a/examples/cu_logstream_demo/src/dashboard.rs
+++ b/examples/cu_logstream_demo/src/dashboard.rs
@@ -28,18 +28,19 @@ const CHART_CAPACITY: usize = 120;
 const TRAIL_CAPACITY: usize = 1200; // One 12-second loop at 100 Hz, UI storage only.
 const UI_TICK: Duration = Duration::from_millis(50);
 
-// Warm graphite and copper, with restrained semantic status colors.
-const BG: Color = Color::Rgb(24, 22, 21);
-const FG: Color = Color::Rgb(231, 222, 211);
-const MUTED: Color = Color::Rgb(149, 137, 125);
-const SAGE: Color = Color::Rgb(166, 184, 150);
-const COPPER: Color = Color::Rgb(224, 157, 112);
-const AMBER: Color = Color::Rgb(228, 191, 117);
-const ERROR: Color = Color::Rgb(222, 119, 112);
-const BAR: Color = Color::Rgb(31, 28, 26);
-const ACTIVE: Color = Color::Rgb(99, 65, 47);
-const INACTIVE: Color = Color::Rgb(46, 41, 37);
-const TRAIL_COLORS: [Color; 3] = [Color::Rgb(87, 58, 43), Color::Rgb(143, 94, 66), COPPER];
+// Official Catppuccin Mocha colors; omit teal, sky, and sapphire accents.
+// https://github.com/catppuccin/palette/blob/main/palette.json
+const BG: Color = Color::Reset; // Preserve the terminal's black/transparent background.
+const FG: Color = Color::Rgb(205, 214, 244); // Text
+const MUTED: Color = Color::Rgb(147, 153, 178); // Overlay 2
+const GREEN: Color = Color::Rgb(166, 227, 161);
+const MAUVE: Color = Color::Rgb(203, 166, 247);
+const YELLOW: Color = Color::Rgb(249, 226, 175);
+const RED: Color = Color::Rgb(243, 139, 168);
+const BAR: Color = Color::Rgb(24, 24, 37); // Mantle
+const ACTIVE: Color = Color::Rgb(88, 91, 112); // Surface 2
+const INACTIVE: Color = Color::Rgb(49, 50, 68); // Surface 0
+const TRAIL_COLORS: [Color; 3] = [ACTIVE, MUTED, MAUVE];
 
 #[derive(Default)]
 struct View {
@@ -146,11 +147,11 @@ impl View {
             frame.area(),
         );
         let (reconstruction, twin_color) = match status.twin.state {
-            ReconstructionState::Waiting => ("Waiting for recovery point", AMBER),
-            ReconstructionState::Recovering => ("Recovering", AMBER),
-            ReconstructionState::Reconstructed => ("Reconstructed locally", COPPER),
-            ReconstructionState::Verified => ("Verified (developer checks)", SAGE),
-            ReconstructionState::Diverged => ("DIVERGED", ERROR),
+            ReconstructionState::Waiting => ("Waiting for recovery point", YELLOW),
+            ReconstructionState::Recovering => ("Recovering", YELLOW),
+            ReconstructionState::Reconstructed => ("Reconstructed locally", MAUVE),
+            ReconstructionState::Verified => ("Verified (developer checks)", GREEN),
+            ReconstructionState::Diverged => ("DIVERGED", RED),
         };
         let tip = if matches!(
             status.twin.state,
@@ -161,17 +162,17 @@ impl View {
             "—".into()
         };
         let (recording, recording_color) = match status.state {
-            RecordingState::Waiting => ("Waiting for robot", AMBER),
-            RecordingState::Recording => ("Recording", SAGE),
+            RecordingState::Waiting => ("Waiting for robot", YELLOW),
+            RecordingState::Recording => ("Recording", GREEN),
             RecordingState::Closed => ("Archive closed", MUTED),
-            RecordingState::Failed => ("RECEIVER ERROR", ERROR),
+            RecordingState::Failed => ("RECEIVER ERROR", RED),
         };
         let view_state = if self.paused {
             "VIEW PAUSED"
         } else {
             "LIVE VIEW"
         };
-        let view_color = if self.paused { AMBER } else { COPPER };
+        let view_color = if self.paused { YELLOW } else { MAUVE };
         let [header, body, footer] = Layout::vertical([
             Constraint::Length(1),
             Constraint::Min(0),
@@ -241,7 +242,7 @@ impl View {
                 state,
             );
             let lines = self.health_lines(status, overwritten, path);
-            let block = panel("Stream health · recording continues while paused", COPPER);
+            let block = panel("Stream health · recording continues while paused", MAUVE);
             let inner = block.inner(details);
             self.health_scroll.0 = self
                 .health_scroll
@@ -274,22 +275,22 @@ impl View {
                     ]),
                     Line::from(
                         [
-                            metric("Shoulder", angle(self.angles.map(|a| a.shoulder)), SAGE),
-                            metric("Elbow", angle(self.angles.map(|a| a.elbow)), SAGE),
+                            metric("Shoulder", angle(self.angles.map(|a| a.shoulder)), GREEN),
+                            metric("Elbow", angle(self.angles.map(|a| a.elbow)), GREEN),
                         ]
                         .concat(),
                     ),
                     Line::from(
                         [
-                            metric("Tip", tip, COPPER),
-                            vec![Span::styled("(local)", Style::default().fg(COPPER))],
+                            metric("Tip", tip, MAUVE),
+                            vec![Span::styled("(local)", Style::default().fg(MAUVE))],
                         ]
                         .concat(),
                     ),
-                    Line::from(value("Payload NOT transmitted", COPPER)),
+                    Line::from(value("Payload NOT transmitted", MAUVE)),
                     Line::from(
                         [
-                            metric("Archived", status.archived, SAGE),
+                            metric("Archived", status.archived, GREEN),
                             metric("Gaps", status.gaps, warning(status.gaps > 0)),
                         ]
                         .concat(),
@@ -315,9 +316,9 @@ impl View {
                 ]),
                 Line::from(
                     [
-                        metric("Shoulder", angle(self.angles.map(|a| a.shoulder)), SAGE),
-                        metric("Elbow", angle(self.angles.map(|a| a.elbow)), SAGE),
-                        metric("Tip", &tip, COPPER),
+                        metric("Shoulder", angle(self.angles.map(|a| a.shoulder)), GREEN),
+                        metric("Elbow", angle(self.angles.map(|a| a.elbow)), GREEN),
+                        metric("Tip", &tip, MAUVE),
                     ]
                     .concat(),
                 ),
@@ -325,7 +326,7 @@ impl View {
                     value(reconstruction, twin_color),
                     Span::styled(
                         " · pose payload not transmitted",
-                        Style::default().fg(COPPER),
+                        Style::default().fg(MAUVE),
                     ),
                 ]),
                 Line::from(
@@ -336,7 +337,7 @@ impl View {
                     .concat(),
                 ),
             ])
-            .block(panel("Captured inputs + Copper twin output", COPPER)),
+            .block(panel("Captured inputs + Copper twin output", MAUVE)),
             values,
         );
         let [encoder_charts, arm] =
@@ -370,22 +371,22 @@ impl View {
                 Sparkline::default()
                     .data(samples)
                     .max(u64::from(FULL_TURN))
-                    .block(panel(title, SAGE).title_bottom(format!("Angle: {}", angle(reading))))
-                    .style(Style::default().fg(SAGE)),
+                    .block(panel(title, GREEN).title_bottom(format!("Angle: {}", angle(reading))))
+                    .style(Style::default().fg(GREEN)),
                 area,
             );
         }
         self.draw_arm(
             frame,
             arm,
-            if self.paused { AMBER } else { twin_color },
+            if self.paused { YELLOW } else { twin_color },
             &tip,
         );
         frame.render_widget(
             Paragraph::new(vec![
                 Line::from(
                     [
-                        metric("Archived", status.archived, SAGE),
+                        metric("Archived", status.archived, GREEN),
                         metric("Source gaps", status.gaps, warning(status.gaps > 0)),
                         metric(
                             "Replay drops",
@@ -401,7 +402,7 @@ impl View {
                         metric("Last packet", age(status.last_packet), FG),
                         vec![Span::styled(
                             "2: stream details",
-                            Style::default().fg(AMBER),
+                            Style::default().fg(YELLOW),
                         )],
                     ]
                     .concat(),
@@ -467,7 +468,7 @@ impl View {
                         y - 0.2,
                         Span::styled(
                             "Task re-executed on ground · pose not transmitted",
-                            Style::default().fg(COPPER),
+                            Style::default().fg(MAUVE),
                         ),
                     );
                     if tip == "—" {
@@ -484,29 +485,29 @@ impl View {
 
     fn health_lines(&self, status: Status, overwritten: u64, path: &str) -> Vec<Line<'static>> {
         vec![
-            Line::from(metric("Packets", status.packets, COPPER)),
+            Line::from(metric("Packets", status.packets, MAUVE)),
             Line::from(metric("Last packet", age(status.last_packet), FG)),
-            Line::from(metric("Archived", status.archived, SAGE)),
-            Line::from(metric("Latest CL", number(status.latest), SAGE)),
+            Line::from(metric("Archived", status.archived, GREEN)),
+            Line::from(metric("Latest CL", number(status.latest), GREEN)),
             Line::from(metric(
                 "Verified recovery point",
                 number(status.recovery_point),
-                COPPER,
+                MAUVE,
             )),
             Line::from(metric("Source gaps", status.gaps, warning(status.gaps > 0))),
             Line::from(metric(
                 "Reconstructed frames",
                 status.twin.reconstructed,
-                COPPER,
+                MAUVE,
             )),
-            Line::from(metric("Verified frames", status.twin.verified, SAGE)),
+            Line::from(metric("Verified frames", status.twin.verified, GREEN)),
             Line::from(metric(
                 "Divergences",
                 status.twin.divergences,
                 if status.twin.divergences > 0 {
-                    ERROR
+                    RED
                 } else {
-                    SAGE
+                    GREEN
                 },
             )),
             Line::from(metric(
@@ -557,7 +558,7 @@ fn metric(label: &str, data: impl ToString, color: Color) -> Vec<Span<'static>> 
 }
 
 fn warning(present: bool) -> Color {
-    if present { AMBER } else { SAGE }
+    if present { YELLOW } else { GREEN }
 }
 
 fn badge(key: &str, label: &str, bg: Color) -> Vec<Span<'static>> {
@@ -566,7 +567,7 @@ fn badge(key: &str, label: &str, bg: Color) -> Vec<Span<'static>> {
         Span::styled(
             format!(" {key} "),
             Style::default()
-                .fg(AMBER)
+                .fg(YELLOW)
                 .bg(bg)
                 .add_modifier(Modifier::BOLD),
         ),
@@ -742,8 +743,8 @@ mod tests {
             .draw(|frame| view.draw(frame, status, 0, "logs/test.copper"))
             .unwrap();
         let buffer = terminal.backend().buffer();
-        assert_eq!(buffer[(0, 1)].fg, ERROR);
-        assert_eq!(buffer[(0, 2)].fg, ERROR);
+        assert_eq!(buffer[(0, 1)].fg, RED);
+        assert_eq!(buffer[(0, 2)].fg, RED);
         assert_eq!(buffer[(49, 5)].bg, BG);
         for _ in 0..20 {
             view.key(KeyCode::Down);

--- a/examples/cu_logstream_demo/src/dashboard.rs
+++ b/examples/cu_logstream_demo/src/dashboard.rs
@@ -28,17 +28,18 @@ const CHART_CAPACITY: usize = 120;
 const TRAIL_CAPACITY: usize = 1200; // One 12-second loop at 100 Hz, UI storage only.
 const UI_TICK: Duration = Duration::from_millis(50);
 
-// Match cu_tuimon's explicit RGB palette and tab/command chrome.
-const BG: Color = Color::Rgb(0, 0, 0);
-const FG: Color = Color::Rgb(221, 221, 221);
-const MUTED: Color = Color::Rgb(118, 118, 118);
-const GREEN: Color = Color::Rgb(25, 203, 0);
-const CYAN: Color = Color::Rgb(13, 205, 205);
-const YELLOW: Color = Color::Rgb(255, 208, 128);
-const RED: Color = Color::Rgb(242, 32, 31);
-const BAR: Color = Color::Rgb(16, 18, 20);
-const ACTIVE: Color = Color::Rgb(56, 110, 120);
-const INACTIVE: Color = Color::Rgb(40, 44, 52);
+// Warm graphite and copper, with restrained semantic status colors.
+const BG: Color = Color::Rgb(24, 22, 21);
+const FG: Color = Color::Rgb(231, 222, 211);
+const MUTED: Color = Color::Rgb(149, 137, 125);
+const SAGE: Color = Color::Rgb(166, 184, 150);
+const COPPER: Color = Color::Rgb(224, 157, 112);
+const AMBER: Color = Color::Rgb(228, 191, 117);
+const ERROR: Color = Color::Rgb(222, 119, 112);
+const BAR: Color = Color::Rgb(31, 28, 26);
+const ACTIVE: Color = Color::Rgb(99, 65, 47);
+const INACTIVE: Color = Color::Rgb(46, 41, 37);
+const TRAIL_COLORS: [Color; 3] = [Color::Rgb(87, 58, 43), Color::Rgb(143, 94, 66), COPPER];
 
 #[derive(Default)]
 struct View {
@@ -145,11 +146,11 @@ impl View {
             frame.area(),
         );
         let (reconstruction, twin_color) = match status.twin.state {
-            ReconstructionState::Waiting => ("Waiting for recovery point", YELLOW),
-            ReconstructionState::Recovering => ("Recovering", YELLOW),
-            ReconstructionState::Reconstructed => ("Reconstructed locally", CYAN),
-            ReconstructionState::Verified => ("Verified (developer checks)", GREEN),
-            ReconstructionState::Diverged => ("DIVERGED", RED),
+            ReconstructionState::Waiting => ("Waiting for recovery point", AMBER),
+            ReconstructionState::Recovering => ("Recovering", AMBER),
+            ReconstructionState::Reconstructed => ("Reconstructed locally", COPPER),
+            ReconstructionState::Verified => ("Verified (developer checks)", SAGE),
+            ReconstructionState::Diverged => ("DIVERGED", ERROR),
         };
         let tip = if matches!(
             status.twin.state,
@@ -160,17 +161,17 @@ impl View {
             "—".into()
         };
         let (recording, recording_color) = match status.state {
-            RecordingState::Waiting => ("Waiting for robot", YELLOW),
-            RecordingState::Recording => ("Recording", GREEN),
+            RecordingState::Waiting => ("Waiting for robot", AMBER),
+            RecordingState::Recording => ("Recording", SAGE),
             RecordingState::Closed => ("Archive closed", MUTED),
-            RecordingState::Failed => ("RECEIVER ERROR", RED),
+            RecordingState::Failed => ("RECEIVER ERROR", ERROR),
         };
         let view_state = if self.paused {
             "VIEW PAUSED"
         } else {
             "LIVE VIEW"
         };
-        let view_color = if self.paused { YELLOW } else { CYAN };
+        let view_color = if self.paused { AMBER } else { COPPER };
         let [header, body, footer] = Layout::vertical([
             Constraint::Length(1),
             Constraint::Min(0),
@@ -209,17 +210,17 @@ impl View {
         );
         let mut commands = vec![Span::raw(" ")];
         if !compact {
-            commands.extend(badge("1-2", "Tabs", Color::Rgb(86, 114, 98)));
+            commands.extend(badge("1-2", "Tabs", INACTIVE));
         }
         commands.extend(badge(
             "Space",
             if self.paused { "Resume" } else { "Pause" },
-            Color::Rgb(92, 102, 150),
+            INACTIVE,
         ));
         if self.health_tab && !compact {
-            commands.extend(badge("hjkl/↑↓←→", "Scroll", Color::Rgb(92, 102, 150)));
+            commands.extend(badge("hjkl/↑↓←→", "Scroll", INACTIVE));
         }
-        commands.extend(badge("q", "Quit", Color::Rgb(124, 118, 76)));
+        commands.extend(badge("q", "Quit", INACTIVE));
         frame.render_widget(
             Paragraph::new(Line::from(commands)).style(Style::default().bg(BAR)),
             footer,
@@ -240,7 +241,7 @@ impl View {
                 state,
             );
             let lines = self.health_lines(status, overwritten, path);
-            let block = panel("Stream health · recording continues while paused", CYAN);
+            let block = panel("Stream health · recording continues while paused", COPPER);
             let inner = block.inner(details);
             self.health_scroll.0 = self
                 .health_scroll
@@ -273,22 +274,22 @@ impl View {
                     ]),
                     Line::from(
                         [
-                            metric("Shoulder", angle(self.angles.map(|a| a.shoulder)), GREEN),
-                            metric("Elbow", angle(self.angles.map(|a| a.elbow)), GREEN),
+                            metric("Shoulder", angle(self.angles.map(|a| a.shoulder)), SAGE),
+                            metric("Elbow", angle(self.angles.map(|a| a.elbow)), SAGE),
                         ]
                         .concat(),
                     ),
                     Line::from(
                         [
-                            metric("Tip", tip, CYAN),
-                            vec![Span::styled("(local)", Style::default().fg(CYAN))],
+                            metric("Tip", tip, COPPER),
+                            vec![Span::styled("(local)", Style::default().fg(COPPER))],
                         ]
                         .concat(),
                     ),
-                    Line::from(value("Payload NOT transmitted", CYAN)),
+                    Line::from(value("Payload NOT transmitted", COPPER)),
                     Line::from(
                         [
-                            metric("Archived", status.archived, GREEN),
+                            metric("Archived", status.archived, SAGE),
                             metric("Gaps", status.gaps, warning(status.gaps > 0)),
                         ]
                         .concat(),
@@ -314,15 +315,18 @@ impl View {
                 ]),
                 Line::from(
                     [
-                        metric("Shoulder", angle(self.angles.map(|a| a.shoulder)), GREEN),
-                        metric("Elbow", angle(self.angles.map(|a| a.elbow)), GREEN),
-                        metric("Tip", &tip, CYAN),
+                        metric("Shoulder", angle(self.angles.map(|a| a.shoulder)), SAGE),
+                        metric("Elbow", angle(self.angles.map(|a| a.elbow)), SAGE),
+                        metric("Tip", &tip, COPPER),
                     ]
                     .concat(),
                 ),
                 Line::from(vec![
                     value(reconstruction, twin_color),
-                    Span::styled(" · pose payload not transmitted", Style::default().fg(CYAN)),
+                    Span::styled(
+                        " · pose payload not transmitted",
+                        Style::default().fg(COPPER),
+                    ),
                 ]),
                 Line::from(
                     [
@@ -332,7 +336,7 @@ impl View {
                     .concat(),
                 ),
             ])
-            .block(panel("Captured inputs + Copper twin output", CYAN)),
+            .block(panel("Captured inputs + Copper twin output", COPPER)),
             values,
         );
         let [encoder_charts, arm] =
@@ -366,22 +370,22 @@ impl View {
                 Sparkline::default()
                     .data(samples)
                     .max(u64::from(FULL_TURN))
-                    .block(panel(title, GREEN).title_bottom(format!("Angle: {}", angle(reading))))
-                    .style(Style::default().fg(GREEN)),
+                    .block(panel(title, SAGE).title_bottom(format!("Angle: {}", angle(reading))))
+                    .style(Style::default().fg(SAGE)),
                 area,
             );
         }
         self.draw_arm(
             frame,
             arm,
-            if self.paused { YELLOW } else { twin_color },
+            if self.paused { AMBER } else { twin_color },
             &tip,
         );
         frame.render_widget(
             Paragraph::new(vec![
                 Line::from(
                     [
-                        metric("Archived", status.archived, GREEN),
+                        metric("Archived", status.archived, SAGE),
                         metric("Source gaps", status.gaps, warning(status.gaps > 0)),
                         metric(
                             "Replay drops",
@@ -397,7 +401,7 @@ impl View {
                         metric("Last packet", age(status.last_packet), FG),
                         vec![Span::styled(
                             "2: stream details",
-                            Style::default().fg(YELLOW),
+                            Style::default().fg(AMBER),
                         )],
                     ]
                     .concat(),
@@ -430,7 +434,7 @@ impl View {
                     for (index, points) in trail.chunks(chunk_size).enumerate() {
                         ctx.draw(&Points {
                             coords: points,
-                            color: [Color::Rgb(0, 65, 65), Color::Rgb(0, 115, 115), CYAN][index],
+                            color: TRAIL_COLORS[index],
                         });
                     }
                     ctx.layer();
@@ -463,7 +467,7 @@ impl View {
                         y - 0.2,
                         Span::styled(
                             "Task re-executed on ground · pose not transmitted",
-                            Style::default().fg(CYAN),
+                            Style::default().fg(COPPER),
                         ),
                     );
                     if tip == "—" {
@@ -480,29 +484,29 @@ impl View {
 
     fn health_lines(&self, status: Status, overwritten: u64, path: &str) -> Vec<Line<'static>> {
         vec![
-            Line::from(metric("Packets", status.packets, CYAN)),
+            Line::from(metric("Packets", status.packets, COPPER)),
             Line::from(metric("Last packet", age(status.last_packet), FG)),
-            Line::from(metric("Archived", status.archived, GREEN)),
-            Line::from(metric("Latest CL", number(status.latest), GREEN)),
+            Line::from(metric("Archived", status.archived, SAGE)),
+            Line::from(metric("Latest CL", number(status.latest), SAGE)),
             Line::from(metric(
                 "Verified recovery point",
                 number(status.recovery_point),
-                CYAN,
+                COPPER,
             )),
             Line::from(metric("Source gaps", status.gaps, warning(status.gaps > 0))),
             Line::from(metric(
                 "Reconstructed frames",
                 status.twin.reconstructed,
-                CYAN,
+                COPPER,
             )),
-            Line::from(metric("Verified frames", status.twin.verified, GREEN)),
+            Line::from(metric("Verified frames", status.twin.verified, SAGE)),
             Line::from(metric(
                 "Divergences",
                 status.twin.divergences,
                 if status.twin.divergences > 0 {
-                    RED
+                    ERROR
                 } else {
-                    GREEN
+                    SAGE
                 },
             )),
             Line::from(metric(
@@ -553,7 +557,7 @@ fn metric(label: &str, data: impl ToString, color: Color) -> Vec<Span<'static>> 
 }
 
 fn warning(present: bool) -> Color {
-    if present { YELLOW } else { GREEN }
+    if present { AMBER } else { SAGE }
 }
 
 fn badge(key: &str, label: &str, bg: Color) -> Vec<Span<'static>> {
@@ -562,7 +566,7 @@ fn badge(key: &str, label: &str, bg: Color) -> Vec<Span<'static>> {
         Span::styled(
             format!(" {key} "),
             Style::default()
-                .fg(YELLOW)
+                .fg(AMBER)
                 .bg(bg)
                 .add_modifier(Modifier::BOLD),
         ),
@@ -738,8 +742,8 @@ mod tests {
             .draw(|frame| view.draw(frame, status, 0, "logs/test.copper"))
             .unwrap();
         let buffer = terminal.backend().buffer();
-        assert_eq!(buffer[(0, 1)].fg, RED);
-        assert_eq!(buffer[(0, 2)].fg, RED);
+        assert_eq!(buffer[(0, 1)].fg, ERROR);
+        assert_eq!(buffer[(0, 2)].fg, ERROR);
         assert_eq!(buffer[(49, 5)].bg, BG);
         for _ in 0..20 {
             view.key(KeyCode::Down);

--- a/examples/cu_logstream_demo/src/dashboard.rs
+++ b/examples/cu_logstream_demo/src/dashboard.rs
@@ -3,14 +3,19 @@ use crate::{
     Result,
     receiver::{self, ReceiverOptions},
 };
+use cu_logstream_demo::tasks::{ArmPose, FULL_TURN, JointAngles};
 use cu_logstream_demo::telemetry::{Frame, RecordingState, Status};
 use cu29_logstream::telemetry::TelemetryReader;
 use ratatui::{
     crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
-    layout::{Constraint, Layout},
+    layout::{Constraint, Layout, Rect},
     style::{Color, Modifier, Style},
+    symbols::Marker,
     text::{Line, Span},
-    widgets::{Block, BorderType, Paragraph, Sparkline},
+    widgets::{
+        Block, BorderType, Paragraph, Sparkline,
+        canvas::{Canvas, Circle, Line as CanvasLine, Points},
+    },
 };
 use std::{
     collections::VecDeque,
@@ -20,6 +25,7 @@ use std::{
 
 const BUFFER_CAPACITY: usize = 64;
 const CHART_CAPACITY: usize = 120;
+const TRAIL_CAPACITY: usize = 1200; // One 12-second loop at 100 Hz, UI storage only.
 const UI_TICK: Duration = Duration::from_millis(50);
 
 // Match cu_tuimon's explicit RGB palette and tab/command chrome.
@@ -39,15 +45,14 @@ struct View {
     paused: bool,
     health_tab: bool,
     health_scroll: (u16, u16),
-    counter: Option<u64>,
-    sum: Option<u64>,
-    derived: Option<u64>,
+    angles: Option<JointAngles>,
+    pose: Option<ArmPose>,
     displayed: Option<u64>,
     missed: u64,
     frame_age: Option<Instant>,
     session: Option<cu29_logstream::StreamIdentity>,
-    history: VecDeque<u64>,
-    derived_history: VecDeque<u64>,
+    history: VecDeque<JointAngles>,
+    trail: VecDeque<[f64; 2]>,
 }
 
 impl View {
@@ -62,44 +67,44 @@ impl View {
             };
             let frame = update.frame;
             self.missed += update.missed;
-            if self.session != Some(frame.identity) {
-                self.history.clear();
-                self.derived_history.clear();
-                self.session = Some(frame.identity);
+            self.accept(frame);
+        }
+    }
+
+    fn accept(&mut self, frame: &Frame) {
+        if self.session != Some(frame.identity) {
+            self.history.clear();
+            self.trail.clear();
+            self.session = Some(frame.identity);
+        } else if self.displayed.and_then(|id| id.checked_add(1)) != Some(frame.copperlist.id) {
+            // Never draw an invented trajectory across dropped/missed frames.
+            self.trail.clear();
+        }
+        self.displayed = Some(frame.copperlist.id);
+        self.frame_age = Some(frame.received_at);
+        self.angles = frame
+            .copperlist
+            .msgs
+            .get_encoders_output()
+            .payload()
+            .copied();
+        self.pose = frame
+            .copperlist
+            .msgs
+            .get_kinematics_output()
+            .payload()
+            .copied();
+        if let Some(angles) = self.angles {
+            if self.history.len() == CHART_CAPACITY {
+                self.history.pop_front();
             }
-            self.displayed = Some(frame.copperlist.id);
-            self.frame_age = Some(frame.received_at);
-            self.counter = frame
-                .copperlist
-                .msgs
-                .get_counter_output()
-                .payload()
-                .map(|sample| sample.0);
-            self.sum = frame
-                .copperlist
-                .msgs
-                .get_sum_output()
-                .payload()
-                .map(|sample| sample.0);
-            self.derived = frame
-                .copperlist
-                .msgs
-                .get_derived_output()
-                .payload()
-                .map(|sample| sample.0);
-            // This history policy belongs to this widget, not the backend.
-            if let Some(counter) = self.counter {
-                if self.history.len() == CHART_CAPACITY {
-                    self.history.pop_front();
-                }
-                self.history.push_back(counter);
+            self.history.push_back(angles);
+        }
+        if let Some(pose) = self.pose {
+            if self.trail.len() == TRAIL_CAPACITY {
+                self.trail.pop_front();
             }
-            if let Some(derived) = self.derived {
-                if self.derived_history.len() == CHART_CAPACITY {
-                    self.derived_history.pop_front();
-                }
-                self.derived_history.push_back(derived);
-            }
+            self.trail.push_back(pose.tip);
         }
     }
 
@@ -146,11 +151,11 @@ impl View {
             ReconstructionState::Verified => ("Verified (developer checks)", GREEN),
             ReconstructionState::Diverged => ("DIVERGED", RED),
         };
-        let derived = if matches!(
+        let tip = if matches!(
             status.twin.state,
             ReconstructionState::Reconstructed | ReconstructionState::Verified
         ) {
-            number(self.derived)
+            position(self.pose.map(|pose| pose.tip))
         } else {
             "—".into()
         };
@@ -268,14 +273,14 @@ impl View {
                     ]),
                     Line::from(
                         [
-                            metric("Counter", number(self.counter), GREEN),
-                            metric("Sum", number(self.sum), GREEN),
+                            metric("Shoulder", angle(self.angles.map(|a| a.shoulder)), GREEN),
+                            metric("Elbow", angle(self.angles.map(|a| a.elbow)), GREEN),
                         ]
                         .concat(),
                     ),
                     Line::from(
                         [
-                            metric("Modulo", derived, CYAN),
+                            metric("Tip", tip, CYAN),
                             vec![Span::styled("(local)", Style::default().fg(CYAN))],
                         ]
                         .concat(),
@@ -309,15 +314,15 @@ impl View {
                 ]),
                 Line::from(
                     [
-                        metric("Counter", number(self.counter), GREEN),
-                        metric("Sum", number(self.sum), GREEN),
-                        metric("Modulo", &derived, CYAN),
+                        metric("Shoulder", angle(self.angles.map(|a| a.shoulder)), GREEN),
+                        metric("Elbow", angle(self.angles.map(|a| a.elbow)), GREEN),
+                        metric("Tip", &tip, CYAN),
                     ]
                     .concat(),
                 ),
                 Line::from(vec![
                     value(reconstruction, twin_color),
-                    Span::styled(" · payload not transmitted", Style::default().fg(CYAN)),
+                    Span::styled(" · pose payload not transmitted", Style::default().fg(CYAN)),
                 ]),
                 Line::from(
                     [
@@ -330,51 +335,47 @@ impl View {
             .block(panel("Captured inputs + Copper twin output", CYAN)),
             values,
         );
-        let [counter_chart, derived_chart] =
-            Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
+        let [encoder_charts, arm] =
+            Layout::horizontal([Constraint::Percentage(40), Constraint::Percentage(60)])
                 .areas(charts);
-        // Show the newest samples when the terminal is narrower than the history.
-        let history: Vec<_> = self
-            .history
-            .iter()
-            .skip(
-                self.history
-                    .len()
-                    .saturating_sub(counter_chart.width.saturating_sub(2) as usize),
-            )
-            .copied()
-            .collect();
-        let derived_history: Vec<_> = self
-            .derived_history
-            .iter()
-            .skip(
-                self.derived_history
-                    .len()
-                    .saturating_sub(derived_chart.width.saturating_sub(2) as usize),
-            )
-            .copied()
-            .collect();
-        frame.render_widget(
-            Sparkline::default()
-                .data(&history)
-                .block(
-                    panel("Counter · received", GREEN)
-                        .title_bottom(format!("Value: {}", number(self.counter))),
-                )
-                .style(Style::default().fg(GREEN)),
-            counter_chart,
+        let [shoulder_chart, elbow_chart] =
+            Layout::vertical([Constraint::Percentage(50), Constraint::Percentage(50)])
+                .areas(encoder_charts);
+        let visible = self.history.iter().skip(
+            self.history
+                .len()
+                .saturating_sub(encoder_charts.width.saturating_sub(2) as usize),
         );
-        let chart_color = if self.paused { YELLOW } else { twin_color };
-        frame.render_widget(
-            Sparkline::default()
-                .data(&derived_history)
-                .max(255)
-                .block(
-                    panel("Modulo · reconstructed locally", chart_color)
-                        .title_bottom(format!("Value: {derived} (sum % 256)")),
-                )
-                .style(Style::default().fg(chart_color)),
-            derived_chart,
+        let shoulder: Vec<_> = visible.clone().map(|a| u64::from(a.shoulder)).collect();
+        let elbow: Vec<_> = visible.map(|a| u64::from(a.elbow)).collect();
+        for (area, title, samples, reading) in [
+            (
+                shoulder_chart,
+                "Shoulder · received",
+                &shoulder,
+                self.angles.map(|a| a.shoulder),
+            ),
+            (
+                elbow_chart,
+                "Elbow · received",
+                &elbow,
+                self.angles.map(|a| a.elbow),
+            ),
+        ] {
+            frame.render_widget(
+                Sparkline::default()
+                    .data(samples)
+                    .max(u64::from(FULL_TURN))
+                    .block(panel(title, GREEN).title_bottom(format!("Angle: {}", angle(reading))))
+                    .style(Style::default().fg(GREEN)),
+                area,
+            );
+        }
+        self.draw_arm(
+            frame,
+            arm,
+            if self.paused { YELLOW } else { twin_color },
+            &tip,
         );
         frame.render_widget(
             Paragraph::new(vec![
@@ -404,6 +405,73 @@ impl View {
             ])
             .block(panel("Recording health", MUTED)),
             health,
+        );
+    }
+
+    fn draw_arm(&self, frame: &mut ratatui::Frame<'_>, area: Rect, color: Color, tip: &str) {
+        let block = panel("Robot arm · reconstructed locally", color)
+            .title_bottom(format!("Tip: {tip} · meters"));
+        let inner = block.inner(area);
+        // Terminal cells are approximately twice as tall as they are wide.
+        let aspect = f64::from(inner.width.max(1)) / (2.0 * f64::from(inner.height.max(1)));
+        let x = 1.85 * aspect.max(1.0);
+        let y = 1.85 / aspect.min(1.0);
+        let trail: Vec<_> = self.trail.iter().map(|p| (p[0], p[1])).collect();
+        frame.render_widget(
+            Canvas::default()
+                .block(block)
+                .background_color(BG)
+                .marker(Marker::Braille)
+                .x_bounds([-x, x])
+                .y_bounds([-y, y])
+                .paint(|ctx| {
+                    // Fade old recorded points. No interpolation or forward kinematics in the UI.
+                    let chunk_size = trail.len().div_ceil(3).max(1);
+                    for (index, points) in trail.chunks(chunk_size).enumerate() {
+                        ctx.draw(&Points {
+                            coords: points,
+                            color: [Color::Rgb(0, 65, 65), Color::Rgb(0, 115, 115), CYAN][index],
+                        });
+                    }
+                    ctx.layer();
+                    if let Some(pose) = self.pose {
+                        ctx.draw(&CanvasLine {
+                            x1: 0.0,
+                            y1: 0.0,
+                            x2: pose.elbow[0],
+                            y2: pose.elbow[1],
+                            color,
+                        });
+                        ctx.draw(&CanvasLine {
+                            x1: pose.elbow[0],
+                            y1: pose.elbow[1],
+                            x2: pose.tip[0],
+                            y2: pose.tip[1],
+                            color,
+                        });
+                        for point in [[0.0, 0.0], pose.elbow, pose.tip] {
+                            ctx.draw(&Circle {
+                                x: point[0],
+                                y: point[1],
+                                radius: 0.04,
+                                color: FG,
+                            });
+                        }
+                    }
+                    ctx.print(
+                        -x + 0.1,
+                        y - 0.2,
+                        Span::styled("Only joint angles transmitted", Style::default().fg(CYAN)),
+                    );
+                    if tip == "—" {
+                        ctx.print(
+                            -x + 0.1,
+                            -y + 0.2,
+                            Span::styled("Waiting · last pose held", Style::default().fg(color)),
+                        );
+                    }
+                }),
+            area,
         );
     }
 
@@ -501,6 +569,13 @@ fn badge(key: &str, label: &str, bg: Color) -> Vec<Span<'static>> {
     ]
 }
 
+fn angle(value: Option<u16>) -> String {
+    value.map_or_else(|| "—".into(), |v| format!("{:.1}°", f64::from(v) / 100.0))
+}
+fn position(value: Option<[f64; 2]>) -> String {
+    value.map_or_else(|| "—".into(), |p| format!("({:+.2}, {:+.2})", p[0], p[1]))
+}
+
 fn number(value: Option<u64>) -> String {
     value.map_or_else(|| "—".into(), |v| v.to_string())
 }
@@ -521,7 +596,7 @@ pub fn run(options: ReceiverOptions) -> Result<()> {
     let ui_result: std::io::Result<()> = ratatui::run(|terminal| {
         let mut view = View {
             history: VecDeque::with_capacity(CHART_CAPACITY),
-            derived_history: VecDeque::with_capacity(CHART_CAPACITY),
+            trail: VecDeque::with_capacity(TRAIL_CAPACITY),
             ..Default::default()
         };
         let mut redraw = Instant::now();
@@ -573,10 +648,54 @@ mod tests {
     use ratatui::{Terminal, backend::TestBackend};
 
     #[test]
+    fn trail_uses_received_poses_and_breaks_at_gaps_and_new_sessions() {
+        let mut frame = Frame {
+            identity: cu29_logstream::StreamIdentity {
+                session_id: [1; 16],
+                sender_id: 41,
+            },
+            received_at: Instant::now(),
+            copperlist: cu_logstream_demo::List::default(),
+        };
+        // Deliberately unrelated angles/positions: the UI must draw the task output.
+        frame
+            .copperlist
+            .msgs
+            .0
+            .0
+            .set_payload(JointAngles::default());
+        frame.copperlist.msgs.0.1.set_payload(ArmPose {
+            elbow: [0.0, 1.0],
+            tip: [0.5, 1.0],
+        });
+        let mut view = View::default();
+        view.accept(&frame);
+        frame.copperlist.id = 1;
+        view.accept(&frame);
+        assert_eq!(view.trail, [[0.5, 1.0]; 2]);
+        frame.copperlist.id = 3;
+        view.accept(&frame);
+        assert_eq!(view.trail.len(), 1);
+        frame.identity.session_id = [2; 16];
+        view.accept(&frame);
+        assert_eq!(view.trail.len(), 1);
+        assert_eq!(view.history.len(), 1);
+        for id in 4..1300 {
+            frame.copperlist.id = id;
+            view.accept(&frame);
+        }
+        assert_eq!(view.trail.len(), TRAIL_CAPACITY);
+        assert_eq!(view.history.len(), CHART_CAPACITY);
+    }
+
+    #[test]
     fn tabs_scroll_and_pause_preserve_the_live_view() {
         let mut view = View {
-            derived: Some(42),
-            derived_history: VecDeque::from([1, 42]),
+            pose: Some(ArmPose {
+                elbow: [1.0, 0.0],
+                tip: [1.65, 0.0],
+            }),
+            trail: VecDeque::from([[1.65, 0.0]]),
             ..Default::default()
         };
         assert!(!view.key(KeyCode::Char('2')));
@@ -591,8 +710,8 @@ mod tests {
         assert_eq!(view.health_scroll, (0, 0));
         view.key(KeyCode::Tab);
         assert!(!view.health_tab);
-        assert_eq!(view.derived, Some(42));
-        assert_eq!(view.derived_history, [1, 42]);
+        assert_eq!(view.pose.unwrap().tip, [1.65, 0.0]);
+        assert_eq!(view.trail, [[1.65, 0.0]]);
         view.key(KeyCode::BackTab);
         view.key(KeyCode::Char('1'));
         assert!(!view.health_tab);
@@ -637,11 +756,14 @@ mod tests {
     }
 
     #[test]
-    fn reconstructed_modulo_is_graphed_on_the_right() {
+    fn reconstructed_arm_is_drawn_on_the_right() {
         let mut terminal = Terminal::new(TestBackend::new(100, 26)).unwrap();
         let mut view = View {
-            derived: Some(255),
-            derived_history: VecDeque::from([0, 64, 128, 255]),
+            pose: Some(ArmPose {
+                elbow: [1.0, 0.0],
+                tip: [1.0, 0.65],
+            }),
+            trail: VecDeque::from([[1.1, 0.5], [1.0, 0.65]]),
             ..Default::default()
         };
         let mut status = Status {
@@ -654,16 +776,21 @@ mod tests {
             .unwrap();
         let buffer = terminal.backend().buffer();
         let right: String = (7..21)
-            .flat_map(|y| (50..100).map(move |x| buffer[(x, y)].symbol()))
+            .flat_map(|y| (40..100).map(move |x| buffer[(x, y)].symbol()))
             .collect();
-        assert!(right.contains("Modulo · reconstructed locally"));
-        assert!(right.contains("Value: 255 (sum % 256)"));
+        assert!(right.contains("Robot arm · reconstructed locally"));
+        assert!(right.contains("Tip: (+1.00, +0.65)"));
         let left: String = (7..21)
-            .flat_map(|y| (0..50).map(move |x| buffer[(x, y)].symbol()))
+            .flat_map(|y| (0..40).map(move |x| buffer[(x, y)].symbol()))
             .collect();
-        assert!(left.contains("Counter · received"));
-        assert!(left.contains("Value: —"));
-        assert!(right.contains('█'));
+        assert!(left.contains("Shoulder · received"));
+        assert!(left.contains("Angle: —"));
+        assert!(
+            right
+                .chars()
+                .any(|c| ('\u{2801}'..='\u{28ff}').contains(&c))
+        );
+        assert!(right.contains("Only joint angles transmitted"));
     }
 
     #[test]

--- a/examples/cu_logstream_demo/src/dashboard.rs
+++ b/examples/cu_logstream_demo/src/dashboard.rs
@@ -34,6 +34,9 @@ const BG: Color = Color::Reset; // Preserve the terminal's black/transparent bac
 const FG: Color = Color::Rgb(205, 214, 244); // Text
 const MUTED: Color = Color::Rgb(147, 153, 178); // Overlay 2
 const GREEN: Color = Color::Rgb(166, 227, 161);
+const BLUE: Color = Color::Rgb(137, 180, 250);
+const SUBTEXT: Color = Color::Rgb(186, 194, 222); // Subtext 1
+const ALERT_TEXT: Color = Color::Rgb(17, 17, 27); // Crust
 const MAUVE: Color = Color::Rgb(203, 166, 247);
 const YELLOW: Color = Color::Rgb(249, 226, 175);
 const RED: Color = Color::Rgb(243, 139, 168);
@@ -153,6 +156,14 @@ impl View {
             ReconstructionState::Verified => ("Verified (developer checks)", GREEN),
             ReconstructionState::Diverged => ("DIVERGED", RED),
         };
+        let reconstruction_color = if matches!(
+            status.twin.state,
+            ReconstructionState::Reconstructed | ReconstructionState::Verified
+        ) {
+            GREEN
+        } else {
+            twin_color
+        };
         let tip = if matches!(
             status.twin.state,
             ReconstructionState::Reconstructed | ReconstructionState::Verified
@@ -172,7 +183,7 @@ impl View {
         } else {
             "LIVE VIEW"
         };
-        let view_color = if self.paused { YELLOW } else { MAUVE };
+        let view_color = if self.paused { YELLOW } else { GREEN };
         let [header, body, footer] = Layout::vertical([
             Constraint::Length(1),
             Constraint::Min(0),
@@ -237,12 +248,12 @@ impl View {
                         Span::raw("  |  "),
                         value(view_state, view_color),
                     ]),
-                    Line::from(value(reconstruction, twin_color)),
+                    Line::from(value(reconstruction, reconstruction_color)),
                 ]),
                 state,
             );
             let lines = self.health_lines(status, overwritten, path);
-            let block = panel("Stream health · recording continues while paused", MAUVE);
+            let block = panel("Stream health · recording continues while paused", BLUE);
             let inner = block.inner(details);
             self.health_scroll.0 = self
                 .health_scroll
@@ -283,11 +294,11 @@ impl View {
                     Line::from(
                         [
                             metric("Tip", tip, MAUVE),
-                            vec![Span::styled("(local)", Style::default().fg(MAUVE))],
+                            vec![Span::styled("(local)", Style::default().fg(SUBTEXT))],
                         ]
                         .concat(),
                     ),
-                    Line::from(value("Payload NOT transmitted", MAUVE)),
+                    Line::from(value("Payload NOT transmitted", SUBTEXT)),
                     Line::from(
                         [
                             metric("Archived", status.archived, GREEN),
@@ -295,7 +306,7 @@ impl View {
                         ]
                         .concat(),
                     ),
-                    Line::from(value(reconstruction, twin_color)),
+                    Line::from(value(reconstruction, reconstruction_color)),
                 ]),
                 body,
             );
@@ -323,21 +334,21 @@ impl View {
                     .concat(),
                 ),
                 Line::from(vec![
-                    value(reconstruction, twin_color),
+                    value(reconstruction, reconstruction_color),
                     Span::styled(
                         " · pose payload not transmitted",
-                        Style::default().fg(MAUVE),
+                        Style::default().fg(SUBTEXT),
                     ),
                 ]),
                 Line::from(
                     [
                         metric("Displayed CL", number(self.displayed), FG),
-                        metric("Frame age", age(self.frame_age), FG),
+                        age_metric("Frame age", self.frame_age.map(|at| at.elapsed())),
                     ]
                     .concat(),
                 ),
             ])
-            .block(panel("Captured inputs + Copper twin output", MAUVE)),
+            .block(panel("Captured inputs + Copper twin output", BLUE)),
             values,
         );
         let [encoder_charts, arm] =
@@ -399,7 +410,7 @@ impl View {
                 Line::from(
                     [
                         metric("UI missed", self.missed, warning(self.missed > 0)),
-                        metric("Last packet", age(status.last_packet), FG),
+                        age_metric("Last packet", status.last_packet.map(|at| at.elapsed())),
                         vec![Span::styled(
                             "2: stream details",
                             Style::default().fg(YELLOW),
@@ -468,7 +479,7 @@ impl View {
                         y - 0.2,
                         Span::styled(
                             "Task re-executed on ground · pose not transmitted",
-                            Style::default().fg(MAUVE),
+                            Style::default().fg(SUBTEXT),
                         ),
                     );
                     if tip == "—" {
@@ -485,14 +496,17 @@ impl View {
 
     fn health_lines(&self, status: Status, overwritten: u64, path: &str) -> Vec<Line<'static>> {
         vec![
-            Line::from(metric("Packets", status.packets, MAUVE)),
-            Line::from(metric("Last packet", age(status.last_packet), FG)),
+            Line::from(metric("Packets", status.packets, BLUE)),
+            Line::from(age_metric(
+                "Last packet",
+                status.last_packet.map(|at| at.elapsed()),
+            )),
             Line::from(metric("Archived", status.archived, GREEN)),
             Line::from(metric("Latest CL", number(status.latest), GREEN)),
             Line::from(metric(
                 "Verified recovery point",
                 number(status.recovery_point),
-                MAUVE,
+                BLUE,
             )),
             Line::from(metric("Source gaps", status.gaps, warning(status.gaps > 0))),
             Line::from(metric(
@@ -587,11 +601,29 @@ fn position(value: Option<[f64; 2]>) -> String {
 fn number(value: Option<u64>) -> String {
     value.map_or_else(|| "—".into(), |v| v.to_string())
 }
-fn age(value: Option<Instant>) -> String {
-    value.map_or_else(
+/// Highlight as soon as the displayed age advances beyond 0.0s.
+fn age_metric(label: &str, age: Option<Duration>) -> Vec<Span<'static>> {
+    let tenths = age.map(|age| age.as_millis() / 100);
+    let stale = tenths.is_some_and(|age| age > 0);
+    let text = tenths.map_or_else(
         || "—".into(),
-        |v| format!("{:.1}s", v.elapsed().as_secs_f32()),
-    )
+        |age| format!("{}.{:01}s", age / 10, age % 10),
+    );
+    let label_style = if stale {
+        Style::default().fg(ALERT_TEXT).bg(RED)
+    } else {
+        Style::default().fg(FG)
+    };
+    let value_style = if stale {
+        label_style
+    } else {
+        Style::default().fg(if age.is_some() { BLUE } else { MUTED })
+    };
+    vec![
+        Span::styled(format!("{label}: "), label_style),
+        Span::styled(text, value_style.add_modifier(Modifier::BOLD)),
+        Span::raw("   "),
+    ]
 }
 
 pub fn run(options: ReceiverOptions) -> Result<()> {
@@ -654,6 +686,29 @@ pub fn run(options: ReceiverOptions) -> Result<()> {
 mod tests {
     use super::*;
     use ratatui::{Terminal, backend::TestBackend};
+
+    #[test]
+    fn ages_highlight_at_first_visible_increase_and_clear_on_fresh_data() {
+        for label in ["Last packet", "Frame age"] {
+            for (age, expected, highlighted) in [
+                (None, "—", false),
+                (Some(Duration::ZERO), "0.0s", false),
+                (Some(Duration::from_millis(99)), "0.0s", false),
+                (Some(Duration::from_millis(100)), "0.1s", true),
+                (Some(Duration::from_millis(1234)), "1.2s", true),
+                (Some(Duration::from_millis(5)), "0.0s", false),
+            ] {
+                let spans = age_metric(label, age);
+                assert_eq!(spans[1].content, expected);
+                for span in &spans[..2] {
+                    assert_eq!(span.style.bg, highlighted.then_some(RED));
+                    if highlighted {
+                        assert_eq!(span.style.fg, Some(ALERT_TEXT));
+                    }
+                }
+            }
+        }
+    }
 
     #[test]
     fn trail_uses_received_poses_and_breaks_at_gaps_and_new_sessions() {

--- a/examples/cu_logstream_demo/src/dashboard.rs
+++ b/examples/cu_logstream_demo/src/dashboard.rs
@@ -409,8 +409,8 @@ impl View {
     }
 
     fn draw_arm(&self, frame: &mut ratatui::Frame<'_>, area: Rect, color: Color, tip: &str) {
-        let block = panel("Robot arm · reconstructed locally", color)
-            .title_bottom(format!("Tip: {tip} · meters"));
+        let block =
+            panel("Kinematics → output pose", color).title_bottom(format!("Tip: {tip} · meters"));
         let inner = block.inner(area);
         // Terminal cells are approximately twice as tall as they are wide.
         let aspect = f64::from(inner.width.max(1)) / (2.0 * f64::from(inner.height.max(1)));
@@ -461,7 +461,10 @@ impl View {
                     ctx.print(
                         -x + 0.1,
                         y - 0.2,
-                        Span::styled("Only joint angles transmitted", Style::default().fg(CYAN)),
+                        Span::styled(
+                            "Task re-executed on ground · pose not transmitted",
+                            Style::default().fg(CYAN),
+                        ),
                     );
                     if tip == "—" {
                         ctx.print(
@@ -778,7 +781,7 @@ mod tests {
         let right: String = (7..21)
             .flat_map(|y| (40..100).map(move |x| buffer[(x, y)].symbol()))
             .collect();
-        assert!(right.contains("Robot arm · reconstructed locally"));
+        assert!(right.contains("Kinematics → output pose"));
         assert!(right.contains("Tip: (+1.00, +0.65)"));
         let left: String = (7..21)
             .flat_map(|y| (0..40).map(move |x| buffer[(x, y)].symbol()))
@@ -790,7 +793,7 @@ mod tests {
                 .chars()
                 .any(|c| ('\u{2801}'..='\u{28ff}').contains(&c))
         );
-        assert!(right.contains("Only joint angles transmitted"));
+        assert!(right.contains("Task re-executed on ground · pose not transmitted"));
     }
 
     #[test]

--- a/examples/cu_logstream_demo/src/main.rs
+++ b/examples/cu_logstream_demo/src/main.rs
@@ -3,7 +3,7 @@ mod dashboard;
 mod receiver;
 
 use clap::{Parser, Subcommand, ValueEnum};
-use cu_logstream_demo::{ITERATIONS, read_lists, tasks::Sample};
+use cu_logstream_demo::{ITERATIONS, read_lists, tasks::JointAngles};
 use cu29::bincode;
 use cu29::continuity::{SourceGapReason, StreamContinuityRecord};
 use cu29::prelude::*;
@@ -16,7 +16,7 @@ use std::{
 type Result<T> = std::result::Result<T, Box<dyn Error>>;
 
 #[derive(Parser)]
-#[command(about = "Stream a deterministic counter → accumulator graph over UDP")]
+#[command(about = "Stream joint encoders and reconstruct a robot arm over UDP")]
 struct Cli {
     #[command(subcommand)]
     command: Command,
@@ -93,8 +93,7 @@ fn verify(sender: &Path, received: &Path, expect: Expectation, iterations: u64) 
     }
     for (id, list) in onboard.iter().enumerate() {
         if list.id != id as u64
-            || list.msgs.get_counter_output().payload() != Some(&Sample(list.id))
-            || list.msgs.get_sum_output().payload() != Some(&Sample(list.id * (list.id + 1) / 2))
+            || list.msgs.get_encoders_output().payload() != Some(&JointAngles::at_tick(list.id))
         {
             return Err(format!("Unexpected deterministic graph output at {id}").into());
         }
@@ -142,21 +141,18 @@ fn verify(sender: &Path, received: &Path, expect: Expectation, iterations: u64) 
             return Err("Archive marks a received record as missing".into());
         }
         let expected = &onboard[list.id as usize];
-        if list.msgs.get_derived_output().payload().is_some() {
-            return Err("Derived payload was transmitted".into());
+        if list.msgs.get_kinematics_output().payload().is_some() {
+            return Err("Arm pose payload was transmitted".into());
         }
-        for (actual, expected) in [
-            (
-                list.msgs.get_counter_output(),
-                expected.msgs.get_counter_output(),
-            ),
-            (list.msgs.get_sum_output(), expected.msgs.get_sum_output()),
-        ] {
-            if bincode::encode_to_vec(actual, bincode::config::standard())?
-                != bincode::encode_to_vec(expected, bincode::config::standard())?
-            {
-                return Err(format!("Captured input or metadata mismatch at {}", list.id).into());
-            }
+        if bincode::encode_to_vec(list.msgs.get_encoders_output(), bincode::config::standard())?
+            != bincode::encode_to_vec(
+                expected.msgs.get_encoders_output(),
+                bincode::config::standard(),
+            )?
+        {
+            return Err(
+                format!("Captured encoder input or metadata mismatch at {}", list.id).into(),
+            );
         }
         next = list.id + 1;
     }

--- a/examples/cu_logstream_demo/src/receiver.rs
+++ b/examples/cu_logstream_demo/src/receiver.rs
@@ -196,8 +196,8 @@ pub fn run(options: &ReceiverOptions) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cu_logstream_demo::run_sender;
     use cu_logstream_demo::telemetry::RecordingState;
-    use cu_logstream_demo::{ITERATIONS, run_sender};
 
     #[test]
     fn native_archive_is_identical_with_fast_stalled_or_disconnected_reader() {
@@ -235,8 +235,11 @@ mod tests {
                         while let Some(update) = reader.try_read() {
                             let list = &update.frame.copperlist;
                             assert_eq!(
-                                list.msgs.get_derived_output().payload().unwrap().0,
-                                list.msgs.get_sum_output().payload().unwrap().0 % ITERATIONS
+                                *list.msgs.get_kinematics_output().payload().unwrap(),
+                                cu_logstream_demo::tasks::forward_kinematics(
+                                    *list.msgs.get_encoders_output().payload().unwrap()
+                                )
+                                .unwrap()
                             );
                         }
                         std::thread::sleep(Duration::from_millis(1));

--- a/examples/cu_logstream_demo/src/resim.rs
+++ b/examples/cu_logstream_demo/src/resim.rs
@@ -46,7 +46,7 @@ fn main() -> CuResult<()> {
     if let Some(debug_base) = cli.debug_base {
         if cu_logstream_demo::read_lists(&cli.log_base)?
             .iter()
-            .any(|list| list.msgs.get_derived_output().payload().is_none())
+            .any(|list| list.msgs.get_kinematics_output().payload().is_none())
         {
             return Err(
                 "Run just resim first, then use resim-debug on the reconstructed full log".into(),

--- a/examples/cu_logstream_demo/src/tasks.rs
+++ b/examples/cu_logstream_demo/src/tasks.rs
@@ -1,3 +1,4 @@
+use cu_transform::{FrameId, TypedTransform3D};
 use cu29::bincode::{
     Decode, Encode,
     de::Decoder,
@@ -5,96 +6,141 @@ use cu29::bincode::{
     error::{DecodeError, EncodeError},
 };
 use cu29::prelude::*;
+use cu29::units::si::f64::{Angle, Length};
 use serde::{Deserialize, Serialize};
 
+pub const FULL_TURN: u16 = 36_000;
+const STEP: u64 = 30; // Hundredths of a degree per 10 ms tick: one turn in 12 seconds.
+pub const UPPER_ARM_M: f64 = 1.0;
+pub const FOREARM_M: f64 = 0.65;
+
+/// Encoder readings in hundredths of a degree; elbow is relative to the upper arm.
 #[derive(
     Clone, Copy, Debug, Default, PartialEq, Eq, Encode, Decode, Serialize, Deserialize, Reflect,
 )]
 #[bincode(crate = "cu29::bincode")]
-pub struct Sample(pub u64);
-
-#[derive(Default, Reflect)]
-pub struct Counter {
-    next: u64,
+pub struct JointAngles {
+    pub shoulder: u16,
+    pub elbow: u16,
 }
 
-impl Freezable for Counter {
+impl JointAngles {
+    pub fn at_tick(tick: u64) -> Self {
+        let shoulder = ((tick % (u64::from(FULL_TURN) / STEP)) * STEP) as u16;
+        let elbow = ((u32::from(FULL_TURN) - (u32::from(shoulder) * 4) % u32::from(FULL_TURN))
+            % u32::from(FULL_TURN)) as u16;
+        Self { shoulder, elbow }
+    }
+}
+
+/// Positions in the base frame, in meters. This payload never crosses the link.
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Encode, Decode, Serialize, Deserialize, Reflect,
+)]
+#[bincode(crate = "cu29::bincode")]
+pub struct ArmPose {
+    pub elbow: [f64; 2],
+    pub tip: [f64; 2],
+}
+
+#[derive(Default, Reflect)]
+pub struct Encoders {
+    tick: u64,
+}
+impl Freezable for Encoders {
     fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        Encode::encode(&self.next, encoder)
+        Encode::encode(&self.tick, encoder)
     }
     fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
-        self.next = Decode::decode(decoder)?;
+        self.tick = Decode::decode(decoder)?;
         Ok(())
     }
 }
-
-impl CuSrcTask for Counter {
+impl CuSrcTask for Encoders {
     type Resources<'r> = ();
-    type Output<'m> = output_msg!(Sample);
+    type Output<'m> = output_msg!(JointAngles);
     fn new(_: Option<&ComponentConfig>, _: ()) -> CuResult<Self> {
         Ok(Self::default())
     }
     fn process(&mut self, ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
-        output.set_payload(Sample(self.next));
+        output.set_payload(JointAngles::at_tick(self.tick));
         output.tov = Tov::Time(ctx.now());
-        self.next += 1;
+        self.tick = self.tick.wrapping_add(1);
         Ok(())
     }
 }
 
+macro_rules! frame {
+    ($name:ident, $id:expr) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        struct $name;
+        impl FrameId for $name {
+            const ID: u32 = $id;
+            const NAME: &'static str = stringify!($name);
+        }
+    };
+}
+frame!(Base, 0);
+frame!(Shoulder, 1);
+frame!(Elbow, 2);
+frame!(Forearm, 3);
+frame!(Tip, 4);
+
+const ZERO_LENGTH: Length = Length { value: 0.0 };
+const ZERO_ANGLE: Angle = Angle { value: 0.0 };
+const UPPER_ARM: TypedTransform3D<f64, Shoulder, Elbow> =
+    TypedTransform3D::<f64, Shoulder, Elbow>::from_translation_euler_xyz(
+        [Length { value: UPPER_ARM_M }, ZERO_LENGTH, ZERO_LENGTH],
+        [ZERO_ANGLE; 3],
+    );
+const FOREARM: TypedTransform3D<f64, Forearm, Tip> =
+    TypedTransform3D::<f64, Forearm, Tip>::from_translation_euler_xyz(
+        [Length { value: FOREARM_M }, ZERO_LENGTH, ZERO_LENGTH],
+        [ZERO_ANGLE; 3],
+    );
+
+const fn rotation<P: FrameId, C: FrameId>(centidegrees: u16) -> TypedTransform3D<f64, P, C> {
+    TypedTransform3D::<f64, P, C>::from_translation_euler_xyz(
+        [ZERO_LENGTH; 3],
+        [
+            ZERO_ANGLE,
+            ZERO_ANGLE,
+            Angle {
+                value: centidegrees as f64 * (core::f64::consts::PI / 18_000.0),
+            },
+        ],
+    )
+}
+
+pub fn forward_kinematics(angles: JointAngles) -> CuResult<ArmPose> {
+    if angles.shoulder >= FULL_TURN || angles.elbow >= FULL_TURN {
+        return Err(CuError::from("Encoder angle outside [0, 360) degrees"));
+    }
+    let elbow = rotation::<Base, Shoulder>(angles.shoulder).then(UPPER_ARM);
+    let tip = elbow
+        .then(rotation::<Elbow, Forearm>(angles.elbow))
+        .then(FOREARM);
+    let elbow = elbow.transform().translation();
+    let tip = tip.transform().translation();
+    Ok(ArmPose {
+        elbow: [elbow[0].value, elbow[1].value],
+        tip: [tip[0].value, tip[1].value],
+    })
+}
+
+/// Same task on the robot and in generated replay; the UI never computes kinematics.
 #[derive(Default, Reflect)]
-pub struct Accumulator {
-    sum: u64,
-}
-
-impl Freezable for Accumulator {
-    fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        Encode::encode(&self.sum, encoder)
-    }
-    fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
-        self.sum = Decode::decode(decoder)?;
-        Ok(())
-    }
-}
-
-impl CuCrossPlatformDeterministic for Accumulator {
+pub struct Kinematics;
+impl Freezable for Kinematics {}
+impl CuCrossPlatformDeterministic for Kinematics {
+    // Bounded integer inputs, scalar f64 const-transform arithmetic, no libm,
+    // SIMD multiplication, wall clock, allocation, or external side effects.
     const REPLAY_ABI: u32 = 1;
 }
-
-impl CuTask for Accumulator {
+impl CuTask for Kinematics {
     type Resources<'r> = ();
-    type Input<'m> = input_msg!(Sample);
-    type Output<'m> = output_msg!(Sample);
-    fn new(_: Option<&ComponentConfig>, _: ()) -> CuResult<Self> {
-        Ok(Self::default())
-    }
-    fn process(
-        &mut self,
-        _: &CuContext,
-        input: &Self::Input<'_>,
-        output: &mut Self::Output<'_>,
-    ) -> CuResult<()> {
-        self.sum += input
-            .payload()
-            .ok_or_else(|| CuError::from("Counter produced no sample"))?
-            .0;
-        output.set_payload(Sample(self.sum));
-        output.tov = input.tov;
-        Ok(())
-    }
-}
-
-/// This task runs on both the robot and the generated ground-side replay runtime.
-#[derive(Default, Reflect)]
-pub struct Derived;
-impl Freezable for Derived {}
-impl CuCrossPlatformDeterministic for Derived {
-    const REPLAY_ABI: u32 = 1;
-}
-impl CuTask for Derived {
-    type Resources<'r> = ();
-    type Input<'m> = input_msg!(Sample);
-    type Output<'m> = output_msg!(Sample);
+    type Input<'m> = input_msg!(JointAngles);
+    type Output<'m> = output_msg!(ArmPose);
     fn new(_: Option<&ComponentConfig>, _: ()) -> CuResult<Self> {
         Ok(Self)
     }
@@ -104,11 +150,89 @@ impl CuTask for Derived {
         input: &Self::Input<'_>,
         output: &mut Self::Output<'_>,
     ) -> CuResult<()> {
-        let sum = input
+        let angles = *input
             .payload()
-            .ok_or_else(|| CuError::from("Accumulator produced no sample"))?;
-        output.set_payload(Sample(sum.0 % 256));
+            .ok_or_else(|| CuError::from("Encoders produced no angles"))?;
+        output.set_payload(forward_kinematics(angles)?);
         output.tov = input.tov;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arm_geometry_matches_known_joint_positions() {
+        for (angles, elbow, tip) in [
+            (
+                JointAngles {
+                    shoulder: 0,
+                    elbow: 0,
+                },
+                [1.0, 0.0],
+                [1.65, 0.0],
+            ),
+            (
+                JointAngles {
+                    shoulder: 9000,
+                    elbow: 0,
+                },
+                [0.0, 1.0],
+                [0.0, 1.65],
+            ),
+            (
+                JointAngles {
+                    shoulder: 0,
+                    elbow: 9000,
+                },
+                [1.0, 0.0],
+                [1.0, 0.65],
+            ),
+            (
+                JointAngles {
+                    shoulder: 9000,
+                    elbow: 9000,
+                },
+                [0.0, 1.0],
+                [-0.65, 1.0],
+            ),
+        ] {
+            let pose = forward_kinematics(angles).unwrap();
+            for (actual, expected) in pose
+                .elbow
+                .into_iter()
+                .chain(pose.tip)
+                .zip(elbow.into_iter().chain(tip))
+            {
+                assert!((actual - expected).abs() < 1e-12, "{angles:?}: {pose:?}");
+            }
+        }
+        assert!(
+            forward_kinematics(JointAngles {
+                shoulder: FULL_TURN,
+                elbow: 0
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn runtime_composition_matches_const_evaluation_bit_for_bit() {
+        const EXPECTED: TypedTransform3D<f64, Base, Tip> = rotation::<Base, Shoulder>(12345)
+            .then(UPPER_ARM)
+            .then(rotation::<Elbow, Forearm>(23456))
+            .then(FOREARM);
+        let actual = forward_kinematics(std::hint::black_box(JointAngles {
+            shoulder: 12345,
+            elbow: 23456,
+        }))
+        .unwrap();
+        let expected = EXPECTED.transform().translation();
+        assert_eq!(
+            actual.tip.map(f64::to_bits),
+            [expected[0].value.to_bits(), expected[1].value.to_bits()]
+        );
     }
 }

--- a/examples/cu_logstream_demo/tests/stateful.ron
+++ b/examples/cu_logstream_demo/tests/stateful.ron
@@ -8,11 +8,11 @@
     tasks: [
         (
             id: "counter",
-            type: "cu_logstream_demo::tasks::Counter",
+            type: "crate::stateful::tasks::Counter",
         ),
         (
             id: "sum",
-            type: "cu_logstream_demo::tasks::Accumulator",
+            type: "crate::stateful::tasks::Accumulator",
             streaming: (
                 replay: reconstruct,
                 replay_abi: 1,
@@ -20,7 +20,7 @@
         ),
         (
             id: "derived",
-            type: "cu_logstream_demo::tasks::Derived",
+            type: "crate::stateful::tasks::Derived",
             streaming: (
                 replay: reconstruct,
                 replay_abi: 1,
@@ -31,17 +31,17 @@
         (
             src: "counter",
             dst: "sum",
-            msg: "cu_logstream_demo::tasks::Sample",
+            msg: "crate::stateful::tasks::Sample",
         ),
         (
             src: "sum",
             dst: "derived",
-            msg: "cu_logstream_demo::tasks::Sample",
+            msg: "crate::stateful::tasks::Sample",
         ),
         (
             src: "derived",
             dst: "__nc__",
-            msg: "cu_logstream_demo::tasks::Sample",
+            msg: "crate::stateful::tasks::Sample",
         ),
     ],
 )

--- a/examples/cu_logstream_demo/tests/support/counter_tasks.rs
+++ b/examples/cu_logstream_demo/tests/support/counter_tasks.rs
@@ -1,0 +1,114 @@
+use cu29::bincode::{
+    Decode, Encode,
+    de::Decoder,
+    enc::Encoder,
+    error::{DecodeError, EncodeError},
+};
+use cu29::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Encode, Decode, Serialize, Deserialize, Reflect,
+)]
+#[bincode(crate = "cu29::bincode")]
+pub struct Sample(pub u64);
+
+#[derive(Default, Reflect)]
+pub struct Counter {
+    next: u64,
+}
+
+impl Freezable for Counter {
+    fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        Encode::encode(&self.next, encoder)
+    }
+    fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
+        self.next = Decode::decode(decoder)?;
+        Ok(())
+    }
+}
+
+impl CuSrcTask for Counter {
+    type Resources<'r> = ();
+    type Output<'m> = output_msg!(Sample);
+    fn new(_: Option<&ComponentConfig>, _: ()) -> CuResult<Self> {
+        Ok(Self::default())
+    }
+    fn process(&mut self, ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
+        output.set_payload(Sample(self.next));
+        output.tov = Tov::Time(ctx.now());
+        self.next += 1;
+        Ok(())
+    }
+}
+
+#[derive(Default, Reflect)]
+pub struct Accumulator {
+    sum: u64,
+}
+
+impl Freezable for Accumulator {
+    fn freeze<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        Encode::encode(&self.sum, encoder)
+    }
+    fn thaw<D: Decoder>(&mut self, decoder: &mut D) -> Result<(), DecodeError> {
+        self.sum = Decode::decode(decoder)?;
+        Ok(())
+    }
+}
+
+impl CuCrossPlatformDeterministic for Accumulator {
+    const REPLAY_ABI: u32 = 1;
+}
+
+impl CuTask for Accumulator {
+    type Resources<'r> = ();
+    type Input<'m> = input_msg!(Sample);
+    type Output<'m> = output_msg!(Sample);
+    fn new(_: Option<&ComponentConfig>, _: ()) -> CuResult<Self> {
+        Ok(Self::default())
+    }
+    fn process(
+        &mut self,
+        _: &CuContext,
+        input: &Self::Input<'_>,
+        output: &mut Self::Output<'_>,
+    ) -> CuResult<()> {
+        self.sum += input
+            .payload()
+            .ok_or_else(|| CuError::from("Counter produced no sample"))?
+            .0;
+        output.set_payload(Sample(self.sum));
+        output.tov = input.tov;
+        Ok(())
+    }
+}
+
+/// This task runs on both the robot and the generated ground-side replay runtime.
+#[derive(Default, Reflect)]
+pub struct Derived;
+impl Freezable for Derived {}
+impl CuCrossPlatformDeterministic for Derived {
+    const REPLAY_ABI: u32 = 1;
+}
+impl CuTask for Derived {
+    type Resources<'r> = ();
+    type Input<'m> = input_msg!(Sample);
+    type Output<'m> = output_msg!(Sample);
+    fn new(_: Option<&ComponentConfig>, _: ()) -> CuResult<Self> {
+        Ok(Self)
+    }
+    fn process(
+        &mut self,
+        _: &CuContext,
+        input: &Self::Input<'_>,
+        output: &mut Self::Output<'_>,
+    ) -> CuResult<()> {
+        let sum = input
+            .payload()
+            .ok_or_else(|| CuError::from("Accumulator produced no sample"))?;
+        output.set_payload(Sample(sum.0 % 256));
+        output.tov = input.tov;
+        Ok(())
+    }
+}

--- a/examples/cu_logstream_demo/tests/twin.rs
+++ b/examples/cu_logstream_demo/tests/twin.rs
@@ -55,7 +55,7 @@ fn capture(list: &List) -> CapturedList<DataSet> {
         captured
             .copperlist
             .msgs
-            .get_derived_output()
+            .get_kinematics_output()
             .payload()
             .is_none()
     );
@@ -259,19 +259,55 @@ fn recovery_discards_captures_waiting_for_an_old_recovery_point() {
 
 mod stateful {
     use cu29::prelude::*;
+    pub mod tasks {
+        include!("support/counter_tasks.rs");
+    }
     #[copper_runtime(config = "tests/stateful.ron", sim_mode = true)]
     struct Replay {}
     pub type Twin = default::Replay;
     pub type DataSet = default::CuStampedDataSet;
+    mod onboard {
+        use cu29::prelude::*;
+        #[copper_runtime(config = "tests/stateful.ron")]
+        struct Onboard {}
+        pub type App = default::Onboard;
+    }
+    pub fn fixture() -> (Vec<CopperList<DataSet>>, Vec<cu29::curuntime::KeyFrame>) {
+        let logs = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("logs");
+        std::fs::create_dir_all(&logs).unwrap();
+        let dir = tempfile::tempdir_in(logs).unwrap();
+        let path = dir.path().join("stateful.copper");
+        let (clock, mock) = RobotClock::mock();
+        let app = onboard::App::builder()
+            .with_clock(clock)
+            .with_log_path(&path, Some(cu_logstream_demo::SLAB_BYTES))
+            .unwrap()
+            .build()
+            .unwrap();
+        let mut running = app.start().unwrap();
+        for id in 0..34 {
+            mock.set_value((id + 1) * cu_logstream_demo::TICK_NS);
+            running.run_one_iteration().unwrap();
+            // Match run_sender's cadence so the async logger can recycle its slots.
+            std::thread::sleep(std::time::Duration::from_nanos(cu_logstream_demo::TICK_NS));
+        }
+        drop(running.stop().unwrap());
+        let lists = cu29_export::copperlists_reader::<DataSet>(UnifiedLoggerIOReader::new(
+            UnifiedLoggerRead::new(&path).unwrap(),
+            UnifiedLogType::CopperList,
+        ))
+        .collect();
+        (lists, cu_logstream_demo::read_keyframes(&path).unwrap())
+    }
 }
 
 #[test]
 fn stateful_reconstruction_restores_keyframes_and_feeds_downstream_tasks() {
     let _serial = SERIAL.lock().unwrap();
-    let (lists, keyframes) = fixture();
+    let (lists, keyframes) = stateful::fixture();
     let mut twin = LiveTwin::<stateful::Twin>::new().unwrap();
-    // The same onboard graph, but both the stateful sum and its downstream
-    // modulo task are omitted from the stream in this reconstruction contract.
+    // Keep the stateful counter/sum/modulo regression as a separate test graph.
+    // Both sum and its downstream modulo output are omitted from the stream.
     for expected in lists[..4].iter().chain(&lists[16..]) {
         let full =
             cu29::bincode::encode_to_vec(expected, cu29::bincode::config::standard()).unwrap();
@@ -313,6 +349,18 @@ fn stateful_reconstruction_restores_keyframes_and_feeds_downstream_tasks() {
 }
 
 #[test]
+fn arm_kinematics_does_not_allocate() {
+    use cu_logstream_demo::tasks::{JointAngles, forward_kinematics};
+    let _serial = SERIAL.lock().unwrap();
+    ALLOCATIONS.with(|count| count.set(Some(0)));
+    for tick in 0..1200 {
+        std::hint::black_box(forward_kinematics(JointAngles::at_tick(tick)).unwrap());
+    }
+    let allocations = ALLOCATIONS.with(|count| count.replace(None).unwrap());
+    assert_eq!(allocations, 0, "kinematics allocated on the task path");
+}
+
+#[test]
 fn capture_encoding_is_native_and_does_not_allocate() {
     use cu29_logstream::capture::CaptureView;
     let _serial = SERIAL.lock().unwrap();
@@ -333,7 +381,7 @@ fn capture_encoding_is_native_and_does_not_allocate() {
     .unwrap();
     assert_eq!(native, expected);
     let decoded = cu29_logstream::decode_copperlist::<DataSet>(native).unwrap();
-    assert!(decoded.msgs.get_derived_output().payload().is_none());
+    assert!(decoded.msgs.get_kinematics_output().payload().is_none());
     if cfg!(feature = "verify-reconstruction") {
         assert_eq!(record.payload.len(), native.len() + 32);
     } else {


### PR DESCRIPTION
## Summary

<img width="1914" height="966" alt="image" src="https://github.com/user-attachments/assets/72f6766f-60a5-4798-a9ea-3a7869ad30bc" />


Replace the counter/modulo demo with a two-link robot arm that makes local reconstruction visible: only shoulder and elbow encoder readings cross the link, while a Copper task reconstructs the elbow and fingertip positions. The dashboard draws those outputs as an animated Braille arm with a fading, four-lobed fingertip trail.

## Related issues

Stacked on #1336; base branch: `gbin/logstream-dashboard-tui`.

## Changes

- Replace the application graph with `Encoders -> Kinematics`. The source publishes bounded integer angles; the pose output is marked `replay: reconstruct` and omitted from native captures.
- Use `cu_transform::TypedTransform3D` for the fixed link geometry and typed joint/frame composition. Kinematics uses scalar, const-capable f64 arithmetic without platform libm calls or task-path allocations.
- Show received shoulder/elbow traces beside the locally reconstructed arm. The bounded UI trail clears at missing frames and session changes, and the UI never computes forward kinematics.
- Adapt archive verification and replay to the arm schema, and retain the original counter/sum/modulo graph as a test-only stateful reconstruction fixture.
- Document the geometry, controls, and reconstruction contract. Existing counter-demo logs use a different schema; the arm demo needs fresh recordings.

## Reminder

- [x] Ran `just fmt` and root `just logstream-twin-check`.
- [x] Updated the demo README.

## Additional context

Validation includes known arm configurations, bit-for-bit runtime/const composition, allocation-free kinematics and capture encoding, pose omission, exact replay with sender metadata, opt-in divergence/recovery checks, bounded UI history and gap handling, terminal rendering, and all streaming/recovery scenarios. Numeric validation was run on the native Linux host; other architectures were not exercised here.
