### PR TITLE
Derive redundant RLC fragment geometry and omit constant kind

### DIFF
--- a/components/res/cu29_logstream_udp/tests/configured_sender.rs
+++ b/components/res/cu29_logstream_udp/tests/configured_sender.rs
@@ -300,7 +300,7 @@ fn source_copperlist_id(datagram: &[u8]) -> Option<u64> {
     let packet = cu29_logstream::WirePacketRef::decode(datagram).unwrap();
     (packet.header.record_kind == RecordKind::CopperList
         && packet.header.symbol_kind == cu29_logstream::FecSymbolKind::Source)
-        .then(|| u64::from_be_bytes(packet.payload[5..13].try_into().unwrap()))
+        .then(|| u64::from_be_bytes(packet.payload[4..12].try_into().unwrap()))
 }
 
 // Reuse actual UDP arrival order; only remove a prefix or one contiguous outage.

--- a/core/cu29/tests/logstream_runtime.rs
+++ b/core/cu29/tests/logstream_runtime.rs
@@ -130,7 +130,7 @@ fn generated_runtime_streams_without_local_copperlist_logging() -> CuResult<()> 
             // Object identity is carried inside the protected source fragment.
             !(packet.header.record_kind == RecordKind::CopperList
                 && packet.header.symbol_kind == FecSymbolKind::Source
-                && u64::from_be_bytes(packet.payload[5..13].try_into().unwrap()) == 1)
+                && u64::from_be_bytes(packet.payload[4..12].try_into().unwrap()) == 1)
         })
         .cloned()
         .collect();

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -204,15 +204,19 @@ length field. All multi-byte header fields use big endian encoding:
 | RLC repair packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), repair payload ID (8), payload length (2), CRC32C (4) | 42 |
 | RaptorQ packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), object ID (8), OTI (12), payload ID (4), payload length (2), CRC32C (4) | 58 |
 | Record | magic (4), kind (1), object ID (8), payload length (8), BLAKE3 digest (32) | 53 |
-| RLC fragment | magic (4), kind (1), object ID (8), record length (4), fragment index (4), fragment count (4), fragment length (2) | 27 |
+| RLC fragment | magic (4), object ID (8), record length (4), fragment index (4) | 20 |
 
 Compared with the original headers, this saves 34 bytes per RLC source packet,
-30 per RLC repair packet, 14 per RaptorQ packet, 3 per record, and 5 per RLC
+30 per RLC repair packet, 14 per RaptorQ packet, 3 per record, and 12 per RLC
 source fragment, plus one bincode byte per session manifest.
 Packet sequence counters are not transmitted; recovery and deduplication use
 FEC symbol identifiers and record identities. RLC packets omit the outer object ID
-and fragment count because the protected source fragment carries both; repairs
-span a window of fragments. Only the active RLC FEC ID bytes are transmitted.
+and fragment count; protected source fragments carry record identity, record
+length, and fragment index. Receivers derive fragment count and payload length
+from that geometry and the configured symbol capacity. Fragment kind is implicitly
+CopperList; the reassembled record must still match that kind and identity and
+pass digest verification. Repairs span a window of fragments. Only the active
+RLC FEC ID bytes are transmitted.
 Savings inside record and fragment headers free symbol payload capacity and can
 reduce fragment counts. Packet-header savings directly shorten each datagram.
 Existing symbol storage capacity is unchanged: a 1200-byte MTU uses at most 1128-byte symbols,

--- a/core/cu29_logstream/src/rlc.rs
+++ b/core/cu29_logstream/src/rlc.rs
@@ -11,7 +11,7 @@ use cu_fec::{
 };
 
 const FRAGMENT_MAGIC: [u8; 4] = *b"CUFR";
-pub(crate) const FRAGMENT_HEADER_LEN: usize = 27;
+pub(crate) const FRAGMENT_HEADER_LEN: usize = 20;
 
 /// Identity shared by one sender's continuous stream.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Encode, Decode)]
