### PR TITLE
Reject reconstructed tasks with unlogged inputs at compile time

### DIFF
--- a/core/cu29_derive/tests/compile_fail/copper_runtime/reconstruct_missing_input.rs
+++ b/core/cu29_derive/tests/compile_fail/copper_runtime/reconstruct_missing_input.rs
@@ -1,0 +1,6 @@
+use cu29_derive::copper_runtime;
+
+#[copper_runtime(config = "config/reconstruct_missing_input.ron")]
+struct App;
+
+fn main() {}

--- a/core/cu29_derive/tests/compile_fail/copper_runtime/reconstruct_missing_input.stderr
+++ b/core/cu29_derive/tests/compile_fail/copper_runtime/reconstruct_missing_input.stderr
@@ -1,0 +1,8 @@
+error: Task 'detect' uses streaming.replay: reconstruct but input 'Image' from 'camera' has logging.enabled: false. Enable logging on 'camera' or use streaming.replay: capture on 'detect'.
+          context:None
+ --> tests/compile_fail/copper_runtime/reconstruct_missing_input.rs:3:1
+  |
+3 | #[copper_runtime(config = "config/reconstruct_missing_input.ron")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `copper_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/core/cu29_derive/tests/compile_fail/copper_runtime/twin_missing_input.rs
+++ b/core/cu29_derive/tests/compile_fail/copper_runtime/twin_missing_input.rs
@@ -1,0 +1,6 @@
+use cu29_derive::copper_runtime;
+
+#[copper_runtime(config = "config/reconstruct_missing_input.ron", sim_mode = true)]
+struct App;
+
+fn main() {}

--- a/core/cu29_derive/tests/compile_fail/copper_runtime/twin_missing_input.stderr
+++ b/core/cu29_derive/tests/compile_fail/copper_runtime/twin_missing_input.stderr
@@ -1,0 +1,8 @@
+error: Task 'detect' uses streaming.replay: reconstruct but input 'Image' from 'camera' has logging.enabled: false. Enable logging on 'camera' or use streaming.replay: capture on 'detect'.
+          context:None
+ --> tests/compile_fail/copper_runtime/twin_missing_input.rs:3:1
+  |
+3 | #[copper_runtime(config = "config/reconstruct_missing_input.ron", sim_mode = true)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `copper_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/core/cu29_derive/tests/config/reconstruct_missing_input.ron
+++ b/core/cu29_derive/tests/config/reconstruct_missing_input.ron
@@ -1,0 +1,52 @@
+(
+    tasks: [
+        (
+            id: "camera",
+            type: "Camera",
+            logging: (enabled: false),
+        ),
+        (
+            id: "detect",
+            type: "Detect",
+            streaming: (
+                replay: reconstruct,
+            ),
+        ),
+        (
+            id: "track",
+            type: "Track",
+            streaming: (
+                replay: reconstruct,
+            ),
+        ),
+        (
+            id: "plan",
+            type: "Plan",
+            streaming: (
+                replay: reconstruct,
+            ),
+        ),
+    ],
+    cnx: [
+        (
+            src: "camera",
+            dst: "detect",
+            msg: "Image",
+        ),
+        (
+            src: "detect",
+            dst: "track",
+            msg: "Detections",
+        ),
+        (
+            src: "track",
+            dst: "plan",
+            msg: "Tracks",
+        ),
+        (
+            src: "plan",
+            dst: "__nc__",
+            msg: "PlanOutput",
+        ),
+    ],
+)

--- a/core/cu29_logstream/README.md
+++ b/core/cu29_logstream/README.md
@@ -210,6 +210,13 @@ Sources and bridge receives stay captured. Reconstruction currently supports
 ordinary synchronous tasks using the lossless native compressed codec; background,
 anytime, custom codec and selective handle policies are rejected for this path.
 
