### PR TITLE
Demo two-way log streaming with visible robot feedback state

### DIFF
--- a/components/libs/cu_tuimon/src/stream_panel.rs
+++ b/components/libs/cu_tuimon/src/stream_panel.rs
@@ -65,6 +65,15 @@ pub(crate) fn rows(
     snapshot: LogStreamStats,
     rates: &StreamRates,
 ) -> Vec<Row<'static>> {
+    let (feedback_state, feedback_color) = match snapshot.feedback {
+        None => ("Disabled", palette::FOREGROUND),
+        Some(feedback) if feedback.failed => ("Failed", palette::LIGHT_RED),
+        Some(feedback) => match feedback.state {
+            LogStreamFeedbackState::Waiting => ("Waiting", palette::YELLOW),
+            LogStreamFeedbackState::Active => ("Active", palette::CYAN),
+            LogStreamFeedbackState::Stale => ("Stale", palette::YELLOW),
+        },
+    };
     let mut rows = vec![
         row(
             "Mode",
@@ -89,6 +98,7 @@ pub(crate) fn rows(
         } else {
             palette::CYAN
         })),
+        row("Feedback", feedback_state).style(Style::default().fg(feedback_color)),
         row(
             "Configured budget",
             format!("{} bit/s", monitor.bitrate_bps),
@@ -121,21 +131,7 @@ pub(crate) fn rows(
     if let Some(feedback) = snapshot.feedback {
         let active = feedback.state == LogStreamFeedbackState::Active && !feedback.failed;
         let current = |value: String| if active { value } else { "n/a".into() };
-        let feedback_state = if feedback.failed {
-            "Failed"
-        } else {
-            match feedback.state {
-                LogStreamFeedbackState::Waiting => "Waiting",
-                LogStreamFeedbackState::Active => "Active",
-                LogStreamFeedbackState::Stale => "Stale",
-            }
-        };
         rows.extend([
-            row("Feedback", feedback_state).style(Style::default().fg(if active {
-                palette::CYAN
-            } else {
-                palette::YELLOW
-            })),
             row(
                 "Report age",
                 feedback.age.map_or_else(

--- a/components/libs/cu_tuimon/src/ui.rs
+++ b/components/libs/cu_tuimon/src/ui.rs
@@ -1267,6 +1267,7 @@ mod tests {
         let text = stream_text(&mut ui, 132, 40);
         assert!(text.contains("Telemetry / TX: ground"));
         assert!(text.contains("One-way"));
+        assert!(text.contains("Disabled"));
         assert!(text.contains("12345"));
         assert!(text.contains("Queue drops"));
         assert!(!text.contains("RX BW"));
@@ -1333,7 +1334,7 @@ mod tests {
         let mut ui = MonitorUi::new(model, MonitorUiOptions::default());
         ui.set_active_screen(MonitorScreen::CopperList);
         ui.scroll(ScrollDirection::Right, 84);
-        ui.scroll(ScrollDirection::Down, 20);
+        ui.scroll(ScrollDirection::Down, 21);
         let text = stream_text(&mut ui, 42, 12);
         assert!(text.contains("Telemetry / TX: second"), "{text}");
         // Tiny terminal sizes and resizing clamp rather than overflow.

--- a/examples/cu_logstream_demo/Cargo.toml
+++ b/examples/cu_logstream_demo/Cargo.toml
@@ -16,6 +16,7 @@ demo = ["cu29/logstream", "cu29/reflect", "dep:cu-transform"]
 replay = ["demo", "cu29/remote-debug"]
 tui = ["demo", "dep:ratatui", "dep:cu29-intern-strs"]
 sender-monitor = ["demo", "dep:cu-consolemon"]
+feedback = ["demo"]
 
 [[bin]]
 name = "cu-logstream-demo"

--- a/examples/cu_logstream_demo/README.md
+++ b/examples/cu_logstream_demo/README.md
@@ -80,6 +80,45 @@ For a headless receiver, substitute
 without a datagram, or fails if no traffic arrives within 15 seconds. The final
 `just sender` argument optionally changes the default 6000 iterations.
 
+## Compare one-way and two-way streaming
+
+`just telemetry` and `just sender` run one-way. On the robot's **BW** tab,
+**Mode** is **One-way** and **Feedback** is **Disabled**.
+
+For two-way streaming, start these in separate terminals:
+
+```sh
+just telemetry-two-way
+just sender-two-way
+```
+
+The robot binds `127.0.0.1:7448`; telemetry listens on `127.0.0.1:7447` and sends
+receiver reports back to the robot. The `feedback` feature selects a statically
+wired reverse UDP resource from `feedbackconfig.ron`. The recipes build both
+processes with the matching feature set and string index.
+
+On the robot's **BW** tab, **Mode** becomes **Two-way**. **Feedback** starts at
+**Waiting**, becomes **Active** when reports arrive, and becomes **Stale** after
+one second without reports. Watch **Feedback reports**, **RX BW**, **Source loss**,
+and **FEC effective interval**. Healthy feedback gradually increases the interval
+above the baseline of four source symbols, sending fewer continuous repair
+packets. Closing telemetry makes feedback stale and restores baseline repairs;
+restart telemetry to see feedback become active again.
+
+To compare a lossy return-enabled run, use `just telemetry-two-way lossy` before
+`just sender-two-way`. It drops every tenth source packet on the receiver and
+keeps repair packets, exercising source-loss reports and FEC adaptation. Overall
+TX bandwidth also includes manifest and recovery-object traffic.
+
+`just run-two-way all` checks all seven headless scenarios and their native
+archives and replays. The sustained-loss check requires at least 90% of the run,
+the final CopperList, and explicit gap records for any missing history.
+
+The first `telemetry-two-way` argument selects impairment; subsequent arguments
+select the listen address, robot feedback address, and archive path. The
+`sender-two-way` arguments select remote address, robot bind address, archive
+path, and iteration count. Set both endpoints explicitly for separate machines.
+
 ## Use it in your application
 
 The reusable integration is the configured sender plus the generated twin

--- a/examples/cu_logstream_demo/feedbackconfig.ron
+++ b/examples/cu_logstream_demo/feedbackconfig.ron
@@ -1,5 +1,7 @@
 (
-    includes: [(path: "copperconfig.ron")],
+    includes: [
+        (path: "copperconfig.ron"),
+    ],
     log_streaming: (
         destinations: [
             (

--- a/examples/cu_logstream_demo/feedbackconfig.ron
+++ b/examples/cu_logstream_demo/feedbackconfig.ron
@@ -1,0 +1,47 @@
+(
+    includes: [(path: "copperconfig.ron")],
+    log_streaming: (
+        destinations: [
+            (
+                id: "ground",
+                transport: (
+                    type: "cu29_logstream_udp::CuUdpLogStreamTx",
+                    resource: "network.tx",
+                ),
+                feedback: (
+                    transport: (
+                        type: "cu29_logstream_udp::CuUdpLogStreamRx",
+                        resource: "network.rx",
+                    ),
+                    report_interval_ms: 100,
+                    timeout_ms: 1000,
+                    adaptation: (
+                        min_repair_every_source_symbols: 1,
+                        max_repair_every_source_symbols: 16,
+                    ),
+                ),
+                link: (
+                    mtu_bytes: 1200,
+                    bitrate_bps: 2000000,
+                    memory_budget_kib: 576,
+                    max_latency_ms: 250,
+                    burst_packets: 8,
+                ),
+                fec: (
+                    continuous: (
+                        field: Gf256,
+                        window_symbols: 64,
+                        repair_every_source_symbols: 4,
+                        repair_density: Full,
+                    ),
+                    objects: (
+                        max_object_bytes: 65536,
+                        repair_symbols_per_block: 2,
+                    ),
+                ),
+                recovery_interval: 16,
+                max_record_bytes: 4096,
+            ),
+        ],
+    ),
+)

--- a/examples/cu_logstream_demo/justfile
+++ b/examples/cu_logstream_demo/justfile
@@ -16,11 +16,26 @@ build-tui:
 build-sender:
     cargo +stable build -p cu-logstream-demo --features replay,sender-monitor --bins
 
+build-two-way:
+    cargo +stable build -p cu-logstream-demo --features replay,tui,sender-monitor,feedback --bins
+
+# Start this first, then `just sender-two-way`. Use `lossy` for ongoing source loss.
+telemetry-two-way impairment="clean" listen="127.0.0.1:7447" feedback_to="127.0.0.1:7448" log="logs/telemetry-two-way.copper": build-two-way
+    {{root}}/target/debug/cu-logstream-demo telemetry --listen {{listen}} --feedback-to {{feedback_to}} --impairment {{impairment}} --log-base {{log}}
+
+# Bind the robot endpoint named by telemetry's feedback_to argument.
+sender-two-way remote="127.0.0.1:7447" bind="127.0.0.1:7448" log="logs/sender-two-way.copper" iterations="6000": build-two-way
+    {{root}}/target/debug/cu-logstream-demo sender --remote {{remote}} --bind {{bind}} --log-base {{log}} --iterations {{iterations}}
+
+# Headless archive and replay checks with a real feedback return path.
+run-two-way scenario="clean": build-two-way
+    python3 run.py {{scenario}} --two-way --binary {{root}}/target/debug/cu-logstream-demo
+
 # Start this first, then `just sender` in another terminal. Space pauses only the view.
 telemetry listen="127.0.0.1:7447" log="logs/telemetry.copper": build-tui
     {{root}}/target/debug/cu-logstream-demo telemetry --listen {{listen}} --log-base {{log}}
 
-# Scenarios: clean, loss, outage, late, restart, idle, all.
+# Scenarios: clean, loss, lossy, outage, late, restart, idle, all.
 run scenario="clean": build
     python3 run.py {{scenario}} --binary {{root}}/target/debug/cu-logstream-demo
 

--- a/examples/cu_logstream_demo/run.py
+++ b/examples/cu_logstream_demo/run.py
@@ -3,18 +3,29 @@
 
 import argparse
 import pathlib
+import socket
 import subprocess
 import time
 
 HERE = pathlib.Path(__file__).resolve().parent
 
 
-def run(binary, scenario):
-    directory = HERE / "logs" / f"{scenario}-{time.time_ns()}"
+def run(binary, scenario, two_way=False):
+    mode = "two-way" if two_way else "one-way"
+    directory = HERE / "logs" / f"{mode}-{scenario}-{time.time_ns()}"
     directory.mkdir(parents=True)
     children = []
+    reservation = None
+    if two_way:
+        reservation = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        reservation.bind(("127.0.0.1", 0))
+        host, port = reservation.getsockname()
+        robot_address = f"{host}:{port}"
 
     def spawn(*args):
+        if two_way and args[0] == "sender":
+            reservation.close()
+            args = (*args, "--bind", robot_address)
         child = subprocess.Popen([str(binary), *map(str, args)], cwd=HERE)
         children.append(child)
         return child
@@ -28,6 +39,8 @@ def run(binary, scenario):
         ready = directory / f"{name}.endpoint"
         args = ["receiver", "--listen", listen, "--log-base", directory / f"{name}.copper",
                 "--ready-file", ready, "--impairment", impairment]
+        if two_way:
+            args += ["--feedback-to", robot_address]
         if stop:
             args += ["--stop-at", "64"]
         child = spawn(*args)
@@ -63,7 +76,7 @@ def run(binary, scenario):
             # This fresh process gets no archive or decoder state from the probe.
             ground, _ = receiver("received", address)
         else:
-            ground, address = receiver("received", impairment=scenario if scenario in ("loss", "outage") else "clean",
+            ground, address = receiver("received", impairment=scenario if scenario in ("loss", "lossy", "outage") else "clean",
                                        stop=scenario == "restart")
             sender = spawn("sender", "--remote", address, "--log-base", directory / "sender.copper")
         if scenario == "restart":
@@ -80,7 +93,7 @@ def run(binary, scenario):
         else:
             wait(sender)
             wait(ground)
-            verify("received", {"idle": "complete", "clean": "complete", "loss": "complete", "outage": "outage", "late": "late"}[scenario])
+            verify("received", {"idle": "complete", "clean": "complete", "loss": "complete", "lossy": "lossy", "outage": "outage", "late": "late"}[scenario])
             replay_names = ["received"]
 
         logreader = binary.with_name("cu-logstream-demo-logreader")
@@ -89,8 +102,10 @@ def run(binary, scenario):
             subprocess.run([str(logreader), str(directory / f"{name}.copper"), "fsck"], check=True, timeout=20, cwd=HERE)
             subprocess.run([str(replay), "--log-base", str(directory / f"{name}.copper"),
                             "--replay-log-base", str(directory / f"{name}-replay.copper")], check=True, timeout=20, cwd=HERE)
-        print(f"PASS {scenario}: {directory}", flush=True)
+        print(f"PASS {mode} {scenario}: {directory}", flush=True)
     finally:
+        if reservation is not None:
+            reservation.close()
         for child in children:
             if child.poll() is None:
                 child.terminate()
@@ -103,9 +118,10 @@ def run(binary, scenario):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("scenario", choices=["clean", "loss", "outage", "late", "restart", "idle", "all"], default="clean", nargs="?")
+    parser.add_argument("scenario", choices=["clean", "loss", "lossy", "outage", "late", "restart", "idle", "all"], default="clean", nargs="?")
     parser.add_argument("--binary", type=pathlib.Path, required=True)
+    parser.add_argument("--two-way", action="store_true", help="Return receiver reports to a feedback-enabled sender")
     args = parser.parse_args()
     binary = args.binary.resolve()
-    for scenario in (["clean", "loss", "outage", "late", "restart", "idle"] if args.scenario == "all" else [args.scenario]):
-        run(binary, scenario)
+    for scenario in (["clean", "loss", "lossy", "outage", "late", "restart", "idle"] if args.scenario == "all" else [args.scenario]):
+        run(binary, scenario, args.two_way)

--- a/examples/cu_logstream_demo/sender-feedbackconfig.ron
+++ b/examples/cu_logstream_demo/sender-feedbackconfig.ron
@@ -1,0 +1,4 @@
+(
+    includes: [(path: "feedbackconfig.ron")],
+    monitor: (type: "cu_consolemon::CuConsoleMon"),
+)

--- a/examples/cu_logstream_demo/sender-feedbackconfig.ron
+++ b/examples/cu_logstream_demo/sender-feedbackconfig.ron
@@ -1,4 +1,8 @@
 (
-    includes: [(path: "feedbackconfig.ron")],
-    monitor: (type: "cu_consolemon::CuConsoleMon"),
+    includes: [
+        (path: "feedbackconfig.ron"),
+    ],
+    monitor: (
+        type: "cu_consolemon::CuConsoleMon",
+    ),
 )

--- a/examples/cu_logstream_demo/src/lib.rs
+++ b/examples/cu_logstream_demo/src/lib.rs
@@ -7,12 +7,20 @@ pub mod telemetry;
 use cu29::prelude::*;
 
 #[cfg_attr(
-    feature = "sender-monitor",
+    all(feature = "sender-monitor", not(feature = "feedback")),
     copper_runtime(config = "senderconfig.ron")
 )]
 #[cfg_attr(
-    not(feature = "sender-monitor"),
+    all(not(feature = "sender-monitor"), not(feature = "feedback")),
     copper_runtime(config = "copperconfig.ron")
+)]
+#[cfg_attr(
+    all(feature = "sender-monitor", feature = "feedback"),
+    copper_runtime(config = "sender-feedbackconfig.ron")
+)]
+#[cfg_attr(
+    all(not(feature = "sender-monitor"), feature = "feedback"),
+    copper_runtime(config = "feedbackconfig.ron")
 )]
 struct Demo {}
 
@@ -48,7 +56,29 @@ pub fn run_sender(
     iterations: u64,
     idle_ms: u64,
 ) -> CuResult<()> {
+    run_sender_bound(
+        remote,
+        "127.0.0.1:0".parse().unwrap(),
+        path,
+        iterations,
+        idle_ms,
+    )
+}
+
+/// Bind the robot's UDP endpoint explicitly for a configured feedback return path.
+pub fn run_sender_bound(
+    remote: std::net::SocketAddr,
+    bind: std::net::SocketAddr,
+    path: &std::path::Path,
+    iterations: u64,
+    idle_ms: u64,
+) -> CuResult<()> {
     let mut config = CuConfig::deserialize_ron(&Demo::original_config())?;
+    config.resources[0]
+        .config
+        .as_mut()
+        .unwrap()
+        .set("bind_addr", bind.to_string());
     config.resources[0]
         .config
         .as_mut()

--- a/examples/cu_logstream_demo/src/main.rs
+++ b/examples/cu_logstream_demo/src/main.rs
@@ -27,6 +27,9 @@ enum Command {
     Sender {
         #[arg(long, default_value = "127.0.0.1:7447")]
         remote: SocketAddr,
+        /// Robot endpoint; use a fixed port when the receiver returns feedback.
+        #[arg(long, default_value = "127.0.0.1:0")]
+        bind: SocketAddr,
         #[arg(long)]
         log_base: PathBuf,
         #[arg(long, default_value_t = ITERATIONS, value_parser = clap::value_parser!(u64).range(1..))]
@@ -58,6 +61,8 @@ enum Command {
 enum Impairment {
     Clean,
     Loss,
+    /// Drop every tenth source packet to exercise ongoing FEC adaptation.
+    Lossy,
     Outage,
     Bootstrap,
 }
@@ -65,6 +70,7 @@ enum Impairment {
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum Expectation {
     Complete,
+    Lossy,
     Outage,
     Late,
     Prefix,
@@ -76,9 +82,15 @@ fn prepare_log(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn sender(remote: SocketAddr, path: &Path, iterations: u64, idle_ms: u64) -> Result<()> {
+fn sender(
+    remote: SocketAddr,
+    bind: SocketAddr,
+    path: &Path,
+    iterations: u64,
+    idle_ms: u64,
+) -> Result<()> {
     prepare_log(path)?;
-    cu_logstream_demo::run_sender(remote, path, iterations, idle_ms)?;
+    cu_logstream_demo::run_sender_bound(remote, bind, path, iterations, idle_ms)?;
     println!(
         "Sender finished {iterations} iterations: {}",
         path.display()
@@ -208,6 +220,9 @@ fn verify(
     }
     let valid = match expect {
         Expectation::Complete => ground.len() == onboard.len() && gaps.is_empty(),
+        Expectation::Lossy => {
+            ground.len() as u64 >= iterations - iterations / 10 && next == iterations
+        }
         Expectation::Outage => {
             !gaps.is_empty()
                 && gaps.iter().any(|&(first, _, _)| first > 0)
@@ -242,10 +257,11 @@ fn main() -> Result<()> {
     match Cli::parse().command {
         Command::Sender {
             remote,
+            bind,
             log_base,
             iterations,
             idle_ms,
-        } => sender(remote, &log_base, iterations, idle_ms),
+        } => sender(remote, bind, &log_base, iterations, idle_ms),
         Command::Receiver(options) => receiver::run(&options),
         #[cfg(feature = "tui")]
         Command::Telemetry(options) => telemetry_screen::run(options),

--- a/examples/cu_logstream_demo/src/receiver.rs
+++ b/examples/cu_logstream_demo/src/receiver.rs
@@ -16,6 +16,9 @@ use std::time::{Duration, Instant};
 pub struct ReceiverOptions {
     #[arg(long, default_value = "127.0.0.1:7447")]
     pub listen: SocketAddr,
+    /// Robot UDP endpoint for advisory receiver reports.
+    #[arg(long)]
+    pub feedback_to: Option<SocketAddr>,
     #[arg(long)]
     pub log_base: PathBuf,
     /// Producing application's string index for the telemetry log pane.
@@ -105,6 +108,7 @@ impl<R: CuStreamRx> CuStreamRx for ImpairedRx<R> {
         let discard = match self.impairment {
             Impairment::Clean => false,
             Impairment::Loss => source_id == Some(20),
+            Impairment::Lossy => source_id.is_some_and(|id| id.is_multiple_of(10)),
             Impairment::Outage => self.in_outage,
             Impairment::Bootstrap => now.duration_since(first) < Duration::from_millis(300),
         };
@@ -122,7 +126,8 @@ pub fn start(
     prepare_log(&options.log_base)?;
     let mut socket = CuUdpLogStreamConfig::new(options.listen);
     socket.recv_buffer_bytes = Some(262144);
-    let (_, rx) = socket.open()?;
+    socket.remote_addr = options.feedback_to;
+    let (feedback_tx, rx) = socket.open()?;
     let address = rx.local_addr()?;
     let stats = Arc::new(ImpairmentStats {
         started: Instant::now(),
@@ -138,6 +143,11 @@ pub fn start(
         in_outage: false,
     };
     let builder = Twin::twin(rx).with_log_path(&options.log_base);
+    let builder = if let Some(tx) = feedback_tx {
+        builder.with_feedback(tx)
+    } else {
+        builder
+    };
     let builder = if options.archive_only {
         builder.archive_only()
     } else {

--- a/examples/cu_logstream_demo/tests/feedback.rs
+++ b/examples/cu_logstream_demo/tests/feedback.rs
@@ -1,0 +1,140 @@
+#![cfg(feature = "feedback")]
+
+use cu29::monitoring::{LogStreamFeedbackState, LogStreamMonitor, LogStreamStats};
+use cu29::prelude::*;
+use cu29_logstream::{CuFeedbackTx, CuStreamTxError};
+use cu29_logstream_udp::{CuUdpLogStreamConfig, CuUdpLogStreamTx};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::time::{Duration, Instant};
+
+thread_local! {
+    static STREAMS: std::cell::RefCell<Option<Arc<[LogStreamMonitor]>>> = const { std::cell::RefCell::new(None) };
+}
+
+struct StreamProbe;
+impl CuMonitor for StreamProbe {
+    fn new(_: CuMonitoringMetadata, runtime: CuMonitoringRuntime) -> CuResult<Self> {
+        STREAMS.with(|streams| *streams.borrow_mut() = runtime.log_streams());
+        Ok(Self)
+    }
+    fn process_copperlist(&self, _: &CuContext, _: CopperListView<'_>) -> CuResult<()> {
+        Ok(())
+    }
+    fn process_error(&self, _: ComponentId, _: CuComponentState, _: &CuError) -> Decision {
+        Decision::Shutdown
+    }
+}
+
+#[copper_runtime(config = "tests/feedbackconfig.ron")]
+struct FeedbackDemo {}
+
+#[derive(Debug)]
+struct ReturnPath {
+    tx: CuUdpLogStreamTx,
+    enabled: Arc<AtomicBool>,
+}
+impl CuFeedbackTx for ReturnPath {
+    fn try_send_feedback(&mut self, packet: &[u8]) -> Result<(), CuStreamTxError> {
+        if self.enabled.load(Ordering::Relaxed) {
+            self.tx.try_send_feedback(packet)
+        } else {
+            Err(CuStreamTxError::WouldBlock)
+        }
+    }
+}
+
+#[test]
+fn real_receiver_feedback_changes_robot_stats_and_stale_feedback_restores_baseline() {
+    let logs = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("logs");
+    std::fs::create_dir_all(&logs).unwrap();
+    let directory = tempfile::tempdir_in(logs).unwrap();
+    let reservation = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    let sender_address = reservation.local_addr().unwrap();
+    let mut ground = CuUdpLogStreamConfig::new("127.0.0.1:0".parse().unwrap());
+    ground.remote_addr = Some(sender_address);
+    let (tx, rx) = ground.open().unwrap();
+    let mut config = CuConfig::deserialize_ron(&FeedbackDemo::original_config()).unwrap();
+    let resource = config.resources[0].config.as_mut().unwrap();
+    resource.set("bind_addr", sender_address.to_string());
+    resource.set("remote_addr", rx.local_addr().unwrap().to_string());
+    drop(reservation);
+    let app = FeedbackDemo::builder()
+        .with_config(config)
+        .with_log_path(
+            directory.path().join("sender.copper"),
+            Some(cu_logstream_demo::SLAB_BYTES),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+    let monitor = STREAMS.with(|streams| streams.borrow().as_ref().unwrap()[0].clone());
+    let return_path = Arc::new(AtomicBool::new(false));
+    let (mut twin, mut reader) = cu_logstream_demo::twin::Twin::twin(rx)
+        .with_feedback(ReturnPath {
+            tx: tx.unwrap(),
+            enabled: return_path.clone(),
+        })
+        .with_log_path(directory.path().join("received.copper"))
+        .spawn()
+        .unwrap();
+    let mut running = app.start().unwrap();
+    let mut until = |ready: &dyn Fn(LogStreamStats) -> bool| {
+        let deadline = Instant::now() + Duration::from_secs(8);
+        loop {
+            running.run_one_iteration().unwrap();
+            std::thread::sleep(Duration::from_millis(10));
+            let snapshot = monitor.snapshot();
+            if ready(snapshot) {
+                break snapshot;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "feedback transition timed out: {snapshot:?}"
+            );
+        }
+    };
+    let waiting = until(&|s| s.packets_sent > 0 && s.feedback.is_some());
+    assert_eq!(
+        waiting.feedback.unwrap().state,
+        LogStreamFeedbackState::Waiting
+    );
+    assert_eq!(waiting.feedback.unwrap().reports, 0);
+    return_path.store(true, Ordering::Relaxed);
+    let active = until(&|s| {
+        s.feedback.is_some_and(|f| {
+            f.state == LogStreamFeedbackState::Active
+                && f.rates_available
+                && f.source_metrics_available
+                && f.effective_repair_every_source_symbols > 4
+        })
+    });
+    assert!(active.feedback.unwrap().bytes_per_second > 0);
+    assert!(reader.status().feedback_reports_sent > 0);
+    let archived = reader.status().archived;
+    return_path.store(false, Ordering::Relaxed);
+    let stale = until(&|s| {
+        s.feedback
+            .is_some_and(|f| f.state == LogStreamFeedbackState::Stale)
+    });
+    assert_eq!(
+        stale
+            .feedback
+            .unwrap()
+            .effective_repair_every_source_symbols,
+        4
+    );
+    assert!(stale.packets_sent > active.packets_sent);
+    assert!(reader.status().archived > archived);
+    return_path.store(true, Ordering::Relaxed);
+    until(&|s| {
+        s.feedback
+            .is_some_and(|f| f.state == LogStreamFeedbackState::Active)
+    });
+    drop(running.stop().unwrap());
+    let status = twin.stop().unwrap();
+    assert!(!status.feedback_failed);
+    assert!(status.archived > 0);
+}

--- a/examples/cu_logstream_demo/tests/feedbackconfig.ron
+++ b/examples/cu_logstream_demo/tests/feedbackconfig.ron
@@ -1,0 +1,4 @@
+(
+    includes: [(path: "../feedbackconfig.ron")],
+    monitor: (type: "StreamProbe"),
+)

--- a/examples/cu_logstream_demo/tests/feedbackconfig.ron
+++ b/examples/cu_logstream_demo/tests/feedbackconfig.ron
@@ -1,4 +1,6 @@
 (
-    includes: [(path: "../feedbackconfig.ron")],
+    includes: [
+        (path: "../feedbackconfig.ron"),
+    ],
     monitor: (type: "StreamProbe"),
 )

--- a/justfile
+++ b/justfile
@@ -602,6 +602,13 @@ logstream-twin-check:
     just logstream-receiver-check
     just --justfile examples/cu_logstream_demo/justfile check
 
+# Two-way demo, feedback transitions, adaptation, and native archive interoperability.
+logstream-feedback-demo-check:
+    cargo +stable test -p cu-tuimon --no-default-features
+    cargo +stable clippy -p cu-logstream-demo --all-targets --features replay,tui,sender-monitor,feedback -- --deny warnings
+    cargo +stable test -p cu-logstream-demo --features demo,tui,sender-monitor,feedback
+    just --justfile examples/cu_logstream_demo/justfile run-two-way all
+
 # Sender monitor, status metadata, and streamed reconstruction interoperability.
 logstream-sender-check:
     cargo +stable test -p cu-tuimon --no-default-features


### PR DESCRIPTION
Adds an optional two-way UDP demo so users can see receiver feedback change the robot-side statistics and FEC repair interval. Start `just telemetry-two-way`, then `just sender-two-way` in another terminal; `just telemetry-two-way lossy` introduces sustained source loss for comparison.

The `feedback` feature selects an explicit reverse UDP resource in RON. Launch recipes bind the robot at port 7448 and return receiver reports from telemetry on port 7447. Addresses are configurable through the recipes and CLI arguments. The existing one-way recipes keep their one-way builds.

The robot's bandwidth panel now puts Feedback beside Sender, showing Disabled, Waiting, Active, Stale, or Failed. Receiver rates, source loss, report counts, and the effective FEC interval expose the effect of feedback. Closing telemetry restores baseline repairs after the configured timeout; restarting it resumes feedback.

Validation: `just fmt`, `just logstream-feedback-demo-check`, and `just logstream-sender-check`. A real-UDP integration test checks waiting → active → stale → active, nonzero receiver rates, a larger repair interval on a healthy link, and baseline restoration while recording continues. Seven scenarios run in each direction mode with native archive checks and replay; sustained loss permits explicit gaps while requiring at least 90% of the run and the final CopperList.

Stacked on #1372 for the renamed telemetry command and structured log pane. The panel layout change is separate in #1373.
