### PR TITLE
Stream structured logs into the remote telemetry log pane

### DIFF
--- a/components/res/cu29_logstream_udp/tests/configured_feedback.ron
+++ b/components/res/cu29_logstream_udp/tests/configured_feedback.ron
@@ -41,7 +41,7 @@
                 link: (
                     mtu_bytes: 1200,
                     bitrate_bps: 1000000,
-                    memory_budget_kib: 512,
+                    memory_budget_kib: 576,
                     max_latency_ms: 250,
                     burst_packets: 8,
                 ),

--- a/components/res/cu29_logstream_udp/tests/configured_sender.ron
+++ b/components/res/cu29_logstream_udp/tests/configured_sender.ron
@@ -28,7 +28,7 @@
                 link: (
                     mtu_bytes: 1200,
                     bitrate_bps: 1000000,
-                    memory_budget_kib: 512,
+                    memory_budget_kib: 576,
                     max_latency_ms: 250,
                     burst_packets: 8,
                 ),

--- a/core/cu29/tests/logstream_configured_runtime.ron
+++ b/core/cu29/tests/logstream_configured_runtime.ron
@@ -21,7 +21,7 @@
                 link: (
                     mtu_bytes: 1200,
                     bitrate_bps: 1000000,
-                    memory_budget_kib: 512,
+                    memory_budget_kib: 576,
                     max_latency_ms: 250,
                     burst_packets: 8,
                 ),

--- a/core/cu29/tests/logstream_runtime.rs
+++ b/core/cu29/tests/logstream_runtime.rs
@@ -36,7 +36,8 @@ impl CuSrcTask for StreamSource {
         Ok(Self::default())
     }
 
