### PR TITLE
Derive LogStream payload length from packet boundaries

### DIFF
--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -200,14 +200,14 @@ length field. All multi-byte header fields use big endian encoding:
 
 | Layer | Header fields, in wire order | Bytes |
 | --- | --- | ---: |
-| RLC source packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), source payload ID (4), payload length (2), CRC32C (4) | 38 |
-| RLC repair packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), repair payload ID (8), payload length (2), CRC32C (4) | 42 |
-| RaptorQ packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), object ID (8), OTI (12), payload ID (4), payload length (2), CRC32C (4) | 58 |
+| RLC source packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), source payload ID (4), CRC32C (4) | 36 |
+| RLC repair packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), repair payload ID (8), CRC32C (4) | 40 |
+| RaptorQ packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), object ID (8), OTI (12), payload ID (4), CRC32C (4) | 56 |
 | Record | magic (4), kind (1), object ID (8), payload length (8), BLAKE3 digest (32) | 53 |
 | RLC fragment | magic (4), object ID (8), record length (4), fragment index (4) | 20 |
 
-Compared with the original headers, this saves 34 bytes per RLC source packet,
-30 per RLC repair packet, 14 per RaptorQ packet, 3 per record, and 12 per RLC
+Compared with the original headers, this saves 36 bytes per RLC source packet,
+32 per RLC repair packet, 16 per RaptorQ packet, 3 per record, and 12 per RLC
 source fragment, plus one bincode byte per session manifest.
 Packet sequence counters are not transmitted; recovery and deduplication use
 FEC symbol identifiers and record identities. RLC packets omit the outer object ID
@@ -220,10 +220,13 @@ RLC FEC ID bytes are transmitted.
 Savings inside record and fragment headers free symbol payload capacity and can
 reduce fragment counts. Packet-header savings directly shorten each datagram.
 Existing symbol storage capacity is unchanged: a 1200-byte MTU uses at most 1128-byte symbols,
-producing RLC source packets up to 1166 bytes, RLC repair packets up to 1170 bytes,
-and RaptorQ packets up to 1186 bytes. `PACKET_HEADER_LEN` is the maximum header
+producing RLC source packets up to 1164 bytes, RLC repair packets up to 1168 bytes,
+and RaptorQ packets up to 1184 bytes. `PACKET_HEADER_LEN` is the maximum header
 length for buffer sizing; encoding returns the exact length for each packet.
 Shared symbol sizing still reserves room for the largest (RaptorQ) header.
+Packet payload length is derived from the complete packet extent supplied by
+`CuStreamRx`; serial/transparent-radio adapters must frame the byte stream into
+complete packets before decoding. The packet header carries no payload length.
 CRC32C remains on every packet until integrity checking moves to the transport
 adapters, including framing for serial and transparent radio.
 

