### PR TITLE
Remove 20 source and 16 repair bytes from RLC packet headers

### DIFF
--- a/components/res/cu29_logstream_udp/tests/configured_sender.rs
+++ b/components/res/cu29_logstream_udp/tests/configured_sender.rs
@@ -184,12 +184,7 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
         let mut recovery_received = bootstrap.is_none();
         while !(source_received && recovery_received) && Instant::now() < deadline {
             if let Some(len) = rx.try_recv(&mut packet).unwrap() {
-                let header = cu29_logstream::WirePacket::decode(&packet[..len])
-                    .unwrap()
-                    .header;
-                source_received |= header.record_kind == RecordKind::CopperList
-                    && header.symbol_kind == cu29_logstream::FecSymbolKind::Source
-                    && header.object_id == id;
+                source_received |= source_copperlist_id(&packet[..len]) == Some(id);
                 traffic.push(packet[..len].to_vec());
                 router.receive_datagram(&packet[..len], &mut emit).unwrap();
                 // The impaired capture starts at this source packet; earlier
@@ -233,12 +228,7 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
     assert!(verified_recovery_point_seen);
     let source_ids: std::collections::BTreeSet<_> = traffic
         .iter()
-        .filter_map(|packet| {
-            let header = cu29_logstream::WirePacket::decode(packet).unwrap().header;
-            (header.record_kind == RecordKind::CopperList
-                && header.symbol_kind == cu29_logstream::FecSymbolKind::Source)
-                .then_some(header.object_id)
-        })
+        .filter_map(|packet| source_copperlist_id(packet))
         .collect();
     assert_eq!(
         source_ids,
@@ -278,10 +268,7 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
     let boundary = |id| {
         traffic
             .iter()
-            .position(|packet| {
-                let header = cu29_logstream::WirePacket::decode(packet).unwrap().header;
-                header.record_kind == RecordKind::CopperList && header.object_id == id
-            })
+            .position(|packet| source_copperlist_id(packet) == Some(id))
             .unwrap()
     };
     let late = boundary(64);
@@ -305,6 +292,15 @@ fn configured_runtime_bootstraps_over_udp_in_actual_arrival_order() -> CuResult<
         false,
     );
     Ok(())
+}
+
+// Read the identity from the protected RLC source fragment, including at capture
+// boundaries. Repair symbols cover a window and have no single object identity.
+fn source_copperlist_id(datagram: &[u8]) -> Option<u64> {
+    let packet = cu29_logstream::WirePacketRef::decode(datagram).unwrap();
+    (packet.header.record_kind == RecordKind::CopperList
+        && packet.header.symbol_kind == cu29_logstream::FecSymbolKind::Source)
+        .then(|| u64::from_be_bytes(packet.payload[5..13].try_into().unwrap()))
 }
 
 // Reuse actual UDP arrival order; only remove a prefix or one contiguous outage.

--- a/core/cu29/tests/logstream_runtime.rs
+++ b/core/cu29/tests/logstream_runtime.rs
@@ -126,10 +126,11 @@ fn generated_runtime_streams_without_local_copperlist_logging() -> CuResult<()> 
     let impaired: Vec<_> = datagrams
         .iter()
         .filter(|datagram| {
-            let header = WirePacket::decode(datagram).unwrap().header;
-            !(header.record_kind == RecordKind::CopperList
-                && header.symbol_kind == FecSymbolKind::Source
-                && header.object_id == 1)
+            let packet = WirePacket::decode(datagram).unwrap();
+            // Object identity is carried inside the protected source fragment.
+            !(packet.header.record_kind == RecordKind::CopperList
+                && packet.header.symbol_kind == FecSymbolKind::Source
+                && u64::from_be_bytes(packet.payload[5..13].try_into().unwrap()) == 1)
         })
         .cloned()
         .collect();

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -200,17 +200,28 @@ length field. All multi-byte header fields use big endian encoding:
 
 | Layer | Header fields, in wire order | Bytes |
 | --- | --- | ---: |
-| Packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), object ID (8), FEC metadata (12), fragment count (4), payload length (2), CRC32C (4) | 58 |
+| RLC source packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), source payload ID (4), payload length (2), CRC32C (4) | 38 |
+| RLC repair packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), repair payload ID (8), payload length (2), CRC32C (4) | 42 |
+| RaptorQ packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), object ID (8), OTI (12), payload ID (4), payload length (2), CRC32C (4) | 58 |
 | Record | magic (4), kind (1), object ID (8), payload length (8), BLAKE3 digest (32) | 53 |
 | RLC fragment | magic (4), kind (1), object ID (8), record length (4), fragment index (4), fragment count (4), fragment length (2) | 27 |
 
