### PR TITLE
Add nonblocking serial I/O and owned Unix RTS resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,13 @@ Implications:
 - macOS regressions still matter because they are exercised in CI.
 - Do not assume feature parity or deep support on Windows.
 
+## Documentation Scope
+
+- Describe what a component does and how to use it. Never describe what is absent or list unrelated features it does not implement.
+- Keep generic component documentation generic. Put device-specific configuration, lifecycle details, and wiring in that device's component documentation or integration example.
+- Explain behavior, requirements, and errors directly, in terms that help the reader use the documented component. Avoid contrasts with unrelated components and implementation history.
+- Apply these rules to READMEs, rustdoc, code comments, and PR descriptions.
+
 ## Practical Development Notes
 
 - Do not paper over issues just to make something work.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 
 members = [
+  "components/libs/cu_serial",
+
   "core/cu29",
   "core/cu29_build",
   "core/cu29_base_derive",
@@ -221,6 +223,8 @@ repository = "https://github.com/copper-project/copper-rs"
 no_individual_tags = true
 
 [workspace.dependencies]
+cu-serial = { path = "components/libs/cu_serial", version = "1.2.0-dev", default-features = false }
+
 
 # Copper Core
 cu29 = { path = "core/cu29", version = "1.2.0-dev" } # default std

--- a/components/libs/cu_serial/Cargo.toml
+++ b/components/libs/cu_serial/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "cu-serial"
+description = "Nonblocking byte I/O contract and embedded-io adapter for Copper"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[package.metadata.copper]
+kind = "lib"
+domains = ["communication/serial"]
+environments = ["host", "embedded"]
+
+[dependencies]
+embedded-io = { version = "0.7.1", default-features = false }
+
+[features]
+default = ["std"]
+std = ["embedded-io/std"]

--- a/components/libs/cu_serial/README.md
+++ b/components/libs/cu_serial/README.md
@@ -1,0 +1,12 @@
+# Nonblocking serial I/O
+
+`SerialIo` provides `try_read` and `try_write` over caller-owned byte slices.
+Calls do one bounded attempt without waiting, locking or allocating. Zero means
+no progress; disconnected devices report an error. Writes may accept a prefix,
+whose length is returned. Implementations must return a count within the slice.
+
+`ReadySerial<S>` adapts embedded-io `Read + Write + ReadReady + WriteReady` HALs.
+It tests readiness and makes at most one read/write call, preserving the HAL's
+nonblocking guarantee. HALs with DMA or different APIs can implement `SerialIo`
+directly. Linux bundles can export `LinuxNonblockingSerialPort` using the explicit
+`serialN_nonblocking` RON setting.

--- a/components/libs/cu_serial/src/lib.rs
+++ b/components/libs/cu_serial/src/lib.rs
@@ -1,0 +1,36 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//! Bounded, nonblocking byte I/O. UART writes can accept a prefix; callers own
+//! the remaining bytes. Zero means no progress, never EOF. Disconnection is an error.
+use embedded_io::{ErrorType, Read, ReadReady, Write, WriteReady};
+
+pub trait SerialIo: ErrorType {
+    /// Read once without waiting, locking, allocating or retrying.
+    fn try_read(&mut self, bytes: &mut [u8]) -> Result<usize, Self::Error>;
+    /// Write once without waiting, locking, allocating or retrying.
+    /// `Ok(n)` accepts exactly the first `n <= bytes.len()` bytes; `Err` accepts none.
+    fn try_write(&mut self, bytes: &[u8]) -> Result<usize, Self::Error>;
+}
+
+/// Adapt a HAL implementing the embedded-io readiness guarantees.
+#[derive(Debug)]
+pub struct ReadySerial<S>(pub S);
+
+impl<S: ErrorType> ErrorType for ReadySerial<S> {
+    type Error = S::Error;
+}
+
+impl<S: Read + ReadReady + Write + WriteReady> SerialIo for ReadySerial<S> {
+    fn try_read(&mut self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        if bytes.is_empty() || !self.0.read_ready()? {
+            return Ok(0);
+        }
+        self.0.read(bytes)
+    }
+    fn try_write(&mut self, bytes: &[u8]) -> Result<usize, Self::Error> {
+        if bytes.is_empty() || !self.0.write_ready()? {
+            return Ok(0);
+        }
+        self.0.write(bytes)
+    }
+}

--- a/components/res/cu_linux_resources/Cargo.toml
+++ b/components/res/cu_linux_resources/Cargo.toml
@@ -19,6 +19,8 @@ environments = ["host"]
 host_os = ["linux"]
 
 [dependencies]
+cu-serial = { workspace = true }
+libc = { workspace = true }
 cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false, features = [
   "std",
 ] }