@@ -314,12 +314,9 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize>
             active_symbol.fill(0);
             encode_fragment_header(
                 active_symbol,
-                decoded.kind,
                 decoded.object_id,
                 record_len,
                 fragment_index as u32,
-                fragment_count,
-                chunk.len() as u16,
             );
             active_symbol[FRAGMENT_HEADER_LEN..FRAGMENT_HEADER_LEN + chunk.len()]
                 .copy_from_slice(chunk);
@@ -1051,72 +1048,45 @@ fn fec_scheme(field: Field) -> FecScheme {
     }
 }
 
-fn encode_fragment_header(
-    symbol: &mut [u8],
-    kind: RecordKind,
-    object_id: u64,
-    record_len: u32,
-    fragment_index: u32,
-    fragment_count: u32,
-    fragment_len: u16,
-) {
+fn encode_fragment_header(symbol: &mut [u8], object_id: u64, record_len: u32, fragment_index: u32) {
     symbol[..4].copy_from_slice(&FRAGMENT_MAGIC);
-    symbol[4] = kind as u8;
-    symbol[5..13].copy_from_slice(&object_id.to_be_bytes());
-    symbol[13..17].copy_from_slice(&record_len.to_be_bytes());
-    symbol[17..21].copy_from_slice(&fragment_index.to_be_bytes());
-    symbol[21..25].copy_from_slice(&fragment_count.to_be_bytes());
-    symbol[25..27].copy_from_slice(&fragment_len.to_be_bytes());
+    symbol[4..12].copy_from_slice(&object_id.to_be_bytes());
+    symbol[12..16].copy_from_slice(&record_len.to_be_bytes());
+    symbol[16..20].copy_from_slice(&fragment_index.to_be_bytes());
 }
 
 fn decode_fragment(symbol: &[u8], fragment_capacity: usize) -> Result<Fragment<'_>> {
     if symbol.len() < FRAGMENT_HEADER_LEN || symbol[..4] != FRAGMENT_MAGIC {
         return Err(Error::InvalidFragment("missing fragment header"));
     }
-    let kind = RecordKind::try_from(symbol[4])?;
-    if kind != RecordKind::CopperList {
-        return Err(Error::InvalidFragment(
-            "continuous lane requires CopperList records",
-        ));
-    }
-    let object_id = u64::from_be_bytes(symbol[5..13].try_into().unwrap());
-    let record_len = u32::from_be_bytes(symbol[13..17].try_into().unwrap()) as usize;
-    let fragment_index = u32::from_be_bytes(symbol[17..21].try_into().unwrap()) as usize;
-    let fragment_count = u32::from_be_bytes(symbol[21..25].try_into().unwrap()) as usize;
-    let fragment_len = u16::from_be_bytes(symbol[25..27].try_into().unwrap()) as usize;
-    if record_len == 0 || fragment_count == 0 || fragment_index >= fragment_count {
+    let object_id = u64::from_be_bytes(symbol[4..12].try_into().unwrap());
+    let record_len = u32::from_be_bytes(symbol[12..16].try_into().unwrap()) as usize;
+    let fragment_index = u32::from_be_bytes(symbol[16..20].try_into().unwrap()) as usize;
+    if record_len == 0 || fragment_capacity == 0 {
         return Err(Error::InvalidFragment("invalid fragment geometry"));
     }
-    let expected_count = record_len.div_ceil(fragment_capacity);
-    if fragment_count != expected_count {
-        return Err(Error::InvalidFragment(
-            "fragment count does not match record length",
-        ));
+    let fragment_count = record_len.div_ceil(fragment_capacity);
+    if fragment_index >= fragment_count {
+        return Err(Error::InvalidFragment("invalid fragment geometry"));
     }
-    let expected_len = if fragment_index + 1 == fragment_count {
-        record_len - fragment_index * fragment_capacity
-    } else {
-        fragment_capacity
-    };
-    if fragment_len != expected_len || FRAGMENT_HEADER_LEN + fragment_len > symbol.len() {
-        return Err(Error::InvalidFragment(
-            "fragment length does not match geometry",
-        ));
-    }
-    if symbol[FRAGMENT_HEADER_LEN + fragment_len..]
-        .iter()
-        .any(|byte| *byte != 0)
-    {
+    // The index bound guarantees that the offset is smaller than record_len.
+    let offset = fragment_index * fragment_capacity;
+    let fragment_len = fragment_capacity.min(record_len - offset);
+    let body = &symbol[FRAGMENT_HEADER_LEN..];
+    let payload = body.get(..fragment_len).ok_or(Error::InvalidFragment(
+        "fragment length does not match geometry",
+    ))?;
+    if body[fragment_len..].iter().any(|byte| *byte != 0) {
         return Err(Error::InvalidFragment("fragment padding is nonzero"));
     }
     Ok(Fragment {
-        kind,
+        kind: RecordKind::CopperList,
         object_id,
         record_len,
         fragment_index,
         fragment_count,
         fragment_capacity,
-        payload: &symbol[FRAGMENT_HEADER_LEN..FRAGMENT_HEADER_LEN + fragment_len],
+        payload,
     })
 }
 
@@ -1126,25 +1096,83 @@ mod tests {
 
     #[test]
     fn fragment_header_round_trips_and_rejects_padding() {
-        let mut symbol = [0_u8; 64];
-        encode_fragment_header(&mut symbol, RecordKind::CopperList, 42, 40, 1, 2, 8);
+        let mut symbol = [0_u8; 52];
+        encode_fragment_header(&mut symbol, 42, 40, 1);
         symbol[FRAGMENT_HEADER_LEN..FRAGMENT_HEADER_LEN + 8].copy_from_slice(b"fragment");
-        assert_eq!(FRAGMENT_HEADER_LEN, 27);
-        assert_eq!(&symbol[..5], b"CUFR\x01");
-        assert_eq!(&symbol[5..13], &42_u64.to_be_bytes());
-        assert_eq!(&symbol[13..17], &40_u32.to_be_bytes());
-        assert_eq!(&symbol[17..21], &1_u32.to_be_bytes());
-        assert_eq!(&symbol[21..25], &2_u32.to_be_bytes());
-        assert_eq!(&symbol[25..27], &8_u16.to_be_bytes());
+        assert_eq!(FRAGMENT_HEADER_LEN, 20);
+        assert_eq!(&symbol[..4], b"CUFR");
+        assert_eq!(&symbol[4..12], &42_u64.to_be_bytes());
+        assert_eq!(&symbol[12..16], &40_u32.to_be_bytes());
+        assert_eq!(&symbol[16..20], &1_u32.to_be_bytes());
         let decoded = decode_fragment(&symbol, 32).unwrap();
+        assert_eq!(decoded.kind, RecordKind::CopperList);
         assert_eq!(decoded.object_id, 42);
+        assert_eq!(decoded.record_len, 40);
         assert_eq!(decoded.fragment_index, 1);
+        assert_eq!(decoded.fragment_count, 2);
         assert_eq!(decoded.payload, b"fragment");
 
-        symbol[63] = 1;
+        symbol[51] = 1;
         assert_eq!(
             decode_fragment(&symbol, 32).unwrap_err(),
             Error::InvalidFragment("fragment padding is nonzero")
+        );
+    }
+
+    #[test]
+    fn fragment_geometry_handles_record_boundaries() {
+        for (record_len, index, count, len) in [
+            (1, 0, 1, 1),
+            (31, 0, 1, 31),
+            (32, 0, 1, 32),
+            (33, 0, 2, 32),
+            (33, 1, 2, 1),
+            (64, 1, 2, 32),
+            (65, 2, 3, 1),
+            (u32::MAX, 134_217_727, 134_217_728, 31),
+        ] {
+            let mut symbol = [0_u8; 52];
+            encode_fragment_header(&mut symbol, u64::MAX, record_len, index);
+            symbol[FRAGMENT_HEADER_LEN..FRAGMENT_HEADER_LEN + len].fill(0xa5);
+            let fragment = decode_fragment(&symbol, 32).unwrap();
+            assert_eq!(fragment.fragment_count, count);
+            assert_eq!(fragment.payload, &vec![0xa5; len]);
+        }
+        // Exercise the largest index and count without allocating a large record.
+        let mut symbol = [0_u8; 21];
+        encode_fragment_header(&mut symbol, 42, u32::MAX, u32::MAX - 1);
+        let fragment = decode_fragment(&symbol, 1).unwrap();
+        assert_eq!(fragment.fragment_count, u32::MAX as usize);
+        assert_eq!(fragment.payload.len(), 1);
+    }
+
+    #[test]
+    fn fragment_rejects_invalid_geometry_and_truncation() {
+        let mut symbol = [0_u8; 52];
+        for (record_len, index, capacity) in [
+            (0, 0, 32),
+            (32, 0, 0),
+            (32, 1, 32),
+            (33, 2, 32),
+            (u32::MAX, u32::MAX, 1),
+        ] {
+            encode_fragment_header(&mut symbol, 42, record_len, index);
+            assert_eq!(
+                decode_fragment(&symbol, capacity).unwrap_err(),
+                Error::InvalidFragment("invalid fragment geometry")
+            );
+        }
+        for (record_len, index, len) in [(32, 0, 32), (40, 1, 8)] {
+            encode_fragment_header(&mut symbol, 42, record_len, index);
+            for end in 0..FRAGMENT_HEADER_LEN + len {
+                assert!(decode_fragment(&symbol[..end], 32).is_err());
+            }
+            assert!(decode_fragment(&symbol[..FRAGMENT_HEADER_LEN + len], 32).is_ok());
+        }
+        symbol[0] ^= 1;
+        assert_eq!(
+            decode_fragment(&symbol, 32).unwrap_err(),
+            Error::InvalidFragment("missing fragment header")
         );
     }
 }

--- a/core/cu29_logstream/tests/continuous_copperlist.rs
+++ b/core/cu29_logstream/tests/continuous_copperlist.rs
@@ -24,7 +24,7 @@ fn source_object_id(datagram: &[u8]) -> u64 {
         packet.header.symbol_kind,
         cu29_logstream::FecSymbolKind::Source
     );
-    u64::from_be_bytes(packet.payload[5..13].try_into().unwrap())
+    u64::from_be_bytes(packet.payload[4..12].try_into().unwrap())
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -103,6 +103,65 @@ fn partial_copperlist(id: u64) -> CopperList<PartialDataSet> {
             ],
         },
     )
+}
+
+#[test]
+fn compact_fragment_fits_and_recovers_a_record_previously_needing_two_symbols() {
+    let identity = StreamIdentity {
+        session_id: *b"test-session-001",
+        sender_id: 7,
+    };
+    // A 140-byte record needed two 160-byte symbols with the former 27-byte header.
+    let record = encode_record(RecordKind::CopperList, 42, &[0xa5; 87]).unwrap();
+    assert_eq!(record.len(), 140);
+    for field in [Field::Gf2, Field::Gf256] {
+        let config = RlcConfig::new(SYMBOL_SIZE, WINDOW_SYMBOLS, field).unwrap();
+        let mut encoder = ContinuousEncoder::<MAX_SYMBOL_SIZE, WINDOW_SYMBOLS>::new(
+            identity,
+            Lane::ReplayCritical,
+            config,
+            4_096,
+            EncodingSymbolId::new(u32::MAX),
+        )
+        .unwrap();
+        let mut datagrams = Vec::new();
+        assert_eq!(encoder.push_record(&record, &mut datagrams).unwrap(), 1);
+        assert_eq!(datagrams.len(), 1);
+        let packet = cu29_logstream::WirePacketRef::decode(&datagrams[0]).unwrap();
+        assert_eq!(packet.payload.len(), SYMBOL_SIZE);
+        assert_eq!(packet.payload.len() + 38, datagrams[0].len());
+        assert_eq!(&packet.payload[20..], record.as_slice());
+        datagrams.clear(); // Lose the only source; recover entirely from its repair.
+        encoder
+            .push_repair(
+                RepairParameters::new(0, DensityThreshold::FULL),
+                &mut datagrams,
+            )
+            .unwrap();
+        let mut decoder = ContinuousDecoder::<MAX_SYMBOL_SIZE, WINDOW_SYMBOLS, MAX_EQUATIONS>::new(
+            identity,
+            Lane::ReplayCritical,
+            config,
+            MAX_EQUATIONS,
+            42,
+            ReceiverLimits::new(4_096, WINDOW_SYMBOLS),
+        )
+        .unwrap();
+        let mut recovered = Vec::new();
+        for datagram in &datagrams {
+            decoder
+                .receive_datagram(datagram, |event| {
+                    let ContinuousReceiveEvent::Record(record) = event else {
+                        panic!("unexpected gap");
+                    };
+                    recovered.push(record.bytes().to_vec());
+                    Ok::<(), core::convert::Infallible>(())
+                })
+                .unwrap();
+        }
+        assert_eq!(recovered, vec![record.clone()]);
+        assert_eq!(decoder.stats().source_symbols_recovered, 1);
+    }
 }
 
 #[test]

