### PR TITLE
Use transport integrity for LogStream data and feedback

### DIFF
--- a/components/res/cu29_logstream_serial/src/lib.rs
+++ b/components/res/cu29_logstream_serial/src/lib.rs
@@ -363,6 +363,41 @@ mod tests {
     }
 
     #[test]
+    fn framing_protects_data_and_feedback_packets_without_inner_checksums() {
+        use cu29_logstream::feedback::{FEEDBACK_BUFFER_BYTES, ReceiverReport};
+        let report = ReceiverReport {
+            session_id: [DELIMITER; 16],
+            receiver_id: [ESCAPE; 16],
+            sequence: 7,
+            elapsed_us: 1,
+            record_capacity: 1,
+            latest_copperlist: Some(42),
+            ..Default::default()
+        };
+        let mut feedback = [0; FEEDBACK_BUFFER_BYTES];
+        let len = report.encode_into(&mut feedback).unwrap();
+        for packet in [packet(), feedback[..len].to_vec()] {
+            let good = encoded(&packet);
+            assert_eq!(received(good.clone()), vec![packet.clone()]);
+            for offset in 0..good.len() {
+                for bit in 0..8 {
+                    let mut damaged = good.clone();
+                    damaged[offset] ^= 1 << bit;
+                    damaged.extend_from_slice(&good);
+                    assert_eq!(received(damaged), vec![packet.clone()], "{offset}:{bit}");
+                }
+            }
+            for end in 0..good.len() - 1 {
+                let mut truncated = good[..end].to_vec();
+                truncated.extend_from_slice(&good);
+                assert_eq!(received(truncated), vec![packet.clone()], "{end}");
+            }
+        }
+        let delivered = received(encoded(&feedback[..len]));
+        assert_eq!(ReceiverReport::decode(&delivered[0]).unwrap(), report);
+    }
+
+    #[test]
     fn checksum_bytes_are_escaped_and_capacity_includes_them() {
         assert_eq!(SerialLogStreamTx::<Uart>::max_packet_bytes(), 252);
         assert_eq!(SerialLogStreamTx::<Uart, 0>::max_packet_bytes(), 0);

--- a/components/res/cu29_logstream_udp/README.md
+++ b/components/res/cu29_logstream_udp/README.md
@@ -134,3 +134,11 @@ For a return channel, bind the sender destination's `feedback.transport` to the 
 The ground receiver explicitly sets `remote_addr` to the sender's bound address and passes its TX
 endpoint to `CuTwinBuilder::with_feedback`. Sharing a socket does not enable feedback implicitly;
 never assign competing readers to the same socket. See the logstream README for FEC bounds and reports.
+
+Packet integrity is supplied by the network/link stack. LogStream adds no packet
+CRC; this carrier relies on external checksum protection being enabled on the
+path. Socket setup leaves UDP checksum generation and validation at their normal
+OS defaults. Deployments that disable network/link integrity need an integrity
+adapter before delivering packets to LogStream FEC. Datagram truncation is still
+rejected by the receive endpoint. Record digests independently verify reconstructed
+content and bind recovery-point references.

--- a/components/res/cu29_logstream_udp/README.md
+++ b/components/res/cu29_logstream_udp/README.md
@@ -135,10 +135,11 @@ The ground receiver explicitly sets `remote_addr` to the sender's bound address 
 endpoint to `CuTwinBuilder::with_feedback`. Sharing a socket does not enable feedback implicitly;
 never assign competing readers to the same socket. See the logstream README for FEC bounds and reports.
 
-Packet integrity is supplied by the network/link stack. LogStream adds no packet
-CRC; this carrier relies on external checksum protection being enabled on the
+Data and feedback packet integrity is supplied by the network/link stack. Neither
+LogStream packet format adds a CRC; this carrier relies on external checksum protection being enabled on the
 path. Socket setup leaves UDP checksum generation and validation at their normal
 OS defaults. Deployments that disable network/link integrity need an integrity
 adapter before delivering packets to LogStream FEC. Datagram truncation is still
-rejected by the receive endpoint. Record digests independently verify reconstructed
+rejected by the receive endpoint. Delivery, ordering, and uniqueness are not guaranteed.
+Record digests independently verify reconstructed
 content and bind recovery-point references.

--- a/components/res/cu29_logstream_udp/src/lib.rs
+++ b/components/res/cu29_logstream_udp/src/lib.rs
@@ -3,6 +3,8 @@
 //! Socket setup happens once, before endpoints enter the output worker. Packet calls
 //! perform one socket operation with no allocation, locking, retry, or acknowledgement.
 //! FEC, pacing, and session policy belong to logstream, above this resource.
+//! Packet integrity relies on external network/link checks; socket setup preserves
+//! OS checksum defaults. The LogStream envelope carries no duplicate checksum.
 
 use cu29::bundle_resources;
 use cu29::config::ComponentConfig;

--- a/core/cu29_logstream/Cargo.toml
+++ b/core/cu29_logstream/Cargo.toml
@@ -22,7 +22,6 @@ atomic-waker = { version = "1.1", optional = true }
 crossbeam-queue = { version = "0.3", optional = true }
 bincode = { workspace = true }
 blake3 = { workspace = true }
-crc = { workspace = true }
 cu-fec = { workspace = true }
 cu29-clock = { workspace = true }
 cu29-log = { workspace = true, optional = true }

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -254,11 +254,13 @@ Shared symbol sizing still reserves room for the largest (RaptorQ) header.
 Packet payload length is derived from the complete packet extent supplied by
 `CuStreamRx`; serial/transparent-radio adapters must frame the byte stream into
 complete packets before decoding. The packet header carries no payload length.
-Packet integrity belongs to the carrier: the common LogStream envelope has no
-CRC. UDP/network and packet-radio carriers rely on their external integrity
-checks. Serial/transparent-radio adapters append a four-byte big endian CRC32C
-to the packet before delimiter escaping, then verify and strip it before delivery.
-They discard damaged frames and resynchronize at the next delimiter, turning
+Both data packets and feedback reports require transport-provided packet integrity;
+neither carries an inner CRC. Delivery, ordering, and uniqueness are not guaranteed.
+UDP supplies integrity through the network stack. Raw serial supplies neither packet
+boundaries nor integrity. The framing adapter between LogStream and raw serial
+appends a four-byte big endian CRC32C before delimiter escaping, then verifies and
+strips it before delivery.
+The adapter discards damaged frames and resynchronizes at the next delimiter, turning
 corruption into packet loss before FEC. Both serial peers must use this framing;
 the older adapter that relied on the common CRC is incompatible.
 Carrier framing/checksum overhead is outside the configured packet MTU and must
@@ -324,8 +326,9 @@ use `FeedbackReporter` with `SessionRouter::feedback_counters`. Programmatic sen
 Omitting feedback preserves one-way operation. The unversioned manifest advertises optional feedback
 capability, destination key, and report cadence. Timeout and adaptation bounds remain in the local
 sender configuration. Reports are also unversioned and require the matching
-application decoder. Reports are bounded
-CRC32C datagrams carrying cumulative counters, receiver identity/sequence, finalized source outcomes,
+application decoder. Reports carry a `CUFB` prefix followed by the fixed-integer bincode payload,
+with integrity supplied by the transport under the same contract as data packets. Reports carry
+cumulative counters, receiver identity/sequence, finalized source outcomes,
 receiver progress/pressure, and an optional request for the latest retained recovery bundle. No data ACKs.
 
 Omit `adaptation` for reports only. Otherwise the existing repair interval is the startup/fallback baseline
@@ -339,8 +342,7 @@ or excessive reports cannot refresh health. After timeout, state is stale and th
 per report period toward baseline. Bitrate, burst, latency, memory, FEC window/field/density, and object FEC
 stay fixed. Feedback failure never stops capture or autonomous recovery; snapshots retain failure state.
 
-Loss excludes the active coding window and unseen history/tails. Invalid packets do not prove corruption;
-CRC is not authentication. Reports and adaptation stay on stream workers. Run `just logstream-feedback-check`.
+Loss excludes the active coding window and unseen history/tails. Reports and adaptation stay on stream workers. Run `just logstream-feedback-check`.
 
 ### TUI bandwidth panel
 

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -199,14 +199,14 @@ length field. All multi-byte header fields use big endian encoding:
 
 | Layer | Header fields, in wire order | Bytes |
 | --- | --- | ---: |
-| RLC source packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), source payload ID (4), CRC32C (4) | 36 |
-| RLC repair packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), repair payload ID (8), CRC32C (4) | 40 |
-| RaptorQ packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), object ID (8), compact OTI (11), payload ID (4), CRC32C (4) | 55 |
+| RLC source packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), source payload ID (4) | 32 |
+| RLC repair packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), repair payload ID (8) | 36 |
+| RaptorQ packet | magic (4), lane (1), record kind (1), FEC scheme (1), symbol kind (1), session ID (16), sender ID (4), object ID (8), compact OTI (11), payload ID (4) | 51 |
 | Record | magic (4), kind (1), object ID (8), BLAKE3 digest (32) | 45 |
 | RLC fragment | magic (4), object ID (8), record length (4), fragment index (4) | 20 |
 