-    fn process(&mut self, _ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
+    fn process(&mut self, ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
+        info!(ctx, "Logstream source iteration {}", self.next);
         output.set_payload(StreamMsg(self.next));
         self.next += 1;
         Ok(())
@@ -110,6 +111,31 @@ fn generated_runtime_streams_without_local_copperlist_logging() -> CuResult<()> 
         datagrams.len() > ITERATIONS,
         "expected source and repair datagrams, got {}",
         datagrams.len()
+    );
+    let mut log_decoder = FiniteObjectDecoder::new(
+        identity,
+        Lane::StructuredLog,
+        FiniteObjectLimits::new(4096, SYMBOL_SIZE as u16, 4),
+    )
+    .unwrap();
+    let mut logs = Vec::new();
+    for packet in &datagrams {
+        log_decoder
+            .receive_datagram(packet, |record| {
+                let (entry, used): (CuLogEntry, usize) = bincode::decode_from_slice(
+                    record.decoded().payload,
+                    bincode::config::standard(),
+                )
+                .unwrap();
+                assert_eq!(used, record.decoded().payload.len());
+                logs.push(entry);
+                Ok::<(), ()>(())
+            })
+            .unwrap();
+    }
+    assert!(
+        logs.iter()
+            .any(|entry| entry.level == CuLogLevel::Info && entry.origin.task_index == Some(0))
     );
     let source_symbols = datagrams
         .iter()

--- a/core/cu29_derive/src/lib.rs
+++ b/core/cu29_derive/src/lib.rs
@@ -5654,14 +5654,14 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         cu29::resource::ResourceKey::<()>::new(cu29::resource::BundleIndex::new(#bundle),
                             cu29::resource::resource_index_by_name::<#provider>(#name)).typed::<#ty>()
                     )?.0;
-                    let (#continuous_ident, #recovery_ident, sender_monitor) = ::cu29::logstream::scheduled_feedback_sinks::<#mission_mod::CuStampedDataSet, _>(
+                    let (mut #continuous_ident, #recovery_ident, sender_monitor) = ::cu29::logstream::scheduled_feedback_sinks::<#mission_mod::CuStampedDataSet, _>(
                         ::cu29::logstream::SeparateFeedback { tx: #transport_ident, feedback_rx }, sender_config,
                         if clock.is_mock() { RobotClock::new() } else { clock.clone() },
                     )?;
                 }
             } else {
                 quote! {
-                    let (#continuous_ident, #recovery_ident, sender_monitor) = ::cu29::logstream::scheduled_sinks::<#mission_mod::CuStampedDataSet, _>(
+                    let (mut #continuous_ident, #recovery_ident, sender_monitor) = ::cu29::logstream::scheduled_sinks::<#mission_mod::CuStampedDataSet, _>(
                         #transport_ident, sender_config,
                         if clock.is_mock() { RobotClock::new() } else { clock.clone() },
                     )?;
@@ -5694,6 +5694,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                     )?
                     .0;
                 #scheduled
+                let structured_outputs = (#continuous_ident.take_structured_log_sink(), structured_outputs);
                 stream_monitors.push(sender_monitor.into_runtime_monitor(&destination.id,
                     destination.link.bitrate_bps, usize::from(destination.fec.continuous.repair_every_source_symbols)));
                 let #continuous_ident = if logstream_schema.reconstruction.is_empty() {
@@ -5736,6 +5737,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 #[allow(unused_mut)]
                 let mut resources = resources;
                 let mut stream_monitors = Vec::with_capacity(#configured_logstream_count + usize::from(logstream.is_some()));
+                let structured_outputs = ();
                 #configured_logstream_session
                 #(#configured_logstream_initializers)*
                 let injected_logstream_sinks = logstream
@@ -5752,20 +5754,22 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                         }
                         let bitrate = sender_config.pacing.bitrate_bps;
                         let baseline = sender_config.continuous.repair_every_source_symbols;
-                        let (copperlist, keyframe, sender_monitor) = ::cu29::logstream::scheduled_sinks::<
+                        let (mut copperlist, keyframe, sender_monitor) = ::cu29::logstream::scheduled_sinks::<
                             #mission_mod::CuStampedDataSet, _
                         >(transport, sender_config,
                             if clock.is_mock() { RobotClock::new() } else { clock.clone() })?;
                         stream_monitors.push(sender_monitor.into_runtime_monitor("injected", bitrate, baseline));
+                        let structured = copperlist.take_structured_log_sink();
                         let copperlist = if schema.reconstruction.is_empty() { copperlist }
                             else { copperlist.with_encoder(::cu29::logstream::capture::encode_capture_record_into) };
-                        Ok::<_, CuError>((copperlist, keyframe))
+                        Ok::<_, CuError>(((copperlist, keyframe), structured))
                     })
                     .transpose()?;
                 let stream_monitors: Option<::std::sync::Arc<[cu29::monitoring::LogStreamMonitor]>> =
                     (!stream_monitors.is_empty()).then(|| stream_monitors.into());
-                let (injected_logstream_sink, injected_logstream_keyframe_sink) =
-                    injected_logstream_sinks.unzip();
+                let (injected_logstream_sinks, injected_structured) = injected_logstream_sinks.unzip();
+                let structured_outputs = (injected_structured.flatten(), structured_outputs);
+                let (injected_logstream_sink, injected_logstream_keyframe_sink) = injected_logstream_sinks.unzip();
                 let copperlist_sink = ::cu29::fanout::OptionalWriteStream::new(
                     local_copperlist_output_required.then_some(local_copperlist_sink),
                 );
@@ -5820,6 +5824,40 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
             quote! { #mission_mod::monitor_instanciator }
         };
 
+        let local_structured_logger_init = quote! {
+            let local_structured_log_sink = ::cu29::prelude::LogStream::new(
+                ::cu29::prelude::UnifiedLogType::StructuredLogLine,
+                unified_logger.clone(), 4096 * 10,
+            )?;
+        };
+        let (early_structured_logger_init, late_structured_logger_init) = if logstream_enabled {
+            (
+                quote! {},
+                quote! {
+                    #local_structured_logger_init
+                    let logger_runtime = if logstream_output_required {
+                        ::cu29::prelude::LoggerRuntime::init(
+                            clock.clone(),
+                            ::cu29::logstream::StructuredLogStream::new(local_structured_log_sink, structured_outputs),
+                            None::<::cu29::prelude::NullLog>,
+                        )
+                    } else {
+                        ::cu29::prelude::LoggerRuntime::init(clock.clone(), local_structured_log_sink, None::<::cu29::prelude::NullLog>)
+                    };
+                },
+            )
+        } else {
+            (
+                quote! {
+                    #local_structured_logger_init
+                    let logger_runtime = ::cu29::prelude::LoggerRuntime::init(
+                        clock.clone(), local_structured_log_sink, None::<::cu29::prelude::NullLog>,
+                    );
+                },
+                quote! {},
+            )
+        };
+
         let build_with_resources_fn = quote! {
             #build_with_resources_sig {
                 let AppResources {
@@ -5829,19 +5867,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                     #build_with_resources_thread_pools_destructure
                 } = app_resources;
 
-                let local_structured_log_sink = ::cu29::prelude::stream_write::<
-                    ::cu29::prelude::CuLogEntry,
-                    S,
-                >(
-                    unified_logger.clone(),
-                    ::cu29::prelude::UnifiedLogType::StructuredLogLine,
-                    4096 * 10,
-                )?;
-                let logger_runtime = ::cu29::prelude::LoggerRuntime::init(
-                    clock.clone(),
-                    local_structured_log_sink,
-                    None::<::cu29::prelude::NullLog>,
-                );
+                #early_structured_logger_init
 
                 // For simple cases we can say the section is just a bunch of Copper Lists.
                 // But we can now have allocations outside of it so we can override it from the config.
@@ -5872,6 +5898,7 @@ pub fn copper_runtime(args: TokenStream, input: TokenStream) -> TokenStream {
                 #local_keyframe_sink_init
 
                 #copperlist_output_graph
+                #late_structured_logger_init
 
                 #[cfg(target_os = "none")]
                 ::cu29::prelude::info!("CuApp new: creating runtime lifecycle stream");

--- a/core/cu29_log/src/lib.rs
+++ b/core/cu29_log/src/lib.rs
@@ -139,15 +139,22 @@ impl<Context> Decode<Context> for CuLogEntry {
         let origin = CuLogOrigin::decode(decoder)?;
         let msg_index = u32::decode(decoder)?;
 
-        let paramname_len = u64::decode(decoder)? as usize;
+        let paramname_len = usize::try_from(u64::decode(decoder)?).map_err(|_| {
+            bincode::error::DecodeError::Other("log parameter name count exceeds usize")
+        })?;
+        decoder.claim_container_read::<u32>(paramname_len)?;
         let mut paramname_indexes = SmallVec::with_capacity(paramname_len);
         for _ in 0..paramname_len {
+            decoder.unclaim_bytes_read(core::mem::size_of::<u32>());
             paramname_indexes.push(u32::decode(decoder)?);
         }
 
-        let params_len = u64::decode(decoder)? as usize;
+        let params_len = usize::try_from(u64::decode(decoder)?)
+            .map_err(|_| bincode::error::DecodeError::Other("log parameter count exceeds usize"))?;
+        decoder.claim_container_read::<Value>(params_len)?;
         let mut params = SmallVec::with_capacity(params_len);
         for _ in 0..params_len {
+            decoder.unclaim_bytes_read(core::mem::size_of::<Value>());
             params.push(Value::decode(decoder)?);
         }
 
@@ -383,6 +390,25 @@ macro_rules! defmt_error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn decode_budget_rejects_untrusted_parameter_counts() {
+        let config = bincode::config::standard().with_limit::<4096>();
+        let prefix = (CuTime::from(0), 0u8, CuLogOrigin::default(), 0u32);
+        for names in [true, false] {
+            let mut bytes = bincode::encode_to_vec(prefix, config).unwrap();
+            if !names {
+                bytes.extend(bincode::encode_to_vec(0u64, config).unwrap());
+            }
+            bytes.extend(bincode::encode_to_vec(u64::MAX, config).unwrap());
+            assert!(bincode::decode_from_slice::<CuLogEntry, _>(&bytes, config).is_err());
+        }
+        let entry = CuLogEntry::new(42, CuLogLevel::Warning);
+        let bytes = bincode::encode_to_vec(&entry, config).unwrap();
+        let (decoded, used) = bincode::decode_from_slice::<CuLogEntry, _>(&bytes, config).unwrap();
+        assert_eq!(decoded, entry);
+        assert_eq!(used, bytes.len());
+    }
 
     #[test]
     fn test_log_level_ordering() {

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -15,7 +15,7 @@ Logreader / replay ← .copper archive ← logstream receiver
 The sender protects log records with recovery data. The receiver reconstructs
 what it can and records explicit gaps for what it cannot. Received archives use
 Copper's native format, so your application's normal logreader and replay tools
-can read them. Sender work runs off the real-time task path.
+can read them. Framing, FEC, and transmission run on background workers.
 
 ## Using it
 
@@ -43,9 +43,9 @@ preserves the received payloads and timestamps.
 - Native archival requires the matching application. `NativeArchive` handles
   full captures; `CaptureArchive` retains selective captures for live/offline replay. Use a separate archive path for each sender session.
 - Generated senders enforce one bitrate/burst budget across continuous data,
-  repairs, and recovery packets. The budget counts Copper packet bytes, excluding
-  UDP/IP or other carrier overhead. Replay and recovery share byte-deficit
-  scheduling with weights 3:1; unused capacity is available to either lane.
+  repairs, recovery packets, and structured logs. The budget counts Copper packet bytes, excluding
+  UDP/IP or other carrier overhead. Replay, recovery, and structured logs share byte-deficit
+  scheduling with weights 3:1:1; unused capacity is available to any ready lane.
 - Manifest and latest complete keyframe/recovery point/boundary recovery repeat on a
   250 ms local deadline, with overlapping requests coalesced. A pending bundle
   finishes before a newer one replaces it. New recovery points wait for older queued
@@ -59,6 +59,59 @@ preserves the received payloads and timestamps.
 Run `just logstream-receiver-check` from the repository root to test reception,
 archival, and replay continuity. See the Rust API docs for receiver limits and
 event handling.
+
+## Structured log records
+
+Configured and injected runtime destinations automatically forward `debug!`,
+`info!`, `warn!`, and `error!` entries alongside local logging. The generated
+static fan-out copies the bytes produced by the existing local serializer into
+one preallocated buffer per destination. Framing, hashing, FEC, and transmission
+run on sender workers. Message templates and parameter names are represented by
+interned numeric IDs; receivers render text with the producing application's
+`cu29_log_index`. Parameter values retain their native types, including strings
+when an application explicitly logs a string value.
+
+The sender reserves four structured-record buffers per destination, each capped
+at 4096 bytes including the existing record header, or `max_object_bytes` when
+smaller. Size overflow, exhausted pools, and stopped destinations increment
+`inbox_drops` while the local record remains intact. These buffers and their
+queue storage count toward `memory_budget_kib`. The demo uses 576 KiB to cover
+its CL/keyframe pools, structured buffers, recovery retention, and packet queues.
+A section rollover resets the copied entry before the local serialization retry;
+only a successful local write admits the completed entry for transmission.
+
+`SenderCore::accept_record` accepts `RecordKind::StructuredLog` records containing
+one native bincode-encoded `CuLogEntry`. Assign increasing object IDs within each
+sender session. The scheduler uses the existing structured-log lane and RaptorQ
+object framing, shares the destination bitrate/burst limit, and reserves a bounded
+packet queue so log traffic cannot fill the replay queue. Object FEC and size bounds
+come from the destination's finite-object policy. Expiry and queue shedding count
+in the sender's ordinary drop counters. Loss beyond object-FEC coverage leaves
+missing entries; the onboard log remains available for complete history.
+
+`SessionRouter` recovers these records independently of CopperList continuity and
+emits `SessionEvent::Object` after the session manifest. Pre-manifest packets share
+the bounded startup buffer. A 64-record window accepts reordering and suppresses
+duplicates; older records are discarded. Structured-object decoder storage uses a
+separate instance of the receiver's finite-object limits.
+
+Pass these events to `NativeArchive` or `CaptureArchive` to retain the original
+entry bytes in `StructuredLogLine` sections. Archived timestamps, levels, origins,
+parameter values, and interned string IDs come from the sender. Entry validation
+uses a 4 MiB bincode decode budget. Use the producing application's string index
+with `extract-text-log` to reconstruct readable text.
+
+A generated live twin exposes `twin.take_log_reader()` once. Its independent
+64-entry ring publishes `ReceivedStructuredLog` after archival succeeds, moving
+the already decoded entry into the display channel. Read `update.frame.entry`
+and render with `rebuild_logline`; `CuTwinStatus::structured_logs` counts archived
+entries. Pausing or dropping either display reader never delays recording.
+Custom archive consumers can obtain the same owned value with
+`archive.take_structured_log()` immediately after `accept`.
+
+Run `just logstream-structured-check` for binary preservation, allocation, local
+section rollover, loss/reordering, shutdown, generated wiring, and telemetry UI
+coverage.
 
 ## Ground-side telemetry
 
@@ -103,7 +156,7 @@ captured payloads alone does not recover task state. Run
 ## Sender storage and lifecycle
 
 `scheduled_sinks` creates one worker owning the transport and FEC state, a pool
-of four encoded CL buffers and two encoded keyframe buffers, and fixed packet
+of four encoded CL buffers, two encoded keyframe buffers, four structured buffers, and fixed packet
 storage. Encoding writes directly into these buffers on the existing output
 workers. Runtime CopperLists and keyframe capture objects are released before
 transmission. Packet staging and recovery retention add bounded copies only on
@@ -127,7 +180,7 @@ shedding are counted. `SenderMonitor::snapshot()` exposes live counters and feed
 the worker also writes its shutdown statistics and failures to Copper structured
 logging. Dropping both sinks stops repetition and drains only until the configured
 latency deadline. An independent running RobotClock bounds teardown of a frozen
-test clock. Production real-time handoff is unchanged.
+test clock. Structured logging adds the bounded byte copy described above; CL and keyframe handoffs retain their existing behavior.
 
 `SenderCore` is available without `std`; callers provide `CuTime` from their
 RobotClock and drive `poll` themselves. The std driver owns thread wakeups.
@@ -139,16 +192,17 @@ checks, including recovery after the entire initial bootstrap transmission is lo
 
 ## Live Copper twin
 
-The demo graph is `counter -> sum -> derived`. The ordinary `Derived` Copper task
-computes `sum % 256` on the robot and in generated ground-side replay. Its payload
-is never transmitted, including repeated recovery point boundaries and FEC repairs. The
-robot's onboard log contains the full output for comparison. Ratatui explicitly
-labels the derived value **reconstructed locally; payload not transmitted**.
+The demo graph is `encoders -> kinematics`. The `Kinematics` Copper task computes
+elbow and fingertip positions from shoulder/elbow angles on the robot and in
+generated ground-side replay. Its payload is omitted from captures, including
+repeated recovery boundaries and FEC repairs. The robot's onboard log contains
+the full output for comparison. The telemetry screen labels the arm pose as
+**reconstructed locally; payload not transmitted**.
 
 Declare the static contract in the same RON used by the robot and ground build:
 
 ```ron
-(id: "derived", type: "tasks::Derived",
+(id: "kinematics", type: "cu_logstream_demo::tasks::Kinematics",
  streaming: (replay: reconstruct, replay_abi: 1)),
 ```
 
@@ -295,7 +349,7 @@ captures and labels them Reconstructed, never Verified.
 Only debug captures that pass comparison are labeled Verified. A mismatch suppresses
 reconstructed frames until the next matching recovery point; native recording continues. Debug
 digests are consumed live and do not add archive sections or change offline log readers.
-Use `just dashboard-verify` and `just sender-verify` to run the development checks.
+Use `just telemetry-verify` and `just sender-verify` to run the development checks.
 `just resim` reconstructs ordinary capture archives offline; the demo's verification
 command compares the result against the full onboard log.
 

--- a/core/cu29_logstream/src/archive.rs
+++ b/core/cu29_logstream/src/archive.rs
@@ -37,6 +37,8 @@ pub struct NativeArchive<P: CopperListTuple> {
     copperlists: NativeStream,
     keyframes: NativeStream,
     continuity: NativeStream,
+    structured: NativeStream,
+    last_structured: Option<cu29_log::CuLogEntry>,
     identity: StreamIdentity,
     manifest_digest: [u8; 32],
     manifest_object_id: u64,
@@ -54,7 +56,7 @@ impl Encode for CanonicalEntry<'_> {
 }
 
 impl<P: CopperListTuple> NativeArchive<P> {
-    /// Creates native CopperList, FrozenTasks and StreamContinuity sections.
+    /// Creates native message, task state, continuity and structured log sections.
     /// The section size must fit the largest accepted canonical entry.
     pub fn new(
         path: &Path,
@@ -103,6 +105,7 @@ impl<P: CopperListTuple> NativeArchive<P> {
         };
         let logger = Arc::new(Mutex::new(logger));
         let mut archive = Self {
+            last_structured: None,
             copperlists: NativeStream::new(
                 UnifiedLogType::CopperList,
                 logger.clone(),
@@ -111,6 +114,12 @@ impl<P: CopperListTuple> NativeArchive<P> {
             .map_err(io_error)?,
             keyframes: NativeStream::new(
                 UnifiedLogType::FrozenTasks,
+                logger.clone(),
+                section_bytes,
+            )
+            .map_err(io_error)?,
+            structured: NativeStream::new(
+                UnifiedLogType::StructuredLogLine,
                 logger.clone(),
                 section_bytes,
             )
@@ -143,6 +152,7 @@ impl<P: CopperListTuple> NativeArchive<P> {
     }
 
     fn accept_capture(&mut self, event: &SessionEventRef<'_>) -> Result<Option<CapturedList<P>>> {
+        self.last_structured = None;
         if self.poisoned {
             return Err(Error::InvalidConfig(
                 "archive failed; close it before continuing",
@@ -245,9 +255,31 @@ impl<P: CopperListTuple> NativeArchive<P> {
                     })
                     .map_err(io_error)?;
             }
-            SessionEvent::Object { .. } => {}
+            SessionEvent::Object { record, .. } => {
+                let decoded = record.decoded();
+                if decoded.kind == RecordKind::StructuredLog {
+                    let (entry, used): (cu29_log::CuLogEntry, usize) = bincode::decode_from_slice(
+                        decoded.payload,
+                        bincode::config::standard().with_limit::<4_194_304>(),
+                    )
+                    .map_err(|_| Error::InvalidConfig("invalid structured log entry"))?;
+                    if used != decoded.payload.len() {
+                        return Err(Error::InvalidConfig("trailing structured log bytes"));
+                    }
+                    self.structured
+                        .log(&CanonicalEntry(decoded.payload))
+                        .map_err(io_error)?;
+                    self.last_structured = Some(entry);
+                }
+            }
         }
         Ok(None)
+    }
+
+    /// Move the structured entry decoded during the most recent successful accept.
+    /// Call before accepting another event; publication can reuse this owned value.
+    pub fn take_structured_log(&mut self) -> Option<cu29_log::CuLogEntry> {
+        self.last_structured.take()
     }
 
     /// Records the receiver's final known boundary and closes native sections.
@@ -293,6 +325,11 @@ impl<P: crate::capture::CaptureDataSet> CaptureArchive<P> {
         event: &SessionEventRef<'_>,
     ) -> Result<Option<crate::capture::CapturedList<P>>> {
         self.0.accept_capture(event)
+    }
+
+    /// Move the structured entry from the most recent successful accept.
+    pub fn take_structured_log(&mut self) -> Option<cu29_log::CuLogEntry> {
+        self.0.take_structured_log()
     }
 
     pub fn finish(self) -> Result<()> {

--- a/core/cu29_logstream/src/lib.rs
+++ b/core/cu29_logstream/src/lib.rs
@@ -19,7 +19,10 @@ pub mod twin;
 #[cfg(feature = "std")]
 mod twin_session;
 #[cfg(feature = "std")]
-pub use twin_session::{CuTwin, CuTwinBuilder, CuTwinReader, CuTwinRecordingState, CuTwinStatus};
+pub use twin_session::{
+    CuTwin, CuTwinBuilder, CuTwinLogReader, CuTwinReader, CuTwinRecordingState, CuTwinStatus,
+    ReceivedStructuredLog,
+};
 
 /// Bounded ground-side delivery to caller-owned telemetry consumers.
 #[cfg(feature = "std")]
@@ -38,13 +41,17 @@ mod rlc;
 mod router;
 mod sender;
 mod stream;
+#[cfg(feature = "std")]
+pub mod structured;
 mod wire;
 #[cfg(feature = "std")]
 mod worker;
 #[cfg(feature = "std")]
+pub use structured::StructuredLogStream;
+#[cfg(feature = "std")]
 pub use worker::{
-    ScheduledCopperListSink, ScheduledKeyFrameSink, SenderMonitor, SenderSnapshot,
-    scheduled_feedback_sinks, scheduled_sinks,
+    ScheduledCopperListSink, ScheduledKeyFrameSink, ScheduledStructuredLogSink, SenderMonitor,
+    SenderSnapshot, scheduled_feedback_sinks, scheduled_sinks,
 };
 
 /// Utilities for testing log streaming over unreliable datagram links.

--- a/core/cu29_logstream/src/pacing.rs
+++ b/core/cu29_logstream/src/pacing.rs
@@ -15,6 +15,7 @@ pub const RECOVERY_REPEAT_INTERVAL: CuDuration = CuDuration(250_000_000);
 const MAX_SENDS_PER_POLL: usize = 64;
 const PENDING_BOUNDARIES: usize = 4;
 const PENDING_KEYFRAMES: usize = 2;
+pub(crate) const STRUCTURED_RECORD_BYTES: usize = 4096;
 
 /// Shared destination budget. Counts complete Copper packets, excluding carrier overhead.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -114,9 +115,11 @@ pub struct SenderCore {
     config: LogStreamSenderConfig,
     continuous: Box<ContinuousEncoder<1128, 64>>,
     finite: FiniteObjectEncoder,
+    structured_encoder: FiniteObjectEncoder,
     repairs: RepairSchedule,
     scratch: Vec<u8>,
     data: Packets,
+    structured: Packets,
     manifest: Packets,
     latest: RecoveryPackets,
     pending_cl: Vec<PendingPackets>,
@@ -128,8 +131,8 @@ pub struct SenderCore {
     last_now: CuTime,
     credit: u128,
     capacity: u128,
-    // Byte deficit fairness: three MTUs of replay for one MTU of recovery.
-    deficit: [usize; 2],
+    // Byte deficit fairness: replay, recovery, structured logs at 3:1:1.
+    deficit: [usize; 3],
     lane: usize,
     stopping: bool,
     transport_pending: bool,
@@ -228,6 +231,20 @@ impl SenderCore {
             .ok_or(Error::InvalidConfig(
                 "sender buffers exceed destination memory budget",
             ))?;
+        let structured_capacity = (queue_capacity / 8).max(
+            finite_capacity(object_bytes.min(STRUCTURED_RECORD_BYTES))
+                .ok_or(Error::InvalidConfig("structured packet bound overflow"))?,
+        );
+        let data_capacity = queue_capacity.saturating_sub(structured_capacity);
+        if data_capacity < boundary_capacity.max(1) {
+            return Err(Error::InvalidConfig(
+                "sender packet queues exceed memory budget",
+            ));
+        }
+        let structured_encoder = FiniteObjectEncoder::new(crate::FiniteObjectSenderConfig {
+            lane: crate::Lane::StructuredLog,
+            ..config.recovery.finite
+        })?;
         let continuous = Box::new(ContinuousEncoder::new(
             config.continuous.identity,
             config.continuous.lane,
@@ -258,8 +275,10 @@ impl SenderCore {
             config,
             continuous,
             finite,
+            structured_encoder,
             scratch: vec![0; mtu],
-            data: Packets::new(queue_capacity, mtu),
+            data: Packets::new(data_capacity, mtu),
+            structured: Packets::new(structured_capacity, mtu),
             manifest,
             latest: recovery(),
             pending_cl: (0..PENDING_BOUNDARIES)
@@ -281,7 +300,7 @@ impl SenderCore {
             last_now: now,
             credit: capacity,
             capacity,
-            deficit: [0; 2],
+            deficit: [0; 3],
             lane: 0,
             stopping: false,
             transport_pending: false,
@@ -333,6 +352,19 @@ impl SenderCore {
                     &mut self.repairs,
                 )?;
             }
+            RecordKind::StructuredLog => {
+                // This lane never advances CopperList continuity or recovery fences.
+                self.structured_encoder.push_record_with(record, |packet| {
+                    if !self.structured.push(packet, now, decoded.object_id) {
+                        self.stats.queue_drops = self.stats.queue_drops.saturating_add(1);
+                    }
+                    self.stats.queue_peak = self
+                        .stats
+                        .queue_peak
+                        .max(self.data.len + self.structured.len);
+                    Ok(())
+                })?;
+            }
             RecordKind::KeyFrame => {
                 if !decoded
                     .object_id
@@ -367,7 +399,7 @@ impl SenderCore {
             }
             _ => {
                 return Err(Error::InvalidConfig(
-                    "sender inbox accepts CLs and keyframes",
+                    "sender inbox accepts CLs, keyframes and structured logs",
                 ));
             }
         }
@@ -469,16 +501,21 @@ impl SenderCore {
     /// Account for work abandoned at the driver's finite shutdown deadline.
     pub fn discard_pending(&mut self) {
         self.stats.shutdown_drops += (self.data.len
+            + self.structured.len
             + self.manifest.len.saturating_sub(self.manifest_cursor)
             + self.recovery_len().saturating_sub(self.recovery_cursor))
             as u64;
         self.data.clear();
+        self.structured.clear();
         self.manifest_cursor = self.manifest.len;
         self.recovery_cursor = self.recovery_len();
     }
 
     pub fn is_idle(&self) -> bool {
-        self.data.len == 0 && self.control_packet().is_none() && !self.transport_pending
+        self.data.len == 0
+            && self.structured.len == 0
+            && self.control_packet().is_none()
+            && !self.transport_pending
     }
 
     /// Send a bounded amount of eligible work and return the next local deadline.
@@ -524,33 +561,39 @@ impl SenderCore {
             self.next_repeat = now + RECOVERY_REPEAT_INTERVAL;
         }
         let mut work = 0;
-        while self.data.len > 0
-            && now >= self.data.times[self.data.head] + self.config.pacing.max_latency
-            && work < MAX_SENDS_PER_POLL
-        {
-            self.data.pop();
-            self.stats.expired_packets += 1;
-            work += 1;
+        for queue in [&mut self.data, &mut self.structured] {
+            while queue.len > 0
+                && now >= queue.times[queue.head] + self.config.pacing.max_latency
+                && work < MAX_SENDS_PER_POLL
+            {
+                queue.pop();
+                self.stats.expired_packets += 1;
+                work += 1;
+            }
         }
         while work < MAX_SENDS_PER_POLL {
-            let has_data = self.data.len > 0;
-            let has_control = self.control_packet().is_some();
-            if !has_data && !has_control {
+            let available = [
+                self.data.len > 0,
+                self.control_packet().is_some(),
+                self.structured.len > 0,
+            ];
+            if !available.iter().any(|ready| *ready) {
                 break;
             }
-            if (self.lane == 0 && !has_data) || (self.lane == 1 && !has_control) {
+            if !available[self.lane] {
                 self.deficit[self.lane] = 0;
-                self.lane ^= 1;
+                self.lane = (self.lane + 1) % 3;
+                continue;
             }
-            let packet = if self.lane == 0 {
-                self.data.get(0)
-            } else {
-                self.control_packet().unwrap()
+            let packet = match self.lane {
+                0 => self.data.get(0),
+                1 => self.control_packet().unwrap(),
+                _ => self.structured.get(0),
             };
             let len = packet.len();
             if self.deficit[self.lane] < len {
                 self.deficit[self.lane] += self.scratch.len() * if self.lane == 0 { 3 } else { 1 };
-                self.lane ^= 1;
+                self.lane = (self.lane + 1) % 3;
                 continue;
             }
             let cost = len as u128 * 8 * 1_000_000_000;
@@ -558,9 +601,11 @@ impl SenderCore {
                 let wait =
                     (cost - self.credit).div_ceil(u128::from(self.config.pacing.bitrate_bps));
                 let mut deadline = now + CuDuration(wait.min(u128::from(u64::MAX)) as u64);
-                if self.data.len > 0 {
-                    deadline = deadline
-                        .min(self.data.times[self.data.head] + self.config.pacing.max_latency);
+                for queue in [&self.data, &self.structured] {
+                    if queue.len > 0 {
+                        deadline =
+                            deadline.min(queue.times[queue.head] + self.config.pacing.max_latency);
+                    }
                 }
                 return Ok(Some(if self.stopping {
                     deadline
@@ -580,6 +625,8 @@ impl SenderCore {
             self.deficit[self.lane] -= len;
             if self.lane == 0 {
                 self.data.pop();
+            } else if self.lane == 2 {
+                self.structured.pop();
             } else if self.manifest_cursor < self.manifest.len {
                 self.manifest_cursor += 1;
             } else {
@@ -588,12 +635,14 @@ impl SenderCore {
             work += 1;
             self.promote_recovery();
         }
-        Ok(if self.data.len != 0 || self.control_packet().is_some() {
-            Some(now)
-        } else if self.stopping {
-            None
-        } else {
-            Some(self.next_repeat)
-        })
+        Ok(
+            if self.data.len != 0 || self.structured.len != 0 || self.control_packet().is_some() {
+                Some(now)
+            } else if self.stopping {
+                None
+            } else {
+                Some(self.next_repeat)
+            },
+        )
     }
 }

--- a/core/cu29_logstream/src/router.rs
+++ b/core/cu29_logstream/src/router.rs
@@ -159,6 +159,8 @@ enum PendingEvent {
 struct RoutedSession<const S: usize, const W: usize, const E: usize> {
     identity: StreamIdentity,
     finite: FiniteObjectDecoder,
+    structured: FiniteObjectDecoder,
+    structured_seen: Option<(u64, u64)>,
     manifest: Option<ReceivedManifest>,
     startup: VecDeque<Vec<u8>>,
     recovery: Vec<RecoveryRecord>,
@@ -274,6 +276,15 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
                 return Ok(());
             }
         };
+        if (packet.header.lane == Lane::StructuredLog
+            || packet.header.record_kind == crate::RecordKind::StructuredLog)
+            && !(packet.header.lane == Lane::StructuredLog
+                && packet.header.record_kind == crate::RecordKind::StructuredLog
+                && packet.header.fec_scheme == FecScheme::RaptorQ)
+        {
+            self.stats.malformed_datagrams += 1;
+            return Ok(());
+        }
         let identity = StreamIdentity {
             session_id: packet.header.session_id,
             sender_id: packet.header.sender_id,
@@ -286,6 +297,9 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
             Some(i) => i,
             None if (packet.header.fec_scheme == FecScheme::RaptorQ
                 && packet.header.lane == Lane::Control)
+                || (packet.header.lane == Lane::StructuredLog
+                    && packet.header.record_kind == crate::RecordKind::StructuredLog
+                    && packet.header.fec_scheme == FecScheme::RaptorQ)
                 || (packet.header.lane == Lane::ReplayCritical
                     && packet.header.record_kind == crate::RecordKind::CopperList) =>
             {
@@ -302,6 +316,12 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
                         Lane::Control,
                         self.limits.finite_objects,
                     )?,
+                    structured: FiniteObjectDecoder::new(
+                        identity,
+                        Lane::StructuredLog,
+                        self.limits.finite_objects,
+                    )?,
+                    structured_seen: None,
                     manifest: None,
                     startup: VecDeque::with_capacity(self.limits.max_startup_packets),
                     recovery: Vec::with_capacity(self.limits.max_recovery_records),
@@ -322,7 +342,16 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
         };
         self.sessions[index].received_bytes += datagram.len() as u64;
         self.sessions[index].received_packets += 1;
-        if packet.header.fec_scheme == FecScheme::RaptorQ {
+        if packet.header.lane == Lane::StructuredLog {
+            if self.sessions[index].manifest.is_some() {
+                self.sessions[index].structured.receive_packet(packet)?;
+                if let Some(record) = self.sessions[index].structured.pop_record() {
+                    self.receive_object(index, record)?;
+                }
+            } else {
+                self.buffer_startup(index, datagram);
+            }
+        } else if packet.header.fec_scheme == FecScheme::RaptorQ {
             self.sessions[index].finite.receive_packet(packet)?;
             if let Some(record) = self.sessions[index].finite.pop_record() {
                 self.receive_object(index, record)?;
@@ -330,20 +359,24 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
         } else if self.sessions[index].continuous.is_some() {
             Self::receive_continuous(&mut self.sessions[index], packet, &mut emit)?;
         } else {
-            self.stats.datagrams_before_manifest += 1;
-            let startup = &mut self.sessions[index].startup;
-            if datagram.len() <= MAX_SYMBOL_SIZE + crate::PACKET_HEADER_LEN
-                && startup.len() < self.limits.max_startup_packets
-            {
-                startup.push_back(datagram.to_vec());
-            } else {
-                self.stats.startup_packets_dropped += 1;
-            }
+            self.buffer_startup(index, datagram);
         }
         self.drain_events(&mut emit)
     }
     /// Retries pending delivery without cloning encoded records. A consumer error
     /// retains the same bytes until a later call succeeds.
+    fn buffer_startup(&mut self, index: usize, datagram: &[u8]) {
+        self.stats.datagrams_before_manifest += 1;
+        let startup = &mut self.sessions[index].startup;
+        if datagram.len() <= MAX_SYMBOL_SIZE + crate::PACKET_HEADER_LEN
+            && startup.len() < self.limits.max_startup_packets
+        {
+            startup.push_back(datagram.to_vec());
+        } else {
+            self.stats.startup_packets_dropped += 1;
+        }
+    }
+
     pub fn drain_events<E>(
         &mut self,
         emit: &mut impl FnMut(SessionEventRef<'_>) -> core::result::Result<(), E>,
@@ -406,11 +439,15 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
                 .position(|session| session.continuous.is_some() && !session.startup.is_empty())
             {
                 let packet = self.sessions[index].startup.pop_front().unwrap();
-                Self::receive_continuous(
-                    &mut self.sessions[index],
-                    WirePacketRef::decode(&packet)?,
-                    emit,
-                )?;
+                let decoded = WirePacketRef::decode(&packet)?;
+                if decoded.header.lane == Lane::StructuredLog {
+                    self.sessions[index].structured.receive_packet(decoded)?;
+                    if let Some(record) = self.sessions[index].structured.pop_record() {
+                        self.receive_object(index, record)?;
+                    }
+                } else {
+                    Self::receive_continuous(&mut self.sessions[index], decoded, emit)?;
+                }
                 continue;
             }
             for index in 0..self.sessions.len() {
@@ -470,6 +507,32 @@ impl<const MAX_SYMBOL_SIZE: usize, const MAX_WINDOW_SYMBOLS: usize, const MAX_EQ
     }
 
     fn receive_object(&mut self, index: usize, mut record: RecoveredRecord) -> Result<()> {
+        if record.decoded().kind == crate::RecordKind::StructuredLog {
+            // Accept reordered records inside a fixed 64-record window and suppress
+            // late duplicates even after the finite decoder evicts its object cache.
+            let id = record.decoded().object_id;
+            let seen = self.sessions[index].structured_seen;
+            let updated = match seen {
+                None => (id, 1),
+                Some((latest, bits)) if id > latest => (
+                    id,
+                    bits.checked_shl((id - latest).min(64) as u32).unwrap_or(0) | 1,
+                ),
+                Some((latest, bits)) => {
+                    let age = latest - id;
+                    if age >= 64 || bits & (1 << age) != 0 {
+                        return Ok(());
+                    }
+                    (latest, bits | (1 << age))
+                }
+            };
+            self.push_event(PendingEvent::Object {
+                identity: self.sessions[index].identity,
+                record,
+            })?;
+            self.sessions[index].structured_seen = Some(updated);
+            return Ok(());
+        }
         if record.decoded().kind == crate::RecordKind::Manifest {
             if let Some(existing) = &self.sessions[index].manifest {
                 if existing.record.decoded().digest != record.decoded().digest {

--- a/core/cu29_logstream/src/structured.rs
+++ b/core/cu29_logstream/src/structured.rs
@@ -1,0 +1,221 @@
+//! Static structured-log fan-out at the local encoder's byte boundary.
+
+use bincode::{
+    Encode,
+    enc::{Encoder, EncoderImpl, write::Writer},
+    error::EncodeError,
+};
+use cu29_log::CuLogEntry;
+use cu29_traits::{CuResult, WriteStream};
+use cu29_unifiedlog::{LogStream, SectionStorage, UnifiedLogWrite};
+use std::{cell::RefCell, fmt::Debug};
+
+/// Statically composed destinations for one local serialization attempt.
+/// A local section rollover starts a fresh attempt; only successful local writes
+/// are committed. Destination overflow must not fail the local write.
+pub trait StructuredLogOutput: Debug + Send + Sync {
+    fn begin(&mut self);
+    fn write(&mut self, bytes: &[u8]);
+    fn finish(&mut self, success: bool);
+}
+
+impl StructuredLogOutput for () {
+    fn begin(&mut self) {}
+    fn write(&mut self, _: &[u8]) {}
+    fn finish(&mut self, _: bool) {}
+}
+impl<O: StructuredLogOutput> StructuredLogOutput for Option<O> {
+    fn begin(&mut self) {
+        if let Some(output) = self {
+            output.begin();
+        }
+    }
+    fn write(&mut self, bytes: &[u8]) {
+        if let Some(output) = self {
+            output.write(bytes);
+        }
+    }
+    fn finish(&mut self, success: bool) {
+        if let Some(output) = self {
+            output.finish(success);
+        }
+    }
+}
+impl<A: StructuredLogOutput, B: StructuredLogOutput> StructuredLogOutput for (A, B) {
+    fn begin(&mut self) {
+        self.0.begin();
+        self.1.begin();
+    }
+    fn write(&mut self, bytes: &[u8]) {
+        self.0.write(bytes);
+        self.1.write(bytes);
+    }
+    fn finish(&mut self, success: bool) {
+        self.0.finish(success);
+        self.1.finish(success);
+    }
+}
+
+/// Copies locally encoded bytes into bounded destination buffers during the
+/// existing serialization pass. Framing, hashing and FEC run on sender workers.
+/// Local errors propagate; streamed overflow leaves the local record intact.
+pub struct StructuredLogStream<S: SectionStorage, L: UnifiedLogWrite<S>, O> {
+    local: LogStream<S, L>,
+    outputs: O,
+}
+impl<S: SectionStorage, L: UnifiedLogWrite<S>, O: StructuredLogOutput>
+    StructuredLogStream<S, L, O>
+{
+    pub fn new(local: LogStream<S, L>, outputs: O) -> Self {
+        Self { local, outputs }
+    }
+}
+impl<S: SectionStorage, L: UnifiedLogWrite<S>, O: Debug> Debug for StructuredLogStream<S, L, O> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StructuredLogStream")
+            .field("local", &self.local)
+            .field("outputs", &self.outputs)
+            .finish()
+    }
+}
+impl<S: SectionStorage, L: UnifiedLogWrite<S>, O: StructuredLogOutput> WriteStream<CuLogEntry>
+    for StructuredLogStream<S, L, O>
+{
+    fn log(&mut self, entry: &CuLogEntry) -> CuResult<()> {
+        let captured = CapturedEntry {
+            entry,
+            outputs: RefCell::new(&mut self.outputs),
+        };
+        let result = self.local.log(&captured);
+        self.outputs.finish(result.is_ok());
+        result
+    }
+    fn flush(&mut self) -> CuResult<()> {
+        <LogStream<S, L> as WriteStream<CuLogEntry>>::flush(&mut self.local)
+    }
+    fn last_log_bytes(&self) -> Option<usize> {
+        <LogStream<S, L> as WriteStream<CuLogEntry>>::last_log_bytes(&self.local)
+    }
+}
+
+struct CapturedEntry<'a, O> {
+    entry: &'a CuLogEntry,
+    outputs: RefCell<&'a mut O>,
+}
+impl<O: StructuredLogOutput> Encode for CapturedEntry<'_, O> {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        let mut outputs = self.outputs.borrow_mut();
+        outputs.begin();
+        let config = *encoder.config();
+        let writer = CapturingWriter {
+            local: encoder.writer(),
+            outputs: &mut **outputs,
+        };
+        self.entry.encode(&mut EncoderImpl::new(writer, config))
+    }
+}
+struct CapturingWriter<'a, W, O> {
+    local: &'a mut W,
+    outputs: &'a mut O,
+}
+impl<W: Writer, O: StructuredLogOutput> Writer for CapturingWriter<'_, W, O> {
+    fn write(&mut self, bytes: &[u8]) -> Result<(), EncodeError> {
+        self.local.write(bytes)?;
+        self.outputs.write(bytes);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cu29_log::CuLogLevel;
+    use cu29_traits::UnifiedLogType;
+    use cu29_unifiedlog::{NoopLogger, NoopSectionStorage};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Debug, Default)]
+    struct Observation {
+        attempts: usize,
+        commits: usize,
+        bytes: Vec<u8>,
+    }
+    #[derive(Debug)]
+    struct Probe(Arc<Mutex<Observation>>);
+    impl StructuredLogOutput for Probe {
+        fn begin(&mut self) {
+            let mut seen = self.0.lock().unwrap();
+            seen.attempts += 1;
+            seen.bytes.clear();
+        }
+        fn write(&mut self, bytes: &[u8]) {
+            self.0.lock().unwrap().bytes.extend_from_slice(bytes);
+        }
+        fn finish(&mut self, success: bool) {
+            self.0.lock().unwrap().commits += usize::from(success);
+        }
+    }
+
+    #[test]
+    fn static_fanout_observes_one_native_serialization_and_preserves_byte_accounting() {
+        let first = Arc::new(Mutex::new(Observation::default()));
+        let second = Arc::new(Mutex::new(Observation::default()));
+        let local = LogStream::<NoopSectionStorage, _>::new(
+            UnifiedLogType::StructuredLogLine,
+            Arc::new(Mutex::new(NoopLogger::new())),
+            1024,
+        )
+        .unwrap();
+        let mut sink =
+            StructuredLogStream::new(local, (Probe(first.clone()), Some(Probe(second.clone()))));
+        let mut entry = CuLogEntry::new(47, CuLogLevel::Info);
+        entry.paramname_indexes.push(0);
+        entry.params.push(cu29_value::Value::U64(42));
+        let canonical = bincode::encode_to_vec(&entry, bincode::config::standard()).unwrap();
+        sink.log(&entry).unwrap();
+        assert_eq!(sink.last_log_bytes(), Some(canonical.len()));
+        for observation in [first, second] {
+            let seen = observation.lock().unwrap();
+            assert_eq!(seen.attempts, 1);
+            assert_eq!(seen.commits, 1);
+            assert_eq!(seen.bytes, canonical);
+        }
+    }
+    #[test]
+    fn section_rollover_commits_only_the_complete_retry() {
+        use cu29_unifiedlog::{UnifiedLogger, UnifiedLoggerBuilder};
+        let seen = Arc::new(Mutex::new(Observation::default()));
+        let logs = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../examples/cu_logstream_demo/logs");
+        std::fs::create_dir_all(&logs).unwrap();
+        let path = logs.join(format!("structured-rollover-{}.copper", std::process::id()));
+        let UnifiedLogger::Write(logger) = UnifiedLoggerBuilder::new()
+            .file_base_name(&path)
+            .preallocated_size(1024 * 1024)
+            .write(true)
+            .create(true)
+            .build()
+            .unwrap()
+        else {
+            panic!("writer")
+        };
+        let local = LogStream::new(
+            UnifiedLogType::StructuredLogLine,
+            Arc::new(Mutex::new(logger)),
+            1024,
+        )
+        .unwrap();
+        let mut sink = StructuredLogStream::new(local, Probe(seen.clone()));
+        for id in 1..=100 {
+            let entry = CuLogEntry::new(id, CuLogLevel::Info);
+            sink.log(&entry).unwrap();
+            assert_eq!(
+                seen.lock().unwrap().bytes,
+                bincode::encode_to_vec(&entry, bincode::config::standard()).unwrap()
+            );
+        }
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.commits, 100);
+        assert!(seen.attempts > 100, "local sections never rolled over");
+    }
+}

--- a/core/cu29_logstream/src/twin_session.rs
+++ b/core/cu29_logstream/src/twin_session.rs
@@ -39,6 +39,7 @@ pub struct CuTwinStatus {
     pub gaps: usize,
     pub packets: usize,
     pub archived: u64,
+    pub structured_logs: u64,
     pub identity: Option<StreamIdentity>,
     pub last_packet: Option<Instant>,
     pub state: CuTwinRecordingState,
@@ -109,6 +110,7 @@ impl<A: LiveReplay, R: CuStreamRx + 'static> CuTwinBuilder<A, R> {
                 .map_err(|e| CuError::new_with_cause("Create twin log directory", e))?;
         }
         let (publisher, reader) = telemetry_channel(self.frame_capacity, CuTwinStatus::default());
+        let (mut log_publisher, log_reader) = telemetry_channel(FRAME_CAPACITY, ());
         let stop = Arc::new(AtomicBool::new(false));
         let stopping = stop.clone();
         let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
@@ -170,7 +172,7 @@ impl<A: LiveReplay, R: CuStreamRx + 'static> CuTwinBuilder<A, R> {
                                     // Recovery objects can arrive before the manifest.
                                     // The router retains them and emits VerifiedRecoveryPoint
                                     // once their manifest/keyframe references agree.
-                                    if matches!(event, SessionEvent::Object { .. }) {
+                                    if matches!(&event, SessionEvent::Object { record, .. } if record.decoded().kind != crate::RecordKind::StructuredLog) {
                                         return Ok(());
                                     }
                                     if let SessionEvent::Manifest(manifest) = &event {
@@ -194,6 +196,14 @@ impl<A: LiveReplay, R: CuStreamRx + 'static> CuTwinBuilder<A, R> {
                                             "capture arrived before its manifest",
                                         ))?;
                                     let capture = writer.accept(&event)?;
+                                    if let Some(entry) = writer.take_structured_log() {
+                                        status.structured_logs += 1;
+                                        if let SessionEvent::Object { identity, record } = &event {
+                                            log_publisher.publish(ReceivedStructuredLog {
+                                                identity: *identity, sequence: record.decoded().object_id, entry,
+                                            });
+                                        }
+                                    }
                                     if let Some(capture) = &capture {
                                         status.latest = Some(capture.copperlist.id);
                                         status.archived += 1;
@@ -276,6 +286,7 @@ impl<A: LiveReplay, R: CuStreamRx + 'static> CuTwinBuilder<A, R> {
                 stop,
                 worker: Some(worker),
                 final_status: None,
+                log_reader: Some(log_reader),
                 app: PhantomData,
             },
             reader,
@@ -290,6 +301,17 @@ fn stream_error(error: crate::Error) -> CuError {
 /// Reader for a generated graph's reconstructed frames and recording status.
 pub type CuTwinReader<A> = TelemetryReader<TwinFrame<<A as LiveReplay>::DataSet>, CuTwinStatus>;
 
+/// One original robot log entry, published only after native archival succeeds.
+#[derive(Debug)]
+pub struct ReceivedStructuredLog {
+    pub identity: StreamIdentity,
+    pub sequence: u64,
+    pub entry: cu29_log::CuLogEntry,
+}
+
+/// Independent bounded log reader; a stalled reader never delays native recording.
+pub type CuTwinLogReader = TelemetryReader<ReceivedStructuredLog, ()>;
+
 /// Running Copper twin. The separately owned reader can be paused or dropped
 /// without affecting recording. `stop()` closes the archive and drains admitted
 /// replay; dropping the handle also stops and joins Copper's workers.
@@ -297,6 +319,7 @@ pub struct CuTwin<A: LiveReplay> {
     stop: Arc<AtomicBool>,
     worker: Option<JoinHandle<CuResult<CuTwinStatus>>>,
     final_status: Option<CuTwinStatus>,
+    log_reader: Option<CuTwinLogReader>,
     app: PhantomData<fn() -> A>,
 }
 
@@ -310,6 +333,12 @@ impl<A: LiveReplay> CuTwin<A> {
             reconstruct: true,
             app: PhantomData,
         }
+    }
+
+    /// Take the independent 64-entry log view once. Entries retain sender string IDs;
+    /// use the producing application's string index to render text.
+    pub fn take_log_reader(&mut self) -> Option<CuTwinLogReader> {
+        self.log_reader.take()
     }
 
     pub fn stop(&mut self) -> CuResult<CuTwinStatus> {

--- a/core/cu29_logstream/src/worker.rs
+++ b/core/cu29_logstream/src/worker.rs
@@ -32,6 +32,93 @@ use std::{
 
 const CL_BUFFERS: usize = 4;
 const KF_BUFFERS: usize = 2;
+const STRUCTURED_BUFFERS: usize = 4;
+use crate::pacing::STRUCTURED_RECORD_BYTES;
+
+struct StructuredRecord {
+    bytes: Box<[u8]>,
+    len: usize,
+    queued_at: CuTime,
+}
+
+struct StructuredInbox {
+    free: crossbeam_queue::ArrayQueue<StructuredRecord>,
+    pending: crossbeam_queue::ArrayQueue<StructuredRecord>,
+}
+
+/// A bounded destination for bytes produced by the local structured-log encoder.
+/// It does not own the sender thread: dropping the CL and keyframe sinks still
+/// drains and joins that worker, even while the global logger holds this sink.
+pub struct ScheduledStructuredLogSink {
+    inbox: Arc<StructuredInbox>,
+    status: Arc<Shared>,
+    thread: Thread,
+    clock: RobotClock,
+    current: Option<StructuredRecord>,
+    oversized: bool,
+}
+
+impl Debug for ScheduledStructuredLogSink {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScheduledStructuredLogSink")
+            .finish_non_exhaustive()
+    }
+}
+
+impl crate::structured::StructuredLogOutput for ScheduledStructuredLogSink {
+    fn begin(&mut self) {
+        if self.current.is_none()
+            && !self.status.stop.load(Ordering::Acquire)
+            && !self.status.failed.load(Ordering::Acquire)
+        {
+            self.current = self.inbox.free.pop();
+        }
+        if let Some(record) = &mut self.current {
+            record.len = crate::record::RECORD_HEADER_LEN;
+        }
+        self.oversized = false;
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        if let Some(record) = &mut self.current
+            && !self.oversized
+        {
+            if bytes.len() > record.bytes.len() - record.len {
+                self.oversized = true;
+            } else {
+                record.bytes[record.len..record.len + bytes.len()].copy_from_slice(bytes);
+                record.len += bytes.len();
+            }
+        }
+    }
+
+    fn finish(&mut self, success: bool) {
+        let record = self.current.take();
+        if !success
+            || self.oversized
+            || self.status.stop.load(Ordering::Acquire)
+            || self.status.failed.load(Ordering::Acquire)
+        {
+            if let Some(record) = record {
+                let _ = self.inbox.free.push(record);
+            }
+            if success {
+                self.status.inbox_drops.fetch_add(1, Ordering::Relaxed);
+            }
+        } else if let Some(mut record) = record {
+            record.queued_at = self.clock.now();
+            // Every owned buffer has a slot in the bounded pending queue.
+            if let Err(record) = self.inbox.pending.push(record) {
+                let _ = self.inbox.free.push(record);
+                self.status.inbox_drops.fetch_add(1, Ordering::Relaxed);
+            } else {
+                self.thread.unpark();
+            }
+        } else {
+            self.status.inbox_drops.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
 
 struct Record {
     bytes: Box<[u8]>,
@@ -162,10 +249,16 @@ impl Inbox {
 /// Encodes directly into a sender-owned buffer on the existing CL output worker.
 pub struct ScheduledCopperListSink<P: CopperListTuple> {
     inbox: Inbox,
+    structured: Option<ScheduledStructuredLogSink>,
     encoder: fn(&CopperList<P>, &mut [u8]) -> crate::Result<usize>,
     _payload: PhantomData<fn() -> P>,
 }
 impl<P: CopperListTuple> ScheduledCopperListSink<P> {
+    /// Take the optional structured-log handoff before installing the CL sink.
+    pub fn take_structured_log_sink(&mut self) -> Option<ScheduledStructuredLogSink> {
+        self.structured.take()
+    }
+
     /// Select the generated capture encoder before handing the sink to its output worker.
     pub fn with_encoder(
         mut self,
@@ -314,12 +407,18 @@ where
     let cl_bytes = config.continuous.max_record_bytes;
     let kf_bytes = usize::try_from(config.recovery.finite.max_object_bytes)
         .map_err(|_| CuError::from("Keyframe limit exceeds usize"))?;
+    let structured_bytes = kf_bytes.min(STRUCTURED_RECORD_BYTES);
     let reserved = cl_bytes
         .checked_mul(CL_BUFFERS)
         .and_then(|v| {
             kf_bytes
                 .checked_mul(KF_BUFFERS)
                 .and_then(|k| v.checked_add(k))
+        })
+        .and_then(|v| {
+            v.checked_add(
+                STRUCTURED_BUFFERS * (structured_bytes + 2 * size_of::<StructuredRecord>()),
+            )
         })
         .ok_or_else(|| CuError::from("Sender pool size overflow"))?;
     let shutdown_clock = if clock.is_mock() {
@@ -344,6 +443,19 @@ where
             .try_send(vec![0; kf_bytes].into_boxed_slice())
             .expect("new pool");
     }
+    let structured = Arc::new(StructuredInbox {
+        free: crossbeam_queue::ArrayQueue::new(STRUCTURED_BUFFERS),
+        pending: crossbeam_queue::ArrayQueue::new(STRUCTURED_BUFFERS),
+    });
+    for _ in 0..STRUCTURED_BUFFERS {
+        let _ = structured.free.push(StructuredRecord {
+            bytes: vec![0; structured_bytes].into_boxed_slice(),
+            len: 0,
+            queued_at: CuTime::default(),
+        });
+    }
+    let structured_worker = structured.clone();
+    let structured_clock = clock.clone();
     let cl_clock = clock.clone();
     let kf_clock = clock.clone();
     let shared = Arc::new(Shared::default());
@@ -363,6 +475,7 @@ where
             let mut feedback_failed = false;
             let mut next_snapshot = clock.now();
             let mut stop_at = None;
+            let mut structured_id = 0u64;
             // Teardown remains finite even for deliberately frozen scheduler test clocks.
             let result = (|| -> crate::Result<()> {
                 loop {
@@ -402,6 +515,18 @@ where
                         result?;
                         received += 1;
                     }
+                    for _ in 0..STRUCTURED_BUFFERS {
+                        let Some(mut record) = structured_worker.pending.pop() else { break; };
+                        let (header, payload) = record.bytes[..record.len].split_at_mut(crate::record::RECORD_HEADER_LEN);
+                        let result = crate::record::encode_record_header(
+                            crate::RecordKind::StructuredLog, structured_id, payload, header,
+                        ).and_then(|()| core.accept_record(&record.bytes[..record.len], record.queued_at));
+                        let _ = structured_worker.free.push(record);
+                        result?;
+                        structured_id = structured_id.checked_add(1)
+                            .ok_or(crate::Error::InvalidConfig("structured log sequence exhausted"))?;
+                        received += 1;
+                    }
                     let next = core.poll(clock.now(), &mut transport)?;
                     let now = clock.now();
                     if now >= next_snapshot {
@@ -435,7 +560,12 @@ where
                 }
                 Ok(())
             })();
+            status.failed.store(result.is_err(), Ordering::Release);
             core.discard_pending();
+            while let Some(record) = structured_worker.pending.pop() {
+                status.inbox_drops.fetch_add(1, Ordering::Relaxed);
+                let _ = structured_worker.free.push(record);
+            }
             let stats = core.stats();
             *status.final_stats.lock().expect("sender stats") = Some(stats);
             *status.snapshot.lock().expect("sender snapshot") = SenderSnapshot {
@@ -459,6 +589,14 @@ where
     });
     Ok((
         ScheduledCopperListSink {
+            structured: Some(ScheduledStructuredLogSink {
+                inbox: structured,
+                status: shared.clone(),
+                thread: worker.thread.clone(),
+                clock: structured_clock,
+                current: None,
+                oversized: false,
+            }),
             encoder: crate::encode_copperlist_record_into,
             inbox: Inbox {
                 clock: cl_clock,

--- a/core/cu29_logstream/tests/pacing.rs
+++ b/core/cu29_logstream/tests/pacing.rs
@@ -369,3 +369,38 @@ fn pending_transport_is_serviced_through_idle_and_shutdown() {
     assert_eq!(tx.remaining, 0);
     assert!(tx.completed > 0);
 }
+
+#[test]
+fn structured_pressure_preserves_replay_recovery_and_shared_budget() {
+    let (clock, mock) = RobotClock::mock();
+    let config = config();
+    let bitrate = config.pacing.bitrate_bps;
+    let mut core = SenderCore::new(config, clock.now(), 0).unwrap();
+    for id in 0..100 {
+        core.accept_record(
+            &encode_record(RecordKind::StructuredLog, id, &[42; 100]).unwrap(),
+            clock.now(),
+        )
+        .unwrap();
+    }
+    core.accept_record(&cl(0), clock.now()).unwrap();
+    core.accept_record(&kf(0), clock.now()).unwrap();
+    let mut tx = Capture::default();
+    advance(&mut core, &mut tx, &clock, &mock, 0, 1000);
+    for kind in [
+        RecordKind::CopperList,
+        RecordKind::KeyFrame,
+        RecordKind::StructuredLog,
+    ] {
+        assert!(
+            tx.packets
+                .iter()
+                .any(|(_, p)| WirePacketRef::decode(p).unwrap().header.record_kind == kind)
+        );
+    }
+    assert!(core.stats().queue_drops > 0);
+    assert!(core.stats().bytes_sent <= bitrate / 8 + 4 * 1200);
+    core.begin_shutdown();
+    core.discard_pending();
+    assert!(core.is_idle());
+}

--- a/core/cu29_logstream/tests/session_router.rs
+++ b/core/cu29_logstream/tests/session_router.rs
@@ -759,3 +759,276 @@ fn manifest_requirements_cannot_exceed_receiver_local_limits() {
     }
     assert!(router.session_manifest(identity).is_some());
 }
+
+#[cfg(feature = "std")]
+#[test]
+fn structured_logs_recover_before_manifest_and_archive_native_entries() {
+    use cu29_log::{CuLogEntry, CuLogLevel, CuLogOrigin};
+    use cu29_traits::UnifiedLogType;
+    use cu29_unifiedlog::{UnifiedLogRead, UnifiedLogger, UnifiedLoggerBuilder};
+    let (sender, mut router) = setup();
+    let mut entry = CuLogEntry::new(47, CuLogLevel::Warning);
+    entry.time = 123456.into();
+    entry.origin = CuLogOrigin {
+        culistid: Some(3),
+        component_id: Some(2),
+        task_index: Some(1),
+    };
+    entry.paramname_indexes.push(19);
+    entry.params.push(cu29_value::Value::U64(42));
+    let encoded = bincode::encode_to_vec(&entry, bincode::config::standard()).unwrap();
+    let record = encode_record(RecordKind::StructuredLog, 0, &encoded).unwrap();
+    let mut encoder = FiniteObjectEncoder::new(cu29_logstream::FiniteObjectSenderConfig {
+        lane: cu29_logstream::Lane::StructuredLog,
+        ..sender.recovery.finite
+    })
+    .unwrap();
+    let mut packets = Vec::new();
+    encoder.push_record(&record, &mut packets).unwrap();
+    let logs = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/cu_logstream_demo/logs");
+    std::fs::create_dir_all(&logs).unwrap();
+    let path = logs.join(format!("structured-receiver-{}.copper", std::process::id()));
+    let mut archive = None;
+    let mut received = 0;
+    // Lose the source and deliver a repair before discovery.
+    let repair = packets
+        .iter()
+        .find(|p| {
+            cu29_logstream::WirePacketRef::decode(p)
+                .unwrap()
+                .header
+                .symbol_kind
+                == cu29_logstream::FecSymbolKind::Repair
+        })
+        .unwrap();
+    router
+        .receive_datagram(repair, |_| Ok::<(), ()>(()))
+        .unwrap();
+    for packet in &objects(&sender, 0)[0] {
+        router
+            .receive_datagram(packet, |event| {
+                if let SessionEvent::Manifest(manifest) = &event {
+                    archive = Some(
+                        cu29_logstream::NativeArchive::<EmptyDataSet>::new(
+                            &path,
+                            manifest,
+                            1024 * 1024,
+                            64 * 1024,
+                        )
+                        .unwrap(),
+                    );
+                }
+                if let SessionEvent::Object { record, .. } = &event {
+                    assert_eq!(record.decoded().payload, encoded);
+                    received += 1;
+                }
+                archive.as_mut().unwrap().accept(&event).unwrap();
+                Ok::<(), ()>(())
+            })
+            .unwrap();
+    }
+    for packet in packets.iter().rev() {
+        router
+            .receive_datagram(packet, |_| {
+                received += 1;
+                Ok::<(), ()>(())
+            })
+            .unwrap();
+    }
+    assert_eq!(received, 1);
+    archive.unwrap().finish().unwrap();
+    let UnifiedLogger::Read(mut reader) = UnifiedLoggerBuilder::new()
+        .file_base_name(&path)
+        .build()
+        .unwrap()
+    else {
+        panic!("reader")
+    };
+    let bytes = reader
+        .read_next_section_type(UnifiedLogType::StructuredLogLine)
+        .unwrap()
+        .unwrap();
+    let (actual, used): (CuLogEntry, usize) =
+        bincode::decode_from_slice(&bytes, bincode::config::standard()).unwrap();
+    assert_eq!(actual, entry);
+    assert_eq!(used, bytes.len());
+}
+
+#[test]
+fn structured_logs_retry_and_deduplicate_beyond_finite_cache() {
+    let (sender, mut router) = setup();
+    for packet in &objects(&sender, 0)[0] {
+        router
+            .receive_datagram(packet, |_| Ok::<(), ()>(()))
+            .unwrap();
+    }
+    let mut encoder = FiniteObjectEncoder::new(cu29_logstream::FiniteObjectSenderConfig {
+        lane: cu29_logstream::Lane::StructuredLog,
+        ..sender.recovery.finite
+    })
+    .unwrap();
+    let mut first = Vec::new();
+    let mut seen = Vec::new();
+    for id in [0, 2, 1, 4, 3, 5] {
+        let mut packets = Vec::new();
+        encoder
+            .push_record(
+                &encode_record(RecordKind::StructuredLog, id, b"entry").unwrap(),
+                &mut packets,
+            )
+            .unwrap();
+        if id == 0 {
+            first = packets.clone();
+        }
+        let mut retry = true;
+        for packet in packets {
+            let result = router.receive_datagram(&packet, |event| {
+                if retry {
+                    retry = false;
+                    return Err(());
+                }
+                if let SessionEvent::Object { record, .. } = event {
+                    seen.push(record.decoded().object_id);
+                }
+                Ok(())
+            });
+            if result.is_err() {
+                router
+                    .drain_events(&mut |event| {
+                        if let SessionEvent::Object { record, .. } = event {
+                            seen.push(record.decoded().object_id);
+                        }
+                        Ok::<(), ()>(())
+                    })
+                    .unwrap();
+            }
+        }
+    }
+    for packet in first {
+        router
+            .receive_datagram(&packet, |_| {
+                panic!("duplicate delivered");
+                #[allow(unreachable_code)]
+                Ok::<(), ()>(())
+            })
+            .unwrap();
+    }
+    assert_eq!(seen, [0, 2, 1, 4, 3, 5]);
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn structured_handoff_allocates_nothing_preserves_local_logs_and_stops_without_logger_drop() {
+    use cu29_log::{CuLogEntry, CuLogLevel};
+    use cu29_traits::{UnifiedLogType, WriteStream};
+    use cu29_unifiedlog::{LogStream, UnifiedLogRead, UnifiedLogger, UnifiedLoggerBuilder};
+    use std::sync::{Arc, Mutex};
+    #[derive(Debug, Clone, Default)]
+    struct Capture(Arc<Mutex<Vec<Vec<u8>>>>);
+    impl cu29_logstream::CuStreamTx for Capture {
+        fn try_send(&mut self, packet: &[u8]) -> Result<(), cu29_logstream::CuStreamTxError> {
+            self.0.lock().unwrap().push(packet.to_vec());
+            Ok(())
+        }
+    }
+    let mut destination = destination();
+    destination.max_record_bytes = 4096;
+    destination.fec.objects.max_object_bytes = 4096;
+    let config = LogStreamPlan::resolve(&destination)
+        .unwrap()
+        .sender_config(
+            setup().0.continuous.identity,
+            ApplicationSchema {
+                outputs: vec![],
+                reconstruction: vec![],
+            },
+        )
+        .unwrap();
+    let captured = Capture::default();
+    let (mut cl, kf, monitor) = cu29_logstream::scheduled_sinks::<EmptyDataSet, _>(
+        captured.clone(),
+        config.clone(),
+        cu29_clock::RobotClock::new(),
+    )
+    .unwrap();
+    let stream = cl.take_structured_log_sink().unwrap();
+    assert!(cl.take_structured_log_sink().is_none());
+    let logs = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/cu_logstream_demo/logs");
+    std::fs::create_dir_all(&logs).unwrap();
+    let path = logs.join(format!("structured-handoff-{}.copper", std::process::id()));
+    let UnifiedLogger::Write(logger) = UnifiedLoggerBuilder::new()
+        .file_base_name(&path)
+        .preallocated_size(1024 * 1024)
+        .write(true)
+        .create(true)
+        .build()
+        .unwrap()
+    else {
+        panic!("writer")
+    };
+    let local = LogStream::new(
+        UnifiedLogType::StructuredLogLine,
+        Arc::new(Mutex::new(logger)),
+        65536,
+    )
+    .unwrap();
+    let mut sink = cu29_logstream::StructuredLogStream::new(local, stream);
+    let mut entry = CuLogEntry::new(47, CuLogLevel::Info);
+    entry.paramname_indexes.push(0);
+    entry.params.push(cu29_value::Value::U64(42));
+    assert_eq!(count_allocations(|| sink.log(&entry).unwrap()), 0);
+    let mut oversized = CuLogEntry::new(48, CuLogLevel::Warning);
+    for _ in 0..700 {
+        oversized.paramname_indexes.push(0);
+        oversized.params.push(cu29_value::Value::U64(u64::MAX));
+    }
+    assert_eq!(count_allocations(|| sink.log(&oversized).unwrap()), 0);
+    assert_eq!(monitor.inbox_drops(), 1);
+    // The logger still owns the structured handoff when output teardown joins.
+    drop((cl, kf));
+    assert!(monitor.final_stats().is_some());
+    assert!(!monitor.failed());
+    assert_eq!(count_allocations(|| sink.log(&entry).unwrap()), 0);
+    assert_eq!(monitor.inbox_drops(), 2);
+    drop(sink);
+    let mut decoder = cu29_logstream::FiniteObjectDecoder::new(
+        config.continuous.identity,
+        cu29_logstream::Lane::StructuredLog,
+        FiniteObjectLimits::new(4096, 1128, 4),
+    )
+    .unwrap();
+    let mut received = Vec::new();
+    for packet in captured.0.lock().unwrap().iter() {
+        decoder
+            .receive_datagram(packet, |record| {
+                received.push(record.decoded().payload.to_vec());
+                Ok::<(), ()>(())
+            })
+            .unwrap();
+    }
+    assert_eq!(
+        received,
+        [bincode::encode_to_vec(&entry, bincode::config::standard()).unwrap()]
+    );
+    let UnifiedLogger::Read(mut reader) = UnifiedLoggerBuilder::new()
+        .file_base_name(&path)
+        .build()
+        .unwrap()
+    else {
+        panic!("reader")
+    };
+    let bytes = reader
+        .read_next_section_type(UnifiedLogType::StructuredLogLine)
+        .unwrap()
+        .unwrap();
+    let mut remaining = bytes.as_slice();
+    for expected in [&entry, &oversized, &entry] {
+        let (actual, used): (CuLogEntry, usize) =
+            bincode::decode_from_slice(remaining, bincode::config::standard()).unwrap();
+        assert_eq!(&actual, expected);
+        remaining = &remaining[used..];
+    }
+    assert!(remaining.is_empty());
+}

--- a/examples/cu_logstream_demo/Cargo.toml
+++ b/examples/cu_logstream_demo/Cargo.toml
@@ -14,7 +14,7 @@ verify-reconstruction = ["demo", "cu29/logstream-verify"]
 # Keep async runtime features out of ordinary workspace builds.
 demo = ["cu29/logstream", "cu29/reflect", "dep:cu-transform"]
 replay = ["demo", "cu29/remote-debug"]
-tui = ["demo", "dep:ratatui"]
+tui = ["demo", "dep:ratatui", "dep:cu29-intern-strs"]
 sender-monitor = ["demo", "dep:cu-consolemon"]
 
 [[bin]]
@@ -42,6 +42,7 @@ cu29-export = { workspace = true }
 cu29-unifiedlog = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true }
+cu29-intern-strs = { workspace = true, optional = true }
 ratatui = { version = "0.30", optional = true }
 
 [build-dependencies]

--- a/examples/cu_logstream_demo/README.md
+++ b/examples/cu_logstream_demo/README.md
@@ -36,29 +36,41 @@ just run idle        # Recover even after captures stop
 
 Each automated run creates a fresh directory under this example's `logs/` and
 prints its path. Python 3 coordinates the processes; Rust verifies the received
-payloads, reconstructed outputs, and metadata against the onboard log.
+payloads, reconstructed outputs, metadata, and original structured entries against the onboard log.
 
 ## Native telemetry screen
 
-Start `just dashboard`, then `just sender` in another terminal. The sender runs
+Start `just telemetry`, then `just sender` in another terminal. The sender runs
 for about a minute. The screen shows captured shoulder/elbow angle traces and a
 robot arm drawn from locally reconstructed kinematics outputs. Its fingertip trail
 clears across gaps. **1** selects Live, **2** selects Health, and **Tab** cycles
 between them; arrow keys or **hjkl** scroll Health details.
+
+The **Robot logs · received over UDP** pane displays an `info!(ctx, ...)` entry
+from the robot once per second: `Simulated encoder health: temperature_c=… supply_mv=…`.
+These simulated temperature and supply-voltage diagnostics are carried only by
+structured logs; the task message carries joint angles.
+Only interned IDs and numeric values cross the link for this statement. The
+telemetry process reconstructs text with `cu29_log_index` beside its executable;
+`--log-index <path>` selects the producing build's index when running elsewhere.
+The received archive retains the original binary entries and task origin.
+Log display has its own bounded ring and missed-entry counter; **Space** pauses
+both display readers while recording continues. On very small terminals, the
+compact view prioritizes robot and recording status.
 
 The sender opens Copper's native task monitor with DAG, latency, bandwidth, and
 memory tabs. Automated scenarios remain headless.
 
 **Space** pauses the view; resume after a second to see missed display samples
 while recording continues. Network gaps and display misses have separate counters.
-**q**, Escape, or Ctrl-C closes the dashboard and finalizes its archive; it stays
+**q**, Escape, or Ctrl-C closes the telemetry and finalizes its archive; it stays
 open after the sender finishes.
 
-Sender, receiver, and dashboard replace logs at the selected base on each run.
+Sender, receiver, and telemetry replace logs at the selected base on each run.
 Choose different paths to retain earlier runs:
 
 ```sh
-just dashboard 127.0.0.1:7447 logs/dashboard-2.copper
+just telemetry 127.0.0.1:7447 logs/telemetry-2.copper
 # In another terminal:
 just sender 127.0.0.1:7447 logs/sender-2.copper
 ```
@@ -102,7 +114,7 @@ failure modes; they are demo machinery.
    report errors. Use a fresh archive path per sender session.
 3. **Consume frames in your UI or analysis loop.** Use `frames.wait_timeout(...)`,
    `frames.try_read()`, and `frames.status()` as in
-   [src/dashboard.rs](src/dashboard.rs). Read typed outputs through generated
+   [src/telemetry.rs](src/telemetry.rs). Read typed outputs through generated
    accessors such as `get_encoders_output()` / `get_kinematics_output()`, and account for `update.missed`.
    The display retains 64 frames by default; `.with_frame_capacity(...)` changes
    that bound. For recording alone, use `.archive_only()` before `.spawn()`.
@@ -117,7 +129,7 @@ failure modes; they are demo machinery.
 
 Skip `ImpairedRx`, `ImpairmentStats`, readiness files, scenario stop conditions,
 [run.py](run.py), and the demo's `verify` command when integrating. Ratatui and
-[src/dashboard.rs](src/dashboard.rs) are optional presentation code. Retain
+[src/telemetry.rs](src/telemetry.rs) are optional presentation code. Retain
 Copper's FEC (forward error correction) and recovery configuration: those handle
 real packet loss.
 
@@ -144,7 +156,7 @@ frames and replay output, not in that archive. Replay needs the matching
 application schema and a matching keyframe to resume across a gap. Remote debug
 uses Copper's standard replay CLI and creates separate outputs per session.
 
-To check reconstruction against the sender live, run `just dashboard-verify`
+To check reconstruction against the sender live, run `just telemetry-verify`
 and `just sender-verify` in separate terminals. These enable
 `cu29/logstream-verify` on both ends: optional digest traffic and comparison work
 label matching frames **Verified**. Ordinary runs label them **Reconstructed**.

--- a/examples/cu_logstream_demo/copperconfig.ron
+++ b/examples/cu_logstream_demo/copperconfig.ron
@@ -30,7 +30,7 @@
                 link: (
                     mtu_bytes: 1200,
                     bitrate_bps: 2000000,
-                    memory_budget_kib: 512,
+                    memory_budget_kib: 576,
                     max_latency_ms: 250,
                     burst_packets: 8,
                 ),

--- a/examples/cu_logstream_demo/justfile
+++ b/examples/cu_logstream_demo/justfile
@@ -11,14 +11,14 @@ build:
     cargo +stable build -p cu-logstream-demo --features replay --bins
 
 build-tui:
-    cargo +stable build -p cu-logstream-demo --features tui --bin cu-logstream-demo
+    cargo +stable build -p cu-logstream-demo --features tui,sender-monitor --bin cu-logstream-demo
 
 build-sender:
     cargo +stable build -p cu-logstream-demo --features replay,sender-monitor --bins
 
 # Start this first, then `just sender` in another terminal. Space pauses only the view.
-dashboard listen="127.0.0.1:7447" log="logs/dashboard.copper": build-tui
-    {{root}}/target/debug/cu-logstream-demo dashboard --listen {{listen}} --log-base {{log}}
+telemetry listen="127.0.0.1:7447" log="logs/telemetry.copper": build-tui
+    {{root}}/target/debug/cu-logstream-demo telemetry --listen {{listen}} --log-base {{log}}
 
 # Scenarios: clean, loss, outage, late, restart, idle, all.
 run scenario="clean": build
@@ -49,9 +49,9 @@ resim-debug log="logs/replay.copper" output="logs/replay.copper" debug_base="cop
     {{root}}/target/debug/cu-logstream-demo-resim --log-base {{log}} --replay-log-base {{output}} --debug-base {{debug_base}}
 
 # Developer-only per-output divergence checks; hashing stays on output workers.
-dashboard-verify listen="127.0.0.1:7447" log="logs/dashboard-verify.copper":
-    cargo +stable build -p cu-logstream-demo --features tui,verify-reconstruction --bin cu-logstream-demo
-    {{root}}/target/debug/cu-logstream-demo dashboard --listen {{listen}} --log-base {{log}}
+telemetry-verify listen="127.0.0.1:7447" log="logs/telemetry-verify.copper":
+    cargo +stable build -p cu-logstream-demo --features tui,verify-reconstruction,sender-monitor --bin cu-logstream-demo
+    {{root}}/target/debug/cu-logstream-demo telemetry --listen {{listen}} --log-base {{log}}
 
 sender-verify remote="127.0.0.1:7447" log="logs/sender-verify.copper" iterations="6000":
     cargo +stable build -p cu-logstream-demo --features tui,verify-reconstruction,sender-monitor --bin cu-logstream-demo

--- a/examples/cu_logstream_demo/run.py
+++ b/examples/cu_logstream_demo/run.py
@@ -43,7 +43,8 @@ def run(binary, scenario):
     def verify(name, expectation):
         wait(spawn("verify", "--sender", directory / "sender.copper", "--received",
                    directory / f"{name}.copper", "--expect", expectation,
-                   "--iterations", "1" if scenario == "idle" else "256"))
+                   "--iterations", "1" if scenario == "idle" else "256",
+                   *(["--require-robot-logs"] if scenario in ("clean", "loss") else [])))
 
     try:
         if scenario == "idle":

--- a/examples/cu_logstream_demo/src/lib.rs
+++ b/examples/cu_logstream_demo/src/lib.rs
@@ -90,3 +90,13 @@ pub fn read_keyframes(path: &std::path::Path) -> CuResult<Vec<cu29::curuntime::K
     ))
     .collect())
 }
+
+/// Read original robot entries from a local or received native archive.
+pub fn read_logs(path: &std::path::Path) -> CuResult<Vec<CuLogEntry>> {
+    cu29_export::structlog_reader(UnifiedLoggerIOReader::new(
+        UnifiedLoggerRead::new(path)
+            .map_err(|error| CuError::new_with_cause("Open structured log archive", error))?,
+        UnifiedLogType::StructuredLogLine,
+    ))
+    .collect()
+}

--- a/examples/cu_logstream_demo/src/main.rs
+++ b/examples/cu_logstream_demo/src/main.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "tui")]
-mod dashboard;
 mod receiver;
+#[cfg(feature = "tui")]
+mod telemetry_screen;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use cu_logstream_demo::{ITERATIONS, read_lists, tasks::JointAngles};
@@ -38,7 +38,7 @@ enum Command {
     Receiver(receiver::ReceiverOptions),
     /// Native telemetry screen; Space pauses only the reader, q closes recording.
     #[cfg(feature = "tui")]
-    Dashboard(receiver::ReceiverOptions),
+    Telemetry(receiver::ReceiverOptions),
     Verify {
         #[arg(long)]
         sender: PathBuf,
@@ -48,6 +48,9 @@ enum Command {
         expect: Expectation,
         #[arg(long, default_value_t = ITERATIONS)]
         iterations: u64,
+        /// Require every demonstrated robot log when the scenario preserves log packets.
+        #[arg(long)]
+        require_robot_logs: bool,
     },
 }
 
@@ -83,7 +86,13 @@ fn sender(remote: SocketAddr, path: &Path, iterations: u64, idle_ms: u64) -> Res
     Ok(())
 }
 
-fn verify(sender: &Path, received: &Path, expect: Expectation, iterations: u64) -> Result<()> {
+fn verify(
+    sender: &Path,
+    received: &Path,
+    expect: Expectation,
+    iterations: u64,
+    require_robot_logs: bool,
+) -> Result<()> {
     let onboard = read_lists(sender)?;
     let ground = read_lists(received)?;
     if onboard.len() as u64 != iterations || ground.is_empty() {
@@ -177,6 +186,26 @@ fn verify(sender: &Path, received: &Path, expect: Expectation, iterations: u64) 
             return Err(format!("Reconstructed output or sender metadata mismatch at {id}").into());
         }
     }
+    let onboard_logs = cu_logstream_demo::read_logs(sender)?;
+    let received_logs = cu_logstream_demo::read_logs(received)?;
+    for entry in &received_logs {
+        if !onboard_logs.contains(entry) {
+            return Err("Received structured log differs from the robot's original entry".into());
+        }
+    }
+    if require_robot_logs {
+        let robot_entries: Vec<_> = onboard_logs
+            .iter()
+            .filter(|entry| entry.origin.task_index == Some(0))
+            .collect();
+        if robot_entries.is_empty()
+            || robot_entries
+                .iter()
+                .any(|entry| !received_logs.contains(entry))
+        {
+            return Err("Missing streamed robot info! entries".into());
+        }
+    }
     let valid = match expect {
         Expectation::Complete => ground.len() == onboard.len() && gaps.is_empty(),
         Expectation::Outage => {
@@ -197,6 +226,10 @@ fn verify(sender: &Path, received: &Path, expect: Expectation, iterations: u64) 
         return Err(format!("Archive does not satisfy {expect:?}").into());
     }
     println!(
+        "Verified {} original robot structured logs.",
+        received_logs.len()
+    );
+    println!(
         "Verified {} received CopperLists against onboard payloads and timestamps; {} explicit gaps, {} verified recovery points ({expect:?}).",
         ground.len(),
         gaps.len(),
@@ -215,12 +248,13 @@ fn main() -> Result<()> {
         } => sender(remote, &log_base, iterations, idle_ms),
         Command::Receiver(options) => receiver::run(&options),
         #[cfg(feature = "tui")]
-        Command::Dashboard(options) => dashboard::run(options),
+        Command::Telemetry(options) => telemetry_screen::run(options),
         Command::Verify {
             sender,
             received,
             expect,
             iterations,
-        } => verify(&sender, &received, expect, iterations),
+            require_robot_logs,
+        } => verify(&sender, &received, expect, iterations, require_robot_logs),
     }
 }

--- a/examples/cu_logstream_demo/src/receiver.rs
+++ b/examples/cu_logstream_demo/src/receiver.rs
@@ -18,6 +18,9 @@ pub struct ReceiverOptions {
     pub listen: SocketAddr,
     #[arg(long)]
     pub log_base: PathBuf,
+    /// Producing application's string index for the telemetry log pane.
+    #[arg(long)]
+    pub log_index: Option<PathBuf>,
     /// Write the bound endpoint for the demo launcher.
     #[arg(long)]
     pub ready_file: Option<PathBuf>,
@@ -229,8 +232,11 @@ mod tests {
             };
             let (mut twin, reader) = builder.spawn().unwrap();
             let mut reader = Some(reader);
+            let mut log_reader = twin.take_log_reader();
+            assert!(twin.take_log_reader().is_none());
             if mode == "disconnected" {
                 drop(reader.take());
+                drop(log_reader.take());
             }
             std::thread::scope(|scope| {
                 let producer = scope.spawn(|| run_sender(address, &sender, COUNT, 0).unwrap());
@@ -257,6 +263,17 @@ mod tests {
             });
             let status = twin.stop().unwrap();
             assert_eq!(status.archived, COUNT);
+            assert!(status.structured_logs > 0);
+            let archived_logs = cu_logstream_demo::read_logs(&received).unwrap();
+            assert_eq!(archived_logs.len() as u64, status.structured_logs);
+            if let Some(reader) = &mut log_reader {
+                let mut received_entries = 0;
+                while let Some(update) = reader.try_read() {
+                    assert!(archived_logs.contains(&update.frame.entry));
+                    received_entries += 1;
+                }
+                assert!(received_entries > 0);
+            }
             assert_eq!(status.state, RecordingState::Closed);
             if mode == "stalled" {
                 let reader = reader.as_mut().unwrap();
@@ -264,7 +281,14 @@ mod tests {
                 assert_eq!(update.missed, COUNT - 4);
                 assert_eq!(update.frame.copperlist.id, COUNT - 4);
             }
-            crate::verify(&sender, &received, crate::Expectation::Complete, COUNT).unwrap();
+            crate::verify(
+                &sender,
+                &received,
+                crate::Expectation::Complete,
+                COUNT,
+                true,
+            )
+            .unwrap();
         }
     }
 }

--- a/examples/cu_logstream_demo/src/tasks.rs
+++ b/examples/cu_logstream_demo/src/tasks.rs
@@ -65,6 +65,15 @@ impl CuSrcTask for Encoders {
     fn process(&mut self, ctx: &CuContext, output: &mut Self::Output<'_>) -> CuResult<()> {
         let angles = JointAngles::at_tick(self.tick);
         output.set_payload(angles);
+        if self.tick.is_multiple_of(100) {
+            let sample = self.tick / 100;
+            let temperature_c = 35 + sample % 5;
+            let supply_mv = 3300 - (sample % 7) * 5;
+            info!(
+                ctx,
+                "Simulated encoder health: temperature_c={} supply_mv={}", temperature_c, supply_mv
+            );
+        }
         #[cfg(feature = "sender-monitor")]
         output.metadata.set_status(format_args!(
             "S:{:03}.{:02} E:{:03}.{:02}",

--- a/examples/cu_logstream_demo/src/telemetry_screen.rs
+++ b/examples/cu_logstream_demo/src/telemetry_screen.rs
@@ -26,6 +26,7 @@ use std::{
 const BUFFER_CAPACITY: usize = 64;
 const CHART_CAPACITY: usize = 120;
 const TRAIL_CAPACITY: usize = 1200; // One 12-second loop at 100 Hz, UI storage only.
+const LOG_CAPACITY: usize = 64;
 const UI_TICK: Duration = Duration::from_millis(50);
 
 // Official Catppuccin Mocha colors; omit teal, sky, and sapphire accents.
@@ -58,6 +59,8 @@ struct View {
     session: Option<cu29_logstream::StreamIdentity>,
     history: VecDeque<JointAngles>,
     trail: VecDeque<[f64; 2]>,
+    logs: VecDeque<(cu29::prelude::CuLogLevel, String)>,
+    logs_missed: u64,
 }
 
 impl View {
@@ -74,6 +77,56 @@ impl View {
             self.missed += update.missed;
             self.accept(frame);
         }
+    }
+
+    fn consume_logs(&mut self, reader: &mut cu29_logstream::CuTwinLogReader, strings: &[String]) {
+        if self.paused {
+            return;
+        }
+        for _ in 0..LOG_CAPACITY {
+            let Some(update) = reader.try_read() else {
+                break;
+            };
+            self.logs_missed += update.missed;
+            let entry = &update.frame.entry;
+            let text = cu29::prelude::rebuild_logline(strings, entry).unwrap_or_else(|error| {
+                format!("Cannot render robot log #{}: {error}", entry.msg_index)
+            });
+            if self.logs.len() == LOG_CAPACITY {
+                self.logs.pop_front();
+            }
+            self.logs.push_back((entry.level, text));
+        }
+    }
+
+    fn draw_logs(&self, frame: &mut ratatui::Frame<'_>, area: Rect, received: u64) {
+        let block = panel("Robot logs · received over UDP", BLUE).title_bottom(format!(
+            "Archived: {received} · view missed: {}",
+            self.logs_missed
+        ));
+        let height = block.inner(area).height as usize;
+        let lines: Vec<Line<'_>> = if self.logs.is_empty() {
+            vec![Line::from(Span::styled(
+                "Waiting for robot info! entries…",
+                Style::default().fg(MUTED),
+            ))]
+        } else {
+            self.logs
+                .iter()
+                .skip(self.logs.len().saturating_sub(height))
+                .map(|(level, text)| {
+                    use cu29::prelude::CuLogLevel;
+                    let color = match level {
+                        CuLogLevel::Debug => MUTED,
+                        CuLogLevel::Info => GREEN,
+                        CuLogLevel::Warning => YELLOW,
+                        CuLogLevel::Error | CuLogLevel::Critical => RED,
+                    };
+                    Line::from(Span::styled(text.as_str(), Style::default().fg(color)))
+                })
+                .collect()
+        };
+        frame.render_widget(Paragraph::new(lines).block(block), area);
     }
 
     fn accept(&mut self, frame: &Frame) {
@@ -206,7 +259,7 @@ impl View {
         ));
         if !compact {
             tab_spans.push(Span::styled(
-                " Copper · UDP ground station",
+                " Copper telemetry · remote robot",
                 Style::default().fg(FG),
             ));
         }
@@ -276,6 +329,15 @@ impl View {
             );
             return;
         }
+        let body = if body.height >= 10 {
+            let log_height = if compact { 4 } else { 6 };
+            let [body, logs] =
+                Layout::vertical([Constraint::Min(0), Constraint::Length(log_height)]).areas(body);
+            self.draw_logs(frame, logs, status.structured_logs);
+            body
+        } else {
+            body
+        };
         if compact {
             frame.render_widget(
                 Paragraph::new(vec![
@@ -629,14 +691,22 @@ fn age_metric(label: &str, age: Option<Duration>) -> Vec<Span<'static>> {
 pub fn run(options: ReceiverOptions) -> Result<()> {
     if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
         return Err(
-            "Dashboard needs a terminal; use the receiver command for headless recording".into(),
+            "Telemetry needs a terminal; use the receiver command for headless recording".into(),
         );
     }
+    let index_path = options
+        .log_index
+        .clone()
+        .unwrap_or(std::env::current_exe()?.with_file_name("cu29_log_index"));
+    let strings = cu29_intern_strs::read_interned_strings(&index_path)
+        .map_err(|error| format!("Read robot string index {}: {error}", index_path.display()))?;
     let (mut twin, mut reader, _) = receiver::start(&options)?;
+    let mut logs = twin.take_log_reader().expect("fresh twin log reader");
     let ui_result: std::io::Result<()> = ratatui::run(|terminal| {
         let mut view = View {
             history: VecDeque::with_capacity(CHART_CAPACITY),
             trail: VecDeque::with_capacity(TRAIL_CAPACITY),
+            logs: VecDeque::with_capacity(LOG_CAPACITY),
             ..Default::default()
         };
         let mut redraw = Instant::now();
@@ -662,6 +732,7 @@ pub fn run(options: ReceiverOptions) -> Result<()> {
                 }
             }
             view.consume(&mut reader);
+            view.consume_logs(&mut logs, &strings);
             let status = reader.status();
             if Instant::now() >= redraw {
                 terminal.draw(|frame| {
@@ -686,6 +757,63 @@ pub fn run(options: ReceiverOptions) -> Result<()> {
 mod tests {
     use super::*;
     use ratatui::{Terminal, backend::TestBackend};
+
+    #[test]
+    fn remote_log_pane_rebuilds_binary_entries_and_pause_keeps_recording_independent() {
+        use cu29::prelude::*;
+        use cu29_logstream::{ReceivedStructuredLog, StreamIdentity, telemetry::telemetry_channel};
+        let (mut publisher, mut reader) = telemetry_channel(2.try_into().unwrap(), ());
+        let mut entry = CuLogEntry::new(1, CuLogLevel::Info);
+        for value in [35u64, 3300] {
+            entry.paramname_indexes.push(0);
+            entry.params.push(cu29::prelude::to_value(value).unwrap());
+        }
+        let strings = vec![
+            String::new(),
+            "Simulated encoder health: temperature_c={} supply_mv={}".into(),
+        ];
+        publisher.publish(ReceivedStructuredLog {
+            identity: StreamIdentity {
+                session_id: [1; 16],
+                sender_id: 41,
+            },
+            sequence: 0,
+            entry,
+        });
+        let mut view = View {
+            paused: true,
+            ..Default::default()
+        };
+        view.consume_logs(&mut reader, &strings);
+        assert!(view.logs.is_empty());
+        view.paused = false;
+        view.consume_logs(&mut reader, &strings);
+        assert_eq!(view.logs.len(), 1);
+        let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
+        terminal
+            .draw(|frame| {
+                view.draw(
+                    frame,
+                    Status {
+                        structured_logs: 1,
+                        ..Default::default()
+                    },
+                    0,
+                    "logs/telemetry.copper",
+                )
+            })
+            .unwrap();
+        let screen: String = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(screen.contains("Robot logs · received over UDP"));
+        assert!(screen.contains("Simulated encoder health: temperature_c=35 supply_mv=3300"));
+        assert!(screen.contains("Archived: 1"));
+    }
 
     #[test]
     fn ages_highlight_at_first_visible_increase_and_clear_on_fresh_data() {

--- a/examples/cu_logstream_demo/tests/twin.rs
+++ b/examples/cu_logstream_demo/tests/twin.rs
@@ -454,7 +454,15 @@ fn sender_status_is_allocation_free_and_keeps_pose_local() {
     use cu_logstream_demo::tasks::{ArmPose, Encoders, JointAngles, Kinematics};
     use cu29::prelude::*;
 
+    let _serial = SERIAL.lock().unwrap();
     let (ctx, _clock) = CuContext::new_mock_clock();
+    let local = LogStream::new(
+        UnifiedLogType::StructuredLogLine,
+        std::sync::Arc::new(std::sync::Mutex::new(NoopLogger::new())),
+        4096,
+    )
+    .unwrap();
+    let _logger = LoggerRuntime::init(ctx.clock.clone(), local, None::<NullLog>);
     let mut encoders = Encoders::default();
     let mut kinematics = Kinematics;
     let mut angles = CuMsg::<JointAngles>::default();

--- a/justfile
+++ b/justfile
@@ -231,6 +231,14 @@ logstream-demo-check:
 	cargo +stable test -p cu29-runtime --test replay_primitives --features cu29/async-cl-io
 	just --justfile examples/cu_logstream_demo/justfile check
 
+# Structured-log binary handoff, generated wiring, archive isolation, and remote telemetry.
+logstream-structured-check:
+	cargo +stable test -p cu29-log --lib
+	cargo +stable check -p cu29-log --no-default-features
+	cargo +stable test -p cu29 --features logstream --test logstream_runtime --test logstream_configured_runtime --test logstream_sim_compile
+	just logstream-telemetry-check
+	just logstream-udp-check
+
 # Pull telemetry, reader overruns, archive isolation, and the native terminal UI.
 logstream-telemetry-check:
 	cargo +stable clippy -p cu29-logstream --all-targets -- --deny warnings


### PR DESCRIPTION
Structured `info!` entries now travel with the live log stream and appear in the remote telemetry log pane. The demo emits simulated encoder temperature and supply-voltage diagnostics once per second; task messages carry joint angles.

The sender copies the existing native serialization into bounded, preallocated per-destination buffers. Workers handle framing, hashing, FEC, and pacing; receivers archive original entries and publish an independent bounded log view. Message templates and parameter names remain interned IDs rendered using the sender build's local string index. Existing transmission headers are unchanged.

The demo command and recipes are renamed from `dashboard` to `telemetry`. Start `just telemetry`, then `just sender` in another terminal from `examples/cu_logstream_demo`.

Validation: `just fmt`, `just logstream-structured-check`, `just logstream-sender-check`, and an embedded `cu29 --no-default-features` check for `thumbv7em-none-eabihf`. Coverage includes zero producer allocations, native-byte archival, local section rollover, duplicate suppression, independent UI readers, and all six UDP loss/replay scenarios. The structured check was rerun after rebasing onto the transport-integrity changes on master.

Book documentation: https://github.com/copper-project/copper-rs-book/pull/65. The matching wiki edit is prepared locally.
