### PR TITLE
Add serial LogStream framing and drain buffered transports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
   "components/libs/cu_serial",
+  "components/res/cu29_logstream_serial",
   "components/bridges/cu_serial_bridge",
 
   "core/cu29",
@@ -225,6 +226,7 @@ no_individual_tags = true
 
 [workspace.dependencies]
 cu-serial = { path = "components/libs/cu_serial", version = "1.2.0-dev", default-features = false }
+cu29-logstream-serial = { path = "components/res/cu29_logstream_serial", version = "1.2.0-dev", default-features = false }
 cu-serial-bridge = { path = "components/bridges/cu_serial_bridge", version = "1.2.0-dev", default-features = false }
 
 

--- a/components/res/cu29_logstream_serial/Cargo.toml
+++ b/components/res/cu29_logstream_serial/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "cu29-logstream-serial"
+description = "Bounded serial framing for Copper log streaming"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[package.metadata.copper]
+kind = "resource"
+domains = ["communication/serial"]
+environments = ["host", "embedded"]
+
+[dependencies]
+embedded-io = { version = "0.7.1", default-features = false }
+cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
+cu-serial = { workspace = true }
+cu29-logstream = { workspace = true }
+
+[features]
+default = ["std"]
+std = ["cu29/std", "cu-serial/std", "cu29-logstream/std"]
+
+[build-dependencies]
+cu29-build = { workspace = true }

--- a/components/res/cu29_logstream_serial/Cargo.toml
+++ b/components/res/cu29_logstream_serial/Cargo.toml
@@ -14,6 +14,7 @@ domains = ["communication/serial"]
 environments = ["host", "embedded"]
 
 [dependencies]
+crc = { workspace = true }
 embedded-io = { version = "0.7.1", default-features = false }
 cu29 = { path = "../../../core/cu29", version = "1.2.0-dev", default-features = false }
 cu-serial = { workspace = true }

--- a/components/res/cu29_logstream_serial/README.md
+++ b/components/res/cu29_logstream_serial/README.md
@@ -1,0 +1,33 @@
+# Serial LogStream transport
+
+`SerialLogStreamTx<S, N>` and `SerialLogStreamRx<S, N>` adapt a
+`cu_serial::SerialIo` resource to Copper's packet-oriented `CuStreamTx`/`CuStreamRx`.
+`SerialLogStreamTxResources<S, N>` consumes a `serial` input and exports `tx`;
+`SerialLogStreamRxResources<S, N>` consumes a `serial` input and exports `rx`.
+Each provider owns its serial resource. Choose a direction for each carrier.
+
+The framing format is a `0x7e` delimiter, escaped LogStream packet bytes, then a
+`0x7e` delimiter. Bytes `0x7e` and `0x7d` are escaped as `0x7d` followed by the
+byte XOR `0x20`. CRC verification uses the LogStream packet CRC. Invalid,
+oversized, interrupted and CRC-invalid frames are discarded, and the next
+delimiter resynchronizes reception. Both serial peers must use this framing.
+
+`N` is the compile-time frame capacity (default 514), allowing packets up to
+`(N - 2) / 2` bytes (default 256) even when every byte requires escaping. TX retains
+one encoded frame. A busy transmitter returns `WouldBlock`; retry that packet
+after the current frame drains. `Ok(())` means one complete packet was accepted
+into the buffer. Encoding runs in the configured LogStream worker.
+
+The scheduled sender services `CuStreamTx::poll_pending()` while idle and while
+draining at shutdown. Applications driving endpoints directly, including
+`no_std` applications, must keep polling `poll_pending()` until it returns false.
+Each poll performs at most one nonblocking UART write.
+
+RX reads at most 64 bytes per call and returns at most one packet. A too-small
+caller buffer returns `BufferTooSmall` and retains that packet for a larger buffer.
+Feed successful packets into `SessionRouter`. LogStream's configured limits,
+recovery and FEC policies apply to these packets.
+
+Configure MTU within the adapter bound and pace below the serial link's usable
+throughput, accounting for escaping and serial start/stop bits. Use a burst of
+one for slow links.

--- a/components/res/cu29_logstream_serial/README.md
+++ b/components/res/cu29_logstream_serial/README.md
@@ -6,14 +6,15 @@
 `SerialLogStreamRxResources<S, N>` consumes a `serial` input and exports `rx`.
 Each provider owns its serial resource. Choose a direction for each carrier.
 
