### PR TITLE
Remove replay ABI and deterministic marker requirements

### DIFF
--- a/api/v1/cu29-runtime.txt
+++ b/api/v1/cu29-runtime.txt
@@ -473,7 +473,6 @@ impl core::default::Default for cu29_runtime::config::NodeLogging
 pub fn cu29_runtime::config::NodeLogging::default() -> Self
 pub struct cu29_runtime::config::NodeStreaming
 pub cu29_runtime::config::NodeStreaming::replay: cu29_runtime::config::StreamReplay
-pub cu29_runtime::config::NodeStreaming::replay_abi: core::option::Option<u32>
 pub struct cu29_runtime::config::PlannerConfig
 impl cu29_runtime::config::PlannerConfig
 pub fn cu29_runtime::config::PlannerConfig::get_config(&self) -> core::option::Option<&cu29_runtime::config::ComponentConfig>

--- a/api/v1/cu29-traits.txt
+++ b/api/v1/cu29-traits.txt
@@ -140,7 +140,6 @@ pub fn cu29_traits::TaskOutputSpec::payload_type_path(&self) -> &'static str
 pub const cu29_traits::COMPACT_STRING_CAPACITY: usize
 pub trait cu29_traits::CopperListTuple: cu_bincode::enc::Encode + cu_bincode::de::Decode<()> + core::fmt::Debug + serde_core::ser::Serialize + cu29_traits::ErasedCuStampedDataSet + cu29_traits::MatchingTasks + core::default::Default
 impl<T> cu29_traits::CopperListTuple for T where T: cu_bincode::enc::Encode + cu_bincode::de::Decode<()> + core::fmt::Debug + serde_core::ser::Serialize + cu29_traits::ErasedCuStampedDataSet + cu29_traits::MatchingTasks + core::default::Default
-pub trait cu29_traits::CuCrossPlatformDeterministic
 pub trait cu29_traits::CuMsgMetadataTrait
 pub fn cu29_traits::CuMsgMetadataTrait::origin(&self) -> core::option::Option<&cu29_traits::CuMsgOrigin>
 pub fn cu29_traits::CuMsgMetadataTrait::process_time(&self) -> cu29_clock::PartialCuTimeRange

--- a/api/v1/cu29-traits.txt
+++ b/api/v1/cu29-traits.txt
@@ -141,7 +141,6 @@ pub const cu29_traits::COMPACT_STRING_CAPACITY: usize
 pub trait cu29_traits::CopperListTuple: cu_bincode::enc::Encode + cu_bincode::de::Decode<()> + core::fmt::Debug + serde_core::ser::Serialize + cu29_traits::ErasedCuStampedDataSet + cu29_traits::MatchingTasks + core::default::Default
 impl<T> cu29_traits::CopperListTuple for T where T: cu_bincode::enc::Encode + cu_bincode::de::Decode<()> + core::fmt::Debug + serde_core::ser::Serialize + cu29_traits::ErasedCuStampedDataSet + cu29_traits::MatchingTasks + core::default::Default
 pub trait cu29_traits::CuCrossPlatformDeterministic
-pub const cu29_traits::CuCrossPlatformDeterministic::REPLAY_ABI: u32
 pub trait cu29_traits::CuMsgMetadataTrait
 pub fn cu29_traits::CuMsgMetadataTrait::origin(&self) -> core::option::Option<&cu29_traits::CuMsgOrigin>
 pub fn cu29_traits::CuMsgMetadataTrait::process_time(&self) -> cu29_clock::PartialCuTimeRange

--- a/api/v1/cu29.txt
+++ b/api/v1/cu29.txt
@@ -58,7 +58,6 @@ pub use cu29::prelude::<<cu29_unifiedlog::*>>
 pub use cu29::prelude::COMPACT_STRING_CAPACITY
 pub use cu29::prelude::CopperListTuple
 pub use cu29::prelude::CuCompactString
-pub use cu29::prelude::CuCrossPlatformDeterministic
 pub use cu29::prelude::CuError
 pub use cu29::prelude::CuMsgMetadataTrait
 pub use cu29::prelude::CuMsgOrigin

