### PR TITLE
Add HC-12 startup resources and radio integration examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
   "components/libs/cu_serial",
+  "components/res/cu_hc12",
   "components/res/cu29_logstream_serial",
   "components/bridges/cu_serial_bridge",
 
@@ -226,6 +227,7 @@ no_individual_tags = true
 
 [workspace.dependencies]
 cu-serial = { path = "components/libs/cu_serial", version = "1.2.0-dev", default-features = false }
+cu-hc12 = { path = "components/res/cu_hc12", version = "1.2.0-dev", default-features = false }
 cu29-logstream-serial = { path = "components/res/cu29_logstream_serial", version = "1.2.0-dev", default-features = false }
 cu-serial-bridge = { path = "components/bridges/cu_serial_bridge", version = "1.2.0-dev", default-features = false }
 

--- a/components/res/cu_hc12/Cargo.toml
+++ b/components/res/cu_hc12/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "cu-hc12"
+description = "HC-12 transparent radio resource for Copper"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[package.metadata.copper]
+kind = "resource"
+domains = ["communication/serial"]
+environments = ["host", "embedded"]
+
+[dependencies]
+embedded-io = { version = "0.7.1", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
+cu-serial = { workspace = true }
+embedded-hal = { version = "1.0", default-features = false }
+
+[features]
+default = ["std"]
+std = ["cu29/std", "cu-serial/std"]
+
+[build-dependencies]
+cu29-build = { workspace = true }
+
+[dev-dependencies]
+cu-linux-resources = { workspace = true, features = ["serial-rts"] }
+cu-serial-bridge = { workspace = true }
+bincode = { workspace = true }
+serde = { workspace = true }
+
+[[example]]
+name = "echo"
+required-features = ["std"]
+
+[[example]]
+name = "pair"
+required-features = ["std"]

--- a/components/res/cu_hc12/README.md
+++ b/components/res/cu_hc12/README.md
@@ -1,0 +1,112 @@
+# HC-12 radio resources
+
+`cu-hc12` configures an HC-12 in FU3 transparent mode at startup and exports an
+owned `radio.serial` resource implementing `cu_serial::SerialIo`. Channel selection
+lives in RON. The same resource can feed a raw byte bridge or a serial LogStream
+adapter; each radio has one owner.
+
+## Wiring and startup
+
+Supply a nonblocking UART, an `embedded_hal::digital::OutputPin` connected to SET,
+and a startup-only `embedded_hal::delay::DelayNs` resource. The UART must already
+match the module's saved baud rate and format (factory default: 9600, 8N1).
+Both radio peers must use matching channel, FU3 mode and baud rate.
+
+Startup waits 200 ms before entering command mode, holds SET low for 40 ms,
+checks `AT`, queries/selects FU3, and queries/sets the channel with `AT+Cxxx`.
+Each command has a bounded 500 ms timeout. Existing matching settings are left
+alone to avoid unnecessary persistent writes. SET is released and an 80 ms
+settling delay is applied on both success and command failure. SET remains owned
+by the radio during operation. The exported serial resource carries transparent
+mode data after startup completes.
+
+Channels 1–127 follow the command range in the supplied V2.6 manual; the manual
+only specifies normal radio performance through channel 100. The radio is
+half duplex and can lose bytes: applications must arrange turn-taking and
+implement the delivery checks required by their protocol.
+
+## Resource composition
+
+For the Unix USB-to-TTL wiring example, enable `cu-linux-resources`'s
+`serial-rts` Cargo feature and connect the adapter's active-low RTS# output to SET.
+Use compatible 3.3 V logic levels and a common ground.
+The resource disables flow control and initializes RTS# high; `set_low` asserts
+RTS to enter command mode, and `set_high` releases it. Adapters with inverted
+RTS polarity require a different pin adapter.
+
+```rust,ignore
+use cu_linux_resources::{LinuxNonblockingSerialPort, LinuxSerialRtsPin};
+type Radio = cu_hc12::Hc12<LinuxNonblockingSerialPort, LinuxSerialRtsPin>;
+type RadioResources = cu_hc12::Hc12Resources<
+    LinuxNonblockingSerialPort, LinuxSerialRtsPin, cu_hc12::host::StartupDelay,
+>;
+type RadioBridge = cu_serial_bridge::SerialBridge<Radio>;
+```
+
+```ron
+resources: [
+    (id: "board", provider: "cu_linux_resources::LinuxResources", config: {
+        "serial0_dev": "/dev/ttyUSB0", "serial0_baudrate": 9600,
+        "serial0_nonblocking": true,
+        "serial0_rts": true,
+    }),
+    (id: "timing", provider: "cu_hc12::host::DelayResources"),
+    (id: "radio", provider: "RadioResources", resources: {
+        "serial": "board.serial0", "set": "board.serial0_rts", "delay": "timing.delay",
+    }, config: { "channel": 21 }),
+],
+```
+
+For a separate Raspberry Pi GPIO, use `LinuxOutputPin`, configure a `gpioN`
+output initially high, and bind `set` to that slot instead of `serial0_rts`.
+Other hardware can supply any compatible SET-pin resource. For embedded hardware, export
+`cu_serial::ReadySerial<YourUart>` when the HAL implements embedded-io readiness,
+or implement `SerialIo` using the HAL's nonblocking/DMA facilities. Bind the
+board's delay and SET-pin resources. The driver and adapters support `no_std`.
+
+Bind a `RadioBridge` to `radio.serial`; its channels are `bytes_rx` and `bytes_tx`,
+with `cu_serial_bridge::ByteChunk` payloads. See the complete
+[echo configuration](examples/echo.ron) and [application](examples/echo.rs).
+From this directory, `just dag` writes `output.svg` showing resource users and
+provider-to-consumer arrows. `just echo` runs the hardware example after you edit
+its device and channel; run the echo application on only one end of a pair.
+Logs go into this component's `logs/` directory.
+
+With two radios attached to this host, run `just pair` to configure both and
+verify 1-, 31-, 128-, and 256-byte binary transfers in each direction. The test
+uses `/dev/ttyACM0` and `/dev/ttyACM1` by default; override them with
+`just pair /dev/ttyUSB0 /dev/ttyUSB1`. Baud rate and channel come from
+`examples/echo.ron`. Each transfer has a five-second deadline, and the test exits
+on a timeout, mismatch, or unexpected trailing bytes. Run it while both radios
+are otherwise idle, with RTS# connected to SET on each adapter.
+
+## LogStream
+
+For LogStream telemetry, bind a framing provider to the radio:
+
+```rust,ignore
+type RadioLogResources = cu29_logstream_serial::SerialLogStreamTxResources<Radio>;
+type RadioLogTx = cu29_logstream_serial::SerialLogStreamTx<Radio>;
+```
+
+```ron
+(id: "telemetry", provider: "RadioLogResources",
+ resources: { "serial": "radio.serial" }),
+```
+
+Use `transport: (type: "RadioLogTx", resource: "telemetry.tx")` in an existing
+`log_streaming.destinations` entry. Enable the application's `cu29/logstream`
+feature. The default serial adapter supports packets up to 256 bytes, so use
+`link.mtu_bytes: 256` or less. Start conservatively at `bitrate_bps: 3000` with
+`burst_packets: 1` for 9600-baud UARTs, allowing for serial framing and 8N1 overhead;
+measure the actual radio link before increasing the rate. This is a low-bandwidth
+telemetry link, so select logged messages and bound record sizes accordingly.
+
+At the receiver, use `SerialLogStreamRxResources<Radio>` and consume
+`telemetry.rx` as `SerialLogStreamRx<Radio>`. Its packets feed the existing
+LogStream receiver/session router. Assign one radio to the TX provider and the
+peer radio to the RX provider for one-way telemetry. See
+[serial framing](../cu29_logstream_serial/README.md).
+
+From the repository root, `just hc12-check` checks drivers, framing, resource
+composition, DAG rendering and `no_std` compatibility using software tests.

--- a/components/res/cu_hc12/README.md
+++ b/components/res/cu_hc12/README.md
@@ -96,15 +96,20 @@ type RadioLogTx = cu29_logstream_serial::SerialLogStreamTx<Radio>;
 
 Use `transport: (type: "RadioLogTx", resource: "telemetry.tx")` in an existing
 `log_streaming.destinations` entry. Enable the application's `cu29/logstream`
-feature. The default serial adapter supports packets up to 256 bytes, so use
-`link.mtu_bytes: 256` or less. Start conservatively at `bitrate_bps: 3000` with
-`burst_packets: 1` for 9600-baud UARTs, allowing for serial framing and 8N1 overhead;
+feature. The default serial adapter supports packets up to 252 bytes, so use
+`link.mtu_bytes: 252` or less. Start conservatively at `bitrate_bps: 3000` with
+`burst_packets: 1` for 9600-baud UARTs, allowing for the framing CRC32C, escaping, and 8N1 overhead;
 measure the actual radio link before increasing the rate. This is a low-bandwidth
 telemetry link, so select logged messages and bound record sizes accordingly.
 
 At the receiver, use `SerialLogStreamRxResources<Radio>` and consume
 `telemetry.rx` as `SerialLogStreamRx<Radio>`. Its packets feed the existing
-LogStream receiver/session router. Assign one radio to the TX provider and the
+LogStream receiver/session router. The framing adapter verifies and strips its
+four-byte CRC32C before delivery to FEC, discards damaged frames, and
+resynchronizes at the next delimiter. Both peers must use this framing; an older
+adapter that relies on the common LogStream packet CRC is incompatible.
+The HC-12 transparent byte stream uses this serial integrity check even if the
+radio hardware also checks its own packets. Assign one radio to the TX provider and the
 peer radio to the RX provider for one-way telemetry. See
 [serial framing](../cu29_logstream_serial/README.md).
 

--- a/components/res/cu_hc12/build.rs
+++ b/components/res/cu_hc12/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    cu29_build::setup();
+}