-Compared with the original headers, this saves 36 bytes per RLC source packet,
-32 per RLC repair packet, 17 per RaptorQ packet, 11 per record, and 12 per RLC
+Compared with the original headers, this saves 40 bytes per RLC source packet,
+36 per RLC repair packet, 21 per RaptorQ packet, 11 per record, and 12 per RLC
 source fragment, plus the manifest savings described below.
 Packet sequence counters are not transmitted; recovery and deduplication use
 FEC symbol identifiers and record identities. RLC packets omit the outer object ID
@@ -247,15 +247,25 @@ requirements, identity, and schema now produce identical manifest records.
 Savings inside record and fragment headers free symbol payload capacity and can
 reduce fragment counts. Packet-header savings directly shorten each datagram.
 Existing symbol storage capacity is unchanged: a 1200-byte MTU uses at most 1128-byte symbols,
-producing RLC source packets up to 1164 bytes, RLC repair packets up to 1168 bytes,
-and RaptorQ packets up to 1183 bytes. `PACKET_HEADER_LEN` is the maximum header
+producing RLC source packets up to 1160 bytes, RLC repair packets up to 1164 bytes,
+and RaptorQ packets up to 1179 bytes. `PACKET_HEADER_LEN` is the maximum header
 length for buffer sizing; encoding returns the exact length for each packet.
 Shared symbol sizing still reserves room for the largest (RaptorQ) header.
 Packet payload length is derived from the complete packet extent supplied by
 `CuStreamRx`; serial/transparent-radio adapters must frame the byte stream into
 complete packets before decoding. The packet header carries no payload length.
