### PR TITLE
Remove 8 bytes of unused sequence overhead from every LogStream packet

### DIFF
--- a/core/cu29/tests/logstream_runtime.rs
+++ b/core/cu29/tests/logstream_runtime.rs
@@ -227,7 +227,6 @@ fn sender_config(identity: StreamIdentity) -> CuResult<LogStreamSenderConfig> {
         .map_err(|error| CuError::from(error.to_string()))?;
     let continuous = ContinuousSenderConfig {
         identity,
-        first_packet_sequence: 0,
         lane: Lane::ReplayCritical,
         fec,
         max_record_bytes: RECORD_BYTES,
@@ -249,7 +248,6 @@ fn sender_config(identity: StreamIdentity) -> CuResult<LogStreamSenderConfig> {
         recovery: RecoverySenderConfig {
             finite: FiniteObjectSenderConfig {
                 identity,
-                first_packet_sequence: 0,
                 lane: Lane::LargeObject,
                 symbol_size: SYMBOL_SIZE as u16,
                 max_object_bytes: 64 * 1024,

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -200,15 +200,17 @@ length field. All multi-byte header fields use big endian encoding:
 
 | Layer | Header fields, in wire order | Bytes |
 | --- | --- | ---: |
-| Packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), packet sequence (8), object ID (8), FEC metadata (12), fragment count (4), payload length (2), CRC32C (4) | 66 |
+| Packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), object ID (8), FEC metadata (12), fragment count (4), payload length (2), CRC32C (4) | 58 |
 | Record | magic (4), kind (1), object ID (8), payload length (8), BLAKE3 digest (32) | 53 |
 | RLC fragment | magic (4), kind (1), object ID (8), record length (4), fragment index (4), fragment count (4), fragment length (2) | 27 |
 
-Compared with the prior headers, this saves 6 bytes per packet, 3 per record,
+Compared with the prior headers, this saves 14 bytes per packet, 3 per record,
 and 5 per RLC source fragment, plus one bincode byte per session manifest.
+Packet sequence counters are not transmitted; recovery and deduplication use
+FEC symbol identifiers and record identities.
 Fixed-size FEC symbols use the recovered space for fragment payload; this can
 reduce fragment counts rather than shortening each symbol. Existing symbol
-storage capacity is unchanged: a 1200-byte MTU now emits at most 1194-byte packets.
+storage capacity is unchanged: a 1200-byte MTU now emits at most 1186-byte packets.
 
 The native codec already carries original/captured presence. There is no proof envelope,
 per-list verification allocation, or new continuity record. The archive writes the

--- a/core/cu29_logstream/src/manifest.rs
+++ b/core/cu29_logstream/src/manifest.rs
@@ -273,7 +273,6 @@ impl LogStreamPlan {
             },
             continuous: ContinuousSenderConfig {
                 identity,
-                first_packet_sequence: 0,
                 lane: Lane::ReplayCritical,
                 fec: self.rlc_config()?,
                 max_record_bytes,
@@ -287,7 +286,6 @@ impl LogStreamPlan {
             recovery: RecoverySenderConfig {
                 finite: FiniteObjectSenderConfig {
                     identity,
-                    first_packet_sequence: 0,
                     lane: Lane::Control,
                     symbol_size: self.symbol_size,
                     max_object_bytes: self.objects.max_object_bytes,

--- a/core/cu29_logstream/src/object.rs
+++ b/core/cu29_logstream/src/object.rs
@@ -15,7 +15,6 @@ const RFC6330_MAX_SOURCE_SYMBOLS_PER_BLOCK: u64 = 56_403;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct FiniteObjectSenderConfig {
     pub identity: StreamIdentity,
-    pub first_packet_sequence: u64,
     pub lane: Lane,
     /// RaptorQ symbol bytes, excluding the Copper wire header.
     pub symbol_size: u16,
@@ -66,16 +65,12 @@ pub struct FiniteObjectRecoveryStats {
 /// Construction and encoding allocate and must run on a non-real-time output worker.
 pub struct FiniteObjectEncoder {
     config: FiniteObjectSenderConfig,
-    packet_sequence: u64,
 }
 
 impl FiniteObjectEncoder {
     pub fn new(config: FiniteObjectSenderConfig) -> Result<Self> {
         validate_sender_config(config)?;
-        Ok(Self {
-            packet_sequence: config.first_packet_sequence,
-            config,
-        })
+        Ok(Self { config })
     }
 
     pub const fn config(&self) -> FiniteObjectSenderConfig {
@@ -160,14 +155,12 @@ impl FiniteObjectEncoder {
             symbol_kind,
             session_id: self.config.identity.session_id,
             sender_id: self.config.identity.sender_id,
-            packet_sequence: self.packet_sequence,
             object_id: record.object_id,
             fec_metadata: oti,
             fragment_count: u32::from_be_bytes(payload_id.serialize()),
         };
         let encoded = encode_packet_into(header, &payload, datagram)?;
         emit(&datagram[..encoded])?;
-        self.packet_sequence = self.packet_sequence.wrapping_add(1);
         Ok(())
     }
 }

--- a/core/cu29_logstream/src/pacing.rs
+++ b/core/cu29_logstream/src/pacing.rs
@@ -220,7 +220,6 @@ impl SenderCore {
             ))?;
         let continuous = Box::new(ContinuousEncoder::new(
             config.continuous.identity,
-            config.continuous.first_packet_sequence,
             config.continuous.lane,
             config.continuous.fec,
             config.continuous.max_record_bytes,

--- a/core/cu29_logstream/src/rlc.rs
+++ b/core/cu29_logstream/src/rlc.rs
@@ -226,7 +226,6 @@ pub struct ContinuousEncoder<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMB
     identity: StreamIdentity,
     lane: Lane,
     max_record_bytes: usize,
-    packet_sequence: u64,
     fec: RlcEncoder<MAX_SYMBOL_SIZE, MAX_WINDOW_SYMBOLS>,
 }
 
@@ -235,7 +234,6 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize>
 {
     pub fn new(
         identity: StreamIdentity,
-        first_packet_sequence: u64,
         lane: Lane,
         config: RlcConfig,
         max_record_bytes: usize,
@@ -246,7 +244,6 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize>
             identity,
             lane,
             max_record_bytes,
-            packet_sequence: first_packet_sequence,
             fec: RlcEncoder::new(config, initial_esi)?,
         })
     }
@@ -406,7 +403,6 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize>
             symbol_kind,
             session_id: self.identity.session_id,
             sender_id: self.identity.sender_id,
-            packet_sequence: self.packet_sequence,
             object_id,
             fec_metadata,
             fragment_count,
@@ -422,7 +418,6 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize>
     ) -> Result<()> {
         let encoded = encode_packet_into(header, payload, datagram)?;
         emit(&datagram[..encoded])?;
-        self.packet_sequence = self.packet_sequence.wrapping_add(1);
         Ok(())
     }
 }

--- a/core/cu29_logstream/src/sender.rs
+++ b/core/cu29_logstream/src/sender.rs
@@ -23,7 +23,6 @@ pub type DefaultContinuousCopperListSink<P, T> =
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ContinuousSenderConfig {
     pub identity: StreamIdentity,
-    pub first_packet_sequence: u64,
     pub lane: Lane,
     pub fec: RlcConfig,
     pub max_record_bytes: usize,
@@ -275,7 +274,6 @@ where
             .ok_or(Error::InvalidConfig("datagram length overflow"))?;
         let encoder = ContinuousEncoder::new(
             config.identity,
-            config.first_packet_sequence,
             config.lane,
             config.fec,
             config.max_record_bytes,

--- a/core/cu29_logstream/src/wire.rs
+++ b/core/cu29_logstream/src/wire.rs
@@ -6,8 +6,8 @@ use alloc::vec::Vec;
 use crc::{CRC_32_ISCSI, Crc};
 
 const PACKET_MAGIC: [u8; 4] = *b"CULS";
-pub const PACKET_HEADER_LEN: usize = 66;
-const CRC_OFFSET: usize = 62;
+pub const PACKET_HEADER_LEN: usize = 58;
+const CRC_OFFSET: usize = 54;
 const CRC32C: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
 
 /// Independently scheduled transport lanes.
@@ -85,7 +85,6 @@ pub struct WireHeader {
     pub symbol_kind: FecSymbolKind,
     pub session_id: [u8; 16],
     pub sender_id: u32,
-    pub packet_sequence: u64,
     pub object_id: u64,
     /// Scheme-specific fixed-width FEC metadata.
     pub fec_metadata: [u8; 12],
@@ -133,7 +132,7 @@ impl<'a> WirePacketRef<'a> {
         if bytes[..4] != PACKET_MAGIC {
             return Err(Error::InvalidMagic);
         }
-        let payload_len = u16::from_be_bytes(bytes[60..62].try_into().unwrap()) as usize;
+        let payload_len = u16::from_be_bytes(bytes[52..54].try_into().unwrap()) as usize;
         if bytes.len() != PACKET_HEADER_LEN + payload_len {
             return Err(Error::PayloadLengthMismatch);
         }
@@ -151,7 +150,7 @@ impl<'a> WirePacketRef<'a> {
         let mut session_id = [0_u8; 16];
         session_id.copy_from_slice(&bytes[8..24]);
         let mut fec_metadata = [0_u8; 12];
-        fec_metadata.copy_from_slice(&bytes[44..56]);
+        fec_metadata.copy_from_slice(&bytes[36..48]);
 
         Ok(Self {
             header: WireHeader {
@@ -161,10 +160,9 @@ impl<'a> WirePacketRef<'a> {
                 symbol_kind: FecSymbolKind::try_from(bytes[7])?,
                 session_id,
                 sender_id: u32::from_be_bytes(bytes[24..28].try_into().unwrap()),
-                packet_sequence: u64::from_be_bytes(bytes[28..36].try_into().unwrap()),
-                object_id: u64::from_be_bytes(bytes[36..44].try_into().unwrap()),
+                object_id: u64::from_be_bytes(bytes[28..36].try_into().unwrap()),
                 fec_metadata,
-                fragment_count: u32::from_be_bytes(bytes[56..60].try_into().unwrap()),
+                fragment_count: u32::from_be_bytes(bytes[48..52].try_into().unwrap()),
             },
             payload: &bytes[PACKET_HEADER_LEN..],
         })
@@ -194,11 +192,10 @@ pub fn encode_packet_into(header: WireHeader, payload: &[u8], output: &mut [u8])
     bytes[7] = header.symbol_kind as u8;
     bytes[8..24].copy_from_slice(&header.session_id);
     bytes[24..28].copy_from_slice(&header.sender_id.to_be_bytes());
-    bytes[28..36].copy_from_slice(&header.packet_sequence.to_be_bytes());
-    bytes[36..44].copy_from_slice(&header.object_id.to_be_bytes());
-    bytes[44..56].copy_from_slice(&header.fec_metadata);
-    bytes[56..60].copy_from_slice(&header.fragment_count.to_be_bytes());
-    bytes[60..62].copy_from_slice(&payload_len.to_be_bytes());
+    bytes[28..36].copy_from_slice(&header.object_id.to_be_bytes());
+    bytes[36..48].copy_from_slice(&header.fec_metadata);
+    bytes[48..52].copy_from_slice(&header.fragment_count.to_be_bytes());
+    bytes[52..54].copy_from_slice(&payload_len.to_be_bytes());
     bytes[PACKET_HEADER_LEN..].copy_from_slice(payload);
     let checksum = CRC32C.checksum(bytes);
     bytes[CRC_OFFSET..PACKET_HEADER_LEN].copy_from_slice(&checksum.to_be_bytes());
@@ -219,7 +216,6 @@ mod tests {
                 symbol_kind: FecSymbolKind::Source,
                 session_id: [0x11; 16],
                 sender_id: 0x2233_4455,
-                packet_sequence: 0x6677_8899_aabb_ccdd,
                 object_id: 0x0102_0304_0506_0708,
                 fec_metadata: [0, 0, 0, 0, 3, 0, 0, 8, 1, 0, 1, 1],
                 fragment_count: 1,
@@ -232,11 +228,12 @@ mod tests {
     fn fixed_header_has_a_stable_golden_prefix() {
         let encoded = fixture().encode().unwrap();
         assert_eq!(&encoded[..8], &[b'C', b'U', b'L', b'S', 2, 2, 2, 0]);
-        assert_eq!(encoded.len(), 66 + fixture().payload.len());
+        assert_eq!(encoded.len(), 58 + fixture().payload.len());
         assert_eq!(&encoded[8..24], &[0x11; 16]);
         assert_eq!(&encoded[24..28], &0x2233_4455_u32.to_be_bytes());
-        assert_eq!(&encoded[60..62], &12_u16.to_be_bytes());
-        assert_eq!(&encoded[66..], fixture().payload);
+        assert_eq!(&encoded[28..36], &0x0102_0304_0506_0708_u64.to_be_bytes());
+        assert_eq!(&encoded[52..54], &12_u16.to_be_bytes());
+        assert_eq!(&encoded[58..], fixture().payload);
         assert_eq!(WirePacket::decode(&encoded).unwrap(), fixture());
     }
 

--- a/core/cu29_logstream/tests/continuous_copperlist.rs
+++ b/core/cu29_logstream/tests/continuous_copperlist.rs
@@ -104,7 +104,6 @@ fn partial_copperlists_survive_a_deterministically_simulated_bad_link() {
     let fec_config = RlcConfig::new(SYMBOL_SIZE, WINDOW_SYMBOLS, Field::Gf256).unwrap();
     let mut encoder = ContinuousEncoder::<MAX_SYMBOL_SIZE, WINDOW_SYMBOLS>::new(
         identity,
-        u64::MAX - 5,
         Lane::ReplayCritical,
         fec_config,
         4_096,
@@ -207,7 +206,6 @@ fn missing_unrepaired_fragments_do_not_claim_semantic_recovery() {
     let fec_config = RlcConfig::new(SYMBOL_SIZE, WINDOW_SYMBOLS, Field::Gf256).unwrap();
     let mut encoder = ContinuousEncoder::<MAX_SYMBOL_SIZE, WINDOW_SYMBOLS>::new(
         identity,
-        0,
         Lane::ReplayCritical,
         fec_config,
         4_096,
@@ -293,7 +291,6 @@ fn receiver_reports_an_incomplete_record_when_its_missing_fragment_expires() {
     let fec_config = RlcConfig::new(SYMBOL_SIZE, 16, Field::Gf256).unwrap();
     let mut encoder = ContinuousEncoder::<MAX_SYMBOL_SIZE, WINDOW_SYMBOLS>::new(
         identity,
-        0,
         Lane::ReplayCritical,
         fec_config,
         4_096,
@@ -367,7 +364,6 @@ fn sender_drops_transport_backpressure_without_blocking_the_output_worker() {
         BackpressureTx::default(),
         ContinuousSenderConfig {
             identity,
-            first_packet_sequence: 0,
             lane: Lane::ReplayCritical,
             fec,
             max_record_bytes: 4_096,
@@ -401,7 +397,6 @@ fn receiver_runs_past_many_windows_with_bounded_state_and_wrapping_sequences() {
     let fec_config = RlcConfig::new(SYMBOL_SIZE, WINDOW_SYMBOLS, Field::Gf256).unwrap();
     let mut encoder = ContinuousEncoder::<MAX_SYMBOL_SIZE, WINDOW_SYMBOLS>::new(
         identity,
-        u64::MAX - 32,
         Lane::ReplayCritical,
         fec_config,
         4_096,
@@ -458,7 +453,6 @@ fn receiver_coalesces_wholly_missing_records_after_the_rlc_window_expires() {
     let fec_config = RlcConfig::new(SYMBOL_SIZE, 16, Field::Gf256).unwrap();
     let mut encoder = ContinuousEncoder::<MAX_SYMBOL_SIZE, WINDOW_SYMBOLS>::new(
         identity,
-        0,
         Lane::ReplayCritical,
         fec_config,
         4_096,
@@ -533,7 +527,6 @@ fn consumer_failure_leaves_the_record_available_for_retry() {
     let fec_config = RlcConfig::new(SYMBOL_SIZE, WINDOW_SYMBOLS, Field::Gf256).unwrap();
     let mut encoder = ContinuousEncoder::<MAX_SYMBOL_SIZE, WINDOW_SYMBOLS>::new(
         identity,
-        0,
         Lane::ReplayCritical,
         fec_config,
         4_096,

--- a/core/cu29_logstream/tests/finite_objects.rs
+++ b/core/cu29_logstream/tests/finite_objects.rs
@@ -23,7 +23,6 @@ fn identity() -> StreamIdentity {
 fn encoder() -> FiniteObjectEncoder {
     FiniteObjectEncoder::new(FiniteObjectSenderConfig {
         identity: identity(),
-        first_packet_sequence: 0,
         lane: Lane::LargeObject,
         symbol_size: SYMBOL_SIZE,
         max_object_bytes: MAX_OBJECT_BYTES,
@@ -129,11 +128,13 @@ fn keyframe_and_recovery_point_recover_independently_and_bind_by_digest() {
     encoder
         .push_record(&recovery_point_record, &mut datagrams)
         .unwrap();
-    datagrams.reverse();
-    datagrams.retain(|datagram| {
-        let packet = WirePacket::decode(datagram).unwrap();
-        !packet.header.packet_sequence.is_multiple_of(7)
+    let mut packet_index = 0usize;
+    datagrams.retain(|_| {
+        let keep = !packet_index.is_multiple_of(7);
+        packet_index += 1;
+        keep
     });
+    datagrams.reverse();
 
     let mut receiver = decoder();
     let mut recovered = Vec::new();
@@ -178,7 +179,6 @@ fn a_late_receiver_restarts_the_continuous_stream_at_the_recovery_point() {
     let rlc = RlcConfig::new(160, WINDOW_SYMBOLS, Field::Gf256).unwrap();
     let mut continuous = ContinuousEncoder::<MAX_RLC_SYMBOL_SIZE, WINDOW_SYMBOLS>::new(
         identity(),
-        0,
         Lane::ReplayCritical,
         rlc,
         1_024,

--- a/core/cu29_logstream/tests/manifest.rs
+++ b/core/cu29_logstream/tests/manifest.rs
@@ -93,9 +93,9 @@ fn generated_capacity_and_memory_budget_are_enforced() {
 #[test]
 fn symbol_size_respects_mtu_without_growing_preallocated_storage() {
     let mut config = destination();
-    config.link.mtu_bytes = 1190;
+    config.link.mtu_bytes = 1100;
     let mut plan = LogStreamPlan::resolve(&config).unwrap();
-    assert_eq!(plan.symbol_size, 1124);
+    assert_eq!(plan.symbol_size, 1042);
     plan.symbol_size += 1;
     assert!(plan.validate().is_err());
     config.link.mtu_bytes = cu29_logstream::PACKET_HEADER_LEN as u16;

--- a/core/cu29_logstream/tests/session_router.rs
+++ b/core/cu29_logstream/tests/session_router.rs
@@ -66,7 +66,6 @@ fn manifest_bootstraps_continuous_decoder_without_out_of_band_fec_config() {
     let record = encode_record(RecordKind::CopperList, 0, b"semantic-copperlist").unwrap();
     let mut continuous = ContinuousEncoder::<1128, 64>::new(
         identity,
-        sender.continuous.first_packet_sequence,
         sender.continuous.lane,
         sender.continuous.fec,
         sender.continuous.max_record_bytes,
@@ -180,7 +179,6 @@ fn continuous(
 ) -> Vec<Vec<u8>> {
     let mut encoder = ContinuousEncoder::<1128, 64>::new(
         sender.continuous.identity,
-        0,
         sender.continuous.lane,
         sender.continuous.fec,
         sender.continuous.max_record_bytes,
@@ -443,7 +441,6 @@ fn warmed_router_reuses_record_buffers_with_reordering_and_consumer_retries() {
     receive(&mut router, &objects(&sender, 0)[0], &mut Vec::new());
     let mut encoder = ContinuousEncoder::<1128, 64>::new(
         sender.continuous.identity,
-        0,
         sender.continuous.lane,
         sender.continuous.fec,
         sender.continuous.max_record_bytes,


### PR DESCRIPTION
Every LogStream packet carries an 8-byte sequence counter that no production receiver uses. Remove it from the wire header, both senders, their configuration and constructor calls. Headers shrink from 66 to 58 bytes; the existing 1128-byte symbol capacity stays unchanged, so a 1200-byte MTU now emits packets of at most 1186 bytes.

FEC symbol IDs and record IDs retain ordering, deduplication and recovery behavior. The loss test uses a local index to preserve its original packet-drop pattern. Packet CRC and record digests are unchanged; migrating integrity to UDP/packet-radio carriers versus serial framing is a separate change. Sender and receiver require the matching wire layout.

Stacked on #1348 (`gbin/logstream-unversioned`).

Validation: `just fmt`; `just logstream-receiver-check` (45 LogStream, 5 replay, 12 UDP tests, no_std check, UDP clippy); focused LogStream clippy with warnings denied; generated-runtime integration (3 tests). Updated the MTU boundary fixture to remain below fixed symbol capacity after shrinking the header.
