### PR TITLE
feat(cu-ros2-payloads): add geometry_msgs, nav_msgs and CompressedImage/CameraInfo

### DIFF
--- a/components/payloads/cu_ros2_payloads/src/builtin.rs
+++ b/components/payloads/cu_ros2_payloads/src/builtin.rs
@@ -1,13 +1,20 @@
 use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+/// `std_msgs/Header`.
+///
+/// `Default` is the ROS default: a zero stamp and an empty `frame_id`. Both are valid on the wire
+/// and neither is useful — a zero stamp turns pipeline latency into apparent jitter downstream,
+/// and an empty frame builds no tf tree — so fill them from the payload's own capture time and
+/// frame rather than defaulting.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct Header {
     pub stamp: Time,
     pub frame_id: CompactString,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+/// `builtin_interfaces/Time`.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct Time {
     pub sec: i32,
     pub nanosec: u32,

--- a/components/payloads/cu_ros2_payloads/src/fixed_array.rs
+++ b/components/payloads/cu_ros2_payloads/src/fixed_array.rs
@@ -1,0 +1,95 @@
+//! CDR-correct serde for fixed-size arrays longer than serde's built-in limit.
+//!
+//! `serde` implements `Serialize`/`Deserialize` for `[T; N]` only up to `N == 32`, which is one
+//! short of the 6x6 covariance matrices ROS uses (`float64[36]`). Encoding one as a `Vec` is not
+//! an option: in CDR a *fixed* array is written as bare elements, while a *sequence* is prefixed
+//! with a `uint32` length, so a `Vec` would insert four bytes that no ROS subscriber expects and
+//! shift every field after it.
+//!
+//! Use it as `#[serde(with = "crate::fixed_array")]` on any `[T; N]` field.
+
+use core::fmt;
+use core::marker::PhantomData;
+use serde::de::{Deserialize, Deserializer, Error as DeError, SeqAccess, Visitor};
+use serde::ser::{Serialize, SerializeTuple, Serializer};
+
+pub fn serialize<S, T, const N: usize>(array: &[T; N], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize,
+{
+    // `serialize_tuple`, not `serialize_seq`: a tuple has a statically known length, which is what
+    // makes the CDR backend omit the length prefix.
+    let mut tuple = serializer.serialize_tuple(N)?;
+    for element in array {
+        tuple.serialize_element(element)?;
+    }
+    tuple.end()
+}
+
+struct ArrayVisitor<T, const N: usize>(PhantomData<T>);
+
+impl<'de, T, const N: usize> Visitor<'de> for ArrayVisitor<T, N>
+where
+    T: Deserialize<'de>,
+{
+    type Value = [T; N];
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "an array of length {N}")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::with_capacity(N);
+        for index in 0..N {
+            let element = seq
+                .next_element()?
+                .ok_or_else(|| DeError::invalid_length(index, &self))?;
+            values.push(element);
+        }
+        values
+            .try_into()
+            .map_err(|_| DeError::invalid_length(N, &self))
+    }
+}
+
+pub fn deserialize<'de, D, T, const N: usize>(deserializer: D) -> Result<[T; N], D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    deserializer.deserialize_tuple(N, ArrayVisitor::<T, N>(PhantomData))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Covariance {
+        #[serde(with = "crate::fixed_array")]
+        values: [f64; 36],
+        // A trailing field so a stray length prefix shows up as a decode failure rather than
+        // silently trailing bytes.
+        tail: u32,
+    }
+
+    #[test]
+    fn fixed_array_roundtrips_without_a_length_prefix() {
+        let original = Covariance {
+            values: core::array::from_fn(|i| i as f64),
+            tail: 0xABCD_1234,
+        };
+
+        let bytes = cdr::serialize::<_, _, cdr::CdrLe>(&original, cdr::Infinite)
+            .expect("cdr encode should succeed");
+        // 4-byte CDR encapsulation header, then 36 f64 and one u32, with no sequence length.
+        assert_eq!(bytes.len(), 4 + 36 * 8 + 4);
+
+        let decoded: Covariance = cdr::deserialize(bytes.as_slice()).expect("cdr decode");
+        assert_eq!(decoded, original);
+    }
+}

