### PR TITLE
ci: run validation for stacked pull requests

### DIFF
--- a/.github/workflows/build-ci-images.yml
+++ b/.github/workflows/build-ci-images.yml
@@ -9,7 +9,6 @@ on:
       - "support/docker/**"
       - ".github/workflows/build-ci-images.yml"
   pull_request:
-    branches: ["master"]
     paths:
       - "support/docker/**"
       - ".github/workflows/build-ci-images.yml"

--- a/.github/workflows/catalog-deploy.yml
+++ b/.github/workflows/catalog-deploy.yml
@@ -9,7 +9,6 @@ on:
       - "Cargo.toml"
       - "components/**/Cargo.toml"
   pull_request:
-    branches: ["master"]
     paths:
       - "catalog/**"
       - "support/cu_catalog/**"

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -3,8 +3,8 @@ name: "CI/CD"
 on:
   push:
     branches: ["master"]
+  # Validate every PR base, including branches used by stacked PRs.
   pull_request:
-    branches: ["master", "release/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
PRs targeting feature branches currently miss CI/CD because the workflow filters base branches to master and release branches. Remove PR base filters so stacked PRs run the full CI suite, plus path-filtered catalog and CI-image validation.

Push triggers, path filters, publishing/deployment conditions, and job permissions remain unchanged.

Validation: `just fmt` and `just fmt-check` (including YAML and repository hygiene checks).