--- a/core/cu29/src/lib.rs
+++ b/core/cu29/src/lib.rs
@@ -329,13 +329,13 @@ pub mod prelude {
     #[allow(deprecated)]
     pub use cu29_traits::PayloadSchemas;
     pub use cu29_traits::{
-        COMPACT_STRING_CAPACITY, CopperListTuple, CuCompactString, CuCrossPlatformDeterministic,
-        CuError, CuMsgMetadataTrait, CuMsgOrigin, CuPayloadRawBytes, CuResult,
-        DebugEnumVariantDescriptor, DebugEnumVariantKind, DebugFieldDescriptor, DebugFieldKind,
-        DebugFieldSemantics, DebugScalarKind, DebugScalarRegistration, DebugScalarType,
-        ErasedCuStampedData, ErasedCuStampedDataSet, MatchingTasks, Metadata, ObservedWriter,
-        ReflectSerializedPayloadSchema, SerializedPayloadSchema, TaskOutputSpec, UnifiedLogType,
-        WriteStream, abort_observed_encode, begin_observed_encode, finish_observed_encode,
+        COMPACT_STRING_CAPACITY, CopperListTuple, CuCompactString, CuError, CuMsgMetadataTrait,
+        CuMsgOrigin, CuPayloadRawBytes, CuResult, DebugEnumVariantDescriptor, DebugEnumVariantKind,
+        DebugFieldDescriptor, DebugFieldKind, DebugFieldSemantics, DebugScalarKind,
+        DebugScalarRegistration, DebugScalarType, ErasedCuStampedData, ErasedCuStampedDataSet,
+        MatchingTasks, Metadata, ObservedWriter, ReflectSerializedPayloadSchema,
+        SerializedPayloadSchema, TaskOutputSpec, UnifiedLogType, WriteStream,
+        abort_observed_encode, begin_observed_encode, finish_observed_encode,
         observed_encode_bytes, record_observed_encode_bytes, with_cause,
     };
     #[cfg(feature = "std")]

--- a/core/cu29_derive/src/live_twin.rs
+++ b/core/cu29_derive/src/live_twin.rs
@@ -9,7 +9,6 @@ pub(super) fn dataset_support(
     codecs: &[Option<SlotCodecBinding>],
 ) -> proc_macro2::TokenStream {
     let mut capture = vec![true; packs.len()];
-    let mut contracts = Vec::new();
     for unit in &plan.steps {
         let CuExecutionUnit::Step(step) = unit else {
             continue;
@@ -26,13 +25,6 @@ pub(super) fn dataset_support(
         {
             return quote! { compile_error!("reconstruct requires an ordinary, synchronous, logged deterministic task"); };
         }
-        let task: Type = parse_str(step.node.get_type()).unwrap();
-        contracts.push(quote! {
-            const _: () = {
-                fn assert_deterministic<T: ::cu29::CuCrossPlatformDeterministic>() {}
-                let _ = assert_deterministic::<#task>;
-            };
-        });
         let slot = step.output_msg_pack.as_ref().unwrap().culist_index as usize;
         capture[slot] = false;
     }
@@ -75,7 +67,6 @@ pub(super) fn dataset_support(
     }
     let schema = hybrid.then(|| quote! { schema.reconstruction = Self::RECONSTRUCTION.to_vec(); });
     quote! {
-        #(#contracts)*
         #encode
         impl ::cu29::logstream::capture::CaptureDataSet for CuStampedDataSet {
             const RECONSTRUCTION: &'static [bool] = &[#(#reconstruction),*];

--- a/core/cu29_derive/src/live_twin.rs
+++ b/core/cu29_derive/src/live_twin.rs
@@ -9,7 +9,6 @@ pub(super) fn dataset_support(
     codecs: &[Option<SlotCodecBinding>],
 ) -> proc_macro2::TokenStream {
     let mut capture = vec![true; packs.len()];
-    let mut abis = vec![quote! { None }; packs.len()];
     let mut contracts = Vec::new();
     for unit in &plan.steps {
         let CuExecutionUnit::Step(step) = unit else {
@@ -27,17 +26,15 @@ pub(super) fn dataset_support(
         {
             return quote! { compile_error!("reconstruct requires an ordinary, synchronous, logged deterministic task"); };
         }
-        let Some(abi) = policy.replay_abi.filter(|abi| *abi != 0) else {
-            return quote! { compile_error!("reconstruct requires a nonzero replay_abi"); };
-        };
         let task: Type = parse_str(step.node.get_type()).unwrap();
         contracts.push(quote! {
-            const _: () = assert!(<#task as ::cu29::CuCrossPlatformDeterministic>::REPLAY_ABI == #abi,
-                "task deterministic replay ABI does not match RON");
+            const _: () = {
+                fn assert_deterministic<T: ::cu29::CuCrossPlatformDeterministic>() {}
+                let _ = assert_deterministic::<#task>;
+            };
         });
         let slot = step.output_msg_pack.as_ref().unwrap().culist_index as usize;
         capture[slot] = false;
-        abis[slot] = quote! { Some(#abi) };
     }
     let hybrid = capture.contains(&false);
     if hybrid
@@ -50,7 +47,7 @@ pub(super) fn dataset_support(
     let encode = build_compressed_culist_tuple_encode(packs, helpers, modes, count, Some(&capture));
     let mut validate = Vec::new();
     let mut digests = Vec::new();
-    let mut flat_abis = Vec::new();
+    let mut reconstruction = Vec::new();
     let mut metadata = Vec::new();
     for (i, pack) in packs.iter().enumerate() {
         let slot = syn::Index::from(i);
@@ -69,7 +66,7 @@ pub(super) fn dataset_support(
                 });
                 digests.push(quote! { self.0.#access.payload().encode(encoder)?; });
             }
-            flat_abis.push(abis[i].clone());
+            reconstruction.push(!capture[i]);
             metadata.push(quote! {
                 self.0.#access.tov = captured.0.#access.tov;
                 self.0.#access.metadata = captured.0.#access.metadata.clone();
@@ -81,7 +78,7 @@ pub(super) fn dataset_support(
         #(#contracts)*
         #encode
         impl ::cu29::logstream::capture::CaptureDataSet for CuStampedDataSet {
-            const RECONSTRUCTION: &'static [Option<u32>] = &[#(#flat_abis),*];
+            const RECONSTRUCTION: &'static [bool] = &[#(#reconstruction),*];
             fn stream_schema() -> ::cu29::logstream::ApplicationSchema {
                 #[allow(unused_mut)]
                 let mut schema = ::cu29::logstream::ApplicationSchema::from_output_specs(

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -203,10 +203,10 @@ Declare the static contract in the same RON used by the robot and ground build:
 
 ```ron
 (id: "kinematics", type: "cu_logstream_demo::tasks::Kinematics",
- streaming: (replay: reconstruct, replay_abi: 1)),
+ streaming: (replay: reconstruct)),
 ```
 
-The task implements `CuCrossPlatformDeterministic` with `REPLAY_ABI = 1`. This is
+The task implements `CuCrossPlatformDeterministic`. This is
 an explicit promise of deterministic behavior and no external side effects.
 Sources and bridge receives stay captured. Reconstruction currently supports
 ordinary synchronous tasks using the lossless native compressed codec; background,

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -206,8 +206,6 @@ Declare the static contract in the same RON used by the robot and ground build:
  streaming: (replay: reconstruct)),
 ```
 
-The task implements `CuCrossPlatformDeterministic`. This is
-an explicit promise of deterministic behavior and no external side effects.
 Sources and bridge receives stay captured. Reconstruction currently supports
 ordinary synchronous tasks using the lossless native compressed codec; background,
 anytime, custom codec and selective handle policies are rejected for this path.

--- a/core/cu29_logstream/src/capture.rs
+++ b/core/cu29_logstream/src/capture.rs
@@ -23,7 +23,8 @@ macro_rules! __with_reconstruction_verification {
 
 /// Generated from RON. Slot dispatch and storage are fixed at compile time.
 pub trait CaptureDataSet: CopperListTuple {
-    const RECONSTRUCTION: &'static [Option<u32>];
+    /// Per-output flags: `true` for reconstructed outputs, `false` for captured outputs.
+    const RECONSTRUCTION: &'static [bool];
     fn stream_schema() -> ApplicationSchema;
     fn encode_capture<E: Encoder>(&self, encoder: &mut E) -> core::result::Result<(), EncodeError>;
     fn validate_capture(&self) -> Result<()>;

--- a/core/cu29_logstream/src/manifest.rs
+++ b/core/cu29_logstream/src/manifest.rs
@@ -56,8 +56,8 @@ pub struct ResolvedObjectFec {
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 pub struct ApplicationSchema {
     pub outputs: Vec<ApplicationOutputSchema>,
-    /// Per-output deterministic ABI; empty means full capture.
-    pub reconstruction: Vec<Option<u32>>,
+    /// Per-output reconstruction flags (`true` means reconstruct); empty means full capture.
+    pub reconstruction: Vec<bool>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -1121,7 +1121,6 @@ pub enum StreamReplay {
 pub struct NodeStreaming {
     #[serde(default)]
     pub replay: StreamReplay,
-    pub replay_abi: Option<u32>,
 }
 
 /// A node in the configuration graph.

--- a/core/cu29_traits/src/lib.rs
+++ b/core/cu29_traits/src/lib.rs
@@ -1131,7 +1131,3 @@ mod std_tests {
         assert!(descriptor.children.is_empty());
     }
 }
-
-/// Explicit promise that a task has no external side effects and replays exactly
-/// across supported targets from its captured inputs, clock and frozen state.
-pub trait CuCrossPlatformDeterministic {}

--- a/core/cu29_traits/src/lib.rs
+++ b/core/cu29_traits/src/lib.rs
@@ -1134,7 +1134,4 @@ mod std_tests {
 
 /// Explicit promise that a task has no external side effects and replays exactly
 /// across supported targets from its captured inputs, clock and frozen state.
-/// Change the nonzero ABI whenever its state encoding or deterministic behavior changes.
-pub trait CuCrossPlatformDeterministic {
-    const REPLAY_ABI: u32;
-}
+pub trait CuCrossPlatformDeterministic {}

--- a/examples/cu_logstream_demo/README.md
+++ b/examples/cu_logstream_demo/README.md
@@ -159,8 +159,8 @@ failure modes; they are demo machinery.
    that bound. For recording alone, use `.archive_only()` before `.spawn()`.
 4. **Optionally omit reconstructible outputs.** Keep outputs captured initially.
    To save payload bandwidth, mark suitable tasks with
-   `streaming: (replay: reconstruct, replay_abi: 1)` and implement
-   `CuCrossPlatformDeterministic` with matching `REPLAY_ABI`, as
+   `streaming: (replay: reconstruct)` and implement
+   `CuCrossPlatformDeterministic`, as
    [Kinematics](src/tasks.rs) does. This promises deterministic behavior across
    platforms and no external side effects. Sources and bridge receives stay
    captured; reconstruction currently supports ordinary synchronous tasks with

--- a/examples/cu_logstream_demo/README.md
+++ b/examples/cu_logstream_demo/README.md
@@ -159,10 +159,8 @@ failure modes; they are demo machinery.
    that bound. For recording alone, use `.archive_only()` before `.spawn()`.
 4. **Optionally omit reconstructible outputs.** Keep outputs captured initially.
    To save payload bandwidth, mark suitable tasks with
-   `streaming: (replay: reconstruct)` and implement
-   `CuCrossPlatformDeterministic`, as
-   [Kinematics](src/tasks.rs) does. This promises deterministic behavior across
-   platforms and no external side effects. Sources and bridge receives stay
+   `streaming: (replay: reconstruct)`, as
+   [Kinematics](src/tasks.rs) does. Sources and bridge receives stay
    captured; reconstruction currently supports ordinary synchronous tasks with
    the lossless native compressed codec.
 

--- a/examples/cu_logstream_demo/copperconfig.ron
+++ b/examples/cu_logstream_demo/copperconfig.ron
@@ -61,7 +61,6 @@
             type: "cu_logstream_demo::tasks::Kinematics",
             streaming: (
                 replay: reconstruct,
-                replay_abi: 1,
             ),
         ),
     ],

--- a/examples/cu_logstream_demo/src/tasks.rs
+++ b/examples/cu_logstream_demo/src/tasks.rs
@@ -150,9 +150,6 @@ pub fn forward_kinematics(angles: JointAngles) -> CuResult<ArmPose> {
 #[derive(Default, Reflect)]
 pub struct Kinematics;
 impl Freezable for Kinematics {}
-// Bounded integer inputs and scalar f64 const-transform arithmetic make this
-// task deterministic across supported targets and free of external side effects.
-impl CuCrossPlatformDeterministic for Kinematics {}
 impl CuTask for Kinematics {
     type Resources<'r> = ();
     type Input<'m> = input_msg!(JointAngles);

--- a/examples/cu_logstream_demo/src/tasks.rs
+++ b/examples/cu_logstream_demo/src/tasks.rs
@@ -150,11 +150,9 @@ pub fn forward_kinematics(angles: JointAngles) -> CuResult<ArmPose> {
 #[derive(Default, Reflect)]
 pub struct Kinematics;
 impl Freezable for Kinematics {}
-impl CuCrossPlatformDeterministic for Kinematics {
-    // Bounded integer inputs, scalar f64 const-transform arithmetic, no libm,
-    // SIMD multiplication, wall clock, allocation, or external side effects.
-    const REPLAY_ABI: u32 = 1;
-}
+// Bounded integer inputs and scalar f64 const-transform arithmetic make this
+// task deterministic across supported targets and free of external side effects.
+impl CuCrossPlatformDeterministic for Kinematics {}
 impl CuTask for Kinematics {
     type Resources<'r> = ();
     type Input<'m> = input_msg!(JointAngles);

--- a/examples/cu_logstream_demo/tests/stateful.ron
+++ b/examples/cu_logstream_demo/tests/stateful.ron
@@ -15,7 +15,6 @@
             type: "crate::stateful::tasks::Accumulator",
             streaming: (
                 replay: reconstruct,
-                replay_abi: 1,
             ),
         ),
         (
@@ -23,7 +22,6 @@
             type: "crate::stateful::tasks::Derived",
             streaming: (
                 replay: reconstruct,
-                replay_abi: 1,
             ),
         ),
     ],

--- a/examples/cu_logstream_demo/tests/support/counter_tasks.rs
+++ b/examples/cu_logstream_demo/tests/support/counter_tasks.rs
@@ -57,9 +57,7 @@ impl Freezable for Accumulator {
     }
 }
 
-impl CuCrossPlatformDeterministic for Accumulator {
-    const REPLAY_ABI: u32 = 1;
-}
+impl CuCrossPlatformDeterministic for Accumulator {}
 
 impl CuTask for Accumulator {
     type Resources<'r> = ();
@@ -88,9 +86,7 @@ impl CuTask for Accumulator {
 #[derive(Default, Reflect)]
 pub struct Derived;
 impl Freezable for Derived {}
-impl CuCrossPlatformDeterministic for Derived {
-    const REPLAY_ABI: u32 = 1;
-}
+impl CuCrossPlatformDeterministic for Derived {}
 impl CuTask for Derived {
     type Resources<'r> = ();
     type Input<'m> = input_msg!(Sample);

--- a/examples/cu_logstream_demo/tests/support/counter_tasks.rs
+++ b/examples/cu_logstream_demo/tests/support/counter_tasks.rs
@@ -57,7 +57,6 @@ impl Freezable for Accumulator {
     }
 }
 
-impl CuCrossPlatformDeterministic for Accumulator {}
 
 impl CuTask for Accumulator {
     type Resources<'r> = ();
@@ -86,7 +85,6 @@ impl CuTask for Accumulator {
 #[derive(Default, Reflect)]
 pub struct Derived;
 impl Freezable for Derived {}
-impl CuCrossPlatformDeterministic for Derived {}
 impl CuTask for Derived {
     type Resources<'r> = ();
     type Input<'m> = input_msg!(Sample);


### PR DESCRIPTION
## Summary

Configure live stream reconstruction with `streaming: (replay: reconstruct)`. Deterministic task behavior is a runtime expectation, and sender and receiver use the same application and Copper version.

## Changes

- Remove `NodeStreaming::replay_abi` and the `CuCrossPlatformDeterministic` trait, including its ABI constant, prelude export, implementations, and generated checks.
- Represent per-output reconstruction in the generated dataset and stream manifest with booleans.
- Update example configs, documentation, and public API snapshots.

The reconstruction schema encoding changes with this update; build both endpoints from the matching application and Copper version.

## Validation

- `just fmt` passed.
- `just logstream-twin-check` passed, including stateful reconstruction, allocation checks, divergence verification, receiver/UDP tests, and all two-process demo scenarios.
- `just api-check` passed.
- `just nostd-ci` passed, including no-default-features tests, embedded clippy/builds, and RP2350 firmware/host builds.
- Book `just build` passed.

## Documentation

- Book: https://github.com/copper-project/copper-rs-book/pull/66
- Wiki: commit `88b5ded` on `gbin/refactor/remove-replay-abi` in `copper-rs.wiki.git`. GitHub wikis do not support PRs.

## Related parameters

The audit found no other task-config compatibility version knobs. Existing unified-log encapsulation, logstats schema, and remote-debug API versions describe their respective formats/protocols.