--- a/components/payloads/cu_ros2_payloads/src/geometry_msgs.rs
+++ b/components/payloads/cu_ros2_payloads/src/geometry_msgs.rs
@@ -1,0 +1,280 @@
+//! `geometry_msgs` wire types.
+//!
+//! These mirror the ROS 2 `.msg` definitions field for field and in order: CDR is positional, so
+//! a reordered or missing field decodes as garbage on the subscriber rather than as an error.
+//!
+//! [`Vector3`] and [`Quaternion`] are defined here, which is where ROS 2 puts them.
+//! [`crate::sensor_msgs`] re-exports both so existing `sensor_msgs::Vector3` paths keep working.
+
+use crate::builtin::Header;
+use crate::{RosMessage, fixed_array};
+use compact_str::CompactString;
+use serde::{Deserialize, Serialize};
+
+/// `geometry_msgs/Vector3`.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct Vector3 {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+}
+
+/// `geometry_msgs/Quaternion`.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Quaternion {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+    pub w: f64,
+}
+
+impl Default for Quaternion {
+    /// The identity rotation.
+    ///
+    /// Not all zeros: a zeroed quaternion has no norm and is not a rotation, so a `Default` that
+    /// returned one would hand every consumer an invalid orientation.
+    fn default() -> Self {
+        Self {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            w: 1.0,
+        }
+    }
+}
+
+/// `geometry_msgs/Point`.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+}
+
+/// `geometry_msgs/Pose`.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct Pose {
+    pub position: Point,
+    pub orientation: Quaternion,
+}
+
+/// `geometry_msgs/PoseStamped`.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct PoseStamped {
+    pub header: Header,
+    pub pose: Pose,
+}
+
+impl RosMessage for PoseStamped {
+    const NAMESPACE: &'static str = "geometry_msgs";
+    const TYPE_NAME: &'static str = "PoseStamped";
+    const TYPE_HASH: &'static str =
+        "RIHS01_10f3786d7d40fd2b54367835614bff85d4ad3b5dab62bf8bca0cc232d73b4cd8";
+}
+
+/// `geometry_msgs/Transform`.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct Transform {
+    pub translation: Vector3,
+    pub rotation: Quaternion,
+}
+
+/// `geometry_msgs/TransformStamped`.
+///
+/// The one message a tf2 listener consumes, so `child_frame_id` and `header.frame_id` are both
+/// load-bearing: an empty pair publishes and decodes cleanly while building no tf tree at all.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct TransformStamped {
+    pub header: Header,
+    pub child_frame_id: CompactString,
+    pub transform: Transform,
+}
+
+impl RosMessage for TransformStamped {
+    const NAMESPACE: &'static str = "geometry_msgs";
+    const TYPE_NAME: &'static str = "TransformStamped";
+    const TYPE_HASH: &'static str =
+        "RIHS01_0a241f87d04668d94099cbb5ba11691d5ad32c2f29682e4eb5653424bd275206";
+}
+
+/// `geometry_msgs/Twist`.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct Twist {
+    pub linear: Vector3,
+    pub angular: Vector3,
+}
+
+impl RosMessage for Twist {
+    const NAMESPACE: &'static str = "geometry_msgs";
+    const TYPE_NAME: &'static str = "Twist";
+    const TYPE_HASH: &'static str =
+        "RIHS01_9c45bf16fe0983d80e3cfe750d6835843d265a9a6c46bd2e609fcddde6fb8d2a";
+}
+
+/// `geometry_msgs/PoseWithCovariance`.
+///
+/// The covariance is a 6x6 row-major matrix stored as a FIXED 36-element array, so it carries no
+/// length prefix on the wire — see [`crate::fixed_array`].
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+pub struct PoseWithCovariance {
+    pub pose: Pose,
+    #[serde(with = "fixed_array")]
+    pub covariance: [f64; 36],
+}
+
+impl Default for PoseWithCovariance {
+    fn default() -> Self {
+        Self {
+            pose: Pose::default(),
+            covariance: [0.0; 36],
+        }
+    }
+}
+
+/// `geometry_msgs/TwistWithCovariance`.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+pub struct TwistWithCovariance {
+    pub twist: Twist,
+    #[serde(with = "fixed_array")]
+    pub covariance: [f64; 36],
+}
+
+impl Default for TwistWithCovariance {
+    fn default() -> Self {
+        Self {
+            twist: Twist::default(),
+            covariance: [0.0; 36],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builtin::Time;
+
+    fn sample_header() -> Header {
+        Header {
+            stamp: Time {
+                sec: 1_700_000_000,
+                nanosec: 123_456_789,
+            },
+            frame_id: "odom".into(),
+        }
+    }
+
+    fn roundtrip<T>(value: &T) -> (T, Vec<u8>)
+    where
+        T: Serialize + for<'de> Deserialize<'de>,
+    {
+        let bytes =
+            cdr::serialize::<_, _, cdr::CdrLe>(value, cdr::Infinite).expect("cdr encode succeeds");
+        let decoded = cdr::deserialize(bytes.as_slice()).expect("cdr decode succeeds");
+        (decoded, bytes)
+    }
+
+    #[test]
+    fn transform_stamped_roundtrips() {
+        let value = TransformStamped {
+            header: sample_header(),
+            child_frame_id: "base_link".into(),
+            transform: Transform {
+                translation: Vector3 {
+                    x: 1.0,
+                    y: 2.0,
+                    z: 3.0,
+                },
+                rotation: Quaternion {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.707,
+                    w: 0.707,
+                },
+            },
+        };
+
+        let (decoded, _) = roundtrip(&value);
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn pose_stamped_roundtrips() {
+        let value = PoseStamped {
+            header: sample_header(),
+            pose: Pose {
+                position: Point {
+                    x: -1.5,
+                    y: 0.25,
+                    z: 9.0,
+                },
+                orientation: Quaternion::default(),
+            },
+        };
+
+        let (decoded, _) = roundtrip(&value);
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn twist_roundtrips_as_six_float64() {
+        let value = Twist {
+            linear: Vector3 {
+                x: 0.5,
+                y: 0.0,
+                z: 0.0,
+            },
+            angular: Vector3 {
+                x: 0.0,
+                y: 0.0,
+                z: -0.25,
+            },
+        };
+
+        let (decoded, bytes) = roundtrip(&value);
+        assert_eq!(decoded, value);
+        // 4-byte CDR encapsulation header then six f64, no padding: every member is 8-aligned and
+        // the first one sits at body offset 0.
+        assert_eq!(bytes.len(), 4 + 6 * 8);
+    }
+
+    #[test]
+    fn pose_with_covariance_writes_no_length_prefix() {
+        let value = PoseWithCovariance {
+            pose: Pose::default(),
+            covariance: core::array::from_fn(|i| i as f64),
+        };
+
+        let (decoded, bytes) = roundtrip(&value);
+        assert_eq!(decoded, value);
+        // Pose is 7 f64 and the covariance is a FIXED 36-element array. A `Vec` would add a
+        // uint32 length here and shift the matrix, which is the bug this asserts against.
+        assert_eq!(bytes.len(), 4 + 7 * 8 + 36 * 8);
+    }
+
+    #[test]
+    fn twist_with_covariance_writes_no_length_prefix() {
+        let value = TwistWithCovariance {
+            twist: Twist::default(),
+            covariance: [1.0; 36],
+        };
+
+        let (decoded, bytes) = roundtrip(&value);
+        assert_eq!(decoded, value);
+        assert_eq!(bytes.len(), 4 + 6 * 8 + 36 * 8);
+    }
+
+    #[test]
+    fn default_quaternion_is_the_identity_rotation() {
+        // A zeroed quaternion is not a rotation; every consumer normalizing it would divide by
+        // zero, so the default must be the identity.
+        assert_eq!(
+            Quaternion::default(),
+            Quaternion {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+                w: 1.0
+            }
+        );
+    }
+}

--- a/components/payloads/cu_ros2_payloads/src/lib.rs
+++ b/components/payloads/cu_ros2_payloads/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod builtin;
+mod fixed_array;
+pub mod geometry_msgs;
+pub mod nav_msgs;
 pub mod sensor_msgs;
 pub mod std_msgs;
 
@@ -14,6 +17,28 @@ use std::convert::From;
 #[macro_export]
 macro_rules! ros_type_name {
     ($t:ty) => {{ std::any::type_name::<$t>().rsplit("::").next().unwrap() }};
+}
+
+/// A ROS 2 message type, identified the way rmw needs it on the wire.
+///
+/// The three constants are exactly what a bridge puts in an rmw_zenoh key expression
+/// (`{domain}/{topic}/{namespace}::msg::dds_::{TYPE_NAME}_/{TYPE_HASH}`), so implementing this
+/// keeps the identity next to the struct instead of copied into every adapter that publishes it.
+///
+/// [`TYPE_HASH`](RosMessage::TYPE_HASH) is the RIHS01 hash of the **Jazzy** IDL. Humble predates
+/// type hashes entirely; the blanket [`RosBridgeAdapter`] impl already substitutes
+/// `"TypeHashNotSupported"` under the `humble` feature, so this constant needs no distro `cfg`.
+///
+/// Only messages with a hash verified against a ROS 2 Jazzy install implement this. Sub-messages
+/// that are never published on their own (`Point`, `Pose`, `Transform`, `RegionOfInterest`, ...)
+/// deliberately do not, rather than carry a guessed literal.
+pub trait RosMessage {
+    /// The ROS namespace, such as `"geometry_msgs"`.
+    const NAMESPACE: &'static str;
+    /// The message name, such as `"TransformStamped"`.
+    const TYPE_NAME: &'static str;
+    /// The RIHS01 type hash of the Jazzy IDL.
+    const TYPE_HASH: &'static str;
 }
 
 /// ROS adaptation trait to convert payload data to ROS compatible message.
@@ -107,5 +132,59 @@ where
 
     fn from_ros_message(msg: Self::RosMessage) -> Result<Self, String> {
         T::try_from(msg).map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RosMessage;
+
+    /// Every [`RosMessage::TYPE_HASH`] must be a well-formed RIHS01 literal, and no two types may
+    /// share one. A wrong or duplicated hash is invisible at runtime: it goes into the rmw_zenoh
+    /// key expression, so the subscriber simply never matches and neither side reports an error.
+    #[test]
+    fn type_hashes_are_well_formed_and_distinct() {
+        fn entry<T: RosMessage>() -> (&'static str, &'static str, &'static str) {
+            (T::NAMESPACE, T::TYPE_NAME, T::TYPE_HASH)
+        }
+
+        let entries = [
+            entry::<crate::geometry_msgs::PoseStamped>(),
+            entry::<crate::geometry_msgs::TransformStamped>(),
+            entry::<crate::geometry_msgs::Twist>(),
+            entry::<crate::nav_msgs::Odometry>(),
+            entry::<crate::nav_msgs::Path>(),
+            entry::<crate::sensor_msgs::CameraInfo>(),
+            entry::<crate::sensor_msgs::CompressedImage>(),
+            entry::<crate::sensor_msgs::Image>(),
+            entry::<crate::sensor_msgs::Imu>(),
+            entry::<crate::sensor_msgs::MagneticField>(),
+            entry::<crate::sensor_msgs::PointCloud2>(),
+            entry::<crate::sensor_msgs::PointField>(),
+        ];
+
+        for (namespace, type_name, hash) in entries {
+            assert!(!namespace.is_empty(), "{type_name} has no namespace");
+            let digest = hash
+                .strip_prefix("RIHS01_")
+                .unwrap_or_else(|| panic!("{namespace}/{type_name} hash lacks the RIHS01 prefix"));
+            assert_eq!(
+                digest.len(),
+                64,
+                "{namespace}/{type_name} hash is not a SHA-256 digest"
+            );
+            assert!(
+                digest
+                    .chars()
+                    .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+                "{namespace}/{type_name} hash is not lowercase hex"
+            );
+        }
+
+        let mut hashes: Vec<&str> = entries.iter().map(|(_, _, hash)| *hash).collect();
+        hashes.sort_unstable();
+        let count = hashes.len();
+        hashes.dedup();
+        assert_eq!(count, hashes.len(), "two message types share a type hash");
     }
 }

--- a/components/payloads/cu_ros2_payloads/src/nav_msgs.rs
+++ b/components/payloads/cu_ros2_payloads/src/nav_msgs.rs
@@ -1,0 +1,127 @@
+//! `nav_msgs` wire types.
+
+use crate::RosMessage;
+use crate::builtin::Header;
+use crate::geometry_msgs::{PoseStamped, PoseWithCovariance, TwistWithCovariance};
+use compact_str::CompactString;
+use serde::{Deserialize, Serialize};
+
+/// `nav_msgs/Odometry`.
+///
+/// `header.frame_id` is the fixed frame the pose is expressed in and `child_frame_id` is the body
+/// frame the twist is expressed in. They are different frames, and swapping them yields a message
+/// that decodes fine and integrates wrongly.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct Odometry {
+    pub header: Header,
+    pub child_frame_id: CompactString,
+    pub pose: PoseWithCovariance,
+    pub twist: TwistWithCovariance,
+}
+
+impl RosMessage for Odometry {
+    const NAMESPACE: &'static str = "nav_msgs";
+    const TYPE_NAME: &'static str = "Odometry";
+    const TYPE_HASH: &'static str =
+        "RIHS01_3cc97dc7fb7502f8714462c526d369e35b603cfc34d946e3f2eda2766dfec6e0";
+}
+
+/// `nav_msgs/Path`.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct Path {
+    pub header: Header,
+    pub poses: Vec<PoseStamped>,
+}
+
+impl RosMessage for Path {
+    const NAMESPACE: &'static str = "nav_msgs";
+    const TYPE_NAME: &'static str = "Path";
+    const TYPE_HASH: &'static str =
+        "RIHS01_1957a5bb3cee5da65c4e52e52b65a93df227efce4c20f8458b36e73066ca334b";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builtin::Time;
+    use crate::geometry_msgs::{Point, Pose, Quaternion, Twist, Vector3};
+
+    fn sample_header(frame: &str) -> Header {
+        Header {
+            stamp: Time {
+                sec: 42,
+                nanosec: 7,
+            },
+            frame_id: frame.into(),
+        }
+    }
+
+    #[test]
+    fn odometry_roundtrips() {
+        let value = Odometry {
+            header: sample_header("odom"),
+            child_frame_id: "base_link".into(),
+            pose: PoseWithCovariance {
+                pose: Pose {
+                    position: Point {
+                        x: 1.0,
+                        y: 2.0,
+                        z: 0.0,
+                    },
+                    orientation: Quaternion::default(),
+                },
+                covariance: core::array::from_fn(|i| i as f64),
+            },
+            twist: TwistWithCovariance {
+                twist: Twist {
+                    linear: Vector3 {
+                        x: 0.3,
+                        y: 0.0,
+                        z: 0.0,
+                    },
+                    angular: Vector3 {
+                        x: 0.0,
+                        y: 0.0,
+                        z: 0.1,
+                    },
+                },
+                covariance: [0.5; 36],
+            },
+        };
+
+        let bytes =
+            cdr::serialize::<_, _, cdr::CdrLe>(&value, cdr::Infinite).expect("cdr encode succeeds");
+        let decoded: Odometry = cdr::deserialize(bytes.as_slice()).expect("cdr decode succeeds");
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn path_roundtrips_with_a_sequence_of_poses() {
+        let value = Path {
+            header: sample_header("map"),
+            poses: vec![
+                PoseStamped {
+                    header: sample_header("map"),
+                    pose: Pose::default(),
+                },
+                PoseStamped {
+                    header: sample_header("map"),
+                    pose: Pose {
+                        position: Point {
+                            x: 1.0,
+                            y: 1.0,
+                            z: 0.0,
+                        },
+                        orientation: Quaternion::default(),
+                    },
+                },
+            ],
+        };
+
+        let bytes =
+            cdr::serialize::<_, _, cdr::CdrLe>(&value, cdr::Infinite).expect("cdr encode succeeds");
+        let decoded: Path = cdr::deserialize(bytes.as_slice()).expect("cdr decode succeeds");
+        assert_eq!(decoded, value);
+        assert_eq!(decoded.poses.len(), 2);
+    }
+}

--- a/components/payloads/cu_ros2_payloads/src/sensor_msgs.rs
+++ b/components/payloads/cu_ros2_payloads/src/sensor_msgs.rs
@@ -11,7 +11,7 @@ use cu29::units::si::magnetic_flux_density::microtesla;
 use cu29::units::si::ratio::percent;
 use serde::{Deserialize, Serialize};
 
-use crate::{RosMsgAdapter, builtin::Header};
+use crate::{RosMessage, RosMsgAdapter, builtin::Header};
 
 const DATATYPE_UINT32: u8 = 6;
 const DATATYPE_FLOAT32: u8 = 7;
@@ -61,20 +61,9 @@ pub struct Image {
     pub data: Vec<u8>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct Vector3 {
-    pub x: f64,
-    pub y: f64,
-    pub z: f64,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct Quaternion {
-    pub x: f64,
-    pub y: f64,
-    pub z: f64,
-    pub w: f64,
-}
+// Both live in `geometry_msgs` in ROS 2, and that is where they are defined now. Re-exported here
+// because `sensor_msgs::Imu` is built from them and because these paths were public API.
+pub use crate::geometry_msgs::{Quaternion, Vector3};
 
 // sensor_msgs/Imu
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -104,6 +93,99 @@ pub struct Temperature {
     pub variance: f64,
 }
 
+// sensor_msgs/CompressedImage
+//
+// Distinct from `Image`, and the difference is the point: this carries the encoder's own bytes
+// (`format` names them, e.g. "jpeg", "png", "h264"), so a hardware-encoded stream can be
+// published without being expanded and re-encoded first.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct CompressedImage {
+    pub header: Header,
+    pub format: String,
+    #[serde(with = "serde_bytes")]
+    pub data: Vec<u8>,
+}
+
+impl RosMessage for CompressedImage {
+    const NAMESPACE: &'static str = "sensor_msgs";
+    const TYPE_NAME: &'static str = "CompressedImage";
+    const TYPE_HASH: &'static str =
+        "RIHS01_15640771531571185e2efc8a100baf923961a4d15d5569652e6cb6691e8e371a";
+}
+
+// sensor_msgs/RegionOfInterest
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct RegionOfInterest {
+    pub x_offset: u32,
+    pub y_offset: u32,
+    pub height: u32,
+    pub width: u32,
+    pub do_rectify: bool,
+}
+
+// sensor_msgs/CameraInfo
+//
+// `d` is a variable-length sequence (its length depends on `distortion_model`), while `k`, `r`
+// and `p` are fixed 3x3, 3x3 and 3x4 row-major matrices. That distinction is on the wire: only
+// `d` carries a length prefix.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct CameraInfo {
+    pub header: Header,
+    pub height: u32,
+    pub width: u32,
+    pub distortion_model: String,
+    pub d: Vec<f64>,
+    pub k: [f64; 9],
+    pub r: [f64; 9],
+    pub p: [f64; 12],
+    pub binning_x: u32,
+    pub binning_y: u32,
+    pub roi: RegionOfInterest,
+}
+
+impl RosMessage for CameraInfo {
+    const NAMESPACE: &'static str = "sensor_msgs";
+    const TYPE_NAME: &'static str = "CameraInfo";
+    const TYPE_HASH: &'static str =
+        "RIHS01_b3dfd68ff46c9d56c80fd3bd4ed22c7a4ddce8c8348f2f59c299e73118e7e275";
+}
+
+// The hashes the existing adapters already publish, kept next to the types they identify.
+impl RosMessage for PointField {
+    const NAMESPACE: &'static str = "sensor_msgs";
+    const TYPE_NAME: &'static str = "PointField";
+    const TYPE_HASH: &'static str =
+        "RIHS01_5c6a4750728c2bcfbbf7037225b20b02d4429634732146b742dee1726637ef01";
+}
+
+impl RosMessage for PointCloud2 {
+    const NAMESPACE: &'static str = "sensor_msgs";
+    const TYPE_NAME: &'static str = "PointCloud2";
+    const TYPE_HASH: &'static str =
+        "RIHS01_9198cabf7da3796ae6fe19c4cb3bdd3525492988c70522628af5daa124bae2b5";
+}
+
+impl RosMessage for Image {
+    const NAMESPACE: &'static str = "sensor_msgs";
+    const TYPE_NAME: &'static str = "Image";
+    const TYPE_HASH: &'static str =
+        "RIHS01_d31d41a9a4c4bc8eae9be757b0beed306564f7526c88ea6a4588fb9582527d47";
+}
+
+impl RosMessage for Imu {
+    const NAMESPACE: &'static str = "sensor_msgs";
+    const TYPE_NAME: &'static str = "Imu";
+    const TYPE_HASH: &'static str =
+        "RIHS01_7d9a00ff131080897a5ec7e26e315954b8eae3353c3f995c55faf71574000b5b";
+}
+
+impl RosMessage for MagneticField {
+    const NAMESPACE: &'static str = "sensor_msgs";
+    const TYPE_NAME: &'static str = "MagneticField";
+    const TYPE_HASH: &'static str =
+        "RIHS01_e80f32f56a20486c9923008fc1a1db07bbb273cbbf6a5b3bfa00835ee00e4dff";
+}
+
 impl<const N: usize> RosMsgAdapter<'static> for PointCloudSoa<N> {
     type Output = PointCloud2;
 
@@ -112,11 +194,11 @@ impl<const N: usize> RosMsgAdapter<'static> for PointCloudSoa<N> {
     }
 
     fn type_name() -> &'static str {
-        "PointCloud2"
+        PointCloud2::TYPE_NAME
     }
 
     fn type_hash() -> &'static str {
-        "RIHS01_9198cabf7da3796ae6fe19c4cb3bdd3525492988c70522628af5daa124bae2b5"
+        PointCloud2::TYPE_HASH
     }
 }
 
@@ -128,11 +210,11 @@ impl<const N: usize> RosMsgAdapter<'static> for PointCloudSoaHandle<N> {
     }
 
     fn type_name() -> &'static str {
-        "PointCloud2"
+        PointCloud2::TYPE_NAME
     }
 
     fn type_hash() -> &'static str {
-        "RIHS01_9198cabf7da3796ae6fe19c4cb3bdd3525492988c70522628af5daa124bae2b5"
+        PointCloud2::TYPE_HASH
     }
 }
 
@@ -157,11 +239,11 @@ impl RosMsgAdapter<'static> for CuImage<Vec<u8>> {
     }
 
     fn type_name() -> &'static str {
-        "Image"
+        Image::TYPE_NAME
     }
 
     fn type_hash() -> &'static str {
-        "RIHS01_d31d41a9a4c4bc8eae9be757b0beed306564f7526c88ea6a4588fb9582527d47"
+        Image::TYPE_HASH
     }
 }
 
@@ -173,11 +255,11 @@ impl RosMsgAdapter<'static> for ImuPayload {
     }
 
     fn type_name() -> &'static str {
-        "Imu"
+        Imu::TYPE_NAME
     }
 
     fn type_hash() -> &'static str {
-        "RIHS01_7d9a00ff131080897a5ec7e26e315954b8eae3353c3f995c55faf71574000b5b"
+        Imu::TYPE_HASH
     }
 }
 