--- a/components/res/cu_hc12/examples/echo.ron
+++ b/components/res/cu_hc12/examples/echo.ron
@@ -1,0 +1,54 @@
+(
+    runtime: (rate_target_hz: 100),
+    logging: (
+        slab_size_mib: 1,
+        section_size_mib: 1,
+    ),
+    resources: [
+        (
+            id: "board",
+            provider: "cu_linux_resources::LinuxResources",
+            config: {
+                "serial0_dev": "/dev/ttyACM0",
+                "serial0_baudrate": 9600,
+                "serial0_nonblocking": true,
+                "serial0_rts": true,
+            },
+        ),
+        (
+            id: "timing",
+            provider: "cu_hc12::host::DelayResources",
+        ),
+        (
+            id: "radio",
+            provider: "RadioResources",
+            resources: {
+                "serial": "board.serial0",
+                "set": "board.serial0_rts",
+                "delay": "timing.delay",
+            },
+            config: {"channel": 21},
+        ),
+    ],
+    bridges: [
+        (
+            id: "bytes",
+            type: "RadioBridge",
+            resources: {
+                "serial": "radio.serial",
+            },
+            channels: [
+                Rx(id: "bytes_rx"),
+                Tx(id: "bytes_tx"),
+            ],
+        ),
+    ],
+    tasks: [],
+    cnx: [
+        (
+            src: "bytes/bytes_rx",
+            dst: "bytes/bytes_tx",
+            msg: "cu_serial_bridge::ByteChunk",
+        ),
+    ],
+)

