### PR TITLE
Omit CopperList state and use cu-bincode 2.1 selective encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,7 +282,7 @@ cu-ros2-payloads = { path = "components/payloads/cu_ros2_payloads", version = "1
 cu-pid = { path = "components/tasks/cu_pid", version = "1.2.0-dev" }
 
 # External serialization
-bincode = { package = "cu-bincode", version = "2.0", default-features = false, features = [
+bincode = { package = "cu-bincode", version = "2.1", default-features = false, features = [
   "derive",
   "alloc",
 ] }

--- a/core/cu29_export/src/lib.rs
+++ b/core/cu29_export/src/lib.rs
@@ -970,7 +970,6 @@ Call register_copperlist_python_type::<P>() from Rust before using this function
         let task_ids = P::get_all_task_ids();
         let root = PyDict::new(py);
         root.set_item("id", entry.id)?;
-        root.set_item("state", entry.get_state().to_string())?;
 
         let mut messages: Vec<Py<PyAny>> = Vec::new();
         for (idx, msg) in entry.cumsgs().into_iter().enumerate() {
@@ -1389,6 +1388,40 @@ Call register_copperlist_python_type::<P>() from Rust before using this function
     #[cfg(test)]
     mod tests {
         use super::*;
+
+        #[derive(Debug, Default, bincode::Encode, bincode::Decode, serde::Serialize)]
+        struct EmptyMessages;
+
+        impl ErasedCuStampedDataSet for EmptyMessages {
+            fn cumsgs(&self) -> Vec<&dyn ErasedCuStampedData> {
+                Vec::new()
+            }
+        }
+
+        impl MatchingTasks for EmptyMessages {
+            fn get_all_task_ids() -> &'static [&'static str] {
+                &[]
+            }
+        }
+
+        #[test]
+        fn copperlist_python_export_omits_runtime_state() {
+            Python::initialize();
+            Python::attach(|py| {
+                let list = CopperList::new(7, EmptyMessages);
+                let value = copperlist_to_py(&list, py).unwrap();
+                assert!(!value.bind(py).hasattr("state").unwrap());
+                assert_eq!(
+                    value
+                        .bind(py)
+                        .getattr("id")
+                        .unwrap()
+                        .extract::<u64>()
+                        .unwrap(),
+                    7
+                );
+            });
+        }
 
         #[test]
         fn value_to_py_preserves_128_bit_integers() {

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -186,7 +186,11 @@ The default receiver supports the 1200-byte-MTU, 64-symbol streaming profile, wi
 captures, one recovery point, one executing frame and 64 display frames; payload storage and
 thread/runtime allocations are additional. `with_frame_capacity` changes display retention.
 
-Production sends the existing native CopperList format with selected payloads omitted.
+Production sends the native CopperList format with selected payloads omitted.
+Record framing version 2 carries `id` followed by `msgs`, without the runtime-only
+lifecycle state. Updated endpoints reject older record versions; archived unified
+logs use format version 2. The compressed metadata bytes are unchanged by moving
+ULEB128 timestamp-delta and backreference encoding into `cu-bincode` 2.1.
 The native codec already carries original/captured presence. There is no proof envelope,
 per-list verification allocation, or new continuity record. The archive writes the
 received native bytes before replay and never stores synthesized outputs. The unreleased

--- a/core/cu29_logstream/src/capture.rs
+++ b/core/cu29_logstream/src/capture.rs
@@ -110,7 +110,7 @@ pub fn encode_capture_record_into<P: CaptureDataSet>(
     }
     let (header, payload) = output.split_at_mut(header_len);
     let len = bincode::encode_into_slice(
-        (list.id, list.get_state(), CaptureView(&list.msgs)),
+        (list.id, CaptureView(&list.msgs)),
         payload,
         bincode::config::standard(),
     )

--- a/core/cu29_logstream/src/record.rs
+++ b/core/cu29_logstream/src/record.rs
@@ -2,7 +2,7 @@ use crate::{Error, Result};
 use alloc::vec::Vec;
 
 const RECORD_MAGIC: [u8; 4] = *b"CUSR";
-const RECORD_VERSION: u8 = 1;
+const RECORD_VERSION: u8 = 2;
 pub const RECORD_HEADER_LEN: usize = 56;
 const RECORD_DIGEST_OFFSET: usize = 24;
 
@@ -148,6 +148,17 @@ fn record_digest(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn previous_record_version_is_rejected_before_payload_decode() {
+        let mut record = encode_record(RecordKind::CopperList, 42, &[42]).unwrap();
+        assert_eq!(record[4], 2);
+        record[4] = 1;
+        assert!(matches!(
+            decode_record(&record),
+            Err(Error::UnsupportedVersion(1))
+        ));
+    }
 
     #[test]
     fn record_digest_binds_identity_and_payload() {

--- a/core/cu29_runtime/src/copperlist.rs
+++ b/core/cu29_runtime/src/copperlist.rs
@@ -51,11 +51,20 @@ impl Display for CopperListState {
     }
 }
 
+/// A cycle's messages and identifier. Lifecycle state exists only in memory;
+/// every serialization contains `id` followed by `msgs`.
 #[derive(Debug, Encode, Decode, Serialize, Deserialize)]
 pub struct CopperList<P: CopperListTuple> {
     pub id: u64,
+    // Runtime bookkeeping only; recorded lists reconstruct the serialization state.
+    #[bincode(skip, default = "deserialized_state")]
+    #[serde(skip, default = "deserialized_state")]
     state: CopperListState,
     pub msgs: P, // This is generated from the runtime.
+}
+
+fn deserialized_state() -> CopperListState {
+    CopperListState::BeingSerialized
 }
 
 impl<P: CopperListTuple> Default for CopperList<P> {
@@ -348,6 +357,50 @@ mod tests {
 
     impl CuListZeroedInit for CuStampedDataSet {
         fn init_zeroed(&mut self) {}
+    }
+
+    #[test]
+    fn serialization_omits_runtime_state() {
+        let expected =
+            bincode::encode_to_vec((42u64, CuStampedDataSet(123)), bincode::config::standard())
+                .unwrap();
+        for state in [
+            CopperListState::Free,
+            CopperListState::Initialized,
+            CopperListState::Processing,
+            CopperListState::DoneProcessing,
+            CopperListState::QueuedForSerialization,
+            CopperListState::BeingSerialized,
+        ] {
+            let mut list = CopperList::new(42, CuStampedDataSet(123));
+            list.change_state(state);
+            let bytes = bincode::encode_to_vec(&list, bincode::config::standard()).unwrap();
+            assert_eq!(bytes, expected);
+            let old_bytes =
+                bincode::encode_to_vec((list.id, state, &list.msgs), bincode::config::standard())
+                    .unwrap();
+            assert_eq!(old_bytes.len(), bytes.len() + 1);
+            let (decoded, used): (CopperList<CuStampedDataSet>, usize) =
+                bincode::decode_from_slice(&bytes, bincode::config::standard()).unwrap();
+            assert_eq!(decoded.id, list.id);
+            assert_eq!(decoded.msgs, list.msgs);
+            assert_eq!(decoded.get_state(), CopperListState::BeingSerialized);
+            assert_eq!(used, bytes.len());
+            let (borrowed, used): (CopperList<CuStampedDataSet>, usize) =
+                bincode::borrow_decode_from_slice(&bytes, bincode::config::standard()).unwrap();
+            assert_eq!(borrowed.get_state(), CopperListState::BeingSerialized);
+            assert_eq!(borrowed.msgs, list.msgs);
+            assert_eq!(used, bytes.len());
+            assert_eq!(list.get_state(), state);
+            #[cfg(feature = "std")]
+            {
+                let json = serde_json::to_value(&list).unwrap();
+                assert_eq!(json, serde_json::json!({"id": 42, "msgs": 123}));
+                let decoded: CopperList<CuStampedDataSet> = serde_json::from_value(json).unwrap();
+                assert_eq!(decoded.get_state(), CopperListState::BeingSerialized);
+                assert_eq!(decoded.msgs, list.msgs);
+            }
+        }
     }
 
     #[test]

--- a/core/cu29_runtime/src/copperlist_codec.rs
+++ b/core/cu29_runtime/src/copperlist_codec.rs
@@ -6,7 +6,7 @@ use bincode::de::read::Reader;
 use bincode::enc::Encoder;
 use bincode::enc::write::Writer;
 use bincode::error::{DecodeError, EncodeError};
-use bincode::{Decode, Encode};
+use bincode::{Decode, Encode, Uleb128};
 use core::array;
 use cu29_clock::{CuTime, CuTimeRange, PartialCuTimeRange, Tov};
 use cu29_traits::{CuCompactString, CuMsgOrigin};
@@ -80,67 +80,17 @@ fn read_u64_le<D: Decoder>(decoder: &mut D) -> Result<u64, DecodeError> {
     Ok(u64::from_le_bytes(bytes))
 }
 
-fn encode_uleb128<E: Encoder>(encoder: &mut E, mut value: u128) -> Result<(), EncodeError> {
-    loop {
-        let mut byte = (value & 0x7f) as u8;
-        value >>= 7;
-        if value != 0 {
-            byte |= 0x80;
-        }
-        write_byte(encoder, byte)?;
-        if value == 0 {
-            return Ok(());
-        }
-    }
-}
-
-fn decode_uleb128<D: Decoder>(decoder: &mut D) -> Result<u128, DecodeError> {
-    let mut value = 0u128;
-    for byte_index in 0..19 {
-        let shift = byte_index * 7;
-        let byte = read_byte(decoder)?;
-        let chunk = u128::from(byte & 0x7f);
-        if byte_index == 18 && chunk > 0x03 {
-            return Err(DecodeError::Other("CopperList ULEB128 overflow"));
-        }
-        value |= chunk << shift;
-        if byte & 0x80 == 0 {
-            return Ok(value);
-        }
-    }
-    Err(DecodeError::Other("CopperList ULEB128 is too long"))
-}
-
-fn zigzag(delta: i128) -> u128 {
-    if delta >= 0 {
-        (delta as u128) << 1
-    } else {
-        ((-delta) as u128) * 2 - 1
-    }
-}
-
-fn unzigzag(value: u128) -> Result<i128, DecodeError> {
-    let magnitude = value >> 1;
-    let magnitude = i128::try_from(magnitude)
-        .map_err(|_| DecodeError::Other("CopperList timestamp delta overflow"))?;
-    Ok(if value & 1 == 0 {
-        magnitude
-    } else {
-        -magnitude - 1
-    })
-}
-
 fn encode_timestamp<E: Encoder>(
     encoder: &mut E,
     value: CuTime,
     anchor: CuTime,
 ) -> Result<(), EncodeError> {
     let delta = i128::from(value.as_nanos()) - i128::from(anchor.as_nanos());
-    encode_uleb128(encoder, zigzag(delta))
+    Uleb128(delta).encode(encoder)
 }
 
 fn decode_timestamp<D: Decoder>(decoder: &mut D, anchor: CuTime) -> Result<CuTime, DecodeError> {
-    let delta = unzigzag(decode_uleb128(decoder)?)?;
+    let Uleb128(delta) = Uleb128::<i128>::decode(decoder)?;
     let nanos = i128::from(anchor.as_nanos())
         .checked_add(delta)
         .and_then(|value| u64::try_from(value).ok())
@@ -294,7 +244,7 @@ pub fn encode_common_metadata<const N: usize, E: Encoder>(
             .iter()
             .position(|previous| previous.metadata.status_txt == slot.metadata.status_txt)
             .map_or(0, |previous| previous + 1);
-        encode_uleb128(encoder, backref as u128)?;
+        Uleb128(backref as u128).encode(encoder)?;
         if backref == 0 {
             slot.metadata.status_txt.encode(encoder)?;
         }
@@ -308,7 +258,7 @@ pub fn encode_common_metadata<const N: usize, E: Encoder>(
             .iter()
             .position(|previous| previous.metadata.origin.as_ref() == Some(origin))
             .map_or(0, |previous| previous + 1);
-        encode_uleb128(encoder, backref as u128)?;
+        Uleb128(backref as u128).encode(encoder)?;
         if backref == 0 {
             origin.encode(encoder)?;
         }
@@ -411,7 +361,7 @@ pub fn decode_common_metadata<const N: usize, D: Decoder<Context = ()>>(
         if !status[index] {
             continue;
         }
-        let backref = usize::try_from(decode_uleb128(decoder)?)
+        let backref = usize::try_from(Uleb128::<u128>::decode(decoder)?.0)
             .map_err(|_| DecodeError::Other("CopperList status backreference overflow"))?;
         slots[index].metadata.status_txt = if backref == 0 {
             CuCompactString::decode(decoder)?
@@ -428,7 +378,7 @@ pub fn decode_common_metadata<const N: usize, D: Decoder<Context = ()>>(
         if !origin[index] {
             continue;
         }
-        let backref = usize::try_from(decode_uleb128(decoder)?)
+        let backref = usize::try_from(Uleb128::<u128>::decode(decoder)?.0)
             .map_err(|_| DecodeError::Other("CopperList origin backreference overflow"))?;
         slots[index].metadata.origin = if backref == 0 {
             Some(CuMsgOrigin::decode(decoder)?)

--- a/core/cu29_runtime/src/debug.rs
+++ b/core/cu29_runtime/src/debug.rs
@@ -348,7 +348,6 @@ where
                     CuError::new_with_cause("Failed to decode runtime CopperList snapshot", e)
                 })?;
                 runtime_cl.id = recorded.id;
-                runtime_cl.change_state(recorded.get_state());
                 bincode::encode_to_vec(&runtime_cl, standard()).map_err(|e| {
                     CuError::new_with_cause("Failed to encode normalized CopperList snapshot", e)
                 })

--- a/core/cu29_runtime/src/remote_debug.rs
+++ b/core/cu29_runtime/src/remote_debug.rs
@@ -4179,7 +4179,6 @@ fn copperlist_snapshot<P: CopperListTuple + 'static>(
 
     Ok(json!({
         "cl": cl.id,
-        "state": format!("{}", cl.get_state()),
         "ts_ns": time_of(cl).map(|t| t.as_nanos()),
         "messages": entries,
         "raw_bincode_hex": raw,
@@ -5625,6 +5624,17 @@ mod tests {
         fn cumsgs(&self) -> Vec<&dyn ErasedCuStampedData> {
             Vec::new()
         }
+    }
+
+    #[test]
+    fn copperlist_snapshot_omits_runtime_state() {
+        let mut list = crate::copperlist::CopperList::new(7, AliasPayloadCopperList);
+        list.change_state(crate::copperlist::CopperListState::Processing);
+        let snapshot =
+            super::copperlist_snapshot(&list, &|_| None, true, true, true, false, None).unwrap();
+        assert!(snapshot.get("state").is_none());
+        assert_eq!(snapshot["cl"], 7);
+        assert_eq!(snapshot["raw_bincode_hex"], "07");
     }
 
     impl MatchingTasks for AliasPayloadCopperList {

--- a/core/cu29_unifiedlog/README.md
+++ b/core/cu29_unifiedlog/README.md
@@ -11,3 +11,15 @@ the same log container format in another project.
 - `std` (default): enables memory-mapped file logging backend.
 - `compact` (default): favors compact log layout.
 
+## Format compatibility
+
+Unified log format version 2 records CopperLists as `id` followed by `msgs`.
+Their lifecycle `state` is runtime bookkeeping and is omitted from binary,
+Serde, Python, and remote-debug output. A decoded list reconstructs
+`BeingSerialized` internally; this value is not recorded history.
+
+Version 1 logs require a reader built against the older layout. Updated readers
+reject incompatible container versions rather than interpreting the state byte
+as message data. Compressed metadata retains its existing byte format: timestamp
+deltas and metadata backreferences use the selective `cu_bincode::Uleb128`
+wrapper, while ordinary integers keep their existing bincode encoding.

--- a/core/cu29_unifiedlog/src/lib.rs
+++ b/core/cu29_unifiedlog/src/lib.rs
@@ -44,7 +44,7 @@ pub const MAIN_MAGIC: [u8; 4] = [0xB4, 0xA5, 0x50, 0xFF]; // BRASS OFF
 pub const SECTION_MAGIC: [u8; 2] = [0xFA, 0x57]; // FAST
 
 /// Version of the unified log file format.
-pub const UNIFIED_LOG_FORMAT_VERSION: u8 = 1;
+pub const UNIFIED_LOG_FORMAT_VERSION: u8 = 2;
 
 pub const SECTION_HEADER_COMPACT_SIZE: u16 = 512; // Usual minimum size for a disk sector.
 

--- a/examples/cu_logstream_demo/tests/twin.rs
+++ b/examples/cu_logstream_demo/tests/twin.rs
@@ -375,7 +375,7 @@ fn capture_encoding_is_native_and_does_not_allocate() {
     let record = cu29_logstream::decode_record(&bytes[..encoded.unwrap()]).unwrap();
     let (capture, native) = decode_capture::<DataSet>(record.payload).unwrap();
     let expected = cu29::bincode::encode_to_vec(
-        (list.id, list.get_state(), CaptureView(&list.msgs)),
+        (list.id, CaptureView(&list.msgs)),
         cu29::bincode::config::standard(),
     )
     .unwrap();

--- a/support/cargo_cunew/templates/cu_full/Cargo.toml.template
+++ b/support/cargo_cunew/templates/cu_full/Cargo.toml.template
@@ -15,7 +15,7 @@ debug-assertions = true
 cu29 = { {%if copper_source == "crates.io" %} version = "{{copper_version}}" {%elsif copper_source == "git" %} git = "{{copper_git_url}}"{{copper_git_ref_snippet}} {%elsif copper_source == "local" %} path = "{{copper_root_path}}/core/cu29" {%endif %} }
 cu29-build = { {%if copper_source == "crates.io" %} version = "{{copper_version}}" {%elsif copper_source == "git" %} git = "{{copper_git_url}}"{{copper_git_ref_snippet}} {%elsif copper_source == "local" %} path = "{{copper_root_path}}/core/cu29_build" {%endif %} }
 cu29-export = { {%if copper_source == "crates.io" %} version = "{{copper_export_version}}" {%elsif copper_source == "git" %} git = "{{copper_git_url}}"{{copper_git_ref_snippet}} {%elsif copper_source == "local" %} path = "{{copper_root_path}}/core/cu29_export" {%endif %} }
-bincode = { package = "cu-bincode", version = "2.0", default-features = false, features = ["derive", "alloc"] }
+bincode = { package = "cu-bincode", version = "2.1", default-features = false, features = ["derive", "alloc"] }
 serde = { version = "1.0", features = ["derive"] }
 # Per-task heap-allocation monitor. Uncomment here and in apps that want it
 # (see apps/cu_example_app/Cargo.toml.template).

--- a/support/cargo_cunew/templates/cu_project/Cargo.toml.template
+++ b/support/cargo_cunew/templates/cu_project/Cargo.toml.template
@@ -42,7 +42,7 @@ sim-debug = ["logreader", "cu29/reflect", "cu29/remote-debug"]
 
 [dependencies]
 cu29 = { {%if copper_source == "crates.io" %} version = "{{copper_version}}" {%elsif copper_source == "git" %} git = "{{copper_git_url}}"{{copper_git_ref_snippet}} {%elsif copper_source == "local" %} path = "{{copper_root_path}}/core/cu29" {%endif %} }
-bincode = { package = "cu-bincode", version = "2.0", default-features = false, features = ["derive", "alloc"] }
+bincode = { package = "cu-bincode", version = "2.1", default-features = false, features = ["derive", "alloc"] }
 serde = { version = "1.0", features = ["derive"] }
 cu29-export = { {%if copper_source == "crates.io" %} version = "{{copper_export_version}}" {%elsif copper_source == "git" %} git = "{{copper_git_url}}"{{copper_git_ref_snippet}} {%elsif copper_source == "local" %} path = "{{copper_root_path}}/core/cu29_export" {%endif %}, optional = true }
 # cu-memmon = { {%if copper_source == "crates.io" %} version = "{{copper_version}}" {%elsif copper_source == "git" %} git = "{{copper_git_url}}"{{copper_git_ref_snippet}} {%elsif copper_source == "local" %} path = "{{copper_root_path}}/components/monitors/cu_memmon" {%endif %}, default-features = false, features = ["std", "memory_monitoring"], optional = true }


### PR DESCRIPTION
**Versioning correction:** [Stacked PR #1348](https://github.com/copper-project/copper-rs/pull/1348) restores unified-log encapsulation version **1**, explicitly documents that it must never change for encoded-content changes, and removes all logstream version fields. Review and land that correction with this PR. Content always requires the producing application's matching logreader.

CopperList lifecycle state is runtime bookkeeping, but it was included in every recorded and transmitted list. Omit it from bincode, Serde, selective capture, Python export, and remote-debug snapshots while retaining the in-memory lifecycle. Decoding reconstructs `BeingSerialized`.

Replace the local ULEB128/zigzag implementation with the selective `cu_bincode::Uleb128` wrapper, preserving the existing compressed metadata bytes and ordinary bincode integer encoding. Depend on the published crates.io `cu-bincode` 2.1 release; both project templates also use 2.1. The version bumps in this branch are incorrect and are reverted in stacked PR #1348; they must not be retained.

Validation:
- Published 2.1.0: 403 runtime tests passed (1 skipped), 21 Python export tests passed, 6 logstream unit tests passed. Published Rust sources match the upstream commit used for broader checks.
- `just logstream-twin-check`, `just nostd-ci`, `just api-check`, caterpillar determinism, and focused runtime/export clippy passed.
- Extended parallel-runtime tests: 403 passed, 2 bridge replay tests failed; both failures reproduce on unchanged master (`ab036e43c9e`).
- Worktree verification temporarily excluded the flight-controller example because its external sibling dependencies resolve back to the original checkout, creating duplicate package paths. Final workspace membership is unchanged.

Upstream codec support: https://github.com/copper-project/cu-bincode/pull/8 (merged and published).
Book documentation: https://github.com/copper-project/copper-rs-book/pull/56.
Wiki documentation is pushed to the wiki repository's `gbin/state-codec` review branch.
