### PR TITLE
Restore encapsulation version 1 and remove logstream version overhead

### DIFF
--- a/.github/workflows/build-ci-images.yml
+++ b/.github/workflows/build-ci-images.yml
@@ -9,7 +9,6 @@ on:
       - "support/docker/**"
       - ".github/workflows/build-ci-images.yml"
   pull_request:
-    branches: ["master"]
     paths:
       - "support/docker/**"
       - ".github/workflows/build-ci-images.yml"

--- a/.github/workflows/catalog-deploy.yml
+++ b/.github/workflows/catalog-deploy.yml
@@ -9,7 +9,6 @@ on:
       - "Cargo.toml"
       - "components/**/Cargo.toml"
   pull_request:
-    branches: ["master"]
     paths:
       - "catalog/**"
       - "support/cu_catalog/**"

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -3,8 +3,8 @@ name: "CI/CD"
 on:
   push:
     branches: ["master"]
+  # Validate every PR base, including branches used by stacked PRs.
   pull_request:
-    branches: ["master", "release/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -187,14 +187,34 @@ captures, one recovery point, one executing frame and 64 display frames; payload
 thread/runtime allocations are additional. `with_frame_capacity` changes display retention.
 
 Production sends the native CopperList format with selected payloads omitted.
-Record framing version 2 carries `id` followed by `msgs`, without the runtime-only
-lifecycle state. Updated endpoints reject older record versions; archived unified
-logs use format version 2. The compressed metadata bytes are unchanged by moving
-ULEB128 timestamp-delta and backreference encoding into `cu-bincode` 2.1.
+CopperLists carry `id` followed by `msgs`, without runtime lifecycle state.
+There are no transmitted version fields in packets, records, RLC fragments, or
+session manifests. Always use the receiver/logreader built for the producing
+application version. Archived unified logs retain encapsulation version **1**;
+that version describes file/section layout only, never encoded content.
+The compressed metadata bytes are unchanged by moving ULEB128 timestamp-delta
+and backreference encoding into `cu-bincode` 2.1.
+
+Headers are packed without reserved alignment bytes or a redundant fixed header
+length field. All multi-byte header fields use big endian encoding:
+
+| Layer | Header fields, in wire order | Bytes |
+| --- | --- | ---: |
+| Packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), packet sequence (8), object ID (8), FEC metadata (12), fragment count (4), payload length (2), CRC32C (4) | 66 |
+| Record | magic (4), kind (1), object ID (8), payload length (8), BLAKE3 digest (32) | 53 |
+| RLC fragment | magic (4), kind (1), object ID (8), record length (4), fragment index (4), fragment count (4), fragment length (2) | 27 |
+
+Compared with the prior headers, this saves 6 bytes per packet, 3 per record,
+and 5 per RLC source fragment, plus one bincode byte per session manifest.
+Fixed-size FEC symbols use the recovered space for fragment payload; this can
+reduce fragment counts rather than shortening each symbol. Existing symbol
+storage capacity is unchanged: a 1200-byte MTU now emits at most 1194-byte packets.
+
 The native codec already carries original/captured presence. There is no proof envelope,
 per-list verification allocation, or new continuity record. The archive writes the
-received native bytes before replay and never stores synthesized outputs. The unreleased
-session manifest stays at **version 1** and binds the reconstruction ABI to the graph.
+received native bytes before replay and never stores synthesized outputs. The
+session manifest binds the reconstruction ABI to the graph; it is not a content
+version or a substitute for the matching application decoder.
 Packet framing, FEC and recovery from a recovery point are unchanged.
 
 Copper restores keyframes, injects captured inputs, executes reconstructible tasks and