--- a/components/res/cu_hc12/examples/echo.rs
+++ b/components/res/cu_hc12/examples/echo.rs
@@ -1,0 +1,34 @@
+//! Run on one end of a radio pair; echoes incoming bytes to the other end.
+#[cfg(unix)]
+mod app {
+    use cu_linux_resources::{LinuxNonblockingSerialPort, LinuxSerialRtsPin};
+    use cu29::prelude::*;
+    type RadioResources = cu_hc12::Hc12Resources<
+        LinuxNonblockingSerialPort,
+        LinuxSerialRtsPin,
+        cu_hc12::host::StartupDelay,
+    >;
+    type Radio = cu_hc12::Hc12<LinuxNonblockingSerialPort, LinuxSerialRtsPin>;
+    type RadioBridge = cu_serial_bridge::SerialBridge<Radio>;
+    #[copper_runtime(config = "examples/echo.ron")]
+    struct Echo {}
+    pub fn run() -> CuResult<()> {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("logs/hc12-echo.copper");
+        std::fs::create_dir_all(path.parent().unwrap())
+            .map_err(|e| CuError::new_with_cause("Create example log directory", e))?;
+        let app = Echo::builder()
+            .with_log_path(&path, Some(1024 * 1024))?
+            .build()?;
+        app.run_until_shutdown()
+            .map(|_| ())
+            .map_err(|failure| failure.error)
+    }
+}
+#[cfg(unix)]
+fn main() -> cu29::CuResult<()> {
+    app::run()
+}
+#[cfg(not(unix))]
+fn main() {
+    eprintln!("This wiring example uses Unix serial RTS resources.");
+}