-CRC32C remains on every packet until integrity checking moves to the transport
-adapters, including framing for serial and transparent radio.
+Packet integrity belongs to the carrier: the common LogStream envelope has no
+CRC. UDP/network and packet-radio carriers rely on their external integrity
+checks. Serial/transparent-radio adapters append a four-byte big endian CRC32C
+to the packet before delimiter escaping, then verify and strip it before delivery.
+They discard damaged frames and resynchronize at the next delimiter, turning
+corruption into packet loss before FEC. Both serial peers must use this framing;
+the older adapter that relied on the common CRC is incompatible.
+Carrier framing/checksum overhead is outside the configured packet MTU and must
+be included when sizing adapter buffers and budgeting physical-link throughput.
+Direct decoder callers must supply complete, carrier-verified packets too.
+Record BLAKE3 digests and recovery-point digest references remain unchanged;
+these bind reconstructed content and do not replace carrier integrity checks.
 
 The native codec already carries original/captured presence. There is no proof envelope,
 per-list verification allocation, or new continuity record. The archive writes the

--- a/core/cu29_logstream/src/error.rs
+++ b/core/cu29_logstream/src/error.rs
@@ -16,7 +16,6 @@ pub enum Error {
     UnknownRecordKind(u8),
     UnknownFecScheme(u8),
     UnknownSymbolKind(u8),
-    CrcMismatch,
     InvalidFecMetadata(&'static str),
     InvalidFragment(&'static str),
     InconsistentObject,
@@ -57,7 +56,6 @@ impl Display for Error {
             Self::UnknownRecordKind(value) => write!(formatter, "unknown record kind {value}"),
             Self::UnknownFecScheme(value) => write!(formatter, "unknown FEC scheme {value}"),
             Self::UnknownSymbolKind(value) => write!(formatter, "unknown FEC symbol kind {value}"),
-            Self::CrcMismatch => formatter.write_str("packet CRC32C mismatch"),
             Self::InvalidFecMetadata(message) => {
                 write!(formatter, "invalid FEC metadata: {message}")
             }

--- a/core/cu29_logstream/src/feedback.rs
+++ b/core/cu29_logstream/src/feedback.rs
@@ -8,7 +8,6 @@ use cu29_runtime::config::LogStreamFeedbackConfig;
 
 pub const FEEDBACK_BUFFER_BYTES: usize = 320;
 const MAGIC: &[u8; 4] = b"CUFB";
-const CRC: crc::Crc<u32> = crc::Crc::<u32>::new(&crc::CRC_32_ISCSI);
 const LOSS_MARGIN_BP: u64 = 200;
 const HEALTHY_REPORTS: u8 = 3;
 
@@ -117,6 +116,7 @@ impl ReceiverReport {
                 == Some(self.sources.finalized)
     }
 
+    /// Encodes one complete report for an integrity-protected packet transport.
     pub fn encode_into(&self, output: &mut [u8]) -> Result<usize> {
         if output.len() < FEEDBACK_BUFFER_BYTES {
             return Err(Error::BufferTooSmall {
@@ -130,24 +130,25 @@ impl ReceiverReport {
         output[..4].copy_from_slice(MAGIC);
         let len = bincode::encode_into_slice(
             self,
-            &mut output[4..FEEDBACK_BUFFER_BYTES - 4],
+            &mut output[4..FEEDBACK_BUFFER_BYTES],
             bincode::config::standard().with_fixed_int_encoding(),
         )
         .map_err(|_| Error::InvalidConfig("feedback report exceeds packet capacity"))?
             + 4;
-        let checksum = CRC.checksum(&output[..len]);
-        output[len..len + 4].copy_from_slice(&checksum.to_le_bytes());
-        Ok(len + 4)
+        Ok(len)
     }
 
+    /// Decodes a complete report after transport integrity verification.
+    /// Reports may arrive late, out of order, or more than once; the feedback
+    /// controller checks their identity, sequence, and cumulative counters.
     pub fn decode(packet: &[u8]) -> Result<Self> {
-        if packet.len() < 8 || packet.len() > FEEDBACK_BUFFER_BYTES || &packet[..4] != MAGIC {
+        if packet.len() < MAGIC.len()
+            || packet.len() > FEEDBACK_BUFFER_BYTES
+            || &packet[..4] != MAGIC
+        {
             return Err(Error::InvalidConfig("invalid feedback framing"));
         }
-        let end = packet.len() - 4;
-        if CRC.checksum(&packet[..end]) != u32::from_le_bytes(packet[end..].try_into().unwrap()) {
-            return Err(Error::InvalidConfig("invalid feedback checksum"));
-        }
+        let end = packet.len();
         let (report, used): (Self, usize) = bincode::decode_from_slice(
             &packet[4..end],
             bincode::config::standard()

--- a/core/cu29_logstream/src/object.rs
+++ b/core/cu29_logstream/src/object.rs
@@ -198,7 +198,8 @@ impl FiniteObjectDecoder {
         self.objects.len().saturating_add(self.ready.len())
     }
 
-    /// Accepts one datagram and emits a digest-verified record when its object completes.
+    /// Accepts one carrier-verified datagram and emits a digest-verified record
+    /// when its object completes. Callers must uphold [`crate::CuStreamRx`] integrity.
     pub fn receive_datagram<E>(
         &mut self,
         datagram: &[u8],

--- a/core/cu29_logstream/src/rlc.rs
+++ b/core/cu29_logstream/src/rlc.rs
@@ -565,9 +565,10 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
         Ok(())
     }
 
-    /// Validates and submits one datagram. Corrupt or foreign packets are counted
+    /// Validates and submits one carrier-verified datagram. Malformed or foreign packets are counted
     /// and ignored before they can contaminate the FEC decoder. Recovered records
     /// and definitive gaps are emitted in CopperList-id order.
+    /// Callers must uphold the packet integrity contract of [`crate::CuStreamRx`].
     pub fn receive_datagram<E>(
         &mut self,
         datagram: &[u8],

--- a/core/cu29_logstream/src/router.rs
+++ b/core/cu29_logstream/src/router.rs
@@ -258,6 +258,8 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
         Ok(true)
     }
 
+    /// Accepts one complete packet whose integrity was verified by the carrier.
+    /// Direct callers must uphold the same contract as [`CuStreamRx`].
     pub fn receive_datagram<E>(
         &mut self,
         datagram: &[u8],

--- a/core/cu29_logstream/src/stream.rs
+++ b/core/cu29_logstream/src/stream.rs
@@ -1,4 +1,10 @@
 //! Transport-independent, packet-oriented stream resource contracts.
+//!
+//! Data and feedback use the same transport guarantees: complete packets with
+//! verified integrity. Delivery, ordering, and uniqueness are not guaranteed.
+//! UDP supplies packet integrity through the network stack. Raw serial supplies
+//! neither packet boundaries nor integrity; the framing adapter between LogStream
+//! and serial adds and verifies a checksum and discards damaged frames.
 
 use core::fmt::Debug;
 
@@ -85,6 +91,11 @@ impl<T: CuStreamRx + ?Sized> CuStreamRx for alloc::boxed::Box<T> {
 /// physical stream carrier. A shared endpoint must have one receive owner and
 /// route complete packet kinds; cloned competing readers cannot provide routing.
 /// Protocol decoding, capability negotiation, and feedback policy belong above it.
+///
+/// The complete-packet integrity contract of [`CuStreamRx`] applies here too.
+/// Discard damaged or truncated frames in the transport adapter before delivery.
+/// Reports may be lost, duplicated, or reordered; report sequencing belongs to
+/// the feedback controller.
 pub trait CuFeedbackRx: Debug + Send + Sync {
     fn try_recv_feedback(
         &mut self,
@@ -92,7 +103,9 @@ pub trait CuFeedbackRx: Debug + Send + Sync {
     ) -> core::result::Result<Option<usize>, CuStreamRxError>;
 }
 
-/// Optional advisory transmit direction; same atomic, bounded contract as stream TX.
+/// Optional advisory transmit direction; same atomic, bounded, complete-packet
+/// integrity contract as [`CuStreamTx`]. Acceptance guarantees neither delivery
+/// nor ordering. A raw byte stream needs a framing and integrity adapter.
 pub trait CuFeedbackTx: Debug + Send + Sync {
     fn try_send_feedback(&mut self, packet: &[u8]) -> core::result::Result<(), CuStreamTxError>;
 }

--- a/core/cu29_logstream/src/stream.rs
+++ b/core/cu29_logstream/src/stream.rs
@@ -25,6 +25,11 @@ pub enum CuStreamRxError {
 /// Implementations must return immediately without waiting, locking, allocating,
 /// retrying, acknowledging, or accepting a partial packet. `Ok(())` means only
 /// that the resource accepted this packet once; it does not guarantee delivery.
+///
+/// Carriers must protect complete packet boundaries and integrity. Packet hardware
+/// or the network stack may supply the checksum; adapters over byte streams must
+/// add framing, an integrity check, and receive resynchronization. The common
+/// LogStream envelope has no checksum. Carrier overhead is outside the packet MTU.
 pub trait CuStreamTx: Debug + Send + Sync {
     /// Advance an accepted packet with bounded, nonblocking work. Returns true
     /// while bytes remain. Drivers must keep polling until it returns false.
@@ -51,6 +56,14 @@ impl<T: CuStreamTx + ?Sized> CuStreamTx for alloc::boxed::Box<T> {
 /// `Ok(None)` means no complete packet is available. `Ok(Some(len))` places one
 /// complete packet in `packet[..len]`. This is the receive half of the one-way
 /// data plane; it does not acknowledge traffic or imply a reverse channel.
+///
+/// Only deliver complete packets that passed the carrier's integrity check. Drop
+/// corrupt, truncated, or malformed frames before exposing them to FEC; corruption
+/// must become packet loss, which FEC can recover. Never deliver a partial packet.
+/// Byte-stream adapters must verify and strip their framing checksum and
+/// resynchronize after damaged frames. In-memory carriers must preserve bytes.
+/// Record digests bind reconstructed content and recovery references separately;
+/// they do not replace this carrier integrity contract.
 pub trait CuStreamRx: Debug + Send + Sync {
     fn try_recv(
         &mut self,

--- a/core/cu29_logstream/src/test_support/link_sim.rs
+++ b/core/cu29_logstream/src/test_support/link_sim.rs
@@ -1,4 +1,4 @@
-//! Deterministic simulation of an unreliable datagram link.
+//! Deterministic simulation of an unreliable datagram link with carrier integrity.
 
 /// Controls the packet loss, corruption, duplication, and reordering introduced
 /// by [`simulate_bad_link`]. Probabilities are expressed in basis points.
@@ -14,6 +14,7 @@ pub struct LinkSimulationConfig {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct LinkSimulationStats {
     pub dropped_datagrams: usize,
+    /// Damaged packets rejected by the simulated carrier integrity check.
     pub corrupted_datagrams: usize,
     pub duplicated_datagrams: usize,
 }
@@ -25,6 +26,8 @@ pub struct LinkSimulationOutput {
 }
 
 /// Simulates a bad datagram link in a deterministic, reproducible way.
+/// Corruption is detected by comparing against the original packet, modeling the
+/// external integrity check. Only intact packets reach the FEC decoder.
 pub fn simulate_bad_link(
     datagrams: &[Vec<u8>],
     config: LinkSimulationConfig,
@@ -56,10 +59,16 @@ pub fn simulate_bad_link(
             stats.corrupted_datagrams = stats.corrupted_datagrams.saturating_add(1);
         }
         let duplicate = rng.basis_points() < config.duplicate_basis_points;
+        if duplicate {
+            stats.duplicated_datagrams = stats.duplicated_datagrams.saturating_add(1);
+        }
+        // A carrier rejects damaged packets, including their duplicate copies.
+        if delivered != *datagram {
+            continue;
+        }
         output.push(delivered.clone());
         if duplicate {
             output.push(delivered);
-            stats.duplicated_datagrams = stats.duplicated_datagrams.saturating_add(1);
         }
     }
 
@@ -113,4 +122,23 @@ fn bad_link_simulation_is_reproducible() {
         simulate_bad_link(&datagrams, config),
         simulate_bad_link(&datagrams, config)
     );
+}
+
+#[test]
+fn carrier_integrity_discards_all_corruption_including_duplicates() {
+    let datagrams = (0..20).map(|value| vec![value; 8]).collect::<Vec<_>>();
+    let result = simulate_bad_link(
+        &datagrams,
+        LinkSimulationConfig {
+            seed: 42,
+            corrupt_basis_points: 10_000,
+            duplicate_basis_points: 10_000,
+            reorder: true,
+            ..LinkSimulationConfig::default()
+        },
+    );
+    assert!(result.datagrams.is_empty());
+    assert_eq!(result.stats.corrupted_datagrams, datagrams.len());
+    assert_eq!(result.stats.duplicated_datagrams, datagrams.len());
+    assert_eq!(result.stats.dropped_datagrams, 0);
 }

--- a/core/cu29_logstream/src/wire.rs
+++ b/core/cu29_logstream/src/wire.rs
@@ -3,15 +3,14 @@
 
 use crate::{Error, RecordKind, Result};
 use alloc::vec::Vec;
-use crc::{CRC_32_ISCSI, Crc};
 
 const PACKET_MAGIC: [u8; 4] = *b"CULS";
 /// Maximum packet header length, used to bound storage and the shared FEC symbol size.
-/// RaptorQ uses 55 bytes; RLC uses 36 for source packets and 40 for repair packets.
-pub const PACKET_HEADER_LEN: usize = 55;
+/// RaptorQ uses 51 bytes; RLC uses 32 for source packets and 36 for repair packets.
+pub const PACKET_HEADER_LEN: usize = 51;
 const COMMON_HEADER_LEN: usize = 28;
-const RLC_SOURCE_HEADER_LEN: usize = 36;
-const RLC_REPAIR_HEADER_LEN: usize = 40;
+const RLC_SOURCE_HEADER_LEN: usize = 32;
+const RLC_REPAIR_HEADER_LEN: usize = 36;
 
 const fn packet_header_len(scheme: FecScheme, kind: FecSymbolKind) -> usize {
     match (scheme, kind) {
@@ -20,7 +19,6 @@ const fn packet_header_len(scheme: FecScheme, kind: FecSymbolKind) -> usize {
         (_, FecSymbolKind::Repair) => RLC_REPAIR_HEADER_LEN,
     }
 }
-const CRC32C: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
 
 /// Independently scheduled transport lanes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -133,7 +131,7 @@ impl WirePacket {
     }
 }
 
-/// Validated packet view borrowing the transport's receive buffer.
+/// Structurally validated packet view borrowing the transport's receive buffer.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WirePacketRef<'a> {
     pub header: WireHeader,
@@ -142,6 +140,8 @@ pub struct WirePacketRef<'a> {
 
 impl<'a> WirePacketRef<'a> {
     /// Decodes exactly one complete packet supplied by the carrier.
+    /// The carrier must verify packet integrity before calling this parser.
+    /// This validates header structure only; FEC cannot correct corrupted symbols.
     /// The payload occupies the remaining packet extent after the header.
     pub fn decode(bytes: &'a [u8]) -> Result<Self> {
         if bytes.len() < COMMON_HEADER_LEN {
@@ -156,17 +156,6 @@ impl<'a> WirePacketRef<'a> {
         if bytes.len() < header_len {
             return Err(Error::TruncatedPacket);
         }
-        let crc_offset = header_len - 4;
-        let expected_checksum =
-            u32::from_be_bytes(bytes[crc_offset..header_len].try_into().unwrap());
-        let mut digest = CRC32C.digest();
-        digest.update(&bytes[..crc_offset]);
-        digest.update(&[0_u8; 4]);
-        digest.update(&bytes[header_len..]);
-        if digest.finalize() != expected_checksum {
-            return Err(Error::CrcMismatch);
-        }
-
         let mut session_id = [0_u8; 16];
         session_id.copy_from_slice(&bytes[8..24]);
         let mut fec_metadata = [0_u8; 12];
@@ -180,8 +169,8 @@ impl<'a> WirePacketRef<'a> {
                 )
             }
             FecScheme::RlcGf2 | FecScheme::RlcGf256 => {
-                let metadata_len = crc_offset - COMMON_HEADER_LEN;
-                fec_metadata[..metadata_len].copy_from_slice(&bytes[COMMON_HEADER_LEN..crc_offset]);
+                let metadata_len = header_len - COMMON_HEADER_LEN;
+                fec_metadata[..metadata_len].copy_from_slice(&bytes[COMMON_HEADER_LEN..header_len]);
                 (0, 0)
             }
         };
@@ -211,7 +200,6 @@ pub fn encode_packet_into(header: WireHeader, payload: &[u8], output: &mut [u8])
         ));
     }
     let header_len = packet_header_len(header.fec_scheme, header.symbol_kind);
-    let crc_offset = header_len - 4;
     let needed = header_len
         .checked_add(payload.len())
         .ok_or(Error::InvalidConfig("packet length overflow"))?;
@@ -239,13 +227,11 @@ pub fn encode_packet_into(header: WireHeader, payload: &[u8], output: &mut [u8])
             bytes[47..51].copy_from_slice(&header.fragment_count.to_be_bytes());
         }
         FecScheme::RlcGf2 | FecScheme::RlcGf256 => {
-            bytes[COMMON_HEADER_LEN..crc_offset]
-                .copy_from_slice(&header.fec_metadata[..crc_offset - COMMON_HEADER_LEN]);
+            bytes[COMMON_HEADER_LEN..header_len]
+                .copy_from_slice(&header.fec_metadata[..header_len - COMMON_HEADER_LEN]);
         }
     }
     bytes[header_len..].copy_from_slice(payload);
-    let checksum = CRC32C.checksum(bytes);
-    bytes[crc_offset..header_len].copy_from_slice(&checksum.to_be_bytes());
     Ok(needed)
 }
 
@@ -275,13 +261,13 @@ mod tests {
     fn fixed_header_has_a_stable_golden_prefix() {
         let encoded = fixture().encode().unwrap();
         assert_eq!(&encoded[..8], &[b'C', b'U', b'L', b'S', 2, 2, 2, 0]);
-        assert_eq!(encoded.len(), 55 + fixture().payload.len());
+        assert_eq!(encoded.len(), 51 + fixture().payload.len());
         assert_eq!(&encoded[8..24], &[0x11; 16]);
         assert_eq!(&encoded[24..28], &0x2233_4455_u32.to_be_bytes());
         assert_eq!(&encoded[28..36], &0x0102_0304_0506_0708_u64.to_be_bytes());
         assert_eq!(&encoded[36..47], &[0, 0, 0, 0, 3, 0, 8, 1, 0, 1, 1]);
         assert_eq!(&encoded[47..51], &1_u32.to_be_bytes());
-        assert_eq!(&encoded[55..], fixture().payload);
+        assert_eq!(&encoded[51..], fixture().payload);
         assert_eq!(WirePacket::decode(&encoded).unwrap(), fixture());
     }
 
@@ -339,8 +325,8 @@ mod tests {
     fn rlc_headers_carry_only_the_active_fec_id() {
         for scheme in [FecScheme::RlcGf2, FecScheme::RlcGf256] {
             for (kind, header_len, id_len) in [
-                (FecSymbolKind::Source, 36, 4),
-                (FecSymbolKind::Repair, 40, 8),
+                (FecSymbolKind::Source, 32, 4),
+                (FecSymbolKind::Repair, 36, 8),
             ] {
                 let packet = rlc_fixture(scheme, kind);
                 let encoded = packet.encode().unwrap();
@@ -364,7 +350,7 @@ mod tests {
                     &encoded[28..28 + id_len],
                     &packet.header.fec_metadata[..id_len]
                 );
-                assert_eq!(header_len, 28 + id_len + 4);
+                assert_eq!(header_len, 28 + id_len);
                 assert_eq!(&encoded[header_len..], packet.payload);
                 assert_eq!(WirePacket::decode(&encoded).unwrap(), packet);
 
@@ -391,7 +377,7 @@ mod tests {
     }
 
     #[test]
-    fn all_header_layouts_reject_truncation_trailing_bytes_and_corruption() {
+    fn all_header_layouts_reject_truncated_headers_and_invalid_tags() {
         for scheme in [FecScheme::RlcGf2, FecScheme::RlcGf256, FecScheme::RaptorQ] {
             for kind in [FecSymbolKind::Source, FecSymbolKind::Repair] {
                 let mut packet = if scheme == FecScheme::RaptorQ {
@@ -404,20 +390,23 @@ mod tests {
                     packet.payload = payload;
                     let encoded = packet.encode().unwrap();
                     assert_eq!(WirePacket::decode(&encoded).unwrap(), packet);
-                    for end in 0..encoded.len() {
-                        assert!(WirePacketRef::decode(&encoded[..end]).is_err());
-                    }
-                    let mut damaged = encoded.clone();
-                    damaged.push(0);
-                    assert_eq!(WirePacketRef::decode(&damaged), Err(Error::CrcMismatch));
-                    damaged.pop();
-                    for offset in 0..damaged.len() {
-                        damaged[offset] ^= 1;
-                        assert!(
-                            WirePacketRef::decode(&damaged).is_err(),
-                            "accepted corruption at {offset} in {scheme:?} {kind:?}"
+                    let header_len = packet_header_len(scheme, kind);
+                    for end in 0..header_len {
+                        assert_eq!(
+                            WirePacketRef::decode(&encoded[..end]),
+                            Err(Error::TruncatedPacket)
                         );
-                        damaged[offset] ^= 1;
+                    }
+                    for (offset, expected) in [
+                        (0, Error::InvalidMagic),
+                        (4, Error::UnknownLane(255)),
+                        (5, Error::UnknownRecordKind(255)),
+                        (6, Error::UnknownFecScheme(255)),
+                        (7, Error::UnknownSymbolKind(255)),
+                    ] {
+                        let mut invalid = encoded.clone();
+                        invalid[offset] = 255;
+                        assert_eq!(WirePacketRef::decode(&invalid), Err(expected));
                     }
                 }
             }
@@ -448,7 +437,16 @@ mod tests {
                     assert_eq!(decoded.header, packet.header);
                     assert_eq!(decoded.payload, packet.payload);
                     assert_eq!(decoded.payload.as_ptr(), storage[header_len..].as_ptr());
-                    assert_eq!(WirePacketRef::decode(&storage), Err(Error::CrcMismatch));
+                    // Complete packet boundaries and integrity belong to the carrier.
+                    let extended = WirePacketRef::decode(&storage).unwrap();
+                    assert_eq!(extended.payload.len(), payload_len + 1);
+                    assert_eq!(extended.payload[payload_len], 0xaa);
+                    for end in [header_len, header_len + payload_len / 2, needed] {
+                        assert_eq!(
+                            WirePacketRef::decode(&storage[..end]).unwrap().payload,
+                            &packet.payload[..end - header_len]
+                        );
+                    }
                     assert_eq!(
                         encode_packet_into(
                             packet.header,
@@ -463,13 +461,6 @@ mod tests {
                 }
             }
         }
-    }
-
-    #[test]
-    fn corruption_is_rejected_before_fec() {
-        let mut encoded = fixture().encode().unwrap();
-        *encoded.last_mut().unwrap() ^= 0x40;
-        assert_eq!(WirePacket::decode(&encoded), Err(Error::CrcMismatch));
     }
 
     #[test]

--- a/core/cu29_logstream/tests/continuous_copperlist.rs
+++ b/core/cu29_logstream/tests/continuous_copperlist.rs
@@ -130,7 +130,7 @@ fn compact_record_fits_and_recovers_a_payload_previously_needing_two_symbols() {
         assert_eq!(datagrams.len(), 1);
         let packet = cu29_logstream::WirePacketRef::decode(&datagrams[0]).unwrap();
         assert_eq!(packet.payload.len(), SYMBOL_SIZE);
-        assert_eq!(packet.payload.len() + 36, datagrams[0].len());
+        assert_eq!(packet.payload.len() + 32, datagrams[0].len());
         assert_eq!(&packet.payload[20..], record.as_slice());
         datagrams.clear(); // Lose the only source; recover entirely from its repair.
         encoder

--- a/core/cu29_logstream/tests/feedback.rs
+++ b/core/cu29_logstream/tests/feedback.rs
@@ -49,24 +49,74 @@ fn controller(adaptive: bool) -> FeedbackController {
     .unwrap()
 }
 #[test]
-fn bounded_protocol_rejects_truncation_corruption_and_invalid_counts() {
+fn bounded_protocol_uses_packet_extent_and_rejects_malformed_reports() {
     let report = report(1, 100, 80, 15);
     let mut buffer = [0; FEEDBACK_BUFFER_BYTES];
-    let len = report.encode_into(&mut buffer).unwrap();
-    assert_eq!(ReceiverReport::decode(&buffer[..len]).unwrap(), report);
-    for end in 0..len {
-        assert!(ReceiverReport::decode(&buffer[..end]).is_err());
-    }
-    for index in 0..len {
-        buffer[index] ^= 1;
-        assert!(ReceiverReport::decode(&buffer[..len]).is_err());
-        buffer[index] ^= 1;
+    for latest_copperlist in [None, Some(42)] {
+        let report = ReceiverReport {
+            latest_copperlist,
+            ..report
+        };
+        let len = report.encode_into(&mut buffer).unwrap();
+        assert_eq!(
+            len,
+            if latest_copperlist.is_some() {
+                166
+            } else {
+                158
+            }
+        );
+        let payload = bincode::encode_to_vec(
+            report,
+            bincode::config::standard().with_fixed_int_encoding(),
+        )
+        .unwrap();
+        assert_eq!(&buffer[..4], b"CUFB");
+        assert_eq!(&buffer[4..len], payload);
+        assert_eq!(ReceiverReport::decode(&buffer[..len]).unwrap(), report);
+        for end in 0..len {
+            assert!(ReceiverReport::decode(&buffer[..end]).is_err());
+        }
+        assert!(ReceiverReport::decode(&buffer[..len + 1]).is_err());
+        for index in 0..4 {
+            buffer[index] ^= 1;
+            assert!(ReceiverReport::decode(&buffer[..len]).is_err());
+            buffer[index] ^= 1;
+        }
     }
     let mut invalid = report;
     invalid.sources.missing += 1;
     assert!(invalid.encode_into(&mut buffer).is_err());
+    let len = bincode::encode_into_slice(
+        invalid,
+        &mut buffer[4..],
+        bincode::config::standard().with_fixed_int_encoding(),
+    )
+    .unwrap()
+        + 4;
+    assert!(ReceiverReport::decode(&buffer[..len]).is_err());
     assert!(ReceiverReport::decode(&[0; FEEDBACK_BUFFER_BYTES + 1]).is_err());
 }
+
+#[test]
+fn intact_reordered_and_duplicate_reports_do_not_refresh_health() {
+    let mut c = controller(true);
+    let mut buffer = [0; FEEDBACK_BUFFER_BYTES];
+    for (index, sequence) in [3, 1, 3, 2].into_iter().enumerate() {
+        let len = report(sequence, sequence * 100, sequence * 100, 0)
+            .encode_into(&mut buffer)
+            .unwrap();
+        let decoded = ReceiverReport::decode(&buffer[..len]).unwrap();
+        c.receive(decoded, time(1000 + index as u64 * 500));
+    }
+    assert_eq!(c.snapshot().accepted_reports, 1);
+    assert_eq!(c.snapshot().rejected_reports, 3);
+    assert_eq!(c.snapshot().report.unwrap().sequence, 3);
+    assert_eq!(c.snapshot().last_received, Some(time(1000)));
+    c.tick(time(3000));
+    assert_eq!(c.snapshot().state, FeedbackState::Stale);
+}
+
 #[test]
 fn adaptive_fec_moves_both_directions_and_stale_returns_to_baseline() {
     let mut c = controller(true);

--- a/core/cu29_logstream/tests/manifest.rs
+++ b/core/cu29_logstream/tests/manifest.rs
@@ -99,7 +99,7 @@ fn symbol_size_respects_mtu_without_growing_preallocated_storage() {
     let mut config = destination();
     config.link.mtu_bytes = 1100;
     let mut plan = LogStreamPlan::resolve(&config).unwrap();
-    assert_eq!(plan.symbol_size, 1045);
+    assert_eq!(plan.symbol_size, 1049);
     plan.symbol_size += 1;
     assert!(plan.validate().is_err());
     config.link.mtu_bytes = cu29_logstream::PACKET_HEADER_LEN as u16;


### PR DESCRIPTION
Use one transport integrity contract for LogStream data packets and feedback reports: complete packets with verified integrity, without guaranteed delivery, ordering, or uniqueness. UDP supplies integrity through its network stack. Raw serial supplies neither packet boundaries nor integrity; the existing framing adapter between LogStream and serial adds, verifies, and strips CRC32C and discards damaged frames.

Remove the inner CRC from both LogStream packet formats and remove the `crc` dependency from LogStream core. RLC source/repair headers shrink from 36/40 to 32/36 bytes and RaptorQ from 55 to 51 bytes. Feedback reports save four bytes and retain their identity, sequence, cumulative-counter, and payload validation. Record digests continue binding reconstructed content and recovery references. The serial framing implementation is unchanged; additional tests exercise checksum-free data and feedback packets through it.

Rebased onto master after #1369, preserving the merged serial, compact manifest, and feedback integrations. Data and feedback decoder contracts both require transport-verified complete packets. Tests verify exact feedback packet extent, malformed payload rejection, duplicate/reordered reports, and every single-bit corruption and truncation boundary of representative serial data and feedback frames, followed by resynchronization.

Validation: `just fmt`, `just logstream-feedback-check`, `just hc12-check`, and `just logstream-demo-check` passed, including clippy, no-default-features builds, generated UDP/feedback integration, and clean/loss/outage/late-join/restart/idle archive and replay scenarios. The demo check was rerun successfully after resolving local disk exhaustion. Physical radio and macOS validation were not repeated locally.

Companion book PR: https://github.com/copper-project/copper-rs-book/pull/64. Wiki review branch: `gbin/transmission-diet-integrity` at `a80c9d7`. Book build and documentation whitespace checks passed.

No automatic merges.