@@ -34,6 +36,7 @@ rppal = { workspace = true, default-features = false, features = ["hal"] }
 
 [features]
 default = []
+serial-rts = []
 defmt = ["embedded-io/defmt", "embedded-hal/defmt-03", "cu29/defmt"]
 alloc = ["embedded-io/alloc"]
 

--- a/components/res/cu_linux_resources/README.md
+++ b/components/res/cu_linux_resources/README.md
@@ -35,6 +35,7 @@ resources: [
 `LinuxResources` exposes embedded-style fixed slots:
 
 - Serial: `serial0`, `serial1`, `serial2`, `serial3`, `serial4`, `serial5`
+- Optional RTS outputs: `serial0_rts` through `serial5_rts` (`serial-rts` feature)
 - I2C: `i2c0`, `i2c1`, `i2c2`
 - GPIO: `gpio0`, `gpio1`, `gpio2`, `gpio3`, `gpio4`, `gpio5`
 
@@ -62,6 +63,51 @@ Supported keys per serial slot `serialN`:
 - `serialN_parity` (`string`: `none`, `odd`, `even`; default `none`)
 - `serialN_stopbits` (`u8`: `1` or `2`; default `1`)
 - `serialN_timeout_ms` (`u64`, default `50`)
+
+Set `serialN_nonblocking: true` to export a `LinuxNonblockingSerialPort`
+implementing `cu_serial::SerialIo` on Unix. Its native descriptor uses
+`O_NONBLOCK`; each call makes one read/write attempt and returns the number of
+bytes transferred. Zero reports backpressure. Opening the device propagates
+startup errors. `serialN_nonblocking` defaults to `false`, which exports
+`LinuxSerialPort` with the configured timeout.
+
+### Serial RTS output
+
+Enable the `serial-rts` Cargo feature, then set `serialN_rts: true` in the bundle's
+RON config. On Unix this exports an owned `LinuxSerialRtsPin` in `serialN_rts`,
+alongside the `serialN` data resource. Both blocking and nonblocking serial slots
+support this option.
+
+```toml
+cu-linux-resources = { version = "1.2.0-dev", features = ["serial-rts"] }
+```
+
+```ron
+(id: "board", provider: "cu_linux_resources::LinuxResources", config: {
+    "serial0_dev": "/dev/ttyUSB0",
+    "serial0_baudrate": 9600,
+    "serial0_nonblocking": true,
+    "serial0_rts": true,
+}),
+```
+
+Bind a consumer's pin input to `board.serial0_rts`. `LinuxSerialRtsPin` implements
+`embedded_hal::digital::OutputPin` for active-low RTS# on USB-to-TTL adapters:
+`set_low()` asserts RTS, and `set_high()` deasserts it. The pin initializes high.
+Use an adapter with compatible logic levels and RTS# polarity for the connected
+device, and connect a common ground.
+
+RTS-enabled ports use manual flow control. The pin owns a duplicated descriptor
+and performs a modem-control ioctl for each output change; this operation may
+wait on the USB driver. The device remains open until both data and pin handles
+are dropped. OS/adapter behavior may briefly change RTS while opening or closing
+the port.
+
+RTS export requires a configured serial device, the `serial-rts` feature, Unix,
+and adapter support for modem control. Startup reports an error when a requested
+RTS output fails these requirements. Direct constructors
+`LinuxSerialPort::open_with_rts` and `LinuxNonblockingSerialPort::open_with_rts`
+return the same `(serial, pin)` pair.
 
 ### I2C
 

--- a/components/res/cu_linux_resources/src/lib.rs
+++ b/components/res/cu_linux_resources/src/lib.rs
@@ -5,6 +5,11 @@ use embedded_io::{ErrorType as EmbeddedErrorType, Read as EmbeddedRead, Write as
 use serialport::{Parity as SerialParity, StopBits as SerialStopBits};
 use std::string::String;
 
+#[cfg(all(unix, feature = "serial-rts"))]
+mod serial_rts;
+#[cfg(all(unix, feature = "serial-rts"))]
+pub use serial_rts::{LinuxSerialRtsPin, SerialRtsError};
+
 pub const SERIAL0_DEV_KEY: &str = "serial0_dev";
 pub const SERIAL0_BAUDRATE_KEY: &str = "serial0_baudrate";
 pub const SERIAL0_PARITY_KEY: &str = "serial0_parity";
@@ -239,6 +244,13 @@ pub struct LinuxSerialPort {
 }
 
 impl LinuxSerialPort {
+    /// Open a UART and an independently owned, active-low RTS# output.
+    #[cfg(all(unix, feature = "serial-rts"))]
+    pub fn open_with_rts(config: &SerialSlotConfig) -> std::io::Result<(Self, LinuxSerialRtsPin)> {
+        let (port, rts) = serial_rts::open(config)?;
+        Ok((Self::new(Box::new(port)), rts))
+    }
+
     pub fn new(inner: Box<dyn serialport::SerialPort>) -> Self {
         Self {
             inner: Exclusive::new(inner),
@@ -302,6 +314,76 @@ impl EmbeddedWrite for LinuxSerialPort {
     }
 }
 
+/// Native nonblocking UART for resource stacks. Configure a serial slot with
+/// `serialN_nonblocking: true` to export this type.
+#[cfg(unix)]
+#[derive(Debug)]
+pub struct LinuxNonblockingSerialPort(std::fs::File);
+
+#[cfg(unix)]
+impl LinuxNonblockingSerialPort {
+    /// Open a nonblocking UART and an independently owned, active-low RTS# output.
+    #[cfg(feature = "serial-rts")]
+    pub fn open_with_rts(config: &SerialSlotConfig) -> std::io::Result<(Self, LinuxSerialRtsPin)> {
+        let (port, rts) = serial_rts::open(config)?;
+        Ok((Self::from_native(port)?, rts))
+    }
+
+    pub fn open_with_config(config: &SerialSlotConfig) -> std::io::Result<Self> {
+        let port = serialport::new(&config.dev, config.baudrate)
+            .parity(config.parity)
+            .stop_bits(config.stop_bits)
+            .open_native()?;
+        Self::from_native(port)
+    }
+
+    /// Take ownership of an already configured native UART.
+    pub fn from_native(port: serialport::TTYPort) -> std::io::Result<Self> {
+        use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd};
+        let fd = port.as_raw_fd();
+        // SAFETY: the live TTYPort owns fd; fcntl changes only its status flags.
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        // SAFETY: ownership transfers once from TTYPort into File.
+        Ok(Self(unsafe {
+            std::fs::File::from_raw_fd(port.into_raw_fd())
+        }))
+    }
+
+    fn result(result: std::io::Result<usize>) -> std::io::Result<usize> {
+        match result {
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::Interrupted
+                ) =>
+            {
+                Ok(0)
+            }
+            other => other,
+        }
+    }
+}
+#[cfg(unix)]
+impl embedded_io::ErrorType for LinuxNonblockingSerialPort {
+    type Error = std::io::Error;
+}
+#[cfg(unix)]
+impl cu_serial::SerialIo for LinuxNonblockingSerialPort {
+    fn try_read(&mut self, bytes: &mut [u8]) -> std::io::Result<usize> {
+        let result = std::io::Read::read(&mut self.0, bytes);
+        if !bytes.is_empty() && matches!(result, Ok(0)) {
+            return Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof));
+        }
+        Self::result(result)
+    }
+    fn try_write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        Self::result(std::io::Write::write(&mut self.0, bytes))
+    }
+}
+
 #[cfg(target_os = "linux")]
 pub type LinuxI2c = Exclusive<linux_embedded_hal::I2cdev>;
 #[cfg(target_os = "linux")]