--- a/core/cu29_logstream/src/error.rs
+++ b/core/cu29_logstream/src/error.rs
@@ -16,7 +16,6 @@ pub enum Error {
     UnknownRecordKind(u8),
     UnknownFecScheme(u8),
     UnknownSymbolKind(u8),
-    PayloadLengthMismatch,
     CrcMismatch,
     InvalidFecMetadata(&'static str),
     InvalidFragment(&'static str),
@@ -59,7 +58,6 @@ impl Display for Error {
             Self::UnknownRecordKind(value) => write!(formatter, "unknown record kind {value}"),
             Self::UnknownFecScheme(value) => write!(formatter, "unknown FEC scheme {value}"),
             Self::UnknownSymbolKind(value) => write!(formatter, "unknown FEC symbol kind {value}"),
-            Self::PayloadLengthMismatch => formatter.write_str("packet payload length mismatch"),
             Self::CrcMismatch => formatter.write_str("packet CRC32C mismatch"),
             Self::InvalidFecMetadata(message) => {
                 write!(formatter, "invalid FEC metadata: {message}")

--- a/core/cu29_logstream/src/wire.rs
+++ b/core/cu29_logstream/src/wire.rs
@@ -7,11 +7,11 @@ use crc::{CRC_32_ISCSI, Crc};
 
 const PACKET_MAGIC: [u8; 4] = *b"CULS";
 /// Maximum packet header length, used to bound storage and the shared FEC symbol size.
-/// RaptorQ uses 58 bytes; RLC uses 38 for source packets and 42 for repair packets.
-pub const PACKET_HEADER_LEN: usize = 58;
+/// RaptorQ uses 56 bytes; RLC uses 36 for source packets and 40 for repair packets.
+pub const PACKET_HEADER_LEN: usize = 56;
 const COMMON_HEADER_LEN: usize = 28;
-const RLC_SOURCE_HEADER_LEN: usize = 38;
-const RLC_REPAIR_HEADER_LEN: usize = 42;
+const RLC_SOURCE_HEADER_LEN: usize = 36;
+const RLC_REPAIR_HEADER_LEN: usize = 40;
 
 const fn packet_header_len(scheme: FecScheme, kind: FecSymbolKind) -> usize {
     match (scheme, kind) {
@@ -139,6 +139,8 @@ pub struct WirePacketRef<'a> {
 }
 
 impl<'a> WirePacketRef<'a> {
+    /// Decodes exactly one complete packet supplied by the carrier.
+    /// The payload occupies the remaining packet extent after the header.
     pub fn decode(bytes: &'a [u8]) -> Result<Self> {
         if bytes.len() < COMMON_HEADER_LEN {
             return Err(Error::TruncatedPacket);
@@ -153,13 +155,6 @@ impl<'a> WirePacketRef<'a> {
             return Err(Error::TruncatedPacket);
         }
         let crc_offset = header_len - 4;
-        let length_offset = crc_offset - 2;
-        let payload_len =
-            u16::from_be_bytes(bytes[length_offset..crc_offset].try_into().unwrap()) as usize;
-        if bytes.len() != header_len + payload_len {
-            return Err(Error::PayloadLengthMismatch);
-        }
-
         let expected_checksum =
             u32::from_be_bytes(bytes[crc_offset..header_len].try_into().unwrap());
         let mut digest = CRC32C.digest();
@@ -182,9 +177,8 @@ impl<'a> WirePacketRef<'a> {
                 )
             }
             FecScheme::RlcGf2 | FecScheme::RlcGf256 => {
-                let metadata_len = length_offset - COMMON_HEADER_LEN;
-                fec_metadata[..metadata_len]
-                    .copy_from_slice(&bytes[COMMON_HEADER_LEN..length_offset]);
+                let metadata_len = crc_offset - COMMON_HEADER_LEN;
+                fec_metadata[..metadata_len].copy_from_slice(&bytes[COMMON_HEADER_LEN..crc_offset]);
                 (0, 0)
             }
         };
@@ -208,11 +202,8 @@ impl<'a> WirePacketRef<'a> {
 
 /// Encodes one packet into caller-owned storage and returns its exact length.
 pub fn encode_packet_into(header: WireHeader, payload: &[u8], output: &mut [u8]) -> Result<usize> {
-    let payload_len = u16::try_from(payload.len())
-        .map_err(|_| Error::InvalidConfig("wire payload exceeds u16"))?;
     let header_len = packet_header_len(header.fec_scheme, header.symbol_kind);
     let crc_offset = header_len - 4;
-    let length_offset = crc_offset - 2;
     let needed = header_len
         .checked_add(payload.len())
         .ok_or(Error::InvalidConfig("packet length overflow"))?;
@@ -239,11 +230,10 @@ pub fn encode_packet_into(header: WireHeader, payload: &[u8], output: &mut [u8])
             bytes[48..52].copy_from_slice(&header.fragment_count.to_be_bytes());
         }
         FecScheme::RlcGf2 | FecScheme::RlcGf256 => {
-            bytes[COMMON_HEADER_LEN..length_offset]
-                .copy_from_slice(&header.fec_metadata[..length_offset - COMMON_HEADER_LEN]);
+            bytes[COMMON_HEADER_LEN..crc_offset]
+                .copy_from_slice(&header.fec_metadata[..crc_offset - COMMON_HEADER_LEN]);
         }
     }
-    bytes[length_offset..crc_offset].copy_from_slice(&payload_len.to_be_bytes());
     bytes[header_len..].copy_from_slice(payload);
     let checksum = CRC32C.checksum(bytes);
     bytes[crc_offset..header_len].copy_from_slice(&checksum.to_be_bytes());
@@ -276,12 +266,13 @@ mod tests {
     fn fixed_header_has_a_stable_golden_prefix() {
         let encoded = fixture().encode().unwrap();
         assert_eq!(&encoded[..8], &[b'C', b'U', b'L', b'S', 2, 2, 2, 0]);
-        assert_eq!(encoded.len(), 58 + fixture().payload.len());
+        assert_eq!(encoded.len(), 56 + fixture().payload.len());
         assert_eq!(&encoded[8..24], &[0x11; 16]);
         assert_eq!(&encoded[24..28], &0x2233_4455_u32.to_be_bytes());
         assert_eq!(&encoded[28..36], &0x0102_0304_0506_0708_u64.to_be_bytes());
-        assert_eq!(&encoded[52..54], &12_u16.to_be_bytes());
-        assert_eq!(&encoded[58..], fixture().payload);
+        assert_eq!(&encoded[36..48], &fixture().header.fec_metadata);
+        assert_eq!(&encoded[48..52], &1_u32.to_be_bytes());
+        assert_eq!(&encoded[56..], fixture().payload);
         assert_eq!(WirePacket::decode(&encoded).unwrap(), fixture());
     }
 
@@ -306,8 +297,8 @@ mod tests {
     fn rlc_headers_carry_only_the_active_fec_id() {
         for scheme in [FecScheme::RlcGf2, FecScheme::RlcGf256] {
             for (kind, header_len, id_len) in [
-                (FecSymbolKind::Source, 38, 4),
-                (FecSymbolKind::Repair, 42, 8),
+                (FecSymbolKind::Source, 36, 4),
+                (FecSymbolKind::Repair, 40, 8),
             ] {
                 let packet = rlc_fixture(scheme, kind);
                 let encoded = packet.encode().unwrap();
@@ -331,7 +322,7 @@ mod tests {
                     &encoded[28..28 + id_len],
                     &packet.header.fec_metadata[..id_len]
                 );
-                assert_eq!(&encoded[28 + id_len..30 + id_len], &12_u16.to_be_bytes());
+                assert_eq!(header_len, 28 + id_len + 4);
                 assert_eq!(&encoded[header_len..], packet.payload);
                 assert_eq!(WirePacket::decode(&encoded).unwrap(), packet);
 
@@ -376,10 +367,7 @@ mod tests {
                     }
                     let mut damaged = encoded.clone();
                     damaged.push(0);
-                    assert_eq!(
-                        WirePacketRef::decode(&damaged),
-                        Err(Error::PayloadLengthMismatch)
-                    );
+                    assert_eq!(WirePacketRef::decode(&damaged), Err(Error::CrcMismatch));
                     damaged.pop();
                     for offset in 0..damaged.len() {
                         damaged[offset] ^= 1;
@@ -389,6 +377,47 @@ mod tests {
                         );
                         damaged[offset] ^= 1;
                     }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn packet_extent_defines_payload_length_for_every_layout() {
+        for scheme in [FecScheme::RlcGf2, FecScheme::RlcGf256, FecScheme::RaptorQ] {
+            for kind in [FecSymbolKind::Source, FecSymbolKind::Repair] {
+                let mut packet = if scheme == FecScheme::RaptorQ {
+                    fixture()
+                } else {
+                    rlc_fixture(scheme, kind)
+                };
+                packet.header.symbol_kind = kind;
+                let header_len = packet_header_len(scheme, kind);
+                for payload_len in [0, 1, crate::DEFAULT_MAX_SYMBOL_SIZE, u16::MAX as usize + 1] {
+                    packet.payload = vec![0x5a; payload_len];
+                    let needed = header_len + payload_len;
+                    let mut storage = vec![0xaa; needed + 1];
+                    assert_eq!(
+                        encode_packet_into(packet.header, &packet.payload, &mut storage).unwrap(),
+                        needed
+                    );
+                    assert_eq!(storage[needed], 0xaa);
+                    let decoded = WirePacketRef::decode(&storage[..needed]).unwrap();
+                    assert_eq!(decoded.header, packet.header);
+                    assert_eq!(decoded.payload, packet.payload);
+                    assert_eq!(decoded.payload.as_ptr(), storage[header_len..].as_ptr());
+                    assert_eq!(WirePacketRef::decode(&storage), Err(Error::CrcMismatch));
+                    assert_eq!(
+                        encode_packet_into(
+                            packet.header,
+                            &packet.payload,
+                            &mut storage[..needed - 1]
+                        ),
+                        Err(Error::BufferTooSmall {
+                            needed,
+                            available: needed - 1,
+                        })
+                    );
                 }
             }
         }

--- a/core/cu29_logstream/tests/continuous_copperlist.rs
+++ b/core/cu29_logstream/tests/continuous_copperlist.rs
@@ -129,7 +129,7 @@ fn compact_fragment_fits_and_recovers_a_record_previously_needing_two_symbols() 
         assert_eq!(datagrams.len(), 1);
         let packet = cu29_logstream::WirePacketRef::decode(&datagrams[0]).unwrap();
         assert_eq!(packet.payload.len(), SYMBOL_SIZE);
-        assert_eq!(packet.payload.len() + 38, datagrams[0].len());
+        assert_eq!(packet.payload.len() + 36, datagrams[0].len());
         assert_eq!(&packet.payload[20..], record.as_slice());
         datagrams.clear(); // Lose the only source; recover entirely from its repair.
         encoder

--- a/core/cu29_logstream/tests/manifest.rs
+++ b/core/cu29_logstream/tests/manifest.rs
@@ -95,7 +95,7 @@ fn symbol_size_respects_mtu_without_growing_preallocated_storage() {
     let mut config = destination();
     config.link.mtu_bytes = 1100;
     let mut plan = LogStreamPlan::resolve(&config).unwrap();
-    assert_eq!(plan.symbol_size, 1042);
+    assert_eq!(plan.symbol_size, 1044);
     plan.symbol_size += 1;
     assert!(plan.validate().is_err());
     config.link.mtu_bytes = cu29_logstream::PACKET_HEADER_LEN as u16;


### PR DESCRIPTION
## Summary

Derive LogStream packet payload length from the complete packet supplied by the carrier, saving two bytes on every packet. Headers now use 36 bytes for RLC sources, 40 for RLC repairs, and 56 for RaptorQ. This is step 4 of the transmission diet series, stacked on #1358.

## Related issues

- Follows #1358; serial framing integration remains in #1352.

## Changes

Remove the encoded u16 payload length and its obsolete mismatch error. Parsing borrows the packet remainder; CRC32C still covers the header and the entire payload. FEC symbol geometry and receiver bounds remain enforced, and preallocated symbol capacity stays at 1128 bytes. At MTU 1200, maximum packet sizes are now 1164/1168/1184 bytes.

Update wire-layout assertions, bounded-storage/MTU fixtures, and crate documentation. Regression coverage exercises all FEC schemes and symbol kinds, empty payloads, exact buffers, payloads beyond the former u16 length limit, every truncation/corruption offset, and appended bytes. The serial adapter already frames by delimiters before calling WirePacketRef; its CRC dependency remains intact.

## Validation

- `just fmt`
- `just logstream-receiver-check` (LogStream, replay primitives, UDP integration, no-default-features check, UDP clippy)
- `cargo +stable clippy -p cu29-logstream --all-targets --offline -- --deny warnings`
- `cargo +stable test -p cu29 --features logstream --test logstream_runtime --offline`
- Demo `run loss` and `run outage`, including native archive comparison and recorded replay

## Reminder

- [ ] I ran `just` from the repo root (used the focused gates above, per the series plan)
- [x] I have updated docs or examples where needed

## Additional context

Sender and receiver must use matching wire layouts. Packet CRC removal and serial framing integrity migration remain a separate step. Book/wiki documentation is updated on matching stacked branches.