-The framing format is a `0x7e` delimiter, escaped LogStream packet bytes, then a
-`0x7e` delimiter. Bytes `0x7e` and `0x7d` are escaped as `0x7d` followed by the
-byte XOR `0x20`. CRC verification uses the LogStream packet CRC. Invalid,
+The framing format is a `0x7e` delimiter, escaped LogStream packet bytes followed by
+an escaped four-byte big endian CRC32C, then a `0x7e` delimiter. The checksum
+covers exactly the unescaped packet bytes. Bytes `0x7e` and `0x7d` are escaped as `0x7d` followed by the
+byte XOR `0x20`. The adapter verifies and removes its checksum before delivering a packet to FEC. Invalid,
 oversized, interrupted and CRC-invalid frames are discarded, and the next
 delimiter resynchronizes reception. Both serial peers must use this framing.
 
 `N` is the compile-time frame capacity (default 514), allowing packets up to
-`(N - 2) / 2` bytes (default 256) even when every byte requires escaping. TX retains
+`(N - 2) / 2 - 4` bytes (default 252) even when every byte requires escaping. TX retains
 one encoded frame. A busy transmitter returns `WouldBlock`; retry that packet
 after the current frame drains. `Ok(())` means one complete packet was accepted
 into the buffer. Encoding runs in the configured LogStream worker.
@@ -29,5 +30,5 @@ Feed successful packets into `SessionRouter`. LogStream's configured limits,
 recovery and FEC policies apply to these packets.
 
 Configure MTU within the adapter bound and pace below the serial link's usable
-throughput, accounting for escaping and serial start/stop bits. Use a burst of
+throughput, accounting for the framing checksum, escaping, and serial start/stop bits. Use a burst of
 one for slow links.

--- a/components/res/cu29_logstream_serial/build.rs
+++ b/components/res/cu29_logstream_serial/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    cu29_build::setup();
+}