--- a/core/cu29_logstream/tests/finite_objects.rs
+++ b/core/cu29_logstream/tests/finite_objects.rs
@@ -206,7 +206,7 @@ fn a_late_receiver_restarts_the_continuous_stream_at_the_recovery_point() {
         let packet = WirePacket::decode(datagram).unwrap();
         packet.header.symbol_kind == cu29_logstream::FecSymbolKind::Repair
             // Source identity lives in the protected fragment, not the packet header.
-            || u64::from_be_bytes(packet.payload[5..13].try_into().unwrap()) >= RECOVERY_POINT_ID
+            || u64::from_be_bytes(packet.payload[4..12].try_into().unwrap()) >= RECOVERY_POINT_ID
     });
 
     let manifest = encode_record(RecordKind::Manifest, 1, b"late-join-manifest").unwrap();

--- a/core/cu29_logstream/tests/pacing.rs
+++ b/core/cu29_logstream/tests/pacing.rs
@@ -284,7 +284,7 @@ fn recovery_never_overtakes_older_queued_source_records() {
             packet.header.record_kind == RecordKind::CopperList
                 && packet.header.symbol_kind == FecSymbolKind::Source
                 // Select the source identity from its protected fragment.
-                && u64::from_be_bytes(packet.payload[5..13].try_into().unwrap()) == id
+                && u64::from_be_bytes(packet.payload[4..12].try_into().unwrap()) == id
         }));
     }
     assert_eq!(core.stats().expired_packets, 0);

