### PR TITLE
Show one-way and two-way telemetry in the TUI bandwidth tab

### DIFF
--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -1382,6 +1382,10 @@ pub enum cu29_runtime::monitoring::Decision
 pub cu29_runtime::monitoring::Decision::Abort
 pub cu29_runtime::monitoring::Decision::Ignore
 pub cu29_runtime::monitoring::Decision::Shutdown
+pub enum cu29_runtime::monitoring::LogStreamFeedbackState
+pub cu29_runtime::monitoring::LogStreamFeedbackState::Active
+pub cu29_runtime::monitoring::LogStreamFeedbackState::Stale
+pub cu29_runtime::monitoring::LogStreamFeedbackState::Waiting
 #[repr(transparent)] pub struct cu29_runtime::monitoring::ComponentId(_)
 impl cu29_runtime::monitoring::ComponentId
 pub const cu29_runtime::monitoring::ComponentId::INVALID: Self
@@ -1488,6 +1492,7 @@ pub fn cu29_runtime::monitoring::CuMonitoringMetadata::with_subsystem_id(self, s
 pub struct cu29_runtime::monitoring::CuMonitoringRuntime
 impl cu29_runtime::monitoring::CuMonitoringRuntime
 pub fn cu29_runtime::monitoring::CuMonitoringRuntime::execution_probe(&self) -> &cu29_runtime::monitoring::MonitorExecutionProbe
+pub fn cu29_runtime::monitoring::CuMonitoringRuntime::log_streams(&self) -> core::option::Option<alloc::sync::Arc<[cu29_runtime::monitoring::LogStreamMonitor]>>
 pub fn cu29_runtime::monitoring::CuMonitoringRuntime::new(execution_probe: cu29_runtime::monitoring::MonitorExecutionProbe) -> Self
 pub fn cu29_runtime::monitoring::CuMonitoringRuntime::register_panic_action<F>(&self, callback: F) -> cu29_runtime::monitoring::PanicHookRegistration where F: core::ops::function::Fn(&cu29_runtime::monitoring::PanicReport) -> core::option::Option<i32> + core::marker::Send + core::marker::Sync + 'static
 pub fn cu29_runtime::monitoring::CuMonitoringRuntime::register_panic_cleanup<F>(&self, callback: F) -> cu29_runtime::monitoring::PanicHookRegistration where F: core::ops::function::Fn(&cu29_runtime::monitoring::PanicReport) + core::marker::Send + core::marker::Sync + 'static
@@ -1524,6 +1529,49 @@ pub fn cu29_runtime::monitoring::LiveStatistics::percentile(&self, percentile: f
 pub fn cu29_runtime::monitoring::LiveStatistics::record(&mut self, value: u64)
 pub fn cu29_runtime::monitoring::LiveStatistics::reset(&mut self)
 pub fn cu29_runtime::monitoring::LiveStatistics::stdev(&self) -> f64
+pub struct cu29_runtime::monitoring::LogStreamFeedbackStats
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::age: core::option::Option<cu29_clock::CuDuration>
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::buffered_records: u32
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::bytes_per_second: u64
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::duplicate_packets: u64
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::effective_repair_every_source_symbols: u16
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::expired_records: u64
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::failed: bool
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::finalized_symbols: u64
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::invalid_packets: u64
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::invalid_reports: u64
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::latest_copperlist: core::option::Option<u64>
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::loss_basis_points: u16
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::packets_per_second: u64
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::rates_available: bool
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::record_capacity: u32
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::recovery_basis_points: u16
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::rejected_reports: u64
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::reports: u64
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::source_metrics_available: bool
+pub cu29_runtime::monitoring::LogStreamFeedbackStats::state: cu29_runtime::monitoring::LogStreamFeedbackState
+pub struct cu29_runtime::monitoring::LogStreamMonitor
+pub cu29_runtime::monitoring::LogStreamMonitor::baseline_repair_every_source_symbols: usize
+pub cu29_runtime::monitoring::LogStreamMonitor::bitrate_bps: u64
+pub cu29_runtime::monitoring::LogStreamMonitor::destination: compact_str::CompactString
+impl cu29_runtime::monitoring::LogStreamMonitor
+pub fn cu29_runtime::monitoring::LogStreamMonitor::new(destination: &str, bitrate_bps: u64, baseline: usize, source: impl cu29_runtime::monitoring::LogStreamStatsSource + 'static) -> Self
+pub fn cu29_runtime::monitoring::LogStreamMonitor::snapshot(&self) -> cu29_runtime::monitoring::LogStreamStats
+pub struct cu29_runtime::monitoring::LogStreamStats
+pub cu29_runtime::monitoring::LogStreamStats::bytes_sent: u64
+pub cu29_runtime::monitoring::LogStreamStats::expired_packets: u64
+pub cu29_runtime::monitoring::LogStreamStats::failed: bool
+pub cu29_runtime::monitoring::LogStreamStats::feedback: core::option::Option<cu29_runtime::monitoring::LogStreamFeedbackStats>
+pub cu29_runtime::monitoring::LogStreamStats::inbox_drops: u64
+pub cu29_runtime::monitoring::LogStreamStats::packets_sent: u64
+pub cu29_runtime::monitoring::LogStreamStats::queue_drops: u64
+pub cu29_runtime::monitoring::LogStreamStats::queue_peak: usize
+pub cu29_runtime::monitoring::LogStreamStats::recovery_rounds: u64
+pub cu29_runtime::monitoring::LogStreamStats::recovery_superseded: u64
+pub cu29_runtime::monitoring::LogStreamStats::sampled_at: cu29_clock::CuTime
+pub cu29_runtime::monitoring::LogStreamStats::shutdown_drops: u64
+pub cu29_runtime::monitoring::LogStreamStats::stopped: bool
+pub cu29_runtime::monitoring::LogStreamStats::transport_drops: u64
 pub struct cu29_runtime::monitoring::MonitorComponentMetadata
 impl cu29_runtime::monitoring::MonitorComponentMetadata
 pub const fn cu29_runtime::monitoring::MonitorComponentMetadata::id(&self) -> &'static str
@@ -1657,6 +1705,8 @@ pub fn (M0, M1)::process_error(&self, component_id: cu29_runtime::monitoring::Co
 pub fn (M0, M1)::process_panic(&self, panic_message: &str)
 pub fn (M0, M1)::start(&mut self, ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
 pub fn (M0, M1)::stop(&mut self, ctx: &cu29_runtime::context::CuContext) -> cu29_traits::CuResult<()>
+pub trait cu29_runtime::monitoring::LogStreamStatsSource: core::fmt::Debug + core::marker::Send + core::marker::Sync
+pub fn cu29_runtime::monitoring::LogStreamStatsSource::snapshot(&self) -> cu29_runtime::monitoring::LogStreamStats
 pub fn cu29_runtime::monitoring::build_monitor_topology(config: &cu29_runtime::config::CuConfig, mission: &str) -> cu29_traits::CuResult<cu29_runtime::monitoring::MonitorTopology>
 pub fn cu29_runtime::monitoring::global_allocated_bytes() -> core::option::Option<usize>
 pub fn cu29_runtime::monitoring::global_deallocated_bytes() -> core::option::Option<usize>

--- a/components/libs/cu_tuimon/src/lib.rs
+++ b/components/libs/cu_tuimon/src/lib.rs
@@ -1,5 +1,6 @@
 mod model;
 mod palette;
+mod stream_panel;
 mod tui_nodes;
 mod ui;
 

--- a/components/libs/cu_tuimon/src/model.rs
+++ b/components/libs/cu_tuimon/src/model.rs
@@ -26,6 +26,7 @@ const DEFAULT_LOG_CAPACITY: usize = 1_024;
 #[derive(Clone)]
 pub struct MonitorModel {
     pub(crate) inner: Arc<MonitorModelInner>,
+    pub(crate) streams: Option<Arc<[cu29::monitoring::LogStreamMonitor]>>,
 }
 
 pub(crate) struct MonitorModelInner {
@@ -45,6 +46,12 @@ pub(crate) struct MonitorModelInner {
 }
 
 impl MonitorModel {
+    /// Attach immutable stream handles once, before cloning the model into a UI thread.
+    pub fn with_runtime(mut self, runtime: &cu29::monitoring::CuMonitoringRuntime) -> Self {
+        self.streams = runtime.log_streams();
+        self
+    }
+
     pub fn from_metadata(metadata: &CuMonitoringMetadata) -> Self {
         Self::from_parts_with_identity(
             metadata.components(),
@@ -77,6 +84,7 @@ impl MonitorModel {
         copperlist_stats.set_info(copperlist_info);
 
         Self {
+            streams: None,
             inner: Arc::new(MonitorModelInner {
                 components,
                 topology,

--- a/components/libs/cu_tuimon/src/stream_panel.rs
+++ b/components/libs/cu_tuimon/src/stream_panel.rs
@@ -1,0 +1,261 @@
+use crate::{palette, ui::format_bytes};
+use cu29::monitoring::{LogStreamFeedbackState, LogStreamMonitor, LogStreamStats};
+use ratatui::{
+    layout::Alignment,
+    style::{Modifier, Style},
+    text::Line,
+    widgets::{Cell, Row},
+};
+
+/// UI-owned differences between worker snapshots; no per-CopperList callbacks.
+#[derive(Default)]
+pub(crate) struct StreamRates {
+    previous: Option<LogStreamStats>,
+    pub(crate) bytes: Option<f64>,
+    pub(crate) packets: Option<f64>,
+}
+impl StreamRates {
+    pub(crate) fn update(&mut self, snapshot: LogStreamStats) {
+        if snapshot.stopped || snapshot.failed {
+            self.bytes = Some(0.0);
+            self.packets = Some(0.0);
+        } else if let Some(previous) = self.previous {
+            let now = snapshot.sampled_at.as_nanos();
+            let before = previous.sampled_at.as_nanos();
+            if now > before {
+                let seconds = (now - before) as f64 / 1_000_000_000.0;
+                self.bytes =
+                    Some(snapshot.bytes_sent.saturating_sub(previous.bytes_sent) as f64 / seconds);
+                self.packets = Some(
+                    snapshot.packets_sent.saturating_sub(previous.packets_sent) as f64 / seconds,
+                );
+            } else if now < before {
+                self.bytes = None;
+                self.packets = None;
+            }
+        }
+        self.previous = Some(snapshot);
+    }
+}
+
+fn row(metric: &'static str, value: impl Into<String>) -> Row<'static> {
+    Row::new([
+        Cell::from(metric),
+        Cell::from(Line::from(value.into()).alignment(Alignment::Right)),
+    ])
+}
+fn count(metric: &'static str, value: u64) -> Row<'static> {
+    let row = row(metric, value.to_string());
+    if value == 0 {
+        row
+    } else {
+        row.style(
+            Style::default()
+                .fg(palette::LIGHT_RED)
+                .add_modifier(Modifier::BOLD),
+        )
+    }
+}
+fn bytes_rate(bytes: f64) -> String {
+    format!("{}/s", format_bytes(bytes))
+}
+
+pub(crate) fn rows(
+    monitor: &LogStreamMonitor,
+    snapshot: LogStreamStats,
+    rates: &StreamRates,
+) -> Vec<Row<'static>> {
+    let mut rows = vec![
+        row(
+            "Mode",
+            if snapshot.feedback.is_some() {
+                "Two-way"
+            } else {
+                "One-way"
+            },
+        ),
+        row(
+            "Sender",
+            if snapshot.failed {
+                "Failed"
+            } else if snapshot.stopped {
+                "Stopped"
+            } else {
+                "Running"
+            },
+        )
+        .style(Style::default().fg(if snapshot.failed {
+            palette::LIGHT_RED
+        } else {
+            palette::CYAN
+        })),
+        row(
+            "Configured budget",
+            format!("{} bit/s", monitor.bitrate_bps),
+        ),
+        row(
+            "TX BW (Copper packets)",
+            rates.bytes.map_or_else(|| "n/a".into(), bytes_rate),
+        ),
+        row(
+            "TX packet rate",
+            rates
+                .packets
+                .map_or_else(|| "n/a".into(), |rate| format!("{rate:.1} pkt/s")),
+        ),
+        row("Sent packets", snapshot.packets_sent.to_string()),
+        row("Sent bytes", format_bytes(snapshot.bytes_sent as f64)),
+        count("Queue drops", snapshot.queue_drops),
+        count("Expired packets", snapshot.expired_packets),
+        count("Transport drops", snapshot.transport_drops),
+        count("Inbox record drops", snapshot.inbox_drops),
+        count("Shutdown drops", snapshot.shutdown_drops),
+        row("Recovery rounds", snapshot.recovery_rounds.to_string()),
+        count("Recovery replaced", snapshot.recovery_superseded),
+        row("Queue peak (packets)", snapshot.queue_peak.to_string()),
+        row(
+            "FEC baseline interval",
+            format!("{} sources", monitor.baseline_repair_every_source_symbols),
+        ),
+    ];
+    if let Some(feedback) = snapshot.feedback {
+        let active = feedback.state == LogStreamFeedbackState::Active && !feedback.failed;
+        let current = |value: String| if active { value } else { "n/a".into() };
+        let feedback_state = if feedback.failed {
+            "Failed"
+        } else {
+            match feedback.state {
+                LogStreamFeedbackState::Waiting => "Waiting",
+                LogStreamFeedbackState::Active => "Active",
+                LogStreamFeedbackState::Stale => "Stale",
+            }
+        };
+        rows.extend([
+            row("Feedback", feedback_state).style(Style::default().fg(if active {
+                palette::CYAN
+            } else {
+                palette::YELLOW
+            })),
+            row(
+                "Report age",
+                feedback.age.map_or_else(
+                    || "n/a".into(),
+                    |age| format!("{} ms", age.as_nanos() / 1_000_000),
+                ),
+            ),
+            row("Feedback reports", feedback.reports.to_string()),
+            count("Rejected reports", feedback.rejected_reports),
+            count("Invalid reports", feedback.invalid_reports),
+            row(
+                "FEC effective interval",
+                format!("{} sources", feedback.effective_repair_every_source_symbols),
+            ),
+            row(
+                "RX BW",
+                if feedback.rates_available {
+                    current(bytes_rate(feedback.bytes_per_second as f64))
+                } else {
+                    "n/a".into()
+                },
+            ),
+            row(
+                "RX packet rate",
+                if feedback.rates_available {
+                    current(format!("{} pkt/s", feedback.packets_per_second))
+                } else {
+                    "n/a".into()
+                },
+            ),
+            row(
+                "Finalized symbols",
+                current(feedback.finalized_symbols.to_string()),
+            ),
+            row(
+                "Source loss",
+                if feedback.source_metrics_available {
+                    current(format!(
+                        "{:.2}%",
+                        f64::from(feedback.loss_basis_points) / 100.0
+                    ))
+                } else {
+                    "n/a".into()
+                },
+            ),
+            row(
+                "Missing recovered (FEC)",
+                if feedback.source_metrics_available {
+                    current(format!(
+                        "{:.2}%",
+                        f64::from(feedback.recovery_basis_points) / 100.0
+                    ))
+                } else {
+                    "n/a".into()
+                },
+            ),
+            row(
+                "RX records buffered",
+                current(format!(
+                    "{} / {}",
+                    feedback.buffered_records, feedback.record_capacity
+                )),
+            ),
+            row(
+                "RX latest CopperList",
+                current(
+                    feedback
+                        .latest_copperlist
+                        .map_or_else(|| "n/a".into(), |id| id.to_string()),
+                ),
+            ),
+            row(
+                "RX invalid packets",
+                current(feedback.invalid_packets.to_string()),
+            ),
+            row(
+                "RX duplicate packets",
+                current(feedback.duplicate_packets.to_string()),
+            ),
+            row(
+                "RX expired records",
+                current(feedback.expired_records.to_string()),
+            ),
+        ]);
+    }
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cu29::clock::CuTime;
+    #[test]
+    fn rates_use_worker_time_and_do_not_double_count_repeated_snapshots() {
+        let mut rates = StreamRates::default();
+        let first = LogStreamStats {
+            sampled_at: CuTime::from_nanos(1_000_000_000),
+            bytes_sent: 1000,
+            packets_sent: 10,
+            ..Default::default()
+        };
+        rates.update(first);
+        assert_eq!(rates.bytes, None);
+        let second = LogStreamStats {
+            sampled_at: CuTime::from_nanos(2_000_000_000),
+            bytes_sent: 3000,
+            packets_sent: 30,
+            ..first
+        };
+        rates.update(second);
+        assert_eq!(rates.bytes, Some(2000.0));
+        assert_eq!(rates.packets, Some(20.0));
+        rates.update(second);
+        assert_eq!(rates.bytes, Some(2000.0));
+        rates.update(LogStreamStats {
+            stopped: true,
+            ..second
+        });
+        assert_eq!(rates.bytes, Some(0.0));
+        rates.update(first);
+        assert_eq!(rates.bytes, None);
+    }
+}

--- a/components/libs/cu_tuimon/src/ui.rs
+++ b/components/libs/cu_tuimon/src/ui.rs
@@ -166,6 +166,8 @@ pub struct MonitorUi {
     help_hitboxes: Vec<HelpHitbox>,
     nodes_scrollable_widget_state: NodesScrollableWidgetState,
     latency_scroll_state: ScrollViewState,
+    bandwidth_scroll_state: ScrollViewState,
+    stream_rates: Vec<crate::stream_panel::StreamRates>,
 
     #[cfg(feature = "sysinfo_pane")]
     system_info: SystemInfo,
@@ -179,6 +181,12 @@ impl MonitorUi {
         let runtime_node_col_width = Self::compute_runtime_node_col_width(model.components());
         let nodes_scrollable_widget_state = NodesScrollableWidgetState::new(model.clone());
 
+        let stream_rates = model.streams.as_ref().map_or_else(Vec::new, |streams| {
+            streams
+                .iter()
+                .map(|_| crate::stream_panel::StreamRates::default())
+                .collect()
+        });
         Self {
             model,
             runtime_node_col_width,
@@ -188,6 +196,8 @@ impl MonitorUi {
             help_hitboxes: Vec::new(),
             nodes_scrollable_widget_state,
             latency_scroll_state: ScrollViewState::default(),
+            bandwidth_scroll_state: ScrollViewState::default(),
+            stream_rates,
 
             #[cfg(feature = "sysinfo_pane")]
             system_info: default_system_info(),
@@ -261,6 +271,17 @@ impl MonitorUi {
 
     pub fn scroll(&mut self, direction: ScrollDirection, steps: usize) {
         match (self.active_screen, direction) {
+            (MonitorScreen::CopperList, direction) => {
+                for _ in 0..steps {
+                    match direction {
+                        ScrollDirection::Up => self.bandwidth_scroll_state.scroll_up(),
+                        ScrollDirection::Down => self.bandwidth_scroll_state.scroll_down(),
+                        ScrollDirection::Left => self.bandwidth_scroll_state.scroll_left(),
+                        ScrollDirection::Right => self.bandwidth_scroll_state.scroll_right(),
+                    }
+                }
+            }
+
             (MonitorScreen::Dag, ScrollDirection::Down) => {
                 self.nodes_scrollable_widget_state
                     .nodes_scrollable_state
@@ -682,7 +703,7 @@ impl MonitorUi {
         f.render_widget(table, area);
     }
 
-    fn draw_copperlist_stats(&self, f: &mut Frame, area: Rect) {
+    fn draw_copperlist_stats(&mut self, f: &mut Frame, area: Rect) {
         let stats = self.model.inner.copperlist_stats.lock().unwrap();
         let size_display = format_bytes_or(stats.size_bytes as u64, "unknown");
         let raw_total = stats.raw_culist_bytes.max(stats.size_bytes as u64);
@@ -785,13 +806,71 @@ impl MonitorUi {
                     .title(" Disk / Encoding "),
             );
 
-        let layout = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints([Constraint::Length(42), Constraint::Length(42)].as_ref())
-            .split(area);
-
-        f.render_widget(mem_table, layout[0]);
-        f.render_widget(disk_table, layout[1]);
+        drop(stats);
+        let mut telemetry = Vec::new();
+        if let Some(streams) = &self.model.streams {
+            for (monitor, rates) in streams.iter().zip(&mut self.stream_rates) {
+                let snapshot = monitor.snapshot();
+                rates.update(snapshot);
+                telemetry.push((
+                    format!(" Telemetry / TX: {} ", monitor.destination),
+                    crate::stream_panel::rows(monitor, snapshot, rates),
+                ));
+            }
+        }
+        if telemetry.is_empty() {
+            telemetry.push((
+                " Telemetry / TX ".to_string(),
+                vec![row("Status", "Not configured".to_string())],
+            ));
+        }
+        let telemetry_height = telemetry
+            .iter()
+            .map(|(_, rows)| rows.len() + 4)
+            .sum::<usize>();
+        let content_size = Size::new(
+            area.width.max(126),
+            area.height
+                .max(telemetry_height.min(u16::MAX as usize) as u16),
+        );
+        let offset = self.bandwidth_scroll_state.offset();
+        self.bandwidth_scroll_state.set_offset(Position::new(
+            offset.x.min(content_size.width.saturating_sub(area.width)),
+            offset
+                .y
+                .min(content_size.height.saturating_sub(area.height)),
+        ));
+        let mut scroll = ScrollView::new(content_size);
+        scroll.render_widget(
+            Block::default().style(Style::default().bg(palette::BACKGROUND)),
+            Rect::new(0, 0, content_size.width, content_size.height),
+        );
+        scroll.render_widget(mem_table, Rect::new(0, 0, 42, content_size.height));
+        scroll.render_widget(disk_table, Rect::new(42, 0, 42, content_size.height));
+        let mut y = 0;
+        for (title, rows) in telemetry {
+            let height =
+                (rows.len() + 4).min(usize::from(content_size.height.saturating_sub(y))) as u16;
+            let table = Table::new(rows, [Constraint::Length(23), Constraint::Min(13)])
+                .header(
+                    Row::new(["Metric", "Value"])
+                        .style(
+                            Style::default()
+                                .fg(palette::YELLOW)
+                                .add_modifier(Modifier::BOLD),
+                        )
+                        .bottom_margin(1),
+                )
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_type(BorderType::Rounded)
+                        .title(title),
+                );
+            scroll.render_widget(table, Rect::new(84, y, content_size.width - 84, height));
+            y = y.saturating_add(height);
+        }
+        scroll.render(area, f.buffer_mut(), &mut self.bandwidth_scroll_state);
     }
 
     fn draw_nodes(&mut self, f: &mut Frame, area: Rect) {
@@ -1142,6 +1221,127 @@ mod tests {
     };
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
+
+    #[derive(Debug)]
+    struct StreamFixture(cu29::monitoring::LogStreamStats);
+    impl cu29::monitoring::LogStreamStatsSource for StreamFixture {
+        fn snapshot(&self) -> cu29::monitoring::LogStreamStats {
+            self.0
+        }
+    }
+
+    fn stream_ui(stats: cu29::monitoring::LogStreamStats) -> MonitorUi {
+        use cu29::monitoring::LogStreamMonitor;
+        let mut model = test_monitor_model();
+        model.streams = Some(std::sync::Arc::from(vec![LogStreamMonitor::new(
+            "ground",
+            1_000_000,
+            4,
+            StreamFixture(stats),
+        )]));
+        let mut ui = MonitorUi::new(model, MonitorUiOptions::default());
+        ui.set_active_screen(MonitorScreen::CopperList);
+        ui
+    }
+
+    fn stream_text(ui: &mut MonitorUi, width: u16, height: u16) -> String {
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal.draw(|f| ui.draw_content(f, f.area())).unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .chunks(usize::from(width))
+            .map(|row| row.iter().map(|cell| cell.symbol()).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn bandwidth_shows_one_way_stats_and_hides_receiver_fields() {
+        let mut ui = stream_ui(cu29::monitoring::LogStreamStats {
+            packets_sent: 12345,
+            queue_drops: 7,
+            ..Default::default()
+        });
+        let text = stream_text(&mut ui, 132, 40);
+        assert!(text.contains("Telemetry / TX: ground"));
+        assert!(text.contains("One-way"));
+        assert!(text.contains("12345"));
+        assert!(text.contains("Queue drops"));
+        assert!(!text.contains("RX BW"));
+    }
+
+    #[test]
+    fn bandwidth_distinguishes_waiting_active_stale_and_failed_feedback() {
+        use cu29::monitoring::{LogStreamFeedbackState, LogStreamFeedbackStats, LogStreamStats};
+        for (state, label, failed) in [
+            (LogStreamFeedbackState::Waiting, "Waiting", false),
+            (LogStreamFeedbackState::Active, "Active", false),
+            (LogStreamFeedbackState::Stale, "Stale", false),
+            (LogStreamFeedbackState::Active, "Failed", true),
+        ] {
+            let mut ui = stream_ui(LogStreamStats {
+                feedback: Some(LogStreamFeedbackStats {
+                    state,
+                    failed,
+                    reports: 4,
+                    finalized_symbols: 100,
+                    rates_available: true,
+                    source_metrics_available: true,
+                    loss_basis_points: 1250,
+                    latest_copperlist: Some(987654321),
+                    effective_repair_every_source_symbols: 2,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+            let text = stream_text(&mut ui, 132, 45);
+            assert!(text.contains("Two-way"));
+            assert!(text.contains(label));
+            assert!(text.contains("RX BW"));
+            assert!(text.contains("FEC effective interval"));
+            assert_eq!(
+                text.contains("987654321"),
+                state == LogStreamFeedbackState::Active && !failed
+            );
+            assert_eq!(
+                text.contains("12.50%"),
+                state == LogStreamFeedbackState::Active && !failed
+            );
+        }
+    }
+
+    #[test]
+    fn bandwidth_scrolls_to_multiple_destinations_on_narrow_terminals() {
+        use cu29::monitoring::{LogStreamMonitor, LogStreamStats};
+        let mut model = test_monitor_model();
+        model.streams = Some(std::sync::Arc::from(vec![
+            LogStreamMonitor::new(
+                "first",
+                1_000_000,
+                4,
+                StreamFixture(LogStreamStats::default()),
+            ),
+            LogStreamMonitor::new(
+                "second",
+                1_000_000,
+                4,
+                StreamFixture(LogStreamStats::default()),
+            ),
+        ]));
+        let mut ui = MonitorUi::new(model, MonitorUiOptions::default());
+        ui.set_active_screen(MonitorScreen::CopperList);
+        ui.scroll(ScrollDirection::Right, 84);
+        ui.scroll(ScrollDirection::Down, 20);
+        let text = stream_text(&mut ui, 42, 12);
+        assert!(text.contains("Telemetry / TX: second"), "{text}");
+        // Tiny terminal sizes and resizing clamp rather than overflow.
+        stream_text(&mut ui, 1, 1);
+        ui.scroll(ScrollDirection::Left, 200);
+        ui.scroll(ScrollDirection::Up, 200);
+        assert!(stream_text(&mut ui, 132, 48).contains("Telemetry / TX: first"));
+    }
 
     #[test]
     fn normalize_text_colors_replaces_reset_fg_and_bg() {
@@ -1624,7 +1824,7 @@ fn spans_from_runs(line: &StyledLine) -> Vec<Span<'static>> {
     spans
 }
 
-fn format_bytes(bytes: f64) -> String {
+pub(crate) fn format_bytes(bytes: f64) -> String {
     const UNITS: [&str; 4] = ["B", "KiB", "MiB", "GiB"];
     let mut value = bytes;
     let mut unit_idx = 0;

--- a/components/monitors/cu_bevymon/src/lib.rs
+++ b/components/monitors/cu_bevymon/src/lib.rs
@@ -39,9 +39,9 @@ impl CuBevyMon {
 }
 
 impl CuMonitor for CuBevyMon {
-    fn new(metadata: CuMonitoringMetadata, _runtime: CuMonitoringRuntime) -> CuResult<Self> {
+    fn new(metadata: CuMonitoringMetadata, runtime: CuMonitoringRuntime) -> CuResult<Self> {
         Ok(Self {
-            model: MonitorModel::from_metadata(&metadata),
+            model: MonitorModel::from_metadata(&metadata).with_runtime(&runtime),
             log_capture: None,
         })
     }

--- a/components/monitors/cu_consolemon/src/lib.rs
+++ b/components/monitors/cu_consolemon/src/lib.rs
@@ -222,7 +222,7 @@ impl UI {
 impl CuMonitor for CuConsoleMon {
     fn new(metadata: CuMonitoringMetadata, runtime: CuMonitoringRuntime) -> CuResult<Self> {
         Ok(Self {
-            model: MonitorModel::from_metadata(&metadata),
+            model: MonitorModel::from_metadata(&metadata).with_runtime(&runtime),
             ui_handle: None,
             quitting: Arc::new(AtomicBool::new(false)),
             monitor_runtime: runtime,

--- a/components/res/cu29_logstream_udp/tests/configured_feedback.ron
+++ b/components/res/cu29_logstream_udp/tests/configured_feedback.ron
@@ -1,4 +1,5 @@
 (
+    monitor: (type: "StreamProbe"),
     logging: (
         enable_task_logging: false,
         enable_keyframe_logging: false,

--- a/components/res/cu29_logstream_udp/tests/configured_feedback.rs
+++ b/components/res/cu29_logstream_udp/tests/configured_feedback.rs
@@ -7,6 +7,34 @@ use cu29_logstream::{
     CuStreamRx, FiniteObjectLimits, RecordKind, SessionEvent, SessionRouter, SessionRouterLimits,
 };
 use std::time::{Duration, Instant};
+thread_local! {
+    static STREAMS: std::cell::RefCell<Option<std::sync::Arc<[cu29::monitoring::LogStreamMonitor]>>> = const { std::cell::RefCell::new(None) };
+}
+struct StreamProbe;
+impl cu29::monitoring::CuMonitor for StreamProbe {
+    fn new(
+        _: cu29::monitoring::CuMonitoringMetadata,
+        runtime: cu29::monitoring::CuMonitoringRuntime,
+    ) -> CuResult<Self> {
+        STREAMS.with(|streams| *streams.borrow_mut() = runtime.log_streams());
+        Ok(Self)
+    }
+    fn process_copperlist(
+        &self,
+        _: &CuContext,
+        _: cu29::monitoring::CopperListView<'_>,
+    ) -> CuResult<()> {
+        Ok(())
+    }
+    fn process_error(
+        &self,
+        _: cu29::monitoring::ComponentId,
+        _: cu29::monitoring::CuComponentState,
+        _: &CuError,
+    ) -> cu29::monitoring::Decision {
+        cu29::monitoring::Decision::Shutdown
+    }
+}
 #[copper_runtime(config = "tests/configured_feedback.ron")]
 struct FeedbackApp {}
 
@@ -89,6 +117,16 @@ fn configured_feedback_resource_is_owned_and_advertised() -> CuResult<()> {
     drop(running.stop()?);
     assert_eq!(sent, 100);
     assert!(reports_sent >= 4);
+    STREAMS.with(|streams| {
+        let streams = streams.borrow();
+        let monitors = streams.as_ref().expect("generated monitor handles");
+        assert_eq!(monitors.len(), 1);
+        assert_eq!(monitors[0].destination, "ground");
+        let snapshot = monitors[0].snapshot();
+        assert!(snapshot.packets_sent > 0);
+        assert!(snapshot.feedback.unwrap().reports > 0);
+        assert!(snapshot.stopped);
+    });
     Ok(())
 }
 

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -5654,14 +5654,14 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         cu29::resource::ResourceKey::<()>::new(cu29::resource::BundleIndex::new(#bundle),
                             cu29::resource::resource_index_by_name::<#provider>(#name)).typed::<#ty>()
                     )?.0;
-                    let (#continuous_ident, #recovery_ident, _) = ::cu29::logstream::scheduled_feedback_sinks::<#mission_mod::CuStampedDataSet, _>(
+                    let (#continuous_ident, #recovery_ident, sender_monitor) = ::cu29::logstream::scheduled_feedback_sinks::<#mission_mod::CuStampedDataSet, _>(
                         ::cu29::logstream::SeparateFeedback { tx: #transport_ident, feedback_rx }, sender_config,
                         if clock.is_mock() { RobotClock::new() } else { clock.clone() },
                     )?;
                 }
             } else {
                 quote! {
-                    let (#continuous_ident, #recovery_ident, _) = ::cu29::logstream::scheduled_sinks::<#mission_mod::CuStampedDataSet, _>(
+                    let (#continuous_ident, #recovery_ident, sender_monitor) = ::cu29::logstream::scheduled_sinks::<#mission_mod::CuStampedDataSet, _>(
                         #transport_ident, sender_config,
                         if clock.is_mock() { RobotClock::new() } else { clock.clone() },
                     )?;
@@ -5694,6 +5694,8 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                     )?
                     .0;
                 #scheduled
+                stream_monitors.push(sender_monitor.into_runtime_monitor(&destination.id,
+                    destination.link.bitrate_bps, usize::from(destination.fec.continuous.repair_every_source_symbols)));
                 let #continuous_ident = if logstream_schema.reconstruction.is_empty() {
                     #continuous_ident
                 } else {
@@ -5733,6 +5735,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 let logstream_output_required = #configured_logstream_count != 0 || logstream.is_some();
                 #[allow(unused_mut)]
                 let mut resources = resources;
+                let mut stream_monitors = Vec::with_capacity(#configured_logstream_count + usize::from(logstream.is_some()));
                 #configured_logstream_session
                 #(#configured_logstream_initializers)*
                 let injected_logstream_sinks = logstream
@@ -5747,15 +5750,20 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                                 return Err(CuError::from("injected sender must use the generated reconstruction schema"));
                             }
                         }
-                        let (copperlist, keyframe, _) = ::cu29::logstream::scheduled_sinks::<
+                        let bitrate = sender_config.pacing.bitrate_bps;
+                        let baseline = sender_config.continuous.repair_every_source_symbols;
+                        let (copperlist, keyframe, sender_monitor) = ::cu29::logstream::scheduled_sinks::<
                             #mission_mod::CuStampedDataSet, _
                         >(transport, sender_config,
                             if clock.is_mock() { RobotClock::new() } else { clock.clone() })?;
+                        stream_monitors.push(sender_monitor.into_runtime_monitor("injected", bitrate, baseline));
                         let copperlist = if schema.reconstruction.is_empty() { copperlist }
                             else { copperlist.with_encoder(::cu29::logstream::capture::encode_capture_record_into) };
                         Ok::<_, CuError>((copperlist, keyframe))
                     })
                     .transpose()?;
+                let stream_monitors: Option<::std::sync::Arc<[cu29::monitoring::LogStreamMonitor]>> =
+                    (!stream_monitors.is_empty()).then(|| stream_monitors.into());
                 let (injected_logstream_sink, injected_logstream_keyframe_sink) =
                     injected_logstream_sinks.unzip();
                 let copperlist_sink = ::cu29::fanout::OptionalWriteStream::new(
@@ -5798,6 +5806,18 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 let copperlist_sink = local_copperlist_sink;
                 let keyframe_sink = local_keyframe_sink;
             }
+        };
+
+        let monitor_instanciator = if logstream_enabled {
+            quote! { |config: &CuConfig, metadata: cu29::monitoring::CuMonitoringMetadata, runtime: cu29::monitoring::CuMonitoringRuntime| {
+                let runtime = match &stream_monitors {
+                    Some(streams) => runtime.with_log_streams(streams.clone()),
+                    None => runtime,
+                };
+                #mission_mod::monitor_instanciator(config, metadata, runtime)
+            } }
+        } else {
+            quote! { #mission_mod::monitor_instanciator }
         };
 
         let build_with_resources_fn = quote! {
@@ -5896,7 +5916,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         #mission_mod::MONITORED_COMPONENTS,
                         #mission_mod::CULIST_COMPONENT_MAPPING,
                         #parallel_rt_metadata_arg
-                        #mission_mod::monitor_instanciator,
+                        #monitor_instanciator,
                         #mission_mod::bridges_instanciator,
                     ),
                     copperlist_sink,

--- a/core/cu29_logstream/Cargo.toml
+++ b/core/cu29_logstream/Cargo.toml
@@ -58,6 +58,7 @@ std = [
   "cu29-unifiedlog/std",
   "blake3/std",
   "cu29-runtime/std",
+  "cu29-runtime/logstream-monitoring",
   "cu29-clock/std",
   "cu29-traits/std",
   "raptorq/std",

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -282,3 +282,19 @@ stay fixed. Feedback failure never stops capture or autonomous recovery; snapsho
 
 Loss excludes the active coding window and unseen history/tails. Invalid packets do not prove corruption;
 CRC is not authentication. Reports and adaptation stay on stream workers. Run `just logstream-feedback-check`.
+
+### TUI bandwidth panel
+
+The console monitor's BW tab includes `Telemetry / TX` panels for each configured destination.
+One-way panels show actual submitted Copper bytes/packets, the configured budget, drops by cause,
+recovery activity, and baseline FEC. These are local submissions, not delivery acknowledgements.
+
+Two-way panels additionally show feedback state/age, receiver throughput, finalized source loss and
+FEC recovery, receiver buffer/progress counters, and the effective repair interval. Waiting, stale,
+and failed feedback show `n/a` for receiver measurements. Arrow keys or `hjkl` scroll the BW content
+horizontally and vertically on small terminals or when several destinations are configured.
+
+Generated apps attach read-only worker handles through `CuMonitoringRuntime`. Console and Bevy monitors
+pass those handles to the shared TUI model; custom monitor frontends can use `runtime.log_streams()`.
+Snapshots are published on sender workers and sampled by the presentation thread. The task path gains
+no monitoring callbacks, serialization, or synchronization. Run `just logstream-monitor-check`.

--- a/core/cu29_logstream/src/feedback.rs
+++ b/core/cu29_logstream/src/feedback.rs
@@ -239,6 +239,8 @@ pub struct FeedbackSnapshot {
     pub report: Option<ReceiverReport>,
     pub effective_repair_every_source_symbols: u16,
     pub baseline_repair_every_source_symbols: u16,
+    pub receiver_rates_available: bool,
+    pub source_metrics_available: bool,
     pub receiver_bytes_per_second: u64,
     pub receiver_packets_per_second: u64,
     pub source_loss_basis_points: u16,
@@ -341,12 +343,14 @@ impl FeedbackController {
         // First report establishes a measurement baseline, including after receiver restart.
         if let Some(previous) = previous.filter(|_| same_peer) {
             let micros = report.elapsed_us - previous.elapsed_us;
+            self.snapshot.receiver_rates_available = true;
             self.snapshot.receiver_bytes_per_second =
                 rate(report.received_bytes - previous.received_bytes, micros);
             self.snapshot.receiver_packets_per_second =
                 rate(report.received_packets - previous.received_packets, micros);
             let n = report.sources.finalized - previous.sources.finalized;
             if n > 0 {
+                self.snapshot.source_metrics_available = true;
                 let lost = n.saturating_sub(report.sources.received - previous.sources.received);
                 let recovered = report.sources.recovered - previous.sources.recovered;
                 let loss = ((u128::from(lost) * 10_000) / u128::from(n)) as u64;
@@ -361,6 +365,8 @@ impl FeedbackController {
         } else {
             self.healthy = 0;
             self.smoothed_loss = None;
+            self.snapshot.receiver_rates_available = false;
+            self.snapshot.source_metrics_available = false;
             self.snapshot.receiver_bytes_per_second = 0;
             self.snapshot.receiver_packets_per_second = 0;
             self.snapshot.source_loss_basis_points = 0;

--- a/core/cu29_logstream/src/worker.rs
+++ b/core/cu29_logstream/src/worker.rs
@@ -477,3 +477,76 @@ where
         SenderMonitor(shared),
     ))
 }
+
+impl SenderMonitor {
+    /// Transfer a read-only worker handle into generated monitoring metadata.
+    pub fn into_runtime_monitor(
+        self,
+        destination: &str,
+        bitrate_bps: u64,
+        baseline: usize,
+    ) -> cu29_runtime::monitoring::LogStreamMonitor {
+        cu29_runtime::monitoring::LogStreamMonitor::new(destination, bitrate_bps, baseline, self)
+    }
+}
+impl cu29_runtime::monitoring::LogStreamStatsSource for SenderMonitor {
+    fn snapshot(&self) -> cu29_runtime::monitoring::LogStreamStats {
+        use cu29_runtime::monitoring::{
+            LogStreamFeedbackState, LogStreamFeedbackStats, LogStreamStats,
+        };
+        let snapshot = SenderMonitor::snapshot(self);
+        let stats = snapshot.stats;
+        LogStreamStats {
+            sampled_at: snapshot.sampled_at,
+            packets_sent: stats.packets_sent,
+            bytes_sent: stats.bytes_sent,
+            queue_drops: stats.queue_drops,
+            expired_packets: stats.expired_packets,
+            transport_drops: stats.transport_drops,
+            inbox_drops: snapshot.inbox_drops,
+            shutdown_drops: stats.shutdown_drops,
+            recovery_rounds: stats.recovery_rounds,
+            recovery_superseded: stats.recovery_superseded,
+            queue_peak: stats.queue_peak,
+            stopped: snapshot.stopped,
+            failed: snapshot.failed,
+            feedback: snapshot.feedback.map(|feedback| {
+                let report = feedback.report.unwrap_or_default();
+                LogStreamFeedbackStats {
+                    state: match feedback.state {
+                        crate::feedback::FeedbackState::Waiting => LogStreamFeedbackState::Waiting,
+                        crate::feedback::FeedbackState::Active => LogStreamFeedbackState::Active,
+                        crate::feedback::FeedbackState::Stale => LogStreamFeedbackState::Stale,
+                    },
+                    age: feedback.last_received.map(|last| {
+                        CuDuration::from_nanos(
+                            snapshot
+                                .sampled_at
+                                .as_nanos()
+                                .saturating_sub(last.as_nanos()),
+                        )
+                    }),
+                    failed: snapshot.feedback_failed,
+                    reports: feedback.accepted_reports,
+                    rejected_reports: feedback.rejected_reports,
+                    invalid_reports: feedback.invalid_reports,
+                    rates_available: feedback.receiver_rates_available,
+                    source_metrics_available: feedback.source_metrics_available,
+                    bytes_per_second: feedback.receiver_bytes_per_second,
+                    packets_per_second: feedback.receiver_packets_per_second,
+                    finalized_symbols: report.sources.finalized,
+                    loss_basis_points: feedback.source_loss_basis_points,
+                    recovery_basis_points: feedback.source_recovery_basis_points,
+                    buffered_records: report.buffered_records,
+                    record_capacity: report.record_capacity,
+                    latest_copperlist: report.latest_copperlist,
+                    effective_repair_every_source_symbols: feedback
+                        .effective_repair_every_source_symbols,
+                    invalid_packets: report.invalid_packets,
+                    duplicate_packets: report.duplicate_packets,
+                    expired_records: report.expired_records,
+                }
+            }),
+        }
+    }
+}

--- a/core/cu29_logstream/tests/feedback.rs
+++ b/core/cu29_logstream/tests/feedback.rs
@@ -108,6 +108,8 @@ fn stale_duplicate_wrong_session_and_competing_receivers_do_not_refresh_health()
     c.receive(foreign, time(2600));
     assert_eq!(c.snapshot().accepted_reports, 2);
     assert_eq!(c.snapshot().report.unwrap().receiver_id, [3; 16]);
+    assert!(!c.snapshot().receiver_rates_available);
+    assert!(!c.snapshot().source_metrics_available);
 }
 #[test]
 fn reporting_only_idle_and_cadence_never_reduce_protection() {

--- a/core/cu29_runtime/Cargo.toml
+++ b/core/cu29_runtime/Cargo.toml
@@ -106,6 +106,8 @@ tempfile = { workspace = true }
 
 [features]
 default = ["std"]
+# Optional worker handles; absent from monitoring contexts when streaming is disabled.
+logstream-monitoring = ["std"]
 defmt = ["cu29-log/defmt", "cu29-log-derive/defmt", "cu29-traits/defmt"]
 cuda = ["dep:cudarc"]
 macro_debug = []

--- a/core/cu29_runtime/src/monitoring.rs
+++ b/core/cu29_runtime/src/monitoring.rs
@@ -1,6 +1,14 @@
 //! Some basic internal monitoring tooling Copper uses to monitor itself and the components it runs.
 //!
 
+#[cfg(feature = "std")]
+mod logstream;
+#[cfg(feature = "std")]
+pub use logstream::{
+    LogStreamFeedbackState, LogStreamFeedbackStats, LogStreamMonitor, LogStreamStats,
+    LogStreamStatsSource,
+};
+
 use crate::config::CuConfig;
 use crate::config::{
     BridgeChannelConfigRepresentation, BridgeConfig, ComponentConfig, CuGraph, Flavor, NodeId,
@@ -730,13 +738,40 @@ impl CuMonitoringMetadata {
 #[derive(Debug, Clone, Default)]
 pub struct CuMonitoringRuntime {
     execution_probe: MonitorExecutionProbe,
+    #[cfg(feature = "logstream-monitoring")]
+    log_streams: Option<Arc<[LogStreamMonitor]>>,
 }
 
 impl CuMonitoringRuntime {
     #[cfg(feature = "std")]
     pub fn new(execution_probe: MonitorExecutionProbe) -> Self {
         ensure_runtime_panic_hook_installed();
-        Self { execution_probe }
+        Self {
+            execution_probe,
+            #[cfg(feature = "logstream-monitoring")]
+            log_streams: None,
+        }
+    }
+
+    /// Statically bound stream workers; absent when the application has no streams.
+    #[cfg(feature = "std")]
+    pub fn log_streams(&self) -> Option<Arc<[LogStreamMonitor]>> {
+        #[cfg(feature = "logstream-monitoring")]
+        {
+            self.log_streams.clone()
+        }
+        #[cfg(not(feature = "logstream-monitoring"))]
+        {
+            None
+        }
+    }
+
+    #[cfg(feature = "logstream-monitoring")]
+    pub fn with_log_streams(mut self, streams: Arc<[LogStreamMonitor]>) -> Self {
+        if !streams.is_empty() {
+            self.log_streams = Some(streams);
+        }
+        self
     }
 
     #[cfg(not(feature = "std"))]

--- a/core/cu29_runtime/src/monitoring/logstream.rs
+++ b/core/cu29_runtime/src/monitoring/logstream.rs
@@ -1,0 +1,86 @@
+//! Read-only handles for statically wired sender workers. No stream protocol dependency.
+use compact_str::CompactString;
+use cu29_clock::{CuDuration, CuTime};
+use std::sync::Arc;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum LogStreamFeedbackState {
+    #[default]
+    Waiting,
+    Active,
+    Stale,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct LogStreamFeedbackStats {
+    pub state: LogStreamFeedbackState,
+    pub age: Option<CuDuration>,
+    pub failed: bool,
+    pub reports: u64,
+    pub rejected_reports: u64,
+    pub invalid_reports: u64,
+    pub rates_available: bool,
+    pub source_metrics_available: bool,
+    pub bytes_per_second: u64,
+    pub packets_per_second: u64,
+    pub finalized_symbols: u64,
+    pub loss_basis_points: u16,
+    pub recovery_basis_points: u16,
+    pub buffered_records: u32,
+    pub record_capacity: u32,
+    pub latest_copperlist: Option<u64>,
+    pub effective_repair_every_source_symbols: u16,
+    pub invalid_packets: u64,
+    pub duplicate_packets: u64,
+    pub expired_records: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct LogStreamStats {
+    pub sampled_at: CuTime,
+    pub packets_sent: u64,
+    pub bytes_sent: u64,
+    pub queue_drops: u64,
+    pub expired_packets: u64,
+    pub transport_drops: u64,
+    pub inbox_drops: u64,
+    pub shutdown_drops: u64,
+    pub recovery_rounds: u64,
+    pub recovery_superseded: u64,
+    pub queue_peak: usize,
+    pub stopped: bool,
+    pub failed: bool,
+    pub feedback: Option<LogStreamFeedbackStats>,
+}
+
+/// Queried only by the monitor's presentation thread, never by task execution.
+pub trait LogStreamStatsSource: core::fmt::Debug + Send + Sync {
+    fn snapshot(&self) -> LogStreamStats;
+}
+
+/// Identity and immutable policy are bound once during generated app construction.
+#[derive(Clone, Debug)]
+pub struct LogStreamMonitor {
+    pub destination: CompactString,
+    pub bitrate_bps: u64,
+    pub baseline_repair_every_source_symbols: usize,
+    source: Arc<dyn LogStreamStatsSource>,
+}
+impl LogStreamMonitor {
+    pub fn new(
+        destination: &str,
+        bitrate_bps: u64,
+        baseline: usize,
+        source: impl LogStreamStatsSource + 'static,
+    ) -> Self {
+        Self {
+            destination: destination.into(),
+            bitrate_bps,
+            baseline_repair_every_source_symbols: baseline,
+            source: Arc::new(source),
+        }
+    }
+    pub fn snapshot(&self) -> LogStreamStats {
+        self.source.snapshot()
+    }
+}

--- a/justfile
+++ b/justfile
@@ -199,6 +199,12 @@ logstream-feedback-check:
 	cargo +stable test -p cu29 --features logstream --test logstream_runtime
 	just logstream-udp-check
 
+# TUI stream snapshots/rates and generated monitor wiring, including feedback.
+logstream-monitor-check:
+	cargo +stable clippy -p cu-tuimon -p cu-consolemon -p cu-bevymon --all-targets -- --deny warnings
+	cargo +stable test -p cu-tuimon -p cu-consolemon
+	just logstream-feedback-check
+
 # Runnable two-process UDP scenarios, archive comparison, and recorded replay.
 logstream-demo-check:
 	cargo +stable clippy -p cu-logstream-demo --all-targets --features replay -- --deny warnings


### PR DESCRIPTION
The BW tab now shows a Telemetry / TX panel for each logstream destination. One-way streams show actual local transmission rates, configured budget, drop counters, and recovery activity. Two-way streams also show receiver throughput/loss/recovery, feedback age and health, buffer/progress counters, and effective FEC. Unavailable or stale measurements display as n/a; narrow terminals and multiple destinations can scroll.

Generated builders retain sender monitor handles and attach them through CuMonitoringRuntime. The shared console/Bevy TUI samples worker snapshots on its presentation thread. Stream-handle storage is feature-gated, and there are no new task-path callbacks, allocations, serialization, or synchronization.

Stacked on #1341. Book documentation: https://github.com/copper-project/copper-rs-book/pull/54 (stacked on #53); wiki updates are committed locally.

Validation: focused `just logstream-monitor-check` passes, including TUI state/rate/scroll tests, generated handle wiring, adaptive feedback, UDP, config, runtime, and no-default-features checks. Formatting and public API checks pass; demo/replay checks cover clean, loss, outage, late join, restart, and idle recovery. The book builds successfully.

Validation used an isolated copy excluding the unrelated flight-controller example, whose optional local dependencies pull conflicting packages from another checkout. The demo launcher used the same compiled artifacts through its expected target path. No workaround is committed to workspace configuration.