--- a/components/res/cu_hc12/examples/pair.rs
+++ b/components/res/cu_hc12/examples/pair.rs
@@ -1,0 +1,125 @@
+//! Bounded over-the-air smoke test for two HC-12s connected to this host.
+#[cfg(unix)]
+mod test_pair {
+    use cu_hc12::{Hc12, host::StartupDelay};
+    use cu_linux_resources::{
+        DEFAULT_SERIAL_PARITY, DEFAULT_SERIAL_STOPBITS, LinuxNonblockingSerialPort,
+        LinuxSerialRtsPin, SerialSlotConfig,
+    };
+    use cu_serial::SerialIo;
+    use cu29::prelude::*;
+    use std::time::{Duration, Instant};
+
+    type Radio = Hc12<LinuxNonblockingSerialPort, LinuxSerialRtsPin>;
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    fn open(device: String, baudrate: u32, channel: u8) -> CuResult<Radio> {
+        let config = SerialSlotConfig {
+            dev: device.clone(),
+            baudrate,
+            parity: DEFAULT_SERIAL_PARITY,
+            stop_bits: DEFAULT_SERIAL_STOPBITS,
+            timeout_ms: 50,
+        };
+        let (serial, set) = LinuxNonblockingSerialPort::open_with_rts(&config)
+            .map_err(|e| CuError::new_with_cause(&format!("Open {device} with RTS"), e))?;
+        let radio = Hc12::configure(serial, set, &mut StartupDelay, channel)
+            .map_err(|e| CuError::new_with_cause(&format!("Configure {device}"), e))?;
+        println!("{device}: AT configuration passed (FU3, channel {channel}, {baudrate} baud)");
+        Ok(radio)
+    }
+
+    fn transfer(tx: &mut Radio, rx: &mut Radio, bytes: &[u8]) -> CuResult<()> {
+        let deadline = Instant::now() + TIMEOUT;
+        let mut sent = 0;
+        let mut received = 0;
+        let mut buffer = [0; 256];
+        while received < bytes.len() {
+            if Instant::now() >= deadline {
+                return Err(CuError::from(format!(
+                    "Radio transfer timed out: accepted {sent}, received {received}, expected {} bytes",
+                    bytes.len()
+                )));
+            }
+            if sent < bytes.len() {
+                sent += tx
+                    .try_write(&bytes[sent..])
+                    .map_err(|e| CuError::new_with_cause("Radio TX", e))?;
+            }
+            let n = rx
+                .try_read(&mut buffer)
+                .map_err(|e| CuError::new_with_cause("Radio RX", e))?;
+            if received + n > bytes.len() || buffer[..n] != bytes[received..received + n] {
+                return Err(CuError::from("Radio payload mismatch or unexpected bytes"));
+            }
+            received += n;
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        // Allow the half-duplex radio to finish before reversing direction.
+        std::thread::sleep(Duration::from_millis(100));
+        if rx
+            .try_read(&mut buffer)
+            .map_err(|e| CuError::new_with_cause("Check trailing radio data", e))?
+            != 0
+        {
+            return Err(CuError::from("Unexpected trailing radio bytes"));
+        }
+        Ok(())
+    }
+
+    pub fn run() -> CuResult<()> {
+        let args: Vec<_> = std::env::args().skip(1).collect();
+        if args.len() != 2 || args[0] == args[1] {
+            return Err(CuError::from(
+                "Usage: just pair /dev/ttyACM0 /dev/ttyACM1 (distinct ports)",
+            ));
+        }
+        // Reuse the example's RON channel and UART speed rather than hidden tuning knobs.
+        let config = cu29::config::read_configuration(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/examples/echo.ron"
+        ))?;
+        let board = config
+            .resources
+            .iter()
+            .find(|r| r.id == "board")
+            .and_then(|r| r.config.as_ref())
+            .ok_or_else(|| CuError::from("Missing board config"))?;
+        let radio = config
+            .resources
+            .iter()
+            .find(|r| r.id == "radio")
+            .and_then(|r| r.config.as_ref())
+            .ok_or_else(|| CuError::from("Missing radio config"))?;
+        let baud = board.get::<u32>("serial0_baudrate")?.unwrap_or(9600);
+        let channel = radio
+            .get::<u8>("channel")?
+            .ok_or_else(|| CuError::from("Missing radio channel"))?;
+        let mut first = open(args[0].clone(), baud, channel)?;
+        let mut second = open(args[1].clone(), baud, channel)?;
+        let mut payload = [0; 256];
+        for (index, byte) in payload.iter_mut().enumerate() {
+            *byte = index as u8;
+        }
+        for len in [1, 31, 128, 256] {
+            transfer(&mut first, &mut second, &payload[..len])?;
+            println!("{} -> {}: {len} bytes verified", args[0], args[1]);
+            payload.reverse();
+            transfer(&mut second, &mut first, &payload[..len])?;
+            println!("{} -> {}: {len} bytes verified", args[1], args[0]);
+            payload.reverse();
+        }
+        println!("PASS: bidirectional radio data, including all 256 byte values");
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn main() -> cu29::CuResult<()> {
+    test_pair::run()
+}
+
+#[cfg(not(unix))]
+fn main() {
+    eprintln!("The pair test requires Unix serial RTS resources.");
+}

--- a/components/res/cu_hc12/justfile
+++ b/components/res/cu_hc12/justfile
@@ -1,0 +1,15 @@
+# Run software checks.
+default:
+    just --justfile ../../../justfile hc12-check
+
+# Echo on one HC-12 (edit examples/echo.ron to match wiring first).
+echo:
+    cargo run -p cu-hc12 --example echo
+
+# Test two radios over the air using the baud/channel from examples/echo.ron.
+pair first="/dev/ttyACM0" second="/dev/ttyACM1":
+    cargo run -p cu-hc12 --example pair -- "{{first}}" "{{second}}"
+
+# Render resource ownership and dependencies.
+dag:
+    cargo run -p cu29-runtime --bin cu29-rendercfg -- examples/echo.ron

--- a/components/res/cu_hc12/src/lib.rs
+++ b/components/res/cu_hc12/src/lib.rs
@@ -1,0 +1,344 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//! HC-12 FU3 radio setup happens once, before the runtime starts. The host UART
+//! must already match the module baud rate (factory default: 9600, 8N1).
+use core::marker::PhantomData;
+use cu_serial::SerialIo;
+use cu29::prelude::*;
+use cu29::resource::{
+    BundleContext, NamedResourceBundleDecl, ResourceBindings, ResourceBundle, ResourceBundleDecl,
+    ResourceManager,
+};
+use embedded_hal::{delay::DelayNs, digital::OutputPin};
+
+const COMMAND_TIMEOUT_MS: u32 = 500;
+const RESPONSE_IDLE_MS: u32 = 20;
+
+/// A configured radio. Keeping SET owned prevents another consumer from putting
+/// the module into command mode while data is flowing.
+pub struct Hc12<S, P> {
+    serial: S,
+    _set: P,
+}
+
+impl<S, P> core::fmt::Debug for Hc12<S, P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("Hc12")
+    }
+}
+
+impl<S: SerialIo, P: OutputPin> Hc12<S, P> {
+    pub fn configure(
+        mut serial: S,
+        mut set: P,
+        delay: &mut impl DelayNs,
+        channel: u8,
+    ) -> CuResult<Self> {
+        if !(1..=127).contains(&channel) {
+            return Err(CuError::from("HC-12 channel must be 1..=127"));
+        }
+        // Allow the module's reset interval to elapse before entering AT mode.
+        set.set_high()
+            .map_err(|_| CuError::from("HC-12 SET high failed"))?;
+        delay.delay_ms(200);
+        set.set_low()
+            .map_err(|_| CuError::from("HC-12 SET low failed"))?;
+        delay.delay_ms(40);
+        let result: CuResult<()> = (|| {
+            // Discard stale bytes with a fixed startup budget.
+            let mut discard = [0; 64];
+            for _ in 0..16 {
+                if serial
+                    .try_read(&mut discard)
+                    .map_err(|_| CuError::from("HC-12 UART read failed"))?
+                    == 0
+                {
+                    break;
+                }
+            }
+            expect(&mut serial, delay, b"AT", b"OK")?;
+            let (reply, len) = command(&mut serial, delay, b"AT+RF")?;
+            if trim(&reply[..len]) != b"OK+FU3" {
+                expect(&mut serial, delay, b"AT+FU3", b"OK+FU3")?;
+            }
+            let digits = [
+                b'0' + channel / 100,
+                b'0' + (channel / 10) % 10,
+                b'0' + channel % 10,
+            ];
+            let (reply, len) = command(&mut serial, delay, b"AT+RC")?;
+            let expected_query = [
+                b'O', b'K', b'+', b'R', b'C', digits[0], digits[1], digits[2],
+            ];
+            let expected = [b'O', b'K', b'+', b'C', digits[0], digits[1], digits[2]];
+            if trim(&reply[..len]) != expected_query && trim(&reply[..len]) != expected {
+                let cmd = [b'A', b'T', b'+', b'C', digits[0], digits[1], digits[2]];
+                expect(&mut serial, delay, &cmd, &expected)?;
+            }
+            Ok(())
+        })();
+        // Restore transparent mode even when a command failed.
+        let restore = set
+            .set_high()
+            .map_err(|_| CuError::from("HC-12 SET high failed"));
+        delay.delay_ms(80);
+        result?;
+        restore?;
+        Ok(Self { serial, _set: set })
+    }
+}
+
+fn trim(mut bytes: &[u8]) -> &[u8] {
+    while bytes.first().is_some_and(u8::is_ascii_whitespace) {
+        bytes = &bytes[1..];
+    }
+    while bytes.last().is_some_and(u8::is_ascii_whitespace) {
+        bytes = &bytes[..bytes.len() - 1];
+    }
+    bytes
+}
+
+fn command(
+    serial: &mut impl SerialIo,
+    delay: &mut impl DelayNs,
+    bytes: &[u8],
+) -> CuResult<([u8; 64], usize)> {
+    let mut written = 0;
+    let mut reply = [0; 64];
+    let mut len = 0;
+    let mut idle = 0;
+    for _ in 0..COMMAND_TIMEOUT_MS {
+        if written < bytes.len() {
+            written += serial
+                .try_write(&bytes[written..])
+                .map_err(|_| CuError::from("HC-12 UART write failed"))?;
+        } else {
+            let count = serial
+                .try_read(&mut reply[len..])
+                .map_err(|_| CuError::from("HC-12 UART read failed"))?;
+            len += count;
+            if len == reply.len() {
+                return Err(CuError::from("HC-12 AT reply too long"));
+            }
+            if count == 0 && len > 0 {
+                idle += 1;
+            } else {
+                idle = 0;
+            }
+            if idle >= RESPONSE_IDLE_MS {
+                return Ok((reply, len));
+            }
+        }
+        delay.delay_ms(1);
+    }
+    Err(CuError::from(
+        "HC-12 AT command timed out; check SET wiring and UART baud rate",
+    ))
+}
+
+fn expect(
+    serial: &mut impl SerialIo,
+    delay: &mut impl DelayNs,
+    cmd: &[u8],
+    expected: &[u8],
+) -> CuResult<()> {
+    let (reply, len) = command(serial, delay, cmd)?;
+    if trim(&reply[..len]) != expected {
+        return Err(CuError::from("Unexpected HC-12 AT reply"));
+    }
+    Ok(())
+}
+
+impl<S: SerialIo, P> embedded_io::ErrorType for Hc12<S, P> {
+    type Error = S::Error;
+}
+impl<S: SerialIo, P> SerialIo for Hc12<S, P> {
+    fn try_read(&mut self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        self.serial.try_read(bytes)
+    }
+    fn try_write(&mut self, bytes: &[u8]) -> Result<usize, Self::Error> {
+        self.serial.try_write(bytes)
+    }
+}
+
+mod inputs {
+    cu29::resources!(for<S, P, D> where S: Send + Sync + 'static, P: Send + Sync + 'static, D: Send + Sync + 'static {
+        serial => Owned<S>, set => Owned<P>, delay => Owned<D>,
+    });
+}
+
+pub struct Hc12Resources<S, P, D>(PhantomData<(S, P, D)>);
+struct Slots;
+cu29::bundle_resources!(Slots: Serial);
+pub use SlotsId as Hc12ResourceId;
+impl<S, P, D> ResourceBundleDecl for Hc12Resources<S, P, D> {
+    type Id = Hc12ResourceId;
+}
+impl<S, P, D> NamedResourceBundleDecl for Hc12Resources<S, P, D> {
+    const NAMES: &'static [&'static str] = <Slots as NamedResourceBundleDecl>::NAMES;
+}
+impl<S, P, D> ResourceBundle for Hc12Resources<S, P, D>
+where
+    S: SerialIo + Send + Sync + 'static,
+    P: OutputPin + Send + Sync + 'static,
+    D: DelayNs + Send + Sync + 'static,
+{
+    const INPUT_NAMES: &'static [&'static str] =
+        <inputs::Resources<S, P, D> as ResourceBindings>::NAMES;
+    fn build(
+        bundle: BundleContext<Self>,
+        config: Option<&ComponentConfig>,
+        manager: &mut ResourceManager,
+    ) -> CuResult<()> {
+        let channel = config
+            .and_then(|cfg| cfg.get::<u8>("channel").transpose())
+            .transpose()?
+            .ok_or_else(|| CuError::from("HC-12 requires a channel in RON"))?;
+        let mut inputs = bundle.inputs::<inputs::Resources<S, P, D>>(manager)?;
+        let radio = Hc12::configure(inputs.serial.0, inputs.set.0, &mut inputs.delay.0, channel)?;
+        manager.add_owned(bundle.key(Hc12ResourceId::Serial), radio)
+    }
+}
+
+#[cfg(feature = "std")]
+pub mod host {
+    use super::*;
+    /// Delay provider for HC-12 startup configuration.
+    pub struct StartupDelay;
+    impl DelayNs for StartupDelay {
+        fn delay_ns(&mut self, ns: u32) {
+            std::thread::sleep(std::time::Duration::from_nanos(u64::from(ns)));
+        }
+    }
+    pub struct DelayResources;
+    cu29::bundle_resources!(DelayResources: Delay);
+    impl ResourceBundle for DelayResources {
+        fn build(
+            bundle: BundleContext<Self>,
+            _: Option<&ComponentConfig>,
+            manager: &mut ResourceManager,
+        ) -> CuResult<()> {
+            manager.add_owned(bundle.key(DelayResourcesId::Delay), StartupDelay)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+    use core::convert::Infallible;
+    use std::{
+        collections::VecDeque,
+        sync::{Arc, Mutex},
+        vec::Vec,
+    };
+    #[derive(Default)]
+    struct State {
+        commands: Vec<Vec<u8>>,
+        delays: Vec<u32>,
+        levels: Vec<bool>,
+    }
+    struct Uart {
+        state: Arc<Mutex<State>>,
+        tx: Vec<u8>,
+        rx: VecDeque<u8>,
+        silent: bool,
+    }
+    impl embedded_io::ErrorType for Uart {
+        type Error = Infallible;
+    }
+    impl SerialIo for Uart {
+        fn try_read(&mut self, out: &mut [u8]) -> Result<usize, Self::Error> {
+            let count = out.len().min(self.rx.len()).min(2);
+            for byte in &mut out[..count] {
+                *byte = self.rx.pop_front().unwrap();
+            }
+            Ok(count)
+        }
+        fn try_write(&mut self, bytes: &[u8]) -> Result<usize, Self::Error> {
+            let count = bytes.len().min(2);
+            self.tx.extend_from_slice(&bytes[..count]);
+            if count == bytes.len() {
+                let cmd = core::mem::take(&mut self.tx);
+                let reply: &[u8] = match cmd.as_slice() {
+                    b"AT" => b"OK",
+                    b"AT+RF" => b"OK+FU3",
+                    b"AT+RC" => b"OK+RC001",
+                    b"AT+C021" => b"OK+C021",
+                    _ => panic!("unexpected command"),
+                };
+                self.state.lock().unwrap().commands.push(cmd);
+                if !self.silent {
+                    self.rx.extend(reply);
+                }
+            }
+            Ok(count)
+        }
+    }
+    struct Pin(Arc<Mutex<State>>);
+    impl embedded_hal::digital::ErrorType for Pin {
+        type Error = Infallible;
+    }
+    impl OutputPin for Pin {
+        fn set_low(&mut self) -> Result<(), Self::Error> {
+            self.0.lock().unwrap().levels.push(false);
+            Ok(())
+        }
+        fn set_high(&mut self) -> Result<(), Self::Error> {
+            self.0.lock().unwrap().levels.push(true);
+            Ok(())
+        }
+    }
+    struct Delay(Arc<Mutex<State>>);
+    impl DelayNs for Delay {
+        fn delay_ns(&mut self, ns: u32) {
+            self.0.lock().unwrap().delays.push(ns);
+        }
+    }
+    fn setup(channel: u8, silent: bool) -> (CuResult<Hc12<Uart, Pin>>, Arc<Mutex<State>>) {
+        let state = Arc::new(Mutex::new(State::default()));
+        let uart = Uart {
+            state: state.clone(),
+            tx: Vec::new(),
+            rx: VecDeque::new(),
+            silent,
+        };
+        let result = Hc12::configure(uart, Pin(state.clone()), &mut Delay(state.clone()), channel);
+        (result, state)
+    }
+    #[test]
+    fn configures_channel_and_restores_transparent_mode() {
+        let (radio, state) = setup(21, false);
+        assert!(radio.is_ok());
+        let state = state.lock().unwrap();
+        assert_eq!(
+            state.commands,
+            [
+                b"AT".to_vec(),
+                b"AT+RF".to_vec(),
+                b"AT+RC".to_vec(),
+                b"AT+C021".to_vec()
+            ]
+        );
+        assert_eq!(state.levels, [true, false, true]);
+        assert_eq!(state.delays[0], 200_000_000);
+        assert_eq!(state.delays[1], 40_000_000);
+        assert_eq!(*state.delays.last().unwrap(), 80_000_000);
+    }
+    #[test]
+    fn unchanged_channel_does_not_write_persistent_settings() {
+        let (radio, state) = setup(1, false);
+        assert!(radio.is_ok());
+        assert_eq!(state.lock().unwrap().commands.len(), 3);
+    }
+    #[test]
+    fn timeout_restores_set_and_invalid_channel_never_touches_hardware() {
+        let (radio, state) = setup(21, true);
+        assert!(radio.is_err());
+        assert_eq!(state.lock().unwrap().levels, [true, false, true]);
+        let (radio, state) = setup(0, false);
+        assert!(radio.is_err());
+        assert!(state.lock().unwrap().levels.is_empty());
+    }
+}

--- a/justfile
+++ b/justfile
@@ -189,6 +189,18 @@ resource-stack-check:
 	cargo +stable test -p cu29-runtime --bin cu29-rendercfg
 	cargo +stable check -p cu29 --no-default-features --target thumbv7em-none-eabihf
 
+# Resource stacking, HC-12 startup, serial bridge/framing, and DAG ownership.
+hc12-check:
+	cargo +stable clippy -p cu-linux-resources --no-default-features --all-targets -- --deny warnings
+	cargo +stable test -p cu-linux-resources --no-default-features
+	cargo +stable clippy -p cu-hc12 -p cu-serial -p cu-serial-bridge -p cu29-logstream-serial -p cu-linux-resources --all-targets --features cu29/reflect -- --deny warnings
+	cargo +stable test -p cu-hc12 -p cu-serial -p cu-serial-bridge -p cu29-logstream-serial -p cu-linux-resources --features cu29/reflect
+	cargo +stable test -p cu29 --test resource_stack
+	cargo +stable test -p cu29-derive --lib resource
+	cargo +stable test -p cu29-runtime --bin cu29-rendercfg
+	cargo +stable test -p cu29-logstream --test pacing
+	cargo +stable check -p cu-hc12 -p cu-serial -p cu-serial-bridge -p cu29-logstream-serial --no-default-features
+
 # Sender budget/retention, generated integration, and one-way UDP recovery.
 logstream-pacing-check:
 	cargo +stable clippy -p cu29-logstream --all-targets -- --deny warnings


### PR DESCRIPTION
Configure an HC-12 radio in FU3 mode at startup, select its channel from RON, and export its transparent serial stream as an owned resource. Startup uses bounded AT exchanges and releases SET after success or command failure.

Includes the HC-12 driver, startup tests, wiring documentation, echo and two-radio examples, and the `just hc12-check` integration target. The LogStream setup uses the serial adapter's framing CRC32C and documents its 252-byte default packet bound. Both peers must use matching framing. The transparent byte stream still needs this integrity check even if the radio checks its own hardware packets.

Depends on #1352 (serial LogStream), including its independent framing CRC migration, and uses #1350 (serial resources) and #1351 (byte bridge). This PR is the HC-12 layer of the split.

Validation: formatting and whitespace checks for the documentation update; the combined CRC-free diet/serial/HC-12 integration passed `just hc12-check` (153 passing test executions, clippy, and no-default-features checks). The original PR records a successful two-radio test on 2026-09-07 at 9600 baud, FU3, channel 21: eight bidirectional transfers totaling 832 bytes. That hardware test predates the split and was not repeated for the CRC migration.

Companion book documentation: https://github.com/copper-project/copper-rs-book/pull/55.