--- a/core/cu29_logstream/src/archive.rs
+++ b/core/cu29_logstream/src/archive.rs
@@ -83,9 +83,6 @@ impl<P: CopperListTuple> NativeArchive<P> {
     ) -> Result<Self> {
         let manifest = received.manifest();
         manifest.plan.validate()?;
-        if manifest.version != crate::SESSION_MANIFEST_VERSION {
-            return Err(Error::UnsupportedManifestVersion(manifest.version));
-        }
         if manifest.application_schema != expected_schema {
             return Err(Error::InvalidConfig(
                 "archive requires the matching application schema",

--- a/core/cu29_logstream/src/error.rs
+++ b/core/cu29_logstream/src/error.rs
@@ -12,9 +12,6 @@ pub enum Error {
     BufferTooSmall { needed: usize, available: usize },
     TruncatedPacket,
     InvalidMagic,
-    UnsupportedVersion(u8),
-    UnsupportedManifestVersion(u16),
-    InvalidHeaderLength(u8),
     UnknownLane(u8),
     UnknownRecordKind(u8),
     UnknownFecScheme(u8),
@@ -58,15 +55,6 @@ impl Display for Error {
             }
             Self::TruncatedPacket => formatter.write_str("truncated logstream packet"),
             Self::InvalidMagic => formatter.write_str("invalid logstream magic"),
-            Self::UnsupportedVersion(version) => {
-                write!(formatter, "unsupported logstream version {version}")
-            }
-            Self::UnsupportedManifestVersion(version) => {
-                write!(formatter, "unsupported session manifest version {version}")
-            }
-            Self::InvalidHeaderLength(length) => {
-                write!(formatter, "invalid logstream header length {length}")
-            }
             Self::UnknownLane(value) => write!(formatter, "unknown logstream lane {value}"),
             Self::UnknownRecordKind(value) => write!(formatter, "unknown record kind {value}"),
             Self::UnknownFecScheme(value) => write!(formatter, "unknown FEC scheme {value}"),

--- a/core/cu29_logstream/src/lib.rs
+++ b/core/cu29_logstream/src/lib.rs
@@ -56,7 +56,7 @@ pub use error::{Error, Result};
 pub use manifest::new_session_id;
 pub use manifest::{
     ApplicationOutputSchema, ApplicationSchema, LogStreamPlan, ResolvedContinuousFec,
-    ResolvedObjectFec, ResolvedRlcField, SESSION_MANIFEST_VERSION, SessionManifest,
+    ResolvedObjectFec, ResolvedRlcField, SessionManifest,
 };
 pub use object::{
     FiniteObjectDecoder, FiniteObjectEncoder, FiniteObjectLimits, FiniteObjectRecoveryStats,
@@ -87,6 +87,6 @@ pub use stream::{
     SeparateFeedback,
 };
 pub use wire::{
-    FecScheme, FecSymbolKind, Lane, PACKET_HEADER_LEN, WIRE_VERSION, WireHeader, WirePacket,
-    WirePacketRef, encode_packet_into,
+    FecScheme, FecSymbolKind, Lane, PACKET_HEADER_LEN, WireHeader, WirePacket, WirePacketRef,
+    encode_packet_into,
 };

--- a/core/cu29_logstream/src/manifest.rs
+++ b/core/cu29_logstream/src/manifest.rs
@@ -14,8 +14,6 @@ use bincode::{Decode, Encode};
 use cu29_runtime::config::{LogStreamDestinationConfig, LogStreamRepairDensity, LogStreamRlcField};
 use cu29_traits::TaskOutputSpec;
 
-pub const SESSION_MANIFEST_VERSION: u16 = 1;
-
 /// Link and codec policy after RON validation and MTU resolution.
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 pub struct LogStreamPlan {
@@ -84,10 +82,12 @@ impl ApplicationSchema {
     }
 }
 
-/// Versioned control object from which a receiver constructs its decoders.
+/// Control object carrying transport configuration and application schema checks.
+///
+/// No content or protocol version is encoded. Receivers must use the matching
+/// application's decoder; these schema checks do not establish binary compatibility.
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 pub struct SessionManifest {
-    pub version: u16,
     pub identity: StreamIdentity,
     pub plan: LogStreamPlan,
     pub application_schema: ApplicationSchema,
@@ -100,7 +100,6 @@ impl SessionManifest {
         application_schema: ApplicationSchema,
     ) -> Self {
         Self {
-            version: SESSION_MANIFEST_VERSION,
             identity,
             plan,
             application_schema,
@@ -128,9 +127,6 @@ impl SessionManifest {
         if consumed != record.payload.len() {
             return Err(Error::Codec("session manifest has trailing bytes".into()));
         }
-        if manifest.version != SESSION_MANIFEST_VERSION {
-            return Err(Error::UnsupportedManifestVersion(manifest.version));
-        }
         manifest.plan.validate()?;
         Ok(manifest)
     }
@@ -138,17 +134,15 @@ impl SessionManifest {
 
 impl LogStreamPlan {
     /// Resolves one RON destination into the exact values carried by the manifest.
+    /// Symbol size is bounded by both the link MTU and preallocated sender storage;
+    /// a larger MTU does not increase the runtime's memory footprint.
     pub fn resolve(config: &LogStreamDestinationConfig) -> Result<Self> {
         let symbol_size = config
             .link
             .mtu_bytes
             .checked_sub(PACKET_HEADER_LEN as u16)
-            .ok_or(Error::InvalidConfig("MTU does not fit the packet header"))?;
-        if usize::from(symbol_size) > crate::DEFAULT_MAX_SYMBOL_SIZE {
-            return Err(Error::InvalidConfig(
-                "MTU exceeds the generated sender symbol capacity",
-            ));
-        }
+            .ok_or(Error::InvalidConfig("MTU does not fit the packet header"))?
+            .min(crate::DEFAULT_MAX_SYMBOL_SIZE as u16);
         if usize::from(config.fec.continuous.window_symbols) > crate::DEFAULT_MAX_WINDOW_SYMBOLS {
             return Err(Error::InvalidConfig(
                 "RLC window exceeds the generated sender capacity",
@@ -190,13 +184,11 @@ impl LogStreamPlan {
 
     /// Validates a resolved plan, including plans decoded from an untrusted manifest.
     pub fn validate(&self) -> Result<()> {
-        let expected_mtu = PACKET_HEADER_LEN
+        let packet_bytes = PACKET_HEADER_LEN
             .checked_add(usize::from(self.symbol_size))
             .ok_or(Error::InvalidConfig("resolved MTU overflow"))?;
-        if usize::from(self.mtu_bytes) != expected_mtu {
-            return Err(Error::InvalidConfig(
-                "resolved symbol size does not match the MTU",
-            ));
+        if usize::from(self.mtu_bytes) < packet_bytes {
+            return Err(Error::InvalidConfig("resolved symbol size exceeds the MTU"));
         }
         if usize::from(self.symbol_size) <= crate::rlc::FRAGMENT_HEADER_LEN {
             return Err(Error::InvalidConfig(

--- a/core/cu29_logstream/src/record.rs
+++ b/core/cu29_logstream/src/record.rs
@@ -1,10 +1,12 @@
+//! Record encapsulation without content versions. Payloads require the producing
+//! application's matching decoder; this envelope does not select a content schema.
+
 use crate::{Error, Result};
 use alloc::vec::Vec;
 
 const RECORD_MAGIC: [u8; 4] = *b"CUSR";
-const RECORD_VERSION: u8 = 2;
-pub const RECORD_HEADER_LEN: usize = 56;
-const RECORD_DIGEST_OFFSET: usize = 24;
+pub const RECORD_HEADER_LEN: usize = 53;
+const RECORD_DIGEST_OFFSET: usize = 21;
 
 /// Semantic record families carried by the log stream.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -41,7 +43,7 @@ impl TryFrom<u8> for RecordKind {
 pub struct DecodedRecord<'a> {
     pub kind: RecordKind,
     pub object_id: u64,
-    /// Digest binding the record version, kind, identity, length, and payload.
+    /// Digest binding the record kind, identity, length, and payload.
     pub digest: [u8; 32],
     pub payload: &'a [u8],
 }
@@ -55,9 +57,7 @@ pub fn encode_record(kind: RecordKind, object_id: u64, payload: &[u8]) -> Result
         .ok_or(Error::InvalidConfig("record length overflow"))?;
     let mut record = Vec::with_capacity(capacity);
     record.extend_from_slice(&RECORD_MAGIC);
-    record.push(RECORD_VERSION);
     record.push(kind as u8);
-    record.extend_from_slice(&0_u16.to_be_bytes());
     record.extend_from_slice(&object_id.to_be_bytes());
     record.extend_from_slice(&payload_len.to_be_bytes());
     record.extend_from_slice(&[0_u8; 32]);
@@ -87,10 +87,9 @@ pub(crate) fn encode_record_header(
     let header = &mut header[..RECORD_HEADER_LEN];
     header.fill(0);
     header[..4].copy_from_slice(&RECORD_MAGIC);
-    header[4] = RECORD_VERSION;
-    header[5] = kind as u8;
-    header[8..16].copy_from_slice(&object_id.to_be_bytes());
-    header[16..24].copy_from_slice(&payload_len.to_be_bytes());
+    header[4] = kind as u8;
+    header[5..13].copy_from_slice(&object_id.to_be_bytes());
+    header[13..21].copy_from_slice(&payload_len.to_be_bytes());
     let digest = record_digest(kind, object_id, payload_len, payload);
     header[RECORD_DIGEST_OFFSET..RECORD_HEADER_LEN].copy_from_slice(digest.as_bytes());
     Ok(())
@@ -104,13 +103,9 @@ pub fn decode_record(record: &[u8]) -> Result<DecodedRecord<'_>> {
     if record[..4] != RECORD_MAGIC {
         return Err(Error::InvalidMagic);
     }
-    let version = record[4];
-    if version != RECORD_VERSION {
-        return Err(Error::UnsupportedVersion(version));
-    }
-    let kind = RecordKind::try_from(record[5])?;
-    let object_id = u64::from_be_bytes(record[8..16].try_into().unwrap());
-    let payload_len = u64::from_be_bytes(record[16..24].try_into().unwrap());
+    let kind = RecordKind::try_from(record[4])?;
+    let object_id = u64::from_be_bytes(record[5..13].try_into().unwrap());
+    let payload_len = u64::from_be_bytes(record[13..21].try_into().unwrap());
     let payload_len = usize::try_from(payload_len).map_err(|_| Error::RecordLengthMismatch)?;
     let expected_len = RECORD_HEADER_LEN
         .checked_add(payload_len)
@@ -138,7 +133,7 @@ fn record_digest(
     payload: &[u8],
 ) -> blake3::Hash {
     let mut hasher = blake3::Hasher::new();
-    hasher.update(&[RECORD_VERSION, kind as u8]);
+    hasher.update(&[kind as u8]);
     hasher.update(&object_id.to_be_bytes());
     hasher.update(&payload_len.to_be_bytes());
     hasher.update(payload);
@@ -150,14 +145,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn previous_record_version_is_rejected_before_payload_decode() {
-        let mut record = encode_record(RecordKind::CopperList, 42, &[42]).unwrap();
-        assert_eq!(record[4], 2);
-        record[4] = 1;
-        assert!(matches!(
-            decode_record(&record),
-            Err(Error::UnsupportedVersion(1))
-        ));
+    fn packed_record_header_contains_only_framing_fields() {
+        let record = encode_record(RecordKind::CopperList, 42, &[42]).unwrap();
+        assert_eq!(record.len(), 54);
+        assert_eq!(&record[..5], b"CUSR\x01");
+        assert_eq!(&record[5..13], &42_u64.to_be_bytes());
+        assert_eq!(&record[13..21], &1_u64.to_be_bytes());
+        assert_eq!(record[53], 42);
+        assert_eq!(decode_record(&record).unwrap().payload, &[42]);
+        let mut header = [0xaa; RECORD_HEADER_LEN];
+        encode_record_header(RecordKind::CopperList, 42, &[42], &mut header).unwrap();
+        assert_eq!(header, record[..RECORD_HEADER_LEN]);
     }
 
     #[test]

--- a/core/cu29_logstream/src/rlc.rs
+++ b/core/cu29_logstream/src/rlc.rs
@@ -11,8 +11,7 @@ use cu_fec::{
 };
 
 const FRAGMENT_MAGIC: [u8; 4] = *b"CUFR";
-const FRAGMENT_VERSION: u8 = 1;
-pub(crate) const FRAGMENT_HEADER_LEN: usize = 32;
+pub(crate) const FRAGMENT_HEADER_LEN: usize = 27;
 
 /// Identity shared by one sender's continuous stream.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Encode, Decode)]
@@ -1112,38 +1111,29 @@ fn encode_fragment_header(
     fragment_len: u16,
 ) {
     symbol[..4].copy_from_slice(&FRAGMENT_MAGIC);
-    symbol[4] = FRAGMENT_VERSION;
-    symbol[5] = kind as u8;
-    symbol[6..8].fill(0);
-    symbol[8..16].copy_from_slice(&object_id.to_be_bytes());
-    symbol[16..20].copy_from_slice(&record_len.to_be_bytes());
-    symbol[20..24].copy_from_slice(&fragment_index.to_be_bytes());
-    symbol[24..28].copy_from_slice(&fragment_count.to_be_bytes());
-    symbol[28..30].copy_from_slice(&fragment_len.to_be_bytes());
-    symbol[30..32].fill(0);
+    symbol[4] = kind as u8;
+    symbol[5..13].copy_from_slice(&object_id.to_be_bytes());
+    symbol[13..17].copy_from_slice(&record_len.to_be_bytes());
+    symbol[17..21].copy_from_slice(&fragment_index.to_be_bytes());
+    symbol[21..25].copy_from_slice(&fragment_count.to_be_bytes());
+    symbol[25..27].copy_from_slice(&fragment_len.to_be_bytes());
 }
 
 fn decode_fragment(symbol: &[u8], fragment_capacity: usize) -> Result<Fragment<'_>> {
     if symbol.len() < FRAGMENT_HEADER_LEN || symbol[..4] != FRAGMENT_MAGIC {
         return Err(Error::InvalidFragment("missing fragment header"));
     }
-    if symbol[4] != FRAGMENT_VERSION {
-        return Err(Error::UnsupportedVersion(symbol[4]));
-    }
-    if symbol[6..8].iter().any(|byte| *byte != 0) || symbol[30..32].iter().any(|byte| *byte != 0) {
-        return Err(Error::InvalidFragment("reserved bytes are nonzero"));
-    }
-    let kind = RecordKind::try_from(symbol[5])?;
+    let kind = RecordKind::try_from(symbol[4])?;
     if kind != RecordKind::CopperList {
         return Err(Error::InvalidFragment(
             "continuous lane requires CopperList records",
         ));
     }
-    let object_id = u64::from_be_bytes(symbol[8..16].try_into().unwrap());
-    let record_len = u32::from_be_bytes(symbol[16..20].try_into().unwrap()) as usize;
-    let fragment_index = u32::from_be_bytes(symbol[20..24].try_into().unwrap()) as usize;
-    let fragment_count = u32::from_be_bytes(symbol[24..28].try_into().unwrap()) as usize;
-    let fragment_len = u16::from_be_bytes(symbol[28..30].try_into().unwrap()) as usize;
+    let object_id = u64::from_be_bytes(symbol[5..13].try_into().unwrap());
+    let record_len = u32::from_be_bytes(symbol[13..17].try_into().unwrap()) as usize;
+    let fragment_index = u32::from_be_bytes(symbol[17..21].try_into().unwrap()) as usize;
+    let fragment_count = u32::from_be_bytes(symbol[21..25].try_into().unwrap()) as usize;
+    let fragment_len = u16::from_be_bytes(symbol[25..27].try_into().unwrap()) as usize;
     if record_len == 0 || fragment_count == 0 || fragment_index >= fragment_count {
         return Err(Error::InvalidFragment("invalid fragment geometry"));
     }
@@ -1189,6 +1179,13 @@ mod tests {
         let mut symbol = [0_u8; 64];
         encode_fragment_header(&mut symbol, RecordKind::CopperList, 42, 40, 1, 2, 8);
         symbol[FRAGMENT_HEADER_LEN..FRAGMENT_HEADER_LEN + 8].copy_from_slice(b"fragment");
+        assert_eq!(FRAGMENT_HEADER_LEN, 27);
+        assert_eq!(&symbol[..5], b"CUFR\x01");
+        assert_eq!(&symbol[5..13], &42_u64.to_be_bytes());
+        assert_eq!(&symbol[13..17], &40_u32.to_be_bytes());
+        assert_eq!(&symbol[17..21], &1_u32.to_be_bytes());
+        assert_eq!(&symbol[21..25], &2_u32.to_be_bytes());
+        assert_eq!(&symbol[25..27], &8_u16.to_be_bytes());
         let decoded = decode_fragment(&symbol, 32).unwrap();
         assert_eq!(decoded.object_id, 42);
         assert_eq!(decoded.fragment_index, 1);

--- a/core/cu29_logstream/src/wire.rs
+++ b/core/cu29_logstream/src/wire.rs
@@ -1,11 +1,13 @@
+//! Packed transport framing. No version or schema is sent in packet headers;
+//! sender and receiver must be built for the matching application.
+
 use crate::{Error, RecordKind, Result};
 use alloc::vec::Vec;
 use crc::{CRC_32_ISCSI, Crc};
 
 const PACKET_MAGIC: [u8; 4] = *b"CULS";
-pub const WIRE_VERSION: u8 = 1;
-pub const PACKET_HEADER_LEN: usize = 72;
-const CRC_OFFSET: usize = 68;
+pub const PACKET_HEADER_LEN: usize = 66;
+const CRC_OFFSET: usize = 62;
 const CRC32C: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
 
 /// Independently scheduled transport lanes.
@@ -131,14 +133,7 @@ impl<'a> WirePacketRef<'a> {
         if bytes[..4] != PACKET_MAGIC {
             return Err(Error::InvalidMagic);
         }
-        let version = bytes[4];
-        if version != WIRE_VERSION {
-            return Err(Error::UnsupportedVersion(version));
-        }
-        if bytes[5] as usize != PACKET_HEADER_LEN {
-            return Err(Error::InvalidHeaderLength(bytes[5]));
-        }
-        let payload_len = u16::from_be_bytes(bytes[64..66].try_into().unwrap()) as usize;
+        let payload_len = u16::from_be_bytes(bytes[60..62].try_into().unwrap()) as usize;
         if bytes.len() != PACKET_HEADER_LEN + payload_len {
             return Err(Error::PayloadLengthMismatch);
         }
@@ -154,22 +149,22 @@ impl<'a> WirePacketRef<'a> {
         }
 
         let mut session_id = [0_u8; 16];
-        session_id.copy_from_slice(&bytes[12..28]);
+        session_id.copy_from_slice(&bytes[8..24]);
         let mut fec_metadata = [0_u8; 12];
-        fec_metadata.copy_from_slice(&bytes[48..60]);
+        fec_metadata.copy_from_slice(&bytes[44..56]);
 
         Ok(Self {
             header: WireHeader {
-                lane: Lane::try_from(bytes[6])?,
-                record_kind: RecordKind::try_from(bytes[7])?,
-                fec_scheme: FecScheme::try_from(bytes[8])?,
-                symbol_kind: FecSymbolKind::try_from(bytes[9])?,
+                lane: Lane::try_from(bytes[4])?,
+                record_kind: RecordKind::try_from(bytes[5])?,
+                fec_scheme: FecScheme::try_from(bytes[6])?,
+                symbol_kind: FecSymbolKind::try_from(bytes[7])?,
                 session_id,
-                sender_id: u32::from_be_bytes(bytes[28..32].try_into().unwrap()),
-                packet_sequence: u64::from_be_bytes(bytes[32..40].try_into().unwrap()),
-                object_id: u64::from_be_bytes(bytes[40..48].try_into().unwrap()),
+                sender_id: u32::from_be_bytes(bytes[24..28].try_into().unwrap()),
+                packet_sequence: u64::from_be_bytes(bytes[28..36].try_into().unwrap()),
+                object_id: u64::from_be_bytes(bytes[36..44].try_into().unwrap()),
                 fec_metadata,
-                fragment_count: u32::from_be_bytes(bytes[60..64].try_into().unwrap()),
+                fragment_count: u32::from_be_bytes(bytes[56..60].try_into().unwrap()),
             },
             payload: &bytes[PACKET_HEADER_LEN..],
         })
@@ -193,19 +188,17 @@ pub fn encode_packet_into(header: WireHeader, payload: &[u8], output: &mut [u8])
     let bytes = &mut output[..needed];
     bytes.fill(0);
     bytes[..4].copy_from_slice(&PACKET_MAGIC);
-    bytes[4] = WIRE_VERSION;
-    bytes[5] = PACKET_HEADER_LEN as u8;
-    bytes[6] = header.lane as u8;
-    bytes[7] = header.record_kind as u8;
-    bytes[8] = header.fec_scheme as u8;
-    bytes[9] = header.symbol_kind as u8;
-    bytes[12..28].copy_from_slice(&header.session_id);
-    bytes[28..32].copy_from_slice(&header.sender_id.to_be_bytes());
-    bytes[32..40].copy_from_slice(&header.packet_sequence.to_be_bytes());
-    bytes[40..48].copy_from_slice(&header.object_id.to_be_bytes());
-    bytes[48..60].copy_from_slice(&header.fec_metadata);
-    bytes[60..64].copy_from_slice(&header.fragment_count.to_be_bytes());
-    bytes[64..66].copy_from_slice(&payload_len.to_be_bytes());
+    bytes[4] = header.lane as u8;
+    bytes[5] = header.record_kind as u8;
+    bytes[6] = header.fec_scheme as u8;
+    bytes[7] = header.symbol_kind as u8;
+    bytes[8..24].copy_from_slice(&header.session_id);
+    bytes[24..28].copy_from_slice(&header.sender_id.to_be_bytes());
+    bytes[28..36].copy_from_slice(&header.packet_sequence.to_be_bytes());
+    bytes[36..44].copy_from_slice(&header.object_id.to_be_bytes());
+    bytes[44..56].copy_from_slice(&header.fec_metadata);
+    bytes[56..60].copy_from_slice(&header.fragment_count.to_be_bytes());
+    bytes[60..62].copy_from_slice(&payload_len.to_be_bytes());
     bytes[PACKET_HEADER_LEN..].copy_from_slice(payload);
     let checksum = CRC32C.checksum(bytes);
     bytes[CRC_OFFSET..PACKET_HEADER_LEN].copy_from_slice(&checksum.to_be_bytes());
@@ -238,10 +231,12 @@ mod tests {
     #[test]
     fn fixed_header_has_a_stable_golden_prefix() {
         let encoded = fixture().encode().unwrap();
-        assert_eq!(
-            &encoded[..12],
-            &[b'C', b'U', b'L', b'S', 1, 72, 2, 2, 2, 0, 0, 0]
-        );
+        assert_eq!(&encoded[..8], &[b'C', b'U', b'L', b'S', 2, 2, 2, 0]);
+        assert_eq!(encoded.len(), 66 + fixture().payload.len());
+        assert_eq!(&encoded[8..24], &[0x11; 16]);
+        assert_eq!(&encoded[24..28], &0x2233_4455_u32.to_be_bytes());
+        assert_eq!(&encoded[60..62], &12_u16.to_be_bytes());
+        assert_eq!(&encoded[66..], fixture().payload);
         assert_eq!(WirePacket::decode(&encoded).unwrap(), fixture());
     }
 

--- a/core/cu29_logstream/tests/manifest.rs
+++ b/core/cu29_logstream/tests/manifest.rs
@@ -1,6 +1,5 @@
 use cu29_logstream::{
-    ApplicationOutputSchema, ApplicationSchema, LogStreamPlan, SESSION_MANIFEST_VERSION,
-    SessionManifest, StreamIdentity,
+    ApplicationOutputSchema, ApplicationSchema, LogStreamPlan, SessionManifest, StreamIdentity,
 };
 use cu29_runtime::config::{
     LogStreamContinuousFecConfig, LogStreamDestinationConfig, LogStreamFecConfig,
@@ -51,7 +50,7 @@ fn schema() -> ApplicationSchema {
 }
 
 #[test]
-fn config_resolves_to_sender_config_and_versioned_manifest() {
+fn config_resolves_to_sender_config_and_manifest() {
     let plan = LogStreamPlan::resolve(&destination()).unwrap();
     assert_eq!(plan.symbol_size, 1128);
     assert_eq!(plan.continuous.repair_density, 15);
@@ -64,8 +63,10 @@ fn config_resolves_to_sender_config_and_versioned_manifest() {
     sender.validate().unwrap();
 
     let manifest = SessionManifest::decode_record(&sender.recovery.manifest_record).unwrap();
-    assert_eq!(manifest.version, SESSION_MANIFEST_VERSION);
-    assert_eq!(manifest.version, 1, "the unreleased protocol remains v1");
+    let payload = bincode::encode_to_vec(&manifest, bincode::config::standard()).unwrap();
+    let expected =
+        bincode::encode_to_vec((&identity, &plan, schema()), bincode::config::standard()).unwrap();
+    assert_eq!(payload, expected, "manifest has no version prefix");
     assert_eq!(manifest.identity, identity);
     assert_eq!(manifest.plan, plan);
     assert_eq!(manifest.application_schema, schema());
@@ -76,11 +77,27 @@ fn config_resolves_to_sender_config_and_versioned_manifest() {
 
 #[test]
 fn generated_capacity_and_memory_budget_are_enforced() {
-    let mut too_large = destination();
-    too_large.link.mtu_bytes = 1201;
-    assert!(LogStreamPlan::resolve(&too_large).is_err());
+    let mut larger_mtu = destination();
+    larger_mtu.link.mtu_bytes = 1201;
+    // An MTU is an upper bound; retain preallocated symbol storage on larger links.
+    assert_eq!(
+        LogStreamPlan::resolve(&larger_mtu).unwrap().symbol_size,
+        1128
+    );
 
     let mut too_small = destination();
     too_small.link.memory_budget_kib = 64;
     assert!(LogStreamPlan::resolve(&too_small).is_err());
+}
+
+#[test]
+fn symbol_size_respects_mtu_without_growing_preallocated_storage() {
+    let mut config = destination();
+    config.link.mtu_bytes = 1190;
+    let mut plan = LogStreamPlan::resolve(&config).unwrap();
+    assert_eq!(plan.symbol_size, 1124);
+    plan.symbol_size += 1;
+    assert!(plan.validate().is_err());
+    config.link.mtu_bytes = cu29_logstream::PACKET_HEADER_LEN as u16;
+    assert!(LogStreamPlan::resolve(&config).is_err());
 }

--- a/core/cu29_unifiedlog/README.md
+++ b/core/cu29_unifiedlog/README.md
@@ -11,15 +11,16 @@ the same log container format in another project.
 - `std` (default): enables memory-mapped file logging backend.
 - `compact` (default): favors compact log layout.
 
-## Format compatibility
+## Encapsulation and application content
 
-Unified log format version 2 records CopperLists as `id` followed by `msgs`.
-Their lifecycle `state` is runtime bookkeeping and is omitted from binary,
-Serde, Python, and remote-debug output. A decoded list reconstructs
-`BeingSerialized` internally; this value is not recorded history.
+`UNIFIED_LOG_FORMAT_VERSION` is **1**, unchanged since Copper's original format.
+It versions only the file/section encapsulation and layout. **Never bump it for
+changes to encoded section content**: CopperLists, payloads, keyframes, and codecs
+are decoded by the logreader built for the exact application version that wrote
+them. The encapsulation version cannot establish content compatibility.
 
-Version 1 logs require a reader built against the older layout. Updated readers
-reject incompatible container versions rather than interpreting the state byte
-as message data. Compressed metadata retains its existing byte format: timestamp
-deltas and metadata backreferences use the selective `cu_bincode::Uleb128`
-wrapper, while ordinary integers keep their existing bincode encoding.
+CopperLists record `id` followed by `msgs`. Their lifecycle `state` is runtime
+bookkeeping and is omitted from binary, Serde, Python, and remote-debug output.
+A decoded list reconstructs `BeingSerialized` internally; this is not recorded
+history. Compressed metadata retains its byte format with the selective
+`cu_bincode::Uleb128` wrapper; ordinary integers retain their bincode encoding.

--- a/core/cu29_unifiedlog/src/lib.rs
+++ b/core/cu29_unifiedlog/src/lib.rs
@@ -43,8 +43,15 @@ pub const MAIN_MAGIC: [u8; 4] = [0xB4, 0xA5, 0x50, 0xFF]; // BRASS OFF
 /// ID to spot a section of Copper Log
 pub const SECTION_MAGIC: [u8; 2] = [0xFA, 0x57]; // FAST
 
-/// Version of the unified log file format.
-pub const UNIFIED_LOG_FORMAT_VERSION: u8 = 2;
+/// Version of the unified log **encapsulation only**: file headers, section
+/// headers, and the layout used to locate sections in a slab.
+///
+/// This is **never** a version of the encoded content inside sections. Changes
+/// to CopperLists, payload types, keyframes, or their serialization must not bump
+/// this value. Decode content with the logreader built for the exact application
+/// version that produced it; this header cannot establish content compatibility.
+/// The encapsulation remains version 1, unchanged since Copper's original format.
+pub const UNIFIED_LOG_FORMAT_VERSION: u8 = 1;
 
 pub const SECTION_HEADER_COMPACT_SIZE: u16 = 512; // Usual minimum size for a disk sector.
 
@@ -52,6 +59,9 @@ pub const SECTION_HEADER_COMPACT_SIZE: u16 = 512; // Usual minimum size for a di
 #[derive(Encode, Decode, Debug)]
 pub struct MainHeader {
     pub magic: [u8; 4], // Magic number to identify the file.
+    /// Encapsulation version only; see [`UNIFIED_LOG_FORMAT_VERSION`].
+    /// Never versions encoded section content or determines decoder compatibility.
+    /// Content requires the producing application's matching logreader.
     pub format_version: u8,
     pub first_section_offset: u16, // This is to align with a page at write time.
     pub page_size: u16,


### PR DESCRIPTION
Stacked on #1347; review this PR against `gbin/state-codec` to see only the correction.

The previous change incorrectly bumped unified-log encapsulation for a CopperList content change. Restore `UNIFIED_LOG_FORMAT_VERSION` to **1**. Rustdoc on both the constant and `MainHeader::format_version` explicitly says this versions only file/section encapsulation, must **never** change for encoded-content changes, and cannot replace the producing application's matching logreader.

Remove all four logstream version fields: packet, record, RLC fragment, and session manifest. Remove their checks, constants, and error variants. Pack the headers without reserved padding or the redundant fixed packet-header-length byte. No replacement version or compatibility decoder is introduced.

| Layer | Before | After | Removed |
| --- | ---: | ---: | --- |
| Packet header | 72 B | 66 B | version (1), fixed header length (1), reserved padding (4) |
| Record header | 56 B | 53 B | version (1), reserved padding (2) |
| RLC fragment header | 32 B | 27 B | version (1), reserved padding (4) |
| Session manifest | version prefix | no prefix | 1 bincode byte |

Existing symbol buffer capacity remains 1128 bytes. MTU is an upper bound: a 1200-byte link now sends at most 1194-byte packets without increasing preallocated runtime buffers. Smaller fragment headers provide 5 more payload bytes per fixed-size RLC source symbol and can reduce fragment counts. CRC32C and record digest checks remain. The README lists every remaining header field in wire order.

Validation:
- `just logstream-twin-check` (clippy, capture/replay, receiver/archive, UDP, demo scenarios).
- Focused logstream tests: 46 passed; unified-log tests: 12 passed.
- `cargo +stable check -p cu29-logstream -p cu29-unifiedlog --no-default-features`.
- Rustdoc builds with warnings denied; book build and `just fmt` pass.
- As in #1347, test setup temporarily excluded the flight-controller example because external sibling dependencies resolve to the original checkout. Final workspace membership is unchanged.

The existing [book PR](https://github.com/copper-project/copper-rs-book/pull/56) and wiki `gbin/state-codec` review branch are corrected to describe encapsulation-only versioning and matching application readers.
