### PR TITLE
Add native sender TUI with live arm task status

### DIFF
--- a/components/libs/cu_tuimon/src/model.rs
+++ b/components/libs/cu_tuimon/src/model.rs
@@ -226,6 +226,27 @@ impl MonitorModel {
             self.upsert_pool_stat(id.to_string(), space_left, total_size, buffer_size);
         }
     }
+
+    pub fn process_copperlist(&self, copperlist_id: u64, view: CopperListView<'_>) {
+        self.inner.component_stats.lock().unwrap().update(view);
+        self.update_copperlist_rate(copperlist_id);
+
+        let mut component_statuses = self.inner.component_statuses.lock().unwrap();
+        for entry in view.entries() {
+            let component_index = entry.component_id.index();
+            assert!(
+                component_index < component_statuses.len(),
+                "cu_tuimon: mapped component index {} out of component_statuses bounds {}",
+                component_index,
+                component_statuses.len()
+            );
+            let CuCompactString(status_txt) = &entry.msg.status_txt;
+            component_statuses[component_index].status_txt = status_txt.clone();
+        }
+        drop(component_statuses);
+
+        self.refresh_pool_stats_from_runtime();
+    }
 }
 
 #[cfg(feature = "log_pane")]
@@ -254,27 +275,6 @@ impl MonitorModel {
 
     pub fn log_line_count(&self) -> usize {
         self.inner.log_lines.lock().unwrap().len()
-    }
-
-    pub fn process_copperlist(&self, copperlist_id: u64, view: CopperListView<'_>) {
-        self.inner.component_stats.lock().unwrap().update(view);
-        self.update_copperlist_rate(copperlist_id);
-
-        let mut component_statuses = self.inner.component_statuses.lock().unwrap();
-        for entry in view.entries() {
-            let component_index = entry.component_id.index();
-            assert!(
-                component_index < component_statuses.len(),
-                "cu_tuimon: mapped component index {} out of component_statuses bounds {}",
-                component_index,
-                component_statuses.len()
-            );
-            let CuCompactString(status_txt) = &entry.msg.status_txt;
-            component_statuses[component_index].status_txt = status_txt.clone();
-        }
-        drop(component_statuses);
-
-        self.refresh_pool_stats_from_runtime();
     }
 }
 

--- a/examples/cu_logstream_demo/Cargo.toml
+++ b/examples/cu_logstream_demo/Cargo.toml
@@ -15,6 +15,7 @@ verify-reconstruction = ["demo", "cu29/logstream-verify"]
 demo = ["cu29/logstream", "cu29/reflect", "dep:cu-transform"]
 replay = ["demo", "cu29/remote-debug"]
 tui = ["demo", "dep:ratatui"]
+sender-monitor = ["demo", "dep:cu-consolemon"]
 
 [[bin]]
 name = "cu-logstream-demo"
@@ -34,6 +35,7 @@ required-features = ["replay"]
 [dependencies]
 cu29 = { workspace = true }
 cu-transform = { path = "../../components/libs/cu_transform", optional = true }
+cu-consolemon = { path = "../../components/monitors/cu_consolemon", default-features = false, optional = true }
 cu29-logstream = { workspace = true, features = ["std"] }
 cu29-logstream-udp = { workspace = true }
 cu29-export = { workspace = true }

--- a/examples/cu_logstream_demo/README.md
+++ b/examples/cu_logstream_demo/README.md
@@ -74,6 +74,14 @@ come exclusively from reconstructed Copper task outputs.
 The screen follows `cu_tuimon` with numbered tabs and command badges. **1** selects
 Live, **2** selects Health, and **Tab** cycles between them. In Health, **hjkl**
 or the arrow keys scroll the details, including the archive path and recovery counters.
