### PR TITLE
docs(ros2-payloads): link the surviving just recipe, not the removed script

### DIFF
--- a/components/payloads/cu_ros2_payloads/README.md
+++ b/components/payloads/cu_ros2_payloads/README.md
@@ -33,7 +33,7 @@ disables ROS type hashes.
 
 To add a new payload, we pregenerated all the RIHS01 in the [RIHS payloads](all_rihs.md) file from Jazzy.
 
-Added the script [extract_rihs01.sh](extract_rihs01.sh) to extract the RIHS01 from Jazzy.
+Run `just ros-rihs01-hashes` (see [Justfile command](#justfile-command) below) to extract the RIHS01 from Jazzy.
 As an alternation you can do:
 
 ```bash


### PR DESCRIPTION
The "Adding new payloads" section links `extract_rihs01.sh`, which 404s on master. It was added under the old `components/payloads/cu_ros_payloads/` path and did not survive the rename to `cu_ros2_payloads`; a recursive listing of master has exactly one `rihs` path, `all_rihs.md`.

The capability it described still exists — `components/payloads/cu_ros2_payloads/justfile` defines `ros-rihs01-hashes`, which emits the same markdown table from `/opt/ros/jazzy/share` — and this README already documents it two sections further down. So rather than delete the instruction, this points it at the recipe that survived.

One line, docs only.

```diff
-Added the script [extract_rihs01.sh](extract_rihs01.sh) to extract the RIHS01 from Jazzy.
+Run `just ros-rihs01-hashes` (see [Justfile command](#justfile-command) below) to extract the RIHS01 from Jazzy.
```

Context, since it explains why I was in this file: I run Copper on an XLeRobot (Jetson Orin, OAK-D stereo VIO plus a Feetech servo base) and publish to `rmw_zenoh` through `cu_ros2_bridge`. I went looking for the RIHS01 extraction procedure while checking my own hand-written hashes against `all_rihs.md`, and found the link dead.