### PR TITLE
test(cu-safetymon): stabilize watchdog fault context check

### DIFF
--- a/components/monitors/cu_safetymon/tests/safety_monitoring.rs
+++ b/components/monitors/cu_safetymon/tests/safety_monitoring.rs
@@ -215,26 +215,28 @@ fn panic_fault_exits_with_configured_code_and_marker_context() {
 #[test]
 fn lock_fault_exits_with_configured_code_and_last_marker() {
     if std::env::var(CHILD_MODE_ENV).ok().as_deref() == Some("lock") {
-        let cfg = safetymon_test_config(79, 80);
+        // Allow the child to finish publishing progress on a busy CI runner.
+        let cfg = safetymon_test_config_with_timing(1_000, 10, 79, 80);
         let probe = Arc::new(RuntimeExecutionProbe::default());
         let (metadata, runtime) = monitor_metadata(&cfg, Some(probe.clone()));
         let layout = metadata.layout();
         let mut monitor = CuSafetyMon::new(metadata, runtime).expect("safetymon new");
         let (ctx, _clock_control) = CuContext::new_mock_clock();
-        monitor.start(&ctx).expect("safetymon start");
         let cl_ctx = CuContext::builder(ctx.clock.clone()).cl_id(9).build();
         let metadata = CuMsgMetadata::default();
         let msgs: [&CuMsgMetadata; 1] = [&metadata];
-        monitor
-            .process_copperlist(&cl_ctx, layout.view(&msgs))
-            .expect("safetymon process_copperlist");
+        // Publish the marker before arming the watchdog.
         probe.record(ExecutionMarker {
             component_id: ComponentId::new(1),
             step: CuComponentState::Process,
             culistid: Some(9),
         });
+        monitor.start(&ctx).expect("safetymon start");
+        monitor
+            .process_copperlist(&cl_ctx, layout.view(&msgs))
+            .expect("safetymon process_copperlist");
 
-        thread::sleep(Duration::from_millis(300));
+        thread::sleep(Duration::from_secs(10));
         std::process::exit(254);
     }
 
@@ -245,13 +247,14 @@ fn lock_fault_exits_with_configured_code_and_last_marker() {
     assert_eq!(
         output.status.code(),
         Some(79),
-        "unexpected lock child exit status: {:?}",
-        output.status
+        "unexpected lock child exit status: {:?}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("cu_safetymon lock fault:"));
-    assert!(stderr.contains("component='driver'"));
-    assert!(stderr.contains("last_culist=9"));
+    assert!(stderr.contains("cu_safetymon lock fault:"), "{stderr}");
+    assert!(stderr.contains("component='driver'"), "{stderr}");
+    assert!(stderr.contains("last_culist=9"), "{stderr}");
     let _ = fs::remove_dir_all(&child_dir);
 }
 


### PR DESCRIPTION
## Summary

The watchdog fault test can exit before publishing its expected execution marker on a busy CI runner, failing the `component='driver'` assertion. Publish the marker before starting the watchdog and increase the test deadline from 40 ms to 1 s, with a 10 s fallback exit. Include child stderr in assertion failures.

## Related issues

Observed in [PR #1351's CI job](https://github.com/copper-project/copper-rs/actions/runs/34236565101/job/102100068941?pr=1351). This test fix is independent of that PR's serial bridge changes.

## Changes

Only the watchdog integration test changes. Its exit-code, component, and CopperList assertions remain intact.

## Validation

- `just fmt` and `just fmt-check` passed on this branch.
- All eight cu-safetymon tests passed with `cu29/reflect,cu29/log-level-debug` in the original checkout; the affected test also passed ten consecutive reruns.
- Package clippy with those features and `--deny warnings` passed in the original checkout.
- Retesting on this master-based worktree was blocked during Cargo metadata resolution by duplicate `cu-ahrs` packages from the two local checkout paths.

## Reminder

- [ ] I ran `just` from the repo root (focused checks listed above)
- [x] I have updated docs or examples where needed (test-only change)