@@ -327,7 +409,13 @@ bundle_resources!(
         Gpio2 = "gpio2",
         Gpio3 = "gpio3",
         Gpio4 = "gpio4",
-        Gpio5 = "gpio5"
+        Gpio5 = "gpio5",
+        Serial0Rts = "serial0_rts",
+        Serial1Rts = "serial1_rts",
+        Serial2Rts = "serial2_rts",
+        Serial3Rts = "serial3_rts",
+        Serial4Rts = "serial4_rts",
+        Serial5Rts = "serial5_rts"
 );
 
 const LINUX_RESOURCE_SLOT_NAMES: &[&str] = &[
@@ -346,10 +434,17 @@ const LINUX_RESOURCE_SLOT_NAMES: &[&str] = &[
     GPIO3_NAME,
     GPIO4_NAME,
     GPIO5_NAME,
+    "serial0_rts",
+    "serial1_rts",
+    "serial2_rts",
+    "serial3_rts",
+    "serial4_rts",
+    "serial5_rts",
 ];
 
 struct SerialSlot {
     id: LinuxResourcesId,
+    rts_id: LinuxResourcesId,
     dev_key: &'static str,
     baudrate_key: &'static str,
     parity_key: &'static str,
@@ -369,6 +464,7 @@ pub struct SerialSlotConfig {
 const SERIAL_SLOTS: &[SerialSlot] = &[
     SerialSlot {
         id: LinuxResourcesId::Serial0,
+        rts_id: LinuxResourcesId::Serial0Rts,
         dev_key: SERIAL0_DEV_KEY,
         baudrate_key: SERIAL0_BAUDRATE_KEY,
         parity_key: SERIAL0_PARITY_KEY,
@@ -377,6 +473,7 @@ const SERIAL_SLOTS: &[SerialSlot] = &[
     },
     SerialSlot {
         id: LinuxResourcesId::Serial1,
+        rts_id: LinuxResourcesId::Serial1Rts,
         dev_key: SERIAL1_DEV_KEY,
         baudrate_key: SERIAL1_BAUDRATE_KEY,
         parity_key: SERIAL1_PARITY_KEY,
@@ -385,6 +482,7 @@ const SERIAL_SLOTS: &[SerialSlot] = &[
     },
     SerialSlot {
         id: LinuxResourcesId::Serial2,
+        rts_id: LinuxResourcesId::Serial2Rts,
         dev_key: SERIAL2_DEV_KEY,
         baudrate_key: SERIAL2_BAUDRATE_KEY,
         parity_key: SERIAL2_PARITY_KEY,
@@ -393,6 +491,7 @@ const SERIAL_SLOTS: &[SerialSlot] = &[
     },
     SerialSlot {
         id: LinuxResourcesId::Serial3,
+        rts_id: LinuxResourcesId::Serial3Rts,
         dev_key: SERIAL3_DEV_KEY,
         baudrate_key: SERIAL3_BAUDRATE_KEY,
         parity_key: SERIAL3_PARITY_KEY,
@@ -401,6 +500,7 @@ const SERIAL_SLOTS: &[SerialSlot] = &[
     },
     SerialSlot {
         id: LinuxResourcesId::Serial4,
+        rts_id: LinuxResourcesId::Serial4Rts,
         dev_key: SERIAL4_DEV_KEY,
         baudrate_key: SERIAL4_BAUDRATE_KEY,
         parity_key: SERIAL4_PARITY_KEY,
@@ -409,6 +509,7 @@ const SERIAL_SLOTS: &[SerialSlot] = &[
     },
     SerialSlot {
         id: LinuxResourcesId::Serial5,
+        rts_id: LinuxResourcesId::Serial5Rts,
         dev_key: SERIAL5_DEV_KEY,
         baudrate_key: SERIAL5_BAUDRATE_KEY,
         parity_key: SERIAL5_PARITY_KEY,
@@ -563,9 +664,53 @@ impl ResourceBundle for LinuxResources {
         manager: &mut ResourceManager,
     ) -> CuResult<()> {
         for slot in SERIAL_SLOTS {
+            let rts = read_serial_rts_config(config, slot)?;
             let Some(serial_config) = read_serial_slot_config(config, slot)? else {
                 continue; // Skip slots without explicit config
             };
+            let nonblocking_key = format!("{}_nonblocking", slot_name(slot.id));
+            let nonblocking = config
+                .and_then(|cfg| cfg.get::<bool>(&nonblocking_key).transpose())
+                .transpose()?
+                .unwrap_or(false);
+            if rts {
+                #[cfg(all(unix, feature = "serial-rts"))]
+                {
+                    if nonblocking {
+                        let (serial, pin) = LinuxNonblockingSerialPort::open_with_rts(
+                            &serial_config,
+                        )
+                        .map_err(|err| CuError::new_with_cause("Open serial RTS resource", err))?;
+                        manager.add_owned(bundle.key(slot.id), serial)?;
+                        manager.add_owned(bundle.key(slot.rts_id), pin)?;
+                    } else {
+                        let (serial, pin) = LinuxSerialPort::open_with_rts(&serial_config)
+                            .map_err(|err| {
+                                CuError::new_with_cause("Open serial RTS resource", err)
+                            })?;
+                        manager.add_owned(bundle.key(slot.id), serial)?;
+                        manager.add_owned(bundle.key(slot.rts_id), pin)?;
+                    }
+                    continue;
+                }
+                #[cfg(not(all(unix, feature = "serial-rts")))]
+                return Err(CuError::from(
+                    "Serial RTS requires Unix and the cu-linux-resources/serial-rts feature",
+                ));
+            }
+            if nonblocking {
+                #[cfg(unix)]
+                {
+                    let serial = LinuxNonblockingSerialPort::open_with_config(&serial_config)
+                        .map_err(|err| {
+                            CuError::new_with_cause("Open nonblocking serial resource", err)
+                        })?;
+                    manager.add_owned(bundle.key(slot.id), serial)?;
+                    continue;
+                }
+                #[cfg(not(unix))]
+                return Err(CuError::from("Nonblocking serial resources require Unix"));
+            }
             match LinuxSerialPort::open_with_config(&serial_config) {
                 Ok(serial) => {
                     manager.add_owned(bundle.key(slot.id), serial)?;
@@ -827,6 +972,18 @@ fn parse_gpio_initial_level_value(raw: &str) -> CuResult<GpioInitialLevel> {
     }
 }
 
+fn read_serial_rts_config(config: Option<&ComponentConfig>, slot: &SerialSlot) -> CuResult<bool> {
+    let key = slot_name(slot.rts_id);
+    let enabled = config
+        .and_then(|cfg| cfg.get::<bool>(key).transpose())
+        .transpose()?
+        .unwrap_or(false);
+    if enabled && get_string(config, slot.dev_key)?.is_none() {
+        return Err(CuError::from(format!("{key} requires {}", slot.dev_key)));
+    }
+    Ok(enabled)
+}
+
 fn slot_name(id: LinuxResourcesId) -> &'static str {
     LINUX_RESOURCE_SLOT_NAMES[id as usize]
 }
@@ -872,6 +1029,49 @@ mod tests {
         for (idx, name) in declared.iter().enumerate() {
             assert_eq!(resource_index_by_name::<LinuxResources>(name), idx);
         }
+    }
+
+    fn rts_config(value: &str) -> ComponentConfig {
+        let ron = format!(
+            r#"(resources: [(id: "board", provider: "cu_linux_resources::LinuxResources",
+                config: {{ "serial0_rts": {value} }})], tasks: [], cnx: [])"#,
+        );
+        cu29::config::CuConfig::deserialize_ron(&ron)
+            .unwrap()
+            .resources
+            .remove(0)
+            .config
+            .unwrap()
+    }
+
+    #[test]
+    fn serial_rts_is_opt_in_and_requires_a_device() {
+        let slot = &SERIAL_SLOTS[0];
+        assert!(!read_serial_rts_config(None, slot).unwrap());
+        let mut config = rts_config("false");
+        assert!(!read_serial_rts_config(Some(&config), slot).unwrap());
+        config = rts_config("true");
+        assert!(read_serial_rts_config(Some(&config), slot).is_err());
+        config.set("serial0_dev", "/dev/ttyUSB0".to_string());
+        assert!(read_serial_rts_config(Some(&config), slot).unwrap());
+        assert!(!read_serial_rts_config(Some(&config), &SERIAL_SLOTS[1]).unwrap());
+        config.set("serial0_rts", "invalid".to_string());
+        assert!(read_serial_rts_config(Some(&config), slot).is_err());
+    }
+
+    #[cfg(not(feature = "serial-rts"))]
+    #[test]
+    fn serial_rts_request_without_feature_fails_before_opening_the_device() {
+        let mut config = rts_config("true");
+        config.set("serial0_dev", "/not/a/serial/device".to_string());
+        let mut manager = ResourceManager::new(&[LINUX_RESOURCE_SLOT_NAMES.len()]);
+        let error = LinuxResources::build(
+            cu29::resource::BundleContext::new(cu29::resource::BundleIndex::new(0), "board"),
+            Some(&config),
+            &mut manager,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("serial-rts feature"));
     }
 
     #[test]
@@ -1092,5 +1292,40 @@ mod tests {
 
         let inner = wrapped.into_inner();
         assert_eq!(&inner.tx[..inner.tx_len], &[9, 8]);
+    }
+}
+
+#[cfg(all(test, unix))]
+mod nonblocking_tests {
+    use super::*;
+    use cu_serial::SerialIo;
+    #[test]
+    fn native_uart_reports_backpressure_and_preserves_binary_bytes() {
+        let (a, b) = serialport::TTYPort::pair().unwrap();
+        let mut tx = LinuxNonblockingSerialPort::from_native(a).unwrap();
+        let mut rx = LinuxNonblockingSerialPort::from_native(b).unwrap();
+        let mut buf = [0; 16];
+        assert_eq!(rx.try_read(&mut buf).unwrap(), 0);
+        assert_eq!(tx.try_write(&[0, 0x7e, 0x7d, 255]).unwrap(), 4);
+        let mut received = 0;
+        for _ in 0..1000 {
+            received += rx.try_read(&mut buf[received..4]).unwrap();
+            if received == 4 {
+                break;
+            }
+            std::thread::yield_now();
+        }
+        assert_eq!(&buf[..received], &[0, 0x7e, 0x7d, 255]);
+        let data = [42; 65536];
+        let written = tx.try_write(&data).unwrap();
+        assert!(written > 0 && written < data.len());
+        let mut blocked = false;
+        for _ in 0..128 {
+            if tx.try_write(&data).unwrap() == 0 {
+                blocked = true;
+                break;
+            }
+        }
+        assert!(blocked);
     }
 }

--- a/components/res/cu_linux_resources/src/serial_rts.rs
+++ b/components/res/cu_linux_resources/src/serial_rts.rs
@@ -1,0 +1,103 @@
+use crate::SerialSlotConfig;
+use embedded_hal::digital::{ErrorType, OutputPin};
+use std::os::fd::{AsRawFd, BorrowedFd, OwnedFd};
+
+/// Owned RTS# output for a USB-to-TTL UART with active-low RTS signaling.
+///
+/// `set_low` asserts RTS; `set_high` deasserts it. The pin starts high.
+/// Output changes use modem-control ioctls.
+/// Its duplicated descriptor keeps the device open independently of the data handle.
+/// Requires the `serial-rts` feature, Unix, and compatible TTL logic levels.
+#[derive(Debug)]
+pub struct LinuxSerialRtsPin(OwnedFd);
+
+#[derive(Debug)]
+pub struct SerialRtsError(std::io::Error);
+
+impl core::fmt::Display for SerialRtsError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::error::Error for SerialRtsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl embedded_hal::digital::Error for SerialRtsError {
+    fn kind(&self) -> embedded_hal::digital::ErrorKind {
+        embedded_hal::digital::ErrorKind::Other
+    }
+}
+
+impl ErrorType for LinuxSerialRtsPin {
+    type Error = SerialRtsError;
+}
+
+impl OutputPin for LinuxSerialRtsPin {
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.set_asserted(true).map_err(SerialRtsError)
+    }
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.set_asserted(false).map_err(SerialRtsError)
+    }
+}
+
+impl LinuxSerialRtsPin {
+    fn set_asserted(&mut self, asserted: bool) -> std::io::Result<()> {
+        let mask: libc::c_int = libc::TIOCM_RTS;
+        let request = if asserted {
+            libc::TIOCMBIS
+        } else {
+            libc::TIOCMBIC
+        };
+        // SAFETY: the owned fd remains live, and these ioctls read a c_int mask.
+        // Changing only RTS avoids overwriting concurrent changes to other lines.
+        if unsafe { libc::ioctl(self.0.as_raw_fd(), request, &mask) } < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn open(
+    config: &SerialSlotConfig,
+) -> std::io::Result<(serialport::TTYPort, LinuxSerialRtsPin)> {
+    let port = serialport::new(&config.dev, config.baudrate)
+        .parity(config.parity)
+        .stop_bits(config.stop_bits)
+        .timeout(std::time::Duration::from_millis(config.timeout_ms))
+        .flow_control(serialport::FlowControl::None)
+        .open_native()?;
+    // SAFETY: port owns the descriptor throughout this borrow. Duplication creates
+    // a separate owned fd without sharing a Rust UART object or adding an I/O lock.
+    let fd = unsafe { BorrowedFd::borrow_raw(port.as_raw_fd()) }.try_clone_to_owned()?;
+    let mut pin = LinuxSerialRtsPin(fd);
+    // Probe support and leave SET inactive before the radio's startup sequence.
+    pin.set_asserted(false)?;
+    Ok((port, pin))
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use serialport::SerialPort;
+
+    #[test]
+    fn unsupported_modem_control_fails_open_instead_of_silently_exporting_a_pin() {
+        let (_master, slave) = serialport::TTYPort::pair().unwrap();
+        let config = SerialSlotConfig {
+            dev: slave.name().unwrap(),
+            baudrate: 9600,
+            parity: serialport::Parity::None,
+            stop_bits: serialport::StopBits::One,
+            timeout_ms: 50,
+        };
+        drop(slave);
+        let err = open(&config).unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(libc::ENOTTY));
+    }
+}

--- a/core/cu29_runtime/src/rendercfg.rs
+++ b/core/cu29_runtime/src/rendercfg.rs
@@ -166,9 +166,28 @@ const RESOURCE_LEGEND_ITEMS: [(&str, &str); 3] = [
     ("Shared", RESOURCE_SHARED_BG),
     ("Unused", RESOURCE_UNUSED_BG),
 ];
-const LINUX_RESOURCE_SLOT_NAMES: [&str; 15] = [
-    "serial0", "serial1", "serial2", "serial3", "serial4", "serial5", "i2c0", "i2c1", "i2c2",
-    "gpio0", "gpio1", "gpio2", "gpio3", "gpio4", "gpio5",
+const LINUX_RESOURCE_SLOT_NAMES: [&str; 21] = [
+    "serial0",
+    "serial1",
+    "serial2",
+    "serial3",
+    "serial4",
+    "serial5",
+    "i2c0",
+    "i2c1",
+    "i2c2",
+    "gpio0",
+    "gpio1",
+    "gpio2",
+    "gpio3",
+    "gpio4",
+    "gpio5",
+    "serial0_rts",
+    "serial1_rts",
+    "serial2_rts",
+    "serial3_rts",
+    "serial4_rts",
+    "serial5_rts",
 ];
 
 #[derive(Parser)]


### PR DESCRIPTION
Add `SerialIo` and `ReadySerial` for bounded serial reads and writes, plus a native Unix implementation exposed through `serialN_nonblocking` in `LinuxResources`. Optional `serial-rts` resources provide independently owned active-low RTS outputs, with corresponding DAG slots.

Includes pseudoterminal backpressure coverage, RTS configuration/error tests, and component usage documentation. Adds the AGENTS.md rule to describe component behavior directly and keep device-specific details in device documentation.

Depends on #1343 (resource composition). This is the first layer extracted from #1344.

Validation is deferred to CI as requested; local checks and hooks were skipped for this split.