-Compared with the prior headers, this saves 14 bytes per packet, 3 per record,
-and 5 per RLC source fragment, plus one bincode byte per session manifest.
+Compared with the original headers, this saves 34 bytes per RLC source packet,
+30 per RLC repair packet, 14 per RaptorQ packet, 3 per record, and 5 per RLC
+source fragment, plus one bincode byte per session manifest.
 Packet sequence counters are not transmitted; recovery and deduplication use
-FEC symbol identifiers and record identities.
-Fixed-size FEC symbols use the recovered space for fragment payload; this can
-reduce fragment counts rather than shortening each symbol. Existing symbol
-storage capacity is unchanged: a 1200-byte MTU now emits at most 1186-byte packets.
+FEC symbol identifiers and record identities. RLC packets omit the outer object ID
+and fragment count because the protected source fragment carries both; repairs
+span a window of fragments. Only the active RLC FEC ID bytes are transmitted.
+Savings inside record and fragment headers free symbol payload capacity and can
+reduce fragment counts. Packet-header savings directly shorten each datagram.
+Existing symbol storage capacity is unchanged: a 1200-byte MTU uses at most 1128-byte symbols,
+producing RLC source packets up to 1166 bytes, RLC repair packets up to 1170 bytes,
+and RaptorQ packets up to 1186 bytes. `PACKET_HEADER_LEN` is the maximum header
+length for buffer sizing; encoding returns the exact length for each packet.
+Shared symbol sizing still reserves room for the largest (RaptorQ) header.
+CRC32C remains on every packet until integrity checking moves to the transport
+adapters, including framing for serial and transparent radio.
 
 The native codec already carries original/captured presence. There is no proof envelope,
 per-list verification allocation, or new continuity record. The archive writes the

--- a/core/cu29_logstream/src/rlc.rs
+++ b/core/cu29_logstream/src/rlc.rs
@@ -326,13 +326,7 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize>
             let esi = self.fec.push_source(active_symbol)?;
             let mut fec_metadata = [0_u8; 12];
             fec_metadata[..4].copy_from_slice(&SourcePayloadId::new(esi).to_bytes());
-            let header = self.packet_header(
-                decoded.kind,
-                decoded.object_id,
-                fragment_count,
-                FecSymbolKind::Source,
-                fec_metadata,
-            );
+            let header = self.packet_header(FecSymbolKind::Source, fec_metadata);
             self.emit_packet_with(header, active_symbol, datagram, emit)?;
             if let Some(schedule) = repair_schedule.as_mut() {
                 schedule.source_symbols_since_repair =
@@ -377,35 +371,22 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize>
         let id = self.fec.encode_repair(parameters, active_symbol)?;
         let mut fec_metadata = [0_u8; 12];
         fec_metadata[..8].copy_from_slice(&id.to_bytes());
-        let header = self.packet_header(
-            RecordKind::CopperList,
-            0,
-            0,
-            FecSymbolKind::Repair,
-            fec_metadata,
-        );
+        let header = self.packet_header(FecSymbolKind::Repair, fec_metadata);
         self.emit_packet_with(header, active_symbol, datagram, &mut emit)?;
         Ok(id)
     }
 