+`just sender` opens Copper's native task monitor (DAG, latency, bandwidth,
+and memory tabs). Encoder status shows `S:DDD.dd E:DDD.dd` in degrees;
+kinematics reports `pose ready (local)`. Use the numbered tabs and `q` to quit.
+Status metadata crosses the link, so it deliberately excludes pose coordinates.
+The `sender-monitor` feature and `senderconfig.ron` enable this monitor only for
+the sender; the ground twin uses the original graph without a monitor.
+Automated scenarios remain headless.
+
 The dashboard uses the official [Catppuccin Mocha palette](https://github.com/catppuccin/palette):
 green for received values and healthy status, mauve for reconstructed pose data,
 blue for headings and transport metrics, neutral text for explanations, yellow for

--- a/examples/cu_logstream_demo/justfile
+++ b/examples/cu_logstream_demo/justfile
@@ -13,6 +13,9 @@ build:
 build-tui:
     cargo +stable build -p cu-logstream-demo --features tui --bin cu-logstream-demo
 
+build-sender:
+    cargo +stable build -p cu-logstream-demo --features replay,sender-monitor --bins
+
 # Start this first, then `just sender` in another terminal. Space pauses only the view.
 dashboard listen="127.0.0.1:7447" log="logs/dashboard.copper": build-tui
     {{root}}/target/debug/cu-logstream-demo dashboard --listen {{listen}} --log-base {{log}}
@@ -23,8 +26,11 @@ run scenario="clean": build
 
 check: (run "all")
 
+check-sender: build-sender
+    python3 run.py all --binary {{root}}/target/debug/cu-logstream-demo
+
 # Start these in separate terminals. Existing output logs are replaced on each run.
-sender remote="127.0.0.1:7447" log="logs/sender.copper" iterations="6000": build
+sender remote="127.0.0.1:7447" log="logs/sender.copper" iterations="6000": build-sender
     {{root}}/target/debug/cu-logstream-demo sender --remote {{remote}} --log-base {{log}} --iterations {{iterations}}
 
 receiver listen="127.0.0.1:7447" log="logs/received.copper": build
@@ -48,5 +54,5 @@ dashboard-verify listen="127.0.0.1:7447" log="logs/dashboard-verify.copper":
     {{root}}/target/debug/cu-logstream-demo dashboard --listen {{listen}} --log-base {{log}}
 
 sender-verify remote="127.0.0.1:7447" log="logs/sender-verify.copper" iterations="6000":
-    cargo +stable build -p cu-logstream-demo --features tui,verify-reconstruction --bin cu-logstream-demo
+    cargo +stable build -p cu-logstream-demo --features tui,verify-reconstruction,sender-monitor --bin cu-logstream-demo
     {{root}}/target/debug/cu-logstream-demo sender --remote {{remote}} --log-base {{log}} --iterations {{iterations}}

--- a/examples/cu_logstream_demo/senderconfig.ron
+++ b/examples/cu_logstream_demo/senderconfig.ron
@@ -1,0 +1,4 @@
+(
+    includes: [(path: "copperconfig.ron")],
+    monitor: (type: "cu_consolemon::CuConsoleMon"),
+)

--- a/examples/cu_logstream_demo/src/lib.rs
+++ b/examples/cu_logstream_demo/src/lib.rs
@@ -6,7 +6,14 @@ pub mod telemetry;
 
 use cu29::prelude::*;
 
-#[copper_runtime(config = "copperconfig.ron")]
+#[cfg_attr(
+    feature = "sender-monitor",
+    copper_runtime(config = "senderconfig.ron")
+)]
+#[cfg_attr(
+    not(feature = "sender-monitor"),
+    copper_runtime(config = "copperconfig.ron")
+)]
 struct Demo {}
 
 pub mod twin {
@@ -41,7 +48,7 @@ pub fn run_sender(
     iterations: u64,
     idle_ms: u64,
 ) -> CuResult<()> {
-    let mut config = CuConfig::deserialize_ron(include_str!("../copperconfig.ron"))?;
+    let mut config = CuConfig::deserialize_ron(&Demo::original_config())?;
     config.resources[0]
         .config
         .as_mut()

--- a/examples/cu_logstream_demo/src/tasks.rs
+++ b/examples/cu_logstream_demo/src/tasks.rs
@@ -63,7 +63,16 @@ impl CuSrcTask for Encoders {
         Ok(Self::default())
     }
     fn process(&mut self, ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
-        output.set_payload(JointAngles::at_tick(self.tick));
+        let angles = JointAngles::at_tick(self.tick);
+        output.set_payload(angles);
+        #[cfg(feature = "sender-monitor")]
+        output.metadata.set_status(format_args!(
+            "S:{:03}.{:02} E:{:03}.{:02}",
+            angles.shoulder / 100,
+            angles.shoulder % 100,
+            angles.elbow / 100,
+            angles.elbow % 100,
+        ));
         output.tov = Tov::Time(ctx.now());
         self.tick = self.tick.wrapping_add(1);
         Ok(())
@@ -154,6 +163,10 @@ impl CuTask for Kinematics {
             .payload()
             .ok_or_else(|| CuError::from("Encoders produced no angles"))?;
         output.set_payload(forward_kinematics(angles)?);
+        // Status metadata is captured even when the pose payload is omitted.
+        // Keep coordinates out of it so reconstruction remains meaningful.
+        #[cfg(feature = "sender-monitor")]
+        output.metadata.set_status("pose ready (local)");
         output.tov = input.tov;
         Ok(())
     }

--- a/examples/cu_logstream_demo/tests/twin.rs
+++ b/examples/cu_logstream_demo/tests/twin.rs
@@ -447,3 +447,25 @@ fn twin_owns_shutdown_and_reports_transport_failure() {
             .contains("test transport failed")
     );
 }
+
+#[cfg(feature = "sender-monitor")]
+#[test]
+fn sender_status_is_allocation_free_and_keeps_pose_local() {
+    use cu_logstream_demo::tasks::{ArmPose, Encoders, JointAngles, Kinematics};
+    use cu29::prelude::*;
+
+    let (ctx, _clock) = CuContext::new_mock_clock();
+    let mut encoders = Encoders::default();
+    let mut kinematics = Kinematics;
+    let mut angles = CuMsg::<JointAngles>::default();
+    let mut pose = CuMsg::<ArmPose>::default();
+    ALLOCATIONS.with(|count| count.set(Some(0)));
+    for _ in 0..1200 {
+        encoders.process(&ctx, &mut angles).unwrap();
+        kinematics.process(&ctx, &angles, &mut pose).unwrap();
+    }
+    let allocations = ALLOCATIONS.with(|count| count.replace(None).unwrap());
+    assert_eq!(allocations, 0, "task status allocated on the task path");
+    assert_eq!(angles.metadata.status_txt.0.as_str(), "S:359.70 E:001.20");
+    assert_eq!(pose.metadata.status_txt.0.as_str(), "pose ready (local)");
+}

--- a/justfile
+++ b/justfile
@@ -553,3 +553,10 @@ logstream-twin-check:
     cargo +stable test -p cu-logstream-demo --features demo --test twin
     just logstream-receiver-check
     just --justfile examples/cu_logstream_demo/justfile check
+
+# Sender monitor, status metadata, and streamed reconstruction interoperability.
+logstream-sender-check:
+    cargo +stable test -p cu-tuimon --no-default-features
+    cargo +stable clippy -p cu-logstream-demo --all-targets --features replay,tui,verify-reconstruction,sender-monitor -- --deny warnings
+    cargo +stable test -p cu-logstream-demo --features demo,tui,verify-reconstruction,sender-monitor
+    just --justfile examples/cu_logstream_demo/justfile check-sender


### PR DESCRIPTION
## Summary

`just sender` now opens Copper’s native TUI monitor so an audience can see the robot’s task graph, live joint angles, and kinematics readiness alongside the ground dashboard.

## Related issues

Stacked on #1337 (`gbin/logstream-arm-demo`).

## Changes

- Add an optional sender-only monitor configuration and enable it in the manual sender recipes. Replay and the ground twin keep the original monitor-free graph.
- Show shoulder/elbow angles in degrees and `pose ready (local)` in native task status. Pose coordinates stay out of status metadata because metadata is transmitted even when the pose payload is reconstructed.
- Keep task status formatting allocation-free and feature-gated; test a full motion cycle.
- Fix `MonitorModel::process_copperlist` being accidentally gated behind the optional log pane, allowing the standard monitor without debug-pane dependencies.
- Document controls and add `just logstream-sender-check`.

## Reminder

- [x] Ran focused root checks: `just fmt` and `just logstream-sender-check`
- [x] Updated example documentation

## Additional context

Validation includes monitor tests without default features, Clippy with warnings denied, demo/UI/twin tests, and all six real sender/receiver loss and recovery scenarios with archive checks and replay. A PTY smoke test confirmed the native DAG, live task statuses, and terminal restoration on completion.