--- a/components/res/cu29_logstream_serial/src/lib.rs
+++ b/components/res/cu29_logstream_serial/src/lib.rs
@@ -1,0 +1,396 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//! Serial packet framing: 0x7e delimiters, 0x7d escaping (byte XOR 0x20).
+//! LogStream's existing packet CRC protects contents. RX resynchronizes at the
+//! next delimiter after corruption. TX owns exactly one pending encoded frame.
+//! Encoding runs in the LogStream sender worker, outside the runtime hot path.
+use core::{fmt, marker::PhantomData};
+use cu_serial::SerialIo;
+use cu29::prelude::*;
+use cu29::resource::{
+    BundleContext, NamedResourceBundleDecl, ResourceBindings, ResourceBundle, ResourceBundleDecl,
+    ResourceManager,
+};
+use cu29_logstream::{CuStreamRx, CuStreamRxError, CuStreamTx, CuStreamTxError, WirePacketRef};
+
+pub const DEFAULT_FRAME_CAPACITY: usize = 514;
+const DELIMITER: u8 = 0x7e;
+const ESCAPE: u8 = 0x7d;
+
+pub struct SerialLogStreamTx<S, const N: usize = DEFAULT_FRAME_CAPACITY> {
+    serial: S,
+    frame: [u8; N],
+    len: usize,
+    sent: usize,
+}
+impl<S, const N: usize> SerialLogStreamTx<S, N> {
+    pub fn new(serial: S) -> Self {
+        Self {
+            serial,
+            frame: [0; N],
+            len: 0,
+            sent: 0,
+        }
+    }
+    pub const fn max_packet_bytes() -> usize {
+        N.saturating_sub(2) / 2
+    }
+}
+impl<S, const N: usize> fmt::Debug for SerialLogStreamTx<S, N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SerialLogStreamTx")
+            .field("pending_bytes", &(self.len - self.sent))
+            .finish()
+    }
+}
+impl<S: SerialIo + Send + Sync, const N: usize> CuStreamTx for SerialLogStreamTx<S, N> {
+    fn try_send(&mut self, packet: &[u8]) -> Result<(), CuStreamTxError> {
+        if N < 2 || packet.is_empty() || packet.len() > Self::max_packet_bytes() {
+            return Err(CuStreamTxError::Failed(
+                "Serial packet exceeds frame capacity",
+            ));
+        }
+        if self.sent < self.len {
+            return Err(CuStreamTxError::WouldBlock);
+        }
+        self.sent = 0;
+        self.len = 1;
+        self.frame[0] = DELIMITER;
+        for &byte in packet {
+            if byte == DELIMITER || byte == ESCAPE {
+                self.frame[self.len] = ESCAPE;
+                self.len += 1;
+                self.frame[self.len] = byte ^ 0x20;
+            } else {
+                self.frame[self.len] = byte;
+            }
+            self.len += 1;
+        }
+        self.frame[self.len] = DELIMITER;
+        self.len += 1;
+        Ok(())
+    }
+    fn poll_pending(&mut self) -> Result<bool, CuStreamTxError> {
+        if self.sent < self.len {
+            self.sent += self
+                .serial
+                .try_write(&self.frame[self.sent..self.len])
+                .map_err(|_| CuStreamTxError::Failed("Serial write failed"))?;
+        }
+        Ok(self.sent < self.len)
+    }
+}
+
+pub struct SerialLogStreamRx<S, const N: usize = DEFAULT_FRAME_CAPACITY> {
+    serial: S,
+    frame: [u8; N],
+    len: usize,
+    ready: bool,
+    active: bool,
+    escaped: bool,
+    input: [u8; 64],
+    input_len: usize,
+    input_pos: usize,
+}
+impl<S, const N: usize> SerialLogStreamRx<S, N> {
+    pub fn new(serial: S) -> Self {
+        Self {
+            serial,
+            frame: [0; N],
+            len: 0,
+            ready: false,
+            active: false,
+            escaped: false,
+            input: [0; 64],
+            input_len: 0,
+            input_pos: 0,
+        }
+    }
+    fn deliver(&mut self, out: &mut [u8]) -> Result<Option<usize>, CuStreamRxError> {
+        if out.len() < self.len {
+            return Err(CuStreamRxError::BufferTooSmall { needed: self.len });
+        }
+        let len = self.len;
+        out[..len].copy_from_slice(&self.frame[..len]);
+        self.ready = false;
+        self.len = 0;
+        Ok(Some(len))
+    }
+}
+impl<S, const N: usize> fmt::Debug for SerialLogStreamRx<S, N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SerialLogStreamRx")
+    }
+}
+impl<S: SerialIo + Send + Sync, const N: usize> CuStreamRx for SerialLogStreamRx<S, N> {
+    fn try_recv(&mut self, out: &mut [u8]) -> Result<Option<usize>, CuStreamRxError> {
+        if self.ready {
+            return self.deliver(out);
+        }
+        // At most one UART read and 64 parser steps per call.
+        if self.input_pos == self.input_len {
+            self.input_len = self
+                .serial
+                .try_read(&mut self.input)
+                .map_err(|_| CuStreamRxError::Failed("Serial read failed"))?;
+            self.input_pos = 0;
+        }
+        while self.input_pos < self.input_len {
+            let byte = self.input[self.input_pos];
+            self.input_pos += 1;
+            if byte == DELIMITER {
+                let valid = self.active
+                    && !self.escaped
+                    && self.len > 0
+                    && WirePacketRef::decode(&self.frame[..self.len]).is_ok();
+                self.active = true;
+                self.escaped = false;
+                if valid {
+                    self.ready = true;
+                    return self.deliver(out);
+                }
+                self.len = 0;
+            } else if self.active {
+                let decoded = if self.escaped {
+                    self.escaped = false;
+                    if byte != (DELIMITER ^ 0x20) && byte != (ESCAPE ^ 0x20) {
+                        self.active = false;
+                        self.len = 0;
+                        continue;
+                    }
+                    byte ^ 0x20
+                } else if byte == ESCAPE {
+                    self.escaped = true;
+                    continue;
+                } else {
+                    byte
+                };
+                if self.len >= N.saturating_sub(2) / 2 {
+                    self.active = false;
+                    self.len = 0;
+                } else {
+                    self.frame[self.len] = decoded;
+                    self.len += 1;
+                }
+            }
+        }
+        Ok(None)
+    }
+}
+
+mod inputs {
+    cu29::resources!(for<S> where S: Send + Sync + 'static { serial => Owned<S> });
+}
+#[allow(dead_code)]
+struct TxSlots;
+cu29::bundle_resources!(TxSlots: Tx);
+pub use TxSlotsId as SerialLogStreamTxId;
+#[allow(dead_code)]
+struct RxSlots;
+cu29::bundle_resources!(RxSlots: Rx);
+pub use RxSlotsId as SerialLogStreamRxId;
+pub struct SerialLogStreamTxResources<S, const N: usize = DEFAULT_FRAME_CAPACITY>(
+    PhantomData<fn() -> S>,
+);
+pub struct SerialLogStreamRxResources<S, const N: usize = DEFAULT_FRAME_CAPACITY>(
+    PhantomData<fn() -> S>,
+);
+macro_rules! provider {
+    ($provider:ident, $endpoint:ident, $id:ident, $slot:ident, $name:literal) => {
+        impl<S, const N: usize> ResourceBundleDecl for $provider<S, N> {
+            type Id = $id;
+        }
+        impl<S, const N: usize> NamedResourceBundleDecl for $provider<S, N> {
+            const NAMES: &'static [&'static str] = &[$name];
+        }
+        impl<S: SerialIo + Send + Sync + 'static, const N: usize> ResourceBundle
+            for $provider<S, N>
+        {
+            const INPUT_NAMES: &'static [&'static str] =
+                <inputs::Resources<S> as ResourceBindings>::NAMES;
+            fn build(
+                bundle: BundleContext<Self>,
+                _: Option<&ComponentConfig>,
+                manager: &mut ResourceManager,
+            ) -> CuResult<()> {
+                if N < 2 * (cu29_logstream::PACKET_HEADER_LEN + 1) + 2 {
+                    return Err(CuError::from(
+                        "Serial frame capacity does not fit a LogStream packet",
+                    ));
+                }
+                let inputs = bundle.inputs::<inputs::Resources<S>>(manager)?;
+                manager.add_owned(
+                    bundle.key($id::$slot),
+                    $endpoint::<S, N>::new(inputs.serial.0),
+                )
+            }
+        }
+    };
+}
+provider!(
+    SerialLogStreamTxResources,
+    SerialLogStreamTx,
+    SerialLogStreamTxId,
+    Tx,
+    "tx"
+);
+provider!(
+    SerialLogStreamRxResources,
+    SerialLogStreamRx,
+    SerialLogStreamRxId,
+    Rx,
+    "rx"
+);
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+    use core::convert::Infallible;
+    use cu29_logstream::{
+        FecScheme, FecSymbolKind, Lane, RecordKind, WireHeader, encode_packet_into,
+    };
+    use std::{collections::VecDeque, vec, vec::Vec};
+    #[derive(Default)]
+    struct Uart {
+        rx: VecDeque<u8>,
+        tx: Vec<u8>,
+        step: usize,
+    }
+    impl embedded_io::ErrorType for Uart {
+        type Error = Infallible;
+    }
+    impl SerialIo for Uart {
+        fn try_read(&mut self, out: &mut [u8]) -> Result<usize, Self::Error> {
+            let n = out.len().min(self.rx.len()).min(self.step);
+            for byte in &mut out[..n] {
+                *byte = self.rx.pop_front().unwrap();
+            }
+            Ok(n)
+        }
+        fn try_write(&mut self, bytes: &[u8]) -> Result<usize, Self::Error> {
+            let n = bytes.len().min(self.step);
+            self.tx.extend_from_slice(&bytes[..n]);
+            Ok(n)
+        }
+    }
+    fn packet() -> Vec<u8> {
+        let mut bytes = vec![0; 256];
+        let n = encode_packet_into(
+            WireHeader {
+                lane: Lane::ReplayCritical,
+                record_kind: RecordKind::CopperList,
+                fec_scheme: FecScheme::RlcGf256,
+                symbol_kind: FecSymbolKind::Source,
+                session_id: [0; 16],
+                sender_id: 1,
+                packet_sequence: 1,
+                object_id: 2,
+                fec_metadata: [0; 12],
+                fragment_count: 1,
+            },
+            &[0, 0x7e, 0x7d, 255],
+            &mut bytes,
+        )
+        .unwrap();
+        bytes.truncate(n);
+        bytes
+    }
+    fn encoded(packet: &[u8]) -> Vec<u8> {
+        let mut tx = SerialLogStreamTx::<_, 514>::new(Uart {
+            step: 3,
+            ..Uart::default()
+        });
+        tx.try_send(packet).unwrap();
+        assert_eq!(tx.try_send(packet), Err(CuStreamTxError::WouldBlock));
+        while tx.poll_pending().unwrap() {}
+        tx.serial.tx
+    }
+    #[test]
+    fn partial_writes_deliver_last_frame_without_another_send() {
+        let packet = packet();
+        let wire = encoded(&packet);
+        let mut rx = SerialLogStreamRx::<_, 514>::new(Uart {
+            rx: wire.into(),
+            step: 1,
+            ..Uart::default()
+        });
+        let mut out = [0; 256];
+        let mut found = None;
+        for _ in 0..514 {
+            if let Some(n) = rx.try_recv(&mut out).unwrap() {
+                found = Some(n);
+                break;
+            }
+        }
+        assert_eq!(&out[..found.unwrap()], packet);
+        assert_eq!(rx.try_recv(&mut out).unwrap(), None);
+    }
+    #[test]
+    fn corruption_oversize_and_truncation_resynchronize() {
+        let packet = packet();
+        let good = encoded(&packet);
+        for prefix in [
+            vec![0x7e; 3],
+            vec![0x7e, 1, 0x7d],
+            vec![1; 600],
+            {
+                let mut bad = good.clone();
+                bad[20] ^= 1;
+                bad
+            },
+            {
+                let mut bad = vec![0x7e];
+                bad.extend(vec![1; 600]);
+                bad
+            },
+        ] {
+            let mut wire = prefix;
+            wire.extend_from_slice(&good);
+            wire.extend_from_slice(&good);
+            let mut rx = SerialLogStreamRx::<_, 514>::new(Uart {
+                rx: wire.into(),
+                step: 64,
+                ..Uart::default()
+            });
+            let mut out = [0; 256];
+            let mut received = 0;
+            for _ in 0..40 {
+                if let Some(n) = rx.try_recv(&mut out).unwrap() {
+                    assert_eq!(&out[..n], packet);
+                    received += 1;
+                }
+            }
+            assert_eq!(received, 2);
+        }
+    }
+    #[test]
+    fn small_destination_retains_the_packet_and_backpressure_is_atomic() {
+        let packet = packet();
+        let wire = encoded(&packet);
+        let mut rx = SerialLogStreamRx::<_, 514>::new(Uart {
+            rx: wire.into(),
+            step: 64,
+            ..Uart::default()
+        });
+        let mut small = [0; 1];
+        loop {
+            match rx.try_recv(&mut small) {
+                Ok(None) => {}
+                Err(CuStreamRxError::BufferTooSmall { needed }) => {
+                    assert_eq!(needed, packet.len());
+                    break;
+                }
+                other => panic!("{other:?}"),
+            }
+        }
+        let mut out = [0; 256];
+        assert_eq!(rx.try_recv(&mut out).unwrap(), Some(packet.len()));
+        let mut tx = SerialLogStreamTx::<_, 514>::new(Uart::default());
+        tx.try_send(&packet).unwrap();
+        assert!(tx.poll_pending().unwrap());
+        assert!(tx.serial.tx.is_empty());
+        assert_eq!(tx.try_send(&packet), Err(CuStreamTxError::WouldBlock));
+        assert!(tx.try_send(&[0; 257]).is_err());
+    }
+}