-    fn packet_header(
-        &self,
-        record_kind: RecordKind,
-        object_id: u64,
-        fragment_count: u32,
-        symbol_kind: FecSymbolKind,
-        fec_metadata: [u8; 12],
-    ) -> WireHeader {
+    fn packet_header(&self, symbol_kind: FecSymbolKind, fec_metadata: [u8; 12]) -> WireHeader {
         WireHeader {
             lane: self.lane,
-            record_kind,
+            record_kind: RecordKind::CopperList,
             fec_scheme: fec_scheme(self.config().field()),
             symbol_kind,
             session_id: self.identity.session_id,
             sender_id: self.identity.sender_id,
-            object_id,
+            object_id: 0,
             fec_metadata,
-            fragment_count,
+            fragment_count: 0,
         }
     }
 
@@ -620,26 +601,9 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
     }
 
     fn receive_source_packet(&mut self, packet: &WirePacketRef<'_>) -> Result<bool> {
-        if packet.header.fec_metadata[4..]
-            .iter()
-            .any(|byte| *byte != 0)
-        {
-            self.stats.invalid_datagrams = self.stats.invalid_datagrams.saturating_add(1);
-            return Ok(false);
-        }
         let id = SourcePayloadId::from_bytes(packet.header.fec_metadata[..4].try_into().unwrap());
-        let fragment = match decode_fragment(packet.payload, fragment_capacity(self.fec.config())?)
-        {
-            Ok(fragment) => fragment,
-            Err(_) => {
-                self.stats.invalid_datagrams = self.stats.invalid_datagrams.saturating_add(1);
-                return Ok(false);
-            }
-        };
-        if packet.header.object_id != fragment.object_id
-            || packet.header.fragment_count as usize != fragment.fragment_count
-        {
-            self.stats.inconsistent_datagrams = self.stats.inconsistent_datagrams.saturating_add(1);
+        if decode_fragment(packet.payload, fragment_capacity(self.fec.config())?).is_err() {
+            self.stats.invalid_datagrams = self.stats.invalid_datagrams.saturating_add(1);
             return Ok(false);
         }
         let report = match self.fec.receive_source(id.esi(), packet.payload) {
@@ -663,15 +627,6 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
     }
 
     fn receive_repair_packet(&mut self, packet: &WirePacketRef<'_>) -> Result<bool> {
-        if packet.header.object_id != 0
-            || packet.header.fragment_count != 0
-            || packet.header.fec_metadata[8..]
-                .iter()
-                .any(|byte| *byte != 0)
-        {
-            self.stats.invalid_datagrams = self.stats.invalid_datagrams.saturating_add(1);
-            return Ok(false);
-        }
         let raw_id: [u8; 8] = packet.header.fec_metadata[..8].try_into().unwrap();
         let id = RepairPayloadId::from_bytes(raw_id)?;
         let report = match self.fec.receive_repair(id, packet.payload) {

--- a/core/cu29_logstream/src/wire.rs
+++ b/core/cu29_logstream/src/wire.rs
@@ -6,8 +6,20 @@ use alloc::vec::Vec;
 use crc::{CRC_32_ISCSI, Crc};
 
 const PACKET_MAGIC: [u8; 4] = *b"CULS";
+/// Maximum packet header length, used to bound storage and the shared FEC symbol size.
+/// RaptorQ uses 58 bytes; RLC uses 38 for source packets and 42 for repair packets.
 pub const PACKET_HEADER_LEN: usize = 58;
-const CRC_OFFSET: usize = 54;
+const COMMON_HEADER_LEN: usize = 28;
+const RLC_SOURCE_HEADER_LEN: usize = 38;
+const RLC_REPAIR_HEADER_LEN: usize = 42;
+
+const fn packet_header_len(scheme: FecScheme, kind: FecSymbolKind) -> usize {
+    match (scheme, kind) {
+        (FecScheme::RaptorQ, _) => PACKET_HEADER_LEN,
+        (_, FecSymbolKind::Source) => RLC_SOURCE_HEADER_LEN,
+        (_, FecSymbolKind::Repair) => RLC_REPAIR_HEADER_LEN,
+    }
+}
 const CRC32C: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
 
 /// Independently scheduled transport lanes.
@@ -85,10 +97,12 @@ pub struct WireHeader {
     pub symbol_kind: FecSymbolKind,
     pub session_id: [u8; 16],
     pub sender_id: u32,
+    /// RaptorQ object identity. Not transmitted for RLC; decoded as zero.
     pub object_id: u64,
-    /// Scheme-specific fixed-width FEC metadata.
+    /// RaptorQ OTI (12 bytes), RLC source ID (first 4), or RLC repair ID (first 8).
+    /// Unused RLC bytes are not transmitted and decode as zero.
     pub fec_metadata: [u8; 12],
-    /// Scheme-specific 32-bit identifier: RLC fragment count or RaptorQ payload ID.
+    /// RaptorQ payload ID. Not transmitted for RLC; decoded as zero.
     pub fragment_count: u32,
 }
 
@@ -102,7 +116,7 @@ pub struct WirePacket {
 
 impl WirePacket {
     pub fn encode(&self) -> Result<Vec<u8>> {
-        let mut bytes = alloc::vec![0; PACKET_HEADER_LEN + self.payload.len()];
+        let mut bytes = alloc::vec![0; packet_header_len(self.header.fec_scheme, self.header.symbol_kind) + self.payload.len()];
         let encoded = encode_packet_into(self.header, &self.payload, &mut bytes)?;
         debug_assert_eq!(encoded, bytes.len());
         Ok(bytes)
@@ -126,23 +140,32 @@ pub struct WirePacketRef<'a> {
 
 impl<'a> WirePacketRef<'a> {
     pub fn decode(bytes: &'a [u8]) -> Result<Self> {
-        if bytes.len() < PACKET_HEADER_LEN {
+        if bytes.len() < COMMON_HEADER_LEN {
             return Err(Error::TruncatedPacket);
         }
         if bytes[..4] != PACKET_MAGIC {
             return Err(Error::InvalidMagic);
         }
-        let payload_len = u16::from_be_bytes(bytes[52..54].try_into().unwrap()) as usize;
-        if bytes.len() != PACKET_HEADER_LEN + payload_len {
+        let fec_scheme = FecScheme::try_from(bytes[6])?;
+        let symbol_kind = FecSymbolKind::try_from(bytes[7])?;
+        let header_len = packet_header_len(fec_scheme, symbol_kind);
+        if bytes.len() < header_len {
+            return Err(Error::TruncatedPacket);
+        }
+        let crc_offset = header_len - 4;
+        let length_offset = crc_offset - 2;
+        let payload_len =
+            u16::from_be_bytes(bytes[length_offset..crc_offset].try_into().unwrap()) as usize;
+        if bytes.len() != header_len + payload_len {
             return Err(Error::PayloadLengthMismatch);
         }
 
         let expected_checksum =
-            u32::from_be_bytes(bytes[CRC_OFFSET..PACKET_HEADER_LEN].try_into().unwrap());
+            u32::from_be_bytes(bytes[crc_offset..header_len].try_into().unwrap());
         let mut digest = CRC32C.digest();
-        digest.update(&bytes[..CRC_OFFSET]);
+        digest.update(&bytes[..crc_offset]);
         digest.update(&[0_u8; 4]);
-        digest.update(&bytes[PACKET_HEADER_LEN..]);
+        digest.update(&bytes[header_len..]);
         if digest.finalize() != expected_checksum {
             return Err(Error::CrcMismatch);
         }
@@ -150,21 +173,35 @@ impl<'a> WirePacketRef<'a> {
         let mut session_id = [0_u8; 16];
         session_id.copy_from_slice(&bytes[8..24]);
         let mut fec_metadata = [0_u8; 12];
-        fec_metadata.copy_from_slice(&bytes[36..48]);
+        let (object_id, fragment_count) = match fec_scheme {
+            FecScheme::RaptorQ => {
+                fec_metadata.copy_from_slice(&bytes[36..48]);
+                (
+                    u64::from_be_bytes(bytes[28..36].try_into().unwrap()),
+                    u32::from_be_bytes(bytes[48..52].try_into().unwrap()),
+                )
+            }
+            FecScheme::RlcGf2 | FecScheme::RlcGf256 => {
+                let metadata_len = length_offset - COMMON_HEADER_LEN;
+                fec_metadata[..metadata_len]
+                    .copy_from_slice(&bytes[COMMON_HEADER_LEN..length_offset]);
+                (0, 0)
+            }
+        };
 
         Ok(Self {
             header: WireHeader {
                 lane: Lane::try_from(bytes[4])?,
                 record_kind: RecordKind::try_from(bytes[5])?,
-                fec_scheme: FecScheme::try_from(bytes[6])?,
-                symbol_kind: FecSymbolKind::try_from(bytes[7])?,
+                fec_scheme,
+                symbol_kind,
                 session_id,
                 sender_id: u32::from_be_bytes(bytes[24..28].try_into().unwrap()),
-                object_id: u64::from_be_bytes(bytes[28..36].try_into().unwrap()),
+                object_id,
                 fec_metadata,
-                fragment_count: u32::from_be_bytes(bytes[48..52].try_into().unwrap()),
+                fragment_count,
             },
-            payload: &bytes[PACKET_HEADER_LEN..],
+            payload: &bytes[header_len..],
         })
     }
 }
@@ -173,7 +210,10 @@ impl<'a> WirePacketRef<'a> {
 pub fn encode_packet_into(header: WireHeader, payload: &[u8], output: &mut [u8]) -> Result<usize> {
     let payload_len = u16::try_from(payload.len())
         .map_err(|_| Error::InvalidConfig("wire payload exceeds u16"))?;
-    let needed = PACKET_HEADER_LEN
+    let header_len = packet_header_len(header.fec_scheme, header.symbol_kind);
+    let crc_offset = header_len - 4;
+    let length_offset = crc_offset - 2;
+    let needed = header_len
         .checked_add(payload.len())
         .ok_or(Error::InvalidConfig("packet length overflow"))?;
     if output.len() < needed {
@@ -192,13 +232,21 @@ pub fn encode_packet_into(header: WireHeader, payload: &[u8], output: &mut [u8])
     bytes[7] = header.symbol_kind as u8;
     bytes[8..24].copy_from_slice(&header.session_id);
     bytes[24..28].copy_from_slice(&header.sender_id.to_be_bytes());
-    bytes[28..36].copy_from_slice(&header.object_id.to_be_bytes());
-    bytes[36..48].copy_from_slice(&header.fec_metadata);
-    bytes[48..52].copy_from_slice(&header.fragment_count.to_be_bytes());
-    bytes[52..54].copy_from_slice(&payload_len.to_be_bytes());
-    bytes[PACKET_HEADER_LEN..].copy_from_slice(payload);
+    match header.fec_scheme {
+        FecScheme::RaptorQ => {
+            bytes[28..36].copy_from_slice(&header.object_id.to_be_bytes());
+            bytes[36..48].copy_from_slice(&header.fec_metadata);
+            bytes[48..52].copy_from_slice(&header.fragment_count.to_be_bytes());
+        }
+        FecScheme::RlcGf2 | FecScheme::RlcGf256 => {
+            bytes[COMMON_HEADER_LEN..length_offset]
+                .copy_from_slice(&header.fec_metadata[..length_offset - COMMON_HEADER_LEN]);
+        }
+    }
+    bytes[length_offset..crc_offset].copy_from_slice(&payload_len.to_be_bytes());
+    bytes[header_len..].copy_from_slice(payload);
     let checksum = CRC32C.checksum(bytes);
-    bytes[CRC_OFFSET..PACKET_HEADER_LEN].copy_from_slice(&checksum.to_be_bytes());
+    bytes[crc_offset..header_len].copy_from_slice(&checksum.to_be_bytes());
     Ok(needed)
 }
 
@@ -235,6 +283,115 @@ mod tests {
         assert_eq!(&encoded[52..54], &12_u16.to_be_bytes());
         assert_eq!(&encoded[58..], fixture().payload);
         assert_eq!(WirePacket::decode(&encoded).unwrap(), fixture());
+    }
+
+    fn rlc_fixture(scheme: FecScheme, kind: FecSymbolKind) -> WirePacket {
+        let mut packet = fixture();
+        packet.header.lane = Lane::ReplayCritical;
+        packet.header.record_kind = RecordKind::CopperList;
+        packet.header.fec_scheme = scheme;
+        packet.header.symbol_kind = kind;
+        packet.header.object_id = 0;
+        packet.header.fragment_count = 0;
+        packet.header.fec_metadata = [0; 12];
+        let id_len = match kind {
+            FecSymbolKind::Source => 4,
+            FecSymbolKind::Repair => 8,
+        };
+        packet.header.fec_metadata[..id_len].copy_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8][..id_len]);
+        packet
+    }
+
+    #[test]
+    fn rlc_headers_carry_only_the_active_fec_id() {
+        for scheme in [FecScheme::RlcGf2, FecScheme::RlcGf256] {
+            for (kind, header_len, id_len) in [
+                (FecSymbolKind::Source, 38, 4),
+                (FecSymbolKind::Repair, 42, 8),
+            ] {
+                let packet = rlc_fixture(scheme, kind);
+                let encoded = packet.encode().unwrap();
+                assert_eq!(encoded.len(), header_len + packet.payload.len());
+                assert_eq!(
+                    &encoded[..8],
+                    &[
+                        b'C',
+                        b'U',
+                        b'L',
+                        b'S',
+                        1,
+                        RecordKind::CopperList as u8,
+                        scheme as u8,
+                        kind as u8
+                    ]
+                );
+                assert_eq!(&encoded[8..24], &[0x11; 16]);
+                assert_eq!(&encoded[24..28], &0x2233_4455_u32.to_be_bytes());
+                assert_eq!(
+                    &encoded[28..28 + id_len],
+                    &packet.header.fec_metadata[..id_len]
+                );
+                assert_eq!(&encoded[28 + id_len..30 + id_len], &12_u16.to_be_bytes());
+                assert_eq!(&encoded[header_len..], packet.payload);
+                assert_eq!(WirePacket::decode(&encoded).unwrap(), packet);
+
+                let mut exact_storage = vec![0; encoded.len()];
+                assert_eq!(
+                    encode_packet_into(packet.header, &packet.payload, &mut exact_storage).unwrap(),
+                    encoded.len()
+                );
+                assert_eq!(exact_storage, encoded);
+                let available = encoded.len() - 1;
+                assert_eq!(
+                    encode_packet_into(
+                        packet.header,
+                        &packet.payload,
+                        &mut exact_storage[..available]
+                    ),
+                    Err(Error::BufferTooSmall {
+                        needed: encoded.len(),
+                        available
+                    })
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn all_header_layouts_reject_truncation_trailing_bytes_and_corruption() {
+        for scheme in [FecScheme::RlcGf2, FecScheme::RlcGf256, FecScheme::RaptorQ] {
+            for kind in [FecSymbolKind::Source, FecSymbolKind::Repair] {
+                let mut packet = if scheme == FecScheme::RaptorQ {
+                    fixture()
+                } else {
+                    rlc_fixture(scheme, kind)
+                };
+                packet.header.symbol_kind = kind;
+                for payload in [vec![], vec![0x5a; 64]] {
+                    packet.payload = payload;
+                    let encoded = packet.encode().unwrap();
+                    assert_eq!(WirePacket::decode(&encoded).unwrap(), packet);
+                    for end in 0..encoded.len() {
+                        assert!(WirePacketRef::decode(&encoded[..end]).is_err());
+                    }
+                    let mut damaged = encoded.clone();
+                    damaged.push(0);
+                    assert_eq!(
+                        WirePacketRef::decode(&damaged),
+                        Err(Error::PayloadLengthMismatch)
+                    );
+                    damaged.pop();
+                    for offset in 0..damaged.len() {
+                        damaged[offset] ^= 1;
+                        assert!(
+                            WirePacketRef::decode(&damaged).is_err(),
+                            "accepted corruption at {offset} in {scheme:?} {kind:?}"
+                        );
+                        damaged[offset] ^= 1;
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/core/cu29_logstream/tests/continuous_copperlist.rs
+++ b/core/cu29_logstream/tests/continuous_copperlist.rs
@@ -17,6 +17,16 @@ const SYMBOL_SIZE: usize = 160;
 const WINDOW_SYMBOLS: usize = 64;
 const MAX_EQUATIONS: usize = 32;
 
+// Loss selection reads identity from the FEC-protected source fragment.
+fn source_object_id(datagram: &[u8]) -> u64 {
+    let packet = cu29_logstream::WirePacketRef::decode(datagram).unwrap();
+    assert_eq!(
+        packet.header.symbol_kind,
+        cu29_logstream::FecSymbolKind::Source
+    );
+    u64::from_be_bytes(packet.payload[5..13].try_into().unwrap())
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ObservedEvent {
     Record(u64),
@@ -225,10 +235,7 @@ fn missing_unrepaired_fragments_do_not_claim_semantic_recovery() {
     let retained = datagrams
         .into_iter()
         .filter(|datagram| {
-            let object_id = cu29_logstream::WirePacket::decode(datagram)
-                .unwrap()
-                .header
-                .object_id;
+            let object_id = source_object_id(datagram);
             if omitted_objects.contains(&object_id) {
                 true
             } else {
@@ -305,8 +312,7 @@ fn receiver_reports_an_incomplete_record_when_its_missing_fragment_expires() {
     }
     let mut omitted_fragment = false;
     datagrams.retain(|datagram| {
-        let packet = cu29_logstream::WirePacket::decode(datagram).unwrap();
-        if packet.header.object_id == 4 && !omitted_fragment {
+        if source_object_id(datagram) == 4 && !omitted_fragment {
             omitted_fragment = true;
             false
         } else {
@@ -466,10 +472,7 @@ fn receiver_coalesces_wholly_missing_records_after_the_rlc_window_expires() {
         encoder.push_record(&record, &mut datagrams).unwrap();
     }
     datagrams.retain(|datagram| {
-        let object_id = cu29_logstream::WirePacket::decode(datagram)
-            .unwrap()
-            .header
-            .object_id;
+        let object_id = source_object_id(datagram);
         !(4..=6).contains(&object_id)
     });
 

--- a/core/cu29_logstream/tests/finite_objects.rs
+++ b/core/cu29_logstream/tests/finite_objects.rs
@@ -205,7 +205,8 @@ fn a_late_receiver_restarts_the_continuous_stream_at_the_recovery_point() {
     continuous_datagrams.retain(|datagram| {
         let packet = WirePacket::decode(datagram).unwrap();
         packet.header.symbol_kind == cu29_logstream::FecSymbolKind::Repair
-            || packet.header.object_id >= RECOVERY_POINT_ID
+            // Source identity lives in the protected fragment, not the packet header.
+            || u64::from_be_bytes(packet.payload[5..13].try_into().unwrap()) >= RECOVERY_POINT_ID
     });
 
     let manifest = encode_record(RecordKind::Manifest, 1, b"late-join-manifest").unwrap();

--- a/core/cu29_logstream/tests/pacing.rs
+++ b/core/cu29_logstream/tests/pacing.rs
@@ -280,10 +280,11 @@ fn recovery_never_overtakes_older_queued_source_records() {
         .unwrap();
     for id in 0..32 {
         assert!(tx.packets[..recovery_point].iter().any(|(_, p)| {
-            let h = WirePacket::decode(p).unwrap().header;
-            h.record_kind == RecordKind::CopperList
-                && h.symbol_kind == FecSymbolKind::Source
-                && h.object_id == id
+            let packet = WirePacket::decode(p).unwrap();
+            packet.header.record_kind == RecordKind::CopperList
+                && packet.header.symbol_kind == FecSymbolKind::Source
+                // Select the source identity from its protected fragment.
+                && u64::from_be_bytes(packet.payload[5..13].try_into().unwrap()) == id
         }));
     }
     assert_eq!(core.stats().expired_packets, 0);

--- a/examples/cu_logstream_demo/src/receiver.rs
+++ b/examples/cu_logstream_demo/src/receiver.rs
@@ -3,7 +3,7 @@ use crate::{Impairment, Result, prepare_log};
 use cu_logstream_demo::telemetry::Status;
 use cu_logstream_demo::twin::Twin;
 use cu29_logstream::{
-    CuStreamRx, CuStreamRxError, CuTwin, CuTwinReader, FecSymbolKind, RecordKind, WirePacket,
+    CuStreamRx, CuStreamRxError, CuTwin, CuTwinReader, FecSymbolKind, RecordKind, WirePacketRef,
 };
 use cu29_logstream_udp::CuUdpLogStreamConfig;
 use std::net::SocketAddr;
@@ -80,21 +80,28 @@ impl<R: CuStreamRx> CuStreamRx for ImpairedRx<R> {
         );
         self.stats.seen_packet.store(true, Ordering::Release);
         let first = *self.first_packet.get_or_insert(now);
-        let wire = WirePacket::decode(&packet[..len])
+        let wire = WirePacketRef::decode(&packet[..len])
             .map_err(|_| CuStreamRxError::Failed("Invalid demo packet"))?;
         let header = wire.header;
-        if header.record_kind == RecordKind::CopperList
+        // RLC object identity lives inside the protected source fragment.
+        // Repairs span a window and cannot identify a single CopperList.
+        let source_id = if header.record_kind == RecordKind::CopperList
             && header.symbol_kind == FecSymbolKind::Source
         {
-            self.in_outage = (32..160).contains(&header.object_id);
+            let id = wire
+                .payload
+                .get(5..13)
+                .ok_or(CuStreamRxError::Failed("Truncated demo source fragment"))?;
+            Some(u64::from_be_bytes(id.try_into().unwrap()))
+        } else {
+            None
+        };
+        if let Some(id) = source_id {
+            self.in_outage = (32..160).contains(&id);
         }
         let discard = match self.impairment {
             Impairment::Clean => false,
-            Impairment::Loss => {
-                header.record_kind == RecordKind::CopperList
-                    && header.symbol_kind == FecSymbolKind::Source
-                    && header.object_id == 20
-            }
+            Impairment::Loss => source_id == Some(20),
             Impairment::Outage => self.in_outage,
             Impairment::Bootstrap => now.duration_since(first) < Duration::from_millis(300),
         };


### PR DESCRIPTION
## Summary

RLC packets repeat the source fragment's object ID and fragment count and pad their FEC IDs to RaptorQ's 12-byte OTI width. Remove those bytes from RLC packets: source headers shrink from 58 to 38 bytes and repair headers from 58 to 42 bytes. RaptorQ remains 58 bytes.

## Related issues

Stacked on #1355. Second transmission-diet change following #1348.

## Changes

- Select header length from the existing FEC scheme and symbol kind, without another wire tag. RLC transmits only its 4-byte source ID or 8-byte repair ID.
- Retain object identity and fragment geometry inside the FEC-protected source fragment. Keep CRC32C validation before FEC, record digests, shared MTU resolution, and preallocated symbol capacity. `PACKET_HEADER_LEN` remains the maximum storage bound; encoding returns the exact packet length.
- At a 1200-byte MTU with 1128-byte symbols, RLC source/repair packets occupy 1166/1170 bytes; RaptorQ remains at most 1186 bytes. No additional sender/receiver allocation or payload copy.
- Update loss, late-join, pacing, and demo impairment selectors to use protected source identity. Cover all header variants with exact-size buffers, short/empty payloads, truncation, trailing bytes, and per-byte corruption tests.

## Validation

- `just fmt`
- `just logstream-receiver-check`: 64 tests, no-default-features check, UDP clippy.
- `cargo +stable clippy -p cu29-logstream --all-targets --offline -- --deny warnings`
- `cargo +stable test -p cu29 --features logstream --test logstream_runtime --offline`: 3 tests.
- Demo loss and outage scenarios: native archive comparison and recorded replay.

## Reminder

- [x] Ran focused root `just logstream-receiver-check`; verification is package-focused as requested.
- [x] Updated crate documentation and demo; book PR https://github.com/copper-project/copper-rs-book/pull/58 and wiki review branch `gbin/transmission-diet-rlc` (commit `8194bed`).

## Additional context

Sender and receiver must use matching wire layouts. In-memory `WireHeader` retains object ID and payload ID (`fragment_count`) for RaptorQ; RLC decodes those fields and its unused metadata tail as zero.

Carrier-integrity migration remains separate: UDP/network and packet-radio hardware may supply integrity externally; Copper's serial/transparent-radio framing must preserve its own integrity check when the common CRC moves (see #1352 and #1344).
