### PR TITLE
ci: update sccache action for Node 24

### DIFF
--- a/.github/actions/embedded-rust-setup/action.yml
+++ b/.github/actions/embedded-rust-setup/action.yml
@@ -35,7 +35,7 @@ runs:
         targets: aarch64-unknown-none,thumbv7em-none-eabihf,thumbv8m.main-none-eabihf,riscv32imac-unknown-none-elf
         components: rustc,cargo,rust-std,rustfmt,clippy
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.9
+      uses: mozilla-actions/sccache-action@v0.0.11
       with:
         version: "v0.16.0"
     - name: Compute cache save policy

--- a/.github/actions/rust-ci-setup/action.yml
+++ b/.github/actions/rust-ci-setup/action.yml
@@ -56,7 +56,7 @@ runs:
         toolchain: ${{ inputs.toolchain }}
         components: rustc,cargo,rust-std,rustfmt,clippy
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.9
+      uses: mozilla-actions/sccache-action@v0.0.11
       with:
         version: "v0.16.0"
     - name: Compute cache save policy


### PR DESCRIPTION
## Summary

The shared Rust CI setup actions use a Node 20 action and emit deprecation warnings on runners that now default to Node 24. Update `mozilla-actions/sccache-action` from `v0.0.9` to `v0.0.11` in both host and embedded setup actions to use its declared Node 24 runtime.

## Changes

Update the two action references. The sccache executable remains pinned to `v0.16.0`.

## Validation

- `just fmt` passed on this branch, including YAML and file hygiene checks.
- `git diff --check` passed.

## Reminder

- [ ] I ran `just` from the repo root
- [x] I have updated docs or examples where needed (CI-only change)

## Additional context

The reported post-job `Unable to locate executable file: undefined` error indicates that `SCCACHE_PATH` was missing. This upgrade addresses the Node runtime warning; the original setup log is still needed to diagnose that separate failure.