--- a/components/res/cu29_logstream_serial/src/lib.rs
+++ b/components/res/cu29_logstream_serial/src/lib.rs
@@ -1,21 +1,24 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 //! Serial packet framing: 0x7e delimiters, 0x7d escaping (byte XOR 0x20).
-//! LogStream's existing packet CRC protects contents. RX resynchronizes at the
+//! A framing CRC32C protects the complete packet. RX resynchronizes at the
 //! next delimiter after corruption. TX owns exactly one pending encoded frame.
 //! Encoding runs in the LogStream sender worker, outside the runtime hot path.
 use core::{fmt, marker::PhantomData};
+use crc::{CRC_32_ISCSI, Crc};
 use cu_serial::SerialIo;
 use cu29::prelude::*;
 use cu29::resource::{
     BundleContext, NamedResourceBundleDecl, ResourceBindings, ResourceBundle, ResourceBundleDecl,
     ResourceManager,
 };
-use cu29_logstream::{CuStreamRx, CuStreamRxError, CuStreamTx, CuStreamTxError, WirePacketRef};
+use cu29_logstream::{CuStreamRx, CuStreamRxError, CuStreamTx, CuStreamTxError};
 
 pub const DEFAULT_FRAME_CAPACITY: usize = 514;
 const DELIMITER: u8 = 0x7e;
 const ESCAPE: u8 = 0x7d;