@@ -189,11 +271,11 @@ impl RosMsgAdapter<'static> for MagnetometerPayload {
     }
 
     fn type_name() -> &'static str {
-        "MagneticField"
+        MagneticField::TYPE_NAME
     }
 
     fn type_hash() -> &'static str {
-        "RIHS01_e80f32f56a20486c9923008fc1a1db07bbb273cbbf6a5b3bfa00835ee00e4dff"
+        MagneticField::TYPE_HASH
     }
 }
 
@@ -894,5 +976,107 @@ mod tests {
         assert!((mag.mag_x.get::<microtesla>() - recovered.mag_x.get::<microtesla>()).abs() < 1e-3);
         assert!((mag.mag_y.get::<microtesla>() - recovered.mag_y.get::<microtesla>()).abs() < 1e-3);
         assert!((mag.mag_z.get::<microtesla>() - recovered.mag_z.get::<microtesla>()).abs() < 1e-3);
+    }
+}
+
+#[cfg(test)]
+mod message_tests {
+    use super::*;
+    use crate::builtin::Time;
+
+    fn sample_header() -> Header {
+        Header {
+            stamp: Time {
+                sec: 1_700_000_000,
+                nanosec: 500,
+            },
+            frame_id: "camera_left".into(),
+        }
+    }
+
+    #[test]
+    fn compressed_image_roundtrips_and_keeps_its_bytes_opaque() {
+        let value = CompressedImage {
+            header: sample_header(),
+            format: "h264".into(),
+            data: (0u8..64).collect(),
+        };
+
+        let bytes =
+            cdr::serialize::<_, _, cdr::CdrLe>(&value, cdr::Infinite).expect("cdr encode succeeds");
+        let decoded: CompressedImage =
+            cdr::deserialize(bytes.as_slice()).expect("cdr decode succeeds");
+        assert_eq!(decoded, value);
+        // The encoder's payload must survive untouched: this type exists so a hardware-encoded
+        // stream is published as-is rather than expanded into an `Image` and re-encoded.
+        assert_eq!(decoded.data, (0u8..64).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn camera_info_roundtrips() {
+        let value = CameraInfo {
+            header: sample_header(),
+            height: 480,
+            width: 640,
+            distortion_model: "plumb_bob".into(),
+            d: vec![0.0; 5],
+            k: [500.0, 0.0, 320.0, 0.0, 500.0, 240.0, 0.0, 0.0, 1.0],
+            r: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+            p: [
+                500.0, 0.0, 320.0, -35.0, 0.0, 500.0, 240.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+            ],
+            binning_x: 0,
+            binning_y: 0,
+            roi: RegionOfInterest::default(),
+        };
+
+        let bytes =
+            cdr::serialize::<_, _, cdr::CdrLe>(&value, cdr::Infinite).expect("cdr encode succeeds");
+        let decoded: CameraInfo = cdr::deserialize(bytes.as_slice()).expect("cdr decode succeeds");
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn camera_info_d_is_a_sequence_while_k_r_p_are_fixed() {
+        let encode = |info: &CameraInfo| {
+            cdr::serialize::<_, _, cdr::CdrLe>(info, cdr::Infinite)
+                .expect("cdr encode succeeds")
+                .len()
+        };
+
+        let mut base = CameraInfo {
+            header: sample_header(),
+            distortion_model: "plumb_bob".into(),
+            d: vec![0.0; 4],
+            ..Default::default()
+        };
+        let four = encode(&base);
+        base.d.push(0.0);
+        let five = encode(&base);
+        // `d` is `float64[]`: one more element is 8 more bytes of content.
+        assert_eq!(five - four, 8);
+
+        // `k`, `r` and `p` are fixed matrices, so changing their VALUES cannot change the size.
+        // If any of them encoded as a sequence there would be a uint32 length here too, and every
+        // field after it would be shifted for a ROS subscriber.
+        let mut changed = base.clone();
+        changed.k = [1.0; 9];
+        changed.r = [2.0; 9];
+        changed.p = [3.0; 12];
+        assert_eq!(encode(&changed), five);
+    }
+
+    #[test]
+    fn fixed_matrices_carry_no_length_prefix() {
+        #[derive(Serialize, Deserialize)]
+        struct ProjectionOnly {
+            p: [f64; 12],
+        }
+
+        let bytes =
+            cdr::serialize::<_, _, cdr::CdrLe>(&ProjectionOnly { p: [1.0; 12] }, cdr::Infinite)
+                .expect("cdr encode succeeds");
+        // 4-byte encapsulation header then twelve bare f64 — no uint32 count.
+        assert_eq!(bytes.len(), 4 + 12 * 8);
     }
 }


### PR DESCRIPTION
## Summary

`cu-ros2-payloads` covers `sensor_msgs`, `std_msgs` scalars and `builtin`. A graph that publishes a
transform, an odometry, a path or a compressed camera stream currently has to define those wire
structs downstream and hand-paste their RIHS01 type hashes — which is silent to get wrong, since the
hash goes into the rmw_zenoh key expression and a mismatch just means the subscriber never matches,
with no error on either side.

This adds the missing message types and gives every hash a single home.

## Related issues
- Closes #

## Changes

**New message types**

- `geometry_msgs`: `Point`, `Pose`, `PoseStamped`, `Transform`, `TransformStamped`, `Twist`,
  `PoseWithCovariance`, `TwistWithCovariance`, plus `Vector3` and `Quaternion`.
- `nav_msgs`: `Odometry`, `Path`.
- `sensor_msgs`: `CompressedImage`, `CameraInfo`, `RegionOfInterest`.

**`Vector3` / `Quaternion` move to `geometry_msgs`, re-exported from `sensor_msgs`**

ROS 2 homes both in `geometry_msgs`, and the namespace is not cosmetic — it feeds `namespace()` and
the key expression. They are defined in `geometry_msgs` now and `sensor_msgs` keeps
`pub use crate::geometry_msgs::{Quaternion, Vector3};`, so existing `sensor_msgs::Vector3` paths
still compile and `Imu` and `Twist` share one type rather than two structurally identical ones.

**A `RosMessage` trait for wire identity**

```rust
pub trait RosMessage {
    const NAMESPACE: &'static str;
    const TYPE_NAME: &'static str;
    const TYPE_HASH: &'static str;
}
```

The three things a bridge puts in an rmw_zenoh key expression, kept next to the struct instead of
copied into every adapter that publishes it. The existing `sensor_msgs` adapters now read their
constants from it; **the literals are byte-identical to what they returned before**. `TYPE_HASH` is
the Jazzy RIHS01 hash and needs no distro `cfg`, because the blanket `RosBridgeAdapter` impl already
substitutes `"TypeHashNotSupported"` under `humble`.

Only types whose hash is verified against a ROS 2 Jazzy install implement the trait. Sub-messages
that are never published on their own (`Point`, `Pose`, `Transform`, `RegionOfInterest`, ...)
deliberately do not, rather than carry a guessed literal.

**A `fixed_array` serde helper (no new dependency)**

`PoseWithCovariance` and `TwistWithCovariance` carry `float64[36]`. serde's built-in `[T; N]` impls
stop at `N == 32`, and encoding the matrix as a `Vec` would prepend a `uint32` length that no ROS
subscriber expects, shifting every field after it. ~30 lines of `serialize_tuple` /
`deserialize_tuple` rather than pulling in `serde_arrays`.

**`Default` on `Header` and `Time`**

Needed so the new messages can derive `Default`. Documented as the ROS default (zero stamp, empty
`frame_id`) with a note that both are valid on the wire and neither is useful — a zero stamp turns
pipeline latency into apparent jitter downstream, and an empty frame builds no tf tree.

**Tests**

CDR round-trips for every new message, plus byte-count assertions for the property that is easy to
break and invisible when broken: fixed arrays carry no length prefix. `camera_info_d_is_a_sequence_while_k_r_p_are_fixed`
pins both halves of that distinction. A cross-module test checks every `TYPE_HASH` is a well-formed
lowercase RIHS01 digest and that no two types share one.

## Reminder
- [ ] I ran `just` from the repo root
- [x] I have updated docs or examples where needed (rustdoc on the new types; no example changes needed)

## Additional context

**On the `just` checkbox** — I could not run the full workspace gate from a clean clone:
`examples/cu_flight_controller` path-depends on `cu-zed` at `../../../zed/components/sources/cu_zed`,
a sibling repo that is not part of this one, so `cargo` fails to load the workspace manifest before
any check runs:

```
error: failed to load manifest for workspace member `examples/cu_flight_controller`
Caused by: failed to read `.../zed/components/sources/cu_zed/Cargo.toml`
```

Excluding that example locally (not part of this diff), I ran the crate-scoped equivalents:

- `cargo test -p cu-ros2-payloads --features jazzy` — 27 passed
- `cargo test -p cu-ros2-payloads --features humble` — 27 passed
- `cargo clippy -p cu-ros2-payloads --features jazzy --all-targets` — clean
- `cargo fmt -p cu-ros2-payloads` — no diff
- `cargo build -p cu-ros2-bridge --features jazzy` — builds against the change

Happy to adjust anything here; flagging the `zed` path dep separately in case a clean-clone
workspace load is meant to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn1oe6gBfhFHenJBbo7nXN