--- a/examples/cu_logstream_demo/src/receiver.rs
+++ b/examples/cu_logstream_demo/src/receiver.rs
@@ -90,7 +90,7 @@ impl<R: CuStreamRx> CuStreamRx for ImpairedRx<R> {
         {
             let id = wire
                 .payload
-                .get(5..13)
+                .get(4..12)
                 .ok_or(CuStreamRxError::Failed("Truncated demo source fragment"))?;
             Some(u64::from_be_bytes(id.try_into().unwrap()))
         } else {


### PR DESCRIPTION
RLC source fragments transmit a constant CopperList kind plus count and length fields already determined by record geometry. Reduce the protected fragment header from 27 to 20 bytes by retaining magic, object ID, record length, and fragment index, and deriving count and payload length from the configured symbol capacity.

A 140-byte record now fits in one 160-byte symbol instead of two. Preallocated symbol buffers and packet headers keep their sizes. Reassembly retains kind/identity matching, digest verification, geometry checks, padding validation, and receiver bounds. Sender and receiver must use the matching wire layout.

Update wire-format documentation and identity offsets used by loss fixtures and the demo. Stacked on #1356.

Validation:

- `just fmt`
- `just logstream-receiver-check` (LogStream, no-default-features, replay primitives, UDP tests and clippy)
- Focused LogStream and generated runtime clippy with warnings denied
- Generated runtime integration tests and continuous CopperList tests
- Loss and outage demos, including native archive comparison and recorded replay

New regressions cover exact wire bytes, partial/full fragments, zero/invalid geometry, u32 boundary arithmetic, truncated headers/payloads, nonzero padding, and recovery from only a repair packet in both GF(2) and GF(256).