+const CHECKSUM_BYTES: usize = 4;
+const CRC32C: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
 
 pub struct SerialLogStreamTx<S, const N: usize = DEFAULT_FRAME_CAPACITY> {
     serial: S,
@@ -33,7 +36,7 @@ impl<S, const N: usize> SerialLogStreamTx<S, N> {
         }
     }
     pub const fn max_packet_bytes() -> usize {
-        N.saturating_sub(2) / 2
+        (N.saturating_sub(2) / 2).saturating_sub(CHECKSUM_BYTES)
     }
 }
 impl<S, const N: usize> fmt::Debug for SerialLogStreamTx<S, N> {
@@ -56,7 +59,8 @@ impl<S: SerialIo + Send + Sync, const N: usize> CuStreamTx for SerialLogStreamTx
         self.sent = 0;
         self.len = 1;
         self.frame[0] = DELIMITER;
-        for &byte in packet {
+        let checksum = CRC32C.checksum(packet).to_be_bytes();
+        for &byte in packet.iter().chain(checksum.iter()) {
             if byte == DELIMITER || byte == ESCAPE {
                 self.frame[self.len] = ESCAPE;
                 self.len += 1;
@@ -141,11 +145,15 @@ impl<S: SerialIo + Send + Sync, const N: usize> CuStreamRx for SerialLogStreamRx
             if byte == DELIMITER {
                 let valid = self.active
                     && !self.escaped
-                    && self.len > 0
-                    && WirePacketRef::decode(&self.frame[..self.len]).is_ok();
+                    && self.len > CHECKSUM_BYTES
+                    && CRC32C
+                        .checksum(&self.frame[..self.len - CHECKSUM_BYTES])
+                        .to_be_bytes()
+                        == self.frame[self.len - CHECKSUM_BYTES..self.len];
                 self.active = true;
                 self.escaped = false;
                 if valid {
+                    self.len -= CHECKSUM_BYTES;
                     self.ready = true;
                     return self.deliver(out);
                 }
@@ -213,7 +221,7 @@ macro_rules! provider {
                 _: Option<&ComponentConfig>,
                 manager: &mut ResourceManager,
             ) -> CuResult<()> {
-                if N < 2 * (cu29_logstream::PACKET_HEADER_LEN + 1) + 2 {
+                if N < 2 * (cu29_logstream::PACKET_HEADER_LEN + 1 + CHECKSUM_BYTES) + 2 {
                     return Err(CuError::from(
                         "Serial frame capacity does not fit a LogStream packet",
                     ));
@@ -306,6 +314,85 @@ mod tests {
         while tx.poll_pending().unwrap() {}
         tx.serial.tx
     }
+    fn received(wire: Vec<u8>) -> Vec<Vec<u8>> {
+        let polls = wire.len() + 1;
+        let mut rx = SerialLogStreamRx::<_, 514>::new(Uart {
+            rx: wire.into(),
+            step: 1,
+            ..Uart::default()
+        });
+        let mut out = [0; 256];
+        let mut packets = Vec::new();
+        for _ in 0..polls {
+            if let Some(n) = rx.try_recv(&mut out).unwrap() {
+                packets.push(out[..n].to_vec());
+            }
+        }
+        packets
+    }
+
+    #[test]
+    fn framing_crc_is_independent_of_logstream_headers() {
+        let packet = b"123456789";
+        let wire = encoded(packet);
+        let mut expected = vec![DELIMITER];
+        expected.extend_from_slice(packet);
+        // Published CRC32C check value, serialized big endian.
+        expected.extend_from_slice(&[0xe3, 0x06, 0x92, 0x83, DELIMITER]);
+        assert_eq!(wire, expected);
+        assert_eq!(received(wire), vec![packet.to_vec()]);
+    }
+
+    #[test]
+    fn damaged_frames_are_dropped_before_delivery_and_resynchronize() {
+        // No inner LogStream CRC: only the adapter can detect this corruption.
+        let packet = [0, DELIMITER, ESCAPE, 255, 1, 2, 3];
+        let good = encoded(&packet);
+        for offset in 0..good.len() {
+            for bit in 0..8 {
+                let mut damaged = good.clone();
+                damaged[offset] ^= 1 << bit;
+                damaged.extend_from_slice(&good);
+                assert_eq!(received(damaged), vec![packet.to_vec()], "{offset}:{bit}");
+            }
+        }
+        for end in 0..good.len() - 1 {
+            let mut truncated = good[..end].to_vec();
+            truncated.extend_from_slice(&good);
+            assert_eq!(received(truncated), vec![packet.to_vec()], "{end}");
+        }
+    }
+
+    #[test]
+    fn checksum_bytes_are_escaped_and_capacity_includes_them() {
+        assert_eq!(SerialLogStreamTx::<Uart>::max_packet_bytes(), 252);
+        assert_eq!(SerialLogStreamTx::<Uart, 0>::max_packet_bytes(), 0);
+        assert_eq!(SerialLogStreamTx::<Uart, 9>::max_packet_bytes(), 0);
+        let mut checksum_escape_seen = false;
+        for byte in 0..=255 {
+            let packet = vec![byte; 252];
+            checksum_escape_seen |= CRC32C
+                .checksum(&packet)
+                .to_be_bytes()
+                .iter()
+                .any(|byte| *byte == DELIMITER || *byte == ESCAPE);
+            let wire = encoded(&packet);
+            assert!(wire.len() <= DEFAULT_FRAME_CAPACITY);
+            assert_eq!(received(wire), vec![packet]);
+        }
+        assert!(checksum_escape_seen);
+        let mut tx = SerialLogStreamTx::<_, 514>::new(Uart::default());
+        assert!(tx.try_send(&[0; 253]).is_err());
+        assert_eq!(tx.len, 0);
+        let mut tiny = SerialLogStreamTx::<_, 12>::new(Uart {
+            step: 12,
+            ..Uart::default()
+        });
+        tiny.try_send(&[DELIMITER]).unwrap();
+        assert!(!tiny.poll_pending().unwrap());
+        assert_eq!(received(tiny.serial.tx), vec![vec![DELIMITER]]);
+    }
+
     #[test]
     fn partial_writes_deliver_last_frame_without_another_send() {
         let packet = packet();

--- a/core/cu29_logstream/src/pacing.rs
+++ b/core/cu29_logstream/src/pacing.rs
@@ -132,6 +132,7 @@ pub struct SenderCore {
     deficit: [usize; 2],
     lane: usize,
     stopping: bool,
+    transport_pending: bool,
     stats: SenderStats,
 }
 
@@ -284,6 +285,7 @@ impl SenderCore {
             deficit: [0; 2],
             lane: 0,
             stopping: false,
+            transport_pending: false,
             stats: SenderStats::default(),
         })
     }
@@ -477,12 +479,32 @@ impl SenderCore {
     }
 
     pub fn is_idle(&self) -> bool {
-        self.data.len == 0 && self.control_packet().is_none()
+        self.data.len == 0 && self.control_packet().is_none() && !self.transport_pending
     }
 
     /// Send a bounded amount of eligible work and return the next local deadline.
     /// Carrier WouldBlock consumes the attempt's budget and drops the packet.
     pub fn poll<T: CuStreamTx>(
+        &mut self,
+        now: CuTime,
+        transport: &mut T,
+    ) -> Result<Option<CuTime>> {
+        let next = self.poll_packets(now, transport)?;
+        self.transport_pending = transport.poll_pending().map_err(|error| match error {
+            CuStreamTxError::WouldBlock => {
+                Error::Transport("Transport poll must report pending instead of WouldBlock")
+            }
+            CuStreamTxError::Failed(message) => Error::Transport(message),
+        })?;
+        Ok(if self.transport_pending {
+            let retry = now + CuDuration::from_millis(1);
+            Some(next.map_or(retry, |deadline| deadline.min(retry)))
+        } else {
+            next
+        })
+    }
+
+    fn poll_packets<T: CuStreamTx>(
         &mut self,
         now: CuTime,
         transport: &mut T,
@@ -567,7 +589,7 @@ impl SenderCore {
             work += 1;
             self.promote_recovery();
         }
-        Ok(if !self.is_idle() {
+        Ok(if self.data.len != 0 || self.control_packet().is_some() {
             Some(now)
         } else if self.stopping {
             None

--- a/core/cu29_logstream/src/stream.rs
+++ b/core/cu29_logstream/src/stream.rs
@@ -26,10 +26,20 @@ pub enum CuStreamRxError {
 /// retrying, acknowledging, or accepting a partial packet. `Ok(())` means only
 /// that the resource accepted this packet once; it does not guarantee delivery.
 pub trait CuStreamTx: Debug + Send + Sync {
+    /// Advance an accepted packet with bounded, nonblocking work. Returns true
+    /// while bytes remain. Drivers must keep polling until it returns false.
+    /// The default implementation reports an idle transport.
+    fn poll_pending(&mut self) -> core::result::Result<bool, CuStreamTxError> {
+        Ok(false)
+    }
+
     fn try_send(&mut self, packet: &[u8]) -> core::result::Result<(), CuStreamTxError>;
 }
 
 impl<T: CuStreamTx + ?Sized> CuStreamTx for alloc::boxed::Box<T> {
+    fn poll_pending(&mut self) -> core::result::Result<bool, CuStreamTxError> {
+        (**self).poll_pending()
+    }
     #[inline]
     fn try_send(&mut self, packet: &[u8]) -> core::result::Result<(), CuStreamTxError> {
         (**self).try_send(packet)
@@ -88,6 +98,10 @@ impl<T> OneWay<T> {
     }
 }
 impl<T: CuStreamTx> CuStreamTx for OneWay<T> {
+    fn poll_pending(&mut self) -> core::result::Result<bool, CuStreamTxError> {
+        self.tx.poll_pending()
+    }
+
     fn try_send(&mut self, packet: &[u8]) -> core::result::Result<(), CuStreamTxError> {
         self.tx.try_send(packet)
     }
@@ -109,6 +123,10 @@ pub struct SeparateFeedback<T, R> {
     pub feedback_rx: R,
 }
 impl<T: CuStreamTx, R: CuFeedbackRx> CuStreamTx for SeparateFeedback<T, R> {
+    fn poll_pending(&mut self) -> core::result::Result<bool, CuStreamTxError> {
+        self.tx.poll_pending()
+    }
+
     fn try_send(&mut self, packet: &[u8]) -> core::result::Result<(), CuStreamTxError> {
         self.tx.try_send(packet)
     }

--- a/core/cu29_logstream/tests/pacing.rs
+++ b/core/cu29_logstream/tests/pacing.rs
@@ -323,3 +323,48 @@ fn feedback_interval_changes_future_repairs_without_changing_the_budget() {
     assert!(total <= budget);
     assert!(core.set_repair_interval(0).is_err());
 }
+
+#[test]
+fn pending_transport_is_serviced_through_idle_and_shutdown() {
+    #[derive(Debug, Default)]
+    struct Partial {
+        remaining: usize,
+        completed: usize,
+    }
+    impl CuStreamTx for Partial {
+        fn try_send(&mut self, _: &[u8]) -> core::result::Result<(), CuStreamTxError> {
+            if self.remaining != 0 {
+                return Err(CuStreamTxError::WouldBlock);
+            }
+            self.remaining = 3;
+            Ok(())
+        }
+        fn poll_pending(&mut self) -> core::result::Result<bool, CuStreamTxError> {
+            if self.remaining > 0 {
+                self.remaining -= 1;
+                if self.remaining == 0 {
+                    self.completed += 1;
+                }
+            }
+            Ok(self.remaining != 0)
+        }
+    }
+    let mut sender = SenderCore::new(config(), CuTime::default(), 0).unwrap();
+    let mut tx = Partial::default();
+    sender.begin_shutdown();
+    let now = CuTime::default();
+    let next = sender.poll(now, &mut tx).unwrap().unwrap();
+    assert!(!sender.is_idle());
+    assert!(next <= now + CuDuration::from_millis(1));
+    for tick in 1..100 {
+        sender
+            .poll(now + CuDuration::from_millis(tick), &mut tx)
+            .unwrap();
+        if sender.is_idle() {
+            break;
+        }
+    }
+    assert!(sender.is_idle());
+    assert_eq!(tx.remaining, 0);
+    assert!(tx.completed > 0);
+}


### PR DESCRIPTION
Add serial LogStream TX/RX resource providers with bounded delimiter/escape framing and receive resynchronization. Framing appends a four-byte big endian CRC32C over the complete unescaped packet, escapes packet and checksum, then verifies and strips that checksum before delivery to FEC. It works independently of the common LogStream packet CRC, so the carrier remains protected when the diet stack removes that CRC. Both serial peers must use the same framing.

The unchanged 514-byte frame buffer supports packets up to 252 bytes under worst-case escaping. `CuStreamTx::poll_pending` and sender pacing keep accepted frames draining while idle and through shutdown. Includes framing/corruption, capacity, partial-write/backpressure, and sender shutdown regressions.

Uses #1350 (serial resources) and follows #1351 (byte bridge) in the stack. The HC-12 consumer in #1344 carries the migration and corresponding MTU documentation. When integrating with #1355 and later diet steps, remove the obsolete `packet_sequence` field from the serial test fixture; this adjustment was verified on the combined local integration branch.

Validation: `just fmt`; six serial framing tests, focused all-targets clippy with warnings denied, and a no-default-features check on this branch. The combined CRC-free diet/serial/HC-12 integration also passed `just hc12-check` (153 passing test executions, clippy and no-default-features checks). No physical radio test was repeated.