+Every input to a reconstructed task must come from a node with logging enabled.
+Copper rejects missing replay inputs at compile time, naming the producer,
+consumer, and message type. To omit camera images, disable camera logging and
+capture the detector output; downstream tracking and planning tasks can then use
+`streaming: (replay: reconstruct)`. Each reconstructed task's incoming connections
+are checked, including every branch of a multi-input task and each mission graph.
+
 A ground station declares `#[copper_runtime(config = "copperconfig.ron", sim_mode = true)]`.
 The generated application exposes a twin builder:
 

--- a/core/cu29_runtime/src/config.rs
+++ b/core/cu29_runtime/src/config.rs
@@ -2394,9 +2394,44 @@ pub struct CuConfig {
     pub graphs: ConfigGraphs,
 }
 
+/// Every reconstructed node needs recorded or reconstructed inputs. Checking
+/// direct edges at every reconstructed node also covers chains and fan-in.
+fn validate_reconstruction_inputs(graph: &CuGraph) -> CuResult<()> {
+    for index in graph.0.node_indices() {
+        let node = &graph.0[index];
+        if node.streaming().replay != StreamReplay::Reconstruct {
+            continue;
+        }
+        for edge in graph.0.edges_directed(index, Incoming) {
+            let source = &graph.0[edge.source()];
+            if !source.is_logging_enabled() {
+                return Err(CuError::from(format!(
+                    "Task '{}' uses streaming.replay: reconstruct but input '{}' from '{}' has logging.enabled: false. Enable logging on '{}' or use streaming.replay: capture on '{}'.",
+                    node.id,
+                    edge.weight().msg,
+                    source.id,
+                    source.id,
+                    node.id
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 impl CuConfig {
-    /// Validates static log-stream topology and bounds before code generation.
+    /// Validates reconstruction inputs, static log-stream topology and bounds before code generation.
     pub fn validate_log_streaming_config(&self) -> CuResult<()> {
+        match &self.graphs {
+            Simple(graph) => validate_reconstruction_inputs(graph)?,
+            Missions(graphs) => {
+                for (mission, graph) in graphs {
+                    validate_reconstruction_inputs(graph)
+                        .map_err(|error| CuError::from(format!("Mission '{mission}': {error}")))?;
+                }
+            }
+        }
+
         let Some(streaming) = &self.log_streaming else {
             return Ok(());
         };

--- a/core/cu29_runtime/tests/stream_replay_config.rs
+++ b/core/cu29_runtime/tests/stream_replay_config.rs
@@ -1,0 +1,86 @@
+use cu29_runtime::config::read_configuration_str;
+
+fn vision_graph(camera_logging: bool, detect_replay: &str, detect_logging: bool) -> String {
+    format!(
+        r#"(
+            tasks: [
+                (id: "camera", type: "Camera", logging: (enabled: {camera_logging})),
+                (id: "detect", type: "Detect", logging: (enabled: {detect_logging}), streaming: (replay: {detect_replay})),
+                (id: "track", type: "Track", streaming: (replay: reconstruct)),
+                (id: "plan", type: "Plan", streaming: (replay: reconstruct)),
+            ],
+            cnx: [
+                (src: "camera", dst: "detect", msg: "Image"),
+                (src: "detect", dst: "track", msg: "Detections"),
+                (src: "track", dst: "plan", msg: "Tracks"),
+                (src: "plan", dst: "__nc__", msg: "PlanOutput"),
+            ],
+        )"#
+    )
+}
+
+#[test]
+fn reconstruction_rejects_unlogged_inputs() {
+    for (camera_logging, detect_replay, detect_logging, source, consumer) in [
+        (false, "reconstruct", true, "camera", "detect"),
+        (true, "capture", false, "detect", "track"),
+        (true, "reconstruct", false, "detect", "track"),
+    ] {
+        let config = vision_graph(camera_logging, detect_replay, detect_logging);
+        let error = read_configuration_str(config, None)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains(&format!(
+                "Task '{consumer}' uses streaming.replay: reconstruct"
+            )),
+            "{error}"
+        );
+        assert!(
+            error.contains(&format!("from '{source}' has logging.enabled: false")),
+            "{error}"
+        );
+    }
+}
+
+#[test]
+fn captured_detections_allow_reconstruction_without_images() {
+    read_configuration_str(vision_graph(false, "capture", true), None).unwrap();
+}
+
+#[test]
+fn captured_images_allow_the_entire_downstream_chain_to_reconstruct() {
+    read_configuration_str(vision_graph(true, "reconstruct", true), None).unwrap();
+}
+
+#[test]
+fn reconstruction_checks_every_fan_in_edge() {
+    let config = vision_graph(false, "capture", true).replace(
+        "cnx: [",
+        "cnx: [(src: \"camera\", dst: \"track\", msg: \"Image\"),",
+    );
+    let error = read_configuration_str(config, None)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("Task 'track' uses streaming.replay: reconstruct"),
+        "{error}"
+    );
+    assert!(error.contains("input 'Image' from 'camera'"), "{error}");
+}
+
+#[test]
+fn reconstruction_is_validated_in_each_mission() {
+    let config = vision_graph(false, "reconstruct", true)
+        .replacen(
+            "tasks: [",
+            "missions: [(id: \"safe\"), (id: \"broken\")], tasks: [",
+            1,
+        )
+        .replace("msg: \"Image\"", "msg: \"Image\", missions: [\"broken\"]");
+    let error = read_configuration_str(config, None)
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("Mission 'broken'"), "{error}");
+    assert!(error.contains("input 'Image' from 'camera'"), "{error}");
+}

--- a/justfile
+++ b/justfile
@@ -602,6 +602,13 @@ logstream-twin-check:
     just logstream-receiver-check
     just --justfile examples/cu_logstream_demo/justfile check
 
+# Compile-time replay input checks and valid downstream reconstruction.
+logstream-replay-inputs-check:
+    cargo +stable clippy -p cu29-runtime -p cu29-derive --lib -- --deny warnings
+    cargo +stable test -p cu29-runtime --test stream_replay_config
+    cargo +stable test -p cu29-derive --lib test_compile_fail
+    cargo +stable test -p cu-logstream-demo --features demo --test twin
+
 # Two-way demo, feedback transitions, adaptation, and native archive interoperability.
 logstream-feedback-demo-check:
     cargo +stable test -p cu-tuimon --no-default-features


### PR DESCRIPTION
## Summary

A graph with camera logging disabled and `detect` configured for reconstruction currently compiles, then gives the twin an empty image input. Reject that graph during configuration validation, before runtime generation, with a diagnostic naming the consumer, producer, message type, and corrective settings.

Camera logging can remain disabled when detector outputs are captured and downstream tracking/planning tasks reconstruct from those outputs.

## Changes

- Check every incoming edge of every reconstructed node in simple and mission graphs, including configurations using injected stream transports.
- Run the check through existing configuration validation used by both sender and simulation macros. The check borrows the graph and allocates only when constructing an error; it adds no work to task execution.
- Add sender/twin compile-fail fixtures, positive capture-boundary and reconstruction-chain tests, and negative intermediate-input, fan-in, and mission tests.
- Add `just logstream-replay-inputs-check` and document the requirement.

## Validation

- `just fmt` passed.
- `just logstream-replay-inputs-check` passed: clippy, five configuration tests, the proc-macro compile-fail/pass suite, and eight live-twin tests.
- `just nostd-ci` passed: 589 tests passed (1 skipped), embedded clippy/builds, and RP2350 firmware/host builds.
- Book `just build` passed.

## Dependencies and documentation

Stacked on #1378; this PR contains only replay-input validation and its tests/docs.

Book: https://github.com/copper-project/copper-rs-book/pull/67

Wiki: commit `44e0aa8` on `gbin/fix/validate-twin-replay-inputs` in `copper-rs.wiki.git` (GitHub wikis do not support PRs).
