### PR TITLE
Frame logging codec payloads directly in Copper storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,7 +292,7 @@ cu-ros2-payloads = { path = "components/payloads/cu_ros2_payloads", version = "1
 cu-pid = { path = "components/tasks/cu_pid", version = "1.2.0-dev" }
 
 # External serialization
-bincode = { package = "cu-bincode", version = "2.1", default-features = false, features = [
+bincode = { package = "cu-bincode", version = "2.2", git = "https://github.com/copper-project/cu-bincode", rev = "f10d7ac8b061cf63e9b69a0a13c76919a3a4599a", default-features = false, features = [
   "derive",
   "alloc",
 ] }

--- a/api/v1/cu29-traits.txt
+++ b/api/v1/cu29-traits.txt
@@ -126,6 +126,8 @@ pub fn cu29_traits::ObservedWriter<W>::inner_mut(&mut self) -> &mut W
 pub fn cu29_traits::ObservedWriter<W>::into_inner(self) -> W
 pub const fn cu29_traits::ObservedWriter<W>::new(inner: W) -> Self
 impl<W: cu_bincode::enc::write::Writer> cu_bincode::enc::write::Writer for cu29_traits::ObservedWriter<W>
+pub fn cu29_traits::ObservedWriter<W>::overwrite(&mut self, position: usize, bytes: &[u8]) -> core::result::Result<(), cu_bincode::error::EncodeError>
+pub fn cu29_traits::ObservedWriter<W>::position(&self) -> core::result::Result<usize, cu_bincode::error::EncodeError>
 pub fn cu29_traits::ObservedWriter<W>::write(&mut self, bytes: &[u8]) -> core::result::Result<(), cu_bincode::error::EncodeError>
 pub struct cu29_traits::ReflectSerializedPayloadSchema
 impl cu29_traits::ReflectSerializedPayloadSchema

--- a/components/codecs/cu_png_codec/src/lib.rs
+++ b/components/codecs/cu_png_codec/src/lib.rs
@@ -70,11 +70,21 @@ impl<W: BincodeWriter> Write for BincodeWriterAdapter<'_, W> {
 struct BincodeReaderAdapter<'a, R> {
     inner: &'a mut R,
     position: u64,
+    // Used only when the enclosing reader cannot lend bytes (e.g. a file reader).
+    buffer: [u8; 1024],
+    buffered_start: usize,
+    buffered_end: usize,
 }
 
 impl<'a, R> BincodeReaderAdapter<'a, R> {
     fn new(inner: &'a mut R) -> Self {
-        Self { inner, position: 0 }
+        Self {
+            inner,
+            position: 0,
+            buffer: [0; 1024],
+            buffered_start: 0,
+            buffered_end: 0,
+        }
     }
 
     fn peek_window_len(&mut self) -> usize
@@ -114,24 +124,30 @@ impl<'a, R> BincodeReaderAdapter<'a, R> {
         }
     }
 
-    fn fill_from_peek(&mut self) -> io::Result<&[u8]>
+    fn fill_input_buffer(&mut self) -> io::Result<&[u8]>
     where
         R: BincodeReader,
     {
-        let peek_len = self.peek_window_len();
-        if peek_len == 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "PNG codec expected more bytes from the bincode decoder",
-            ));
+        if self.buffered_start < self.buffered_end {
+            return Ok(&self.buffer[self.buffered_start..self.buffered_end]);
         }
-
-        self.inner.peek_read(peek_len).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "PNG codec expected more bytes from the bincode decoder",
-            )
-        })
+        let peek_len = self.peek_window_len();
+        if peek_len != 0 {
+            return self
+                .inner
+                .peek_read(peek_len)
+                .ok_or_else(|| io::Error::other("PNG codec reader lost its peeked bytes"));
+        }
+        self.buffered_start = 0;
+        self.buffered_end = self
+            .inner
+            .read_some(&mut self.buffer)
+            .map_err(|err| match err {
+                DecodeError::UnexpectedEnd { .. } => io::Error::from(io::ErrorKind::UnexpectedEof),
+                DecodeError::Io { inner, .. } => inner,
+                other => io::Error::other(other.to_string()),
+            })?;
+        Ok(&self.buffer[..self.buffered_end])
     }
 }
 
@@ -141,7 +157,7 @@ impl<R: BincodeReader> Read for BincodeReaderAdapter<'_, R> {
             return Ok(0);
         }
 
-        let available = self.fill_from_peek()?;
+        let available = self.fill_input_buffer()?;
         let count = available.len().min(buf.len());
         buf[..count].copy_from_slice(&available[..count]);
         self.consume(count);
@@ -151,11 +167,15 @@ impl<R: BincodeReader> Read for BincodeReaderAdapter<'_, R> {
 
 impl<R: BincodeReader> BufRead for BincodeReaderAdapter<'_, R> {
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
-        self.fill_from_peek()
+        self.fill_input_buffer()
     }
 
     fn consume(&mut self, amt: usize) {
-        self.inner.consume(amt);
+        if self.buffered_start < self.buffered_end {
+            self.buffered_start += amt.min(self.buffered_end - self.buffered_start);
+        } else {
+            self.inner.consume(amt);
+        }
         self.position = self.position.saturating_add(amt as u64);
     }
 }
@@ -474,6 +494,71 @@ mod tests {
             bytes.to_vec()
         });
         assert_eq!(decoded_bytes, original_bytes);
+    }
+
+    #[test]
+    fn png_codec_adjacent_frames_preserve_pixels_and_following_fields() {
+        let first = sample_image();
+        let mut noise = 1u32;
+        let second = CuImage {
+            seq: 8,
+            format: CuImageBufferFormat {
+                width: 64,
+                height: 48,
+                stride: 64 * 3,
+                pixel_format: *b"RGB3",
+            },
+            buffer_handle: CuHandle::new_detached(
+                (0..64 * 48 * 3)
+                    .map(|_| {
+                        noise = noise.wrapping_mul(1664525).wrapping_add(1013904223);
+                        (noise >> 24) as u8
+                    })
+                    .collect::<Vec<_>>(),
+            ),
+        };
+        let mut storage = [0; 32768];
+        let encoded = |image| EncodedWithCodec {
+            image,
+            codec: std::cell::RefCell::new(CuPngCodec::new(CuPngCodecConfig::default()).unwrap()),
+        };
+        let len = bincode::encode_into_slice(
+            (encoded(&first), encoded(&second), 42u8),
+            &mut storage,
+            standard(),
+        )
+        .unwrap();
+        let ((a, b, tail), consumed): ((DecodedWithCodec, DecodedWithCodec, u8), usize) =
+            decode_from_slice(&storage[..len], standard()).unwrap();
+        assert_eq!(consumed, len);
+        assert!(len > 1024, "exercise multiple file-reader buffer fills");
+        assert_eq!(tail, 42);
+        let mut source = &storage[..len];
+        let (file_a, file_b, file_tail): (DecodedWithCodec, DecodedWithCodec, u8) =
+            bincode::decode_from_std_read(&mut source, standard()).unwrap();
+        assert_eq!(file_a.0.seq, first.seq);
+        assert_eq!(file_b.0.seq, second.seq);
+        assert_eq!(file_tail, 42);
+        assert!(source.is_empty());
+        for (decoded, original) in [
+            (&a.0, &first),
+            (&b.0, &second),
+            (&file_a.0, &first),
+            (&file_b.0, &second),
+        ] {
+            assert_eq!(decoded.seq, original.seq);
+            assert_eq!(decoded.format.width, original.format.width);
+            assert_eq!(decoded.format.height, original.format.height);
+            assert_eq!(decoded.format.stride, original.format.stride);
+            assert_eq!(decoded.format.pixel_format, original.format.pixel_format);
+            decoded.buffer_handle.with_inner(|actual| {
+                original.buffer_handle.with_inner(|expected| {
+                    let actual: &[u8] = actual;
+                    let expected: &[u8] = expected;
+                    assert_eq!(actual, expected);
+                });
+            });
+        }
     }
 
     #[test]

--- a/core/cu29_runtime/src/cuasynctask.rs
+++ b/core/cu29_runtime/src/cuasynctask.rs
@@ -61,6 +61,20 @@ impl Writer for BufferWriter<'_> {
         self.0.extend_from_slice(bytes);
         Ok(())
     }
+
+    fn position(&self) -> Result<usize, EncodeError> {
+        Ok(self.0.len())
+    }
+
+    fn overwrite(&mut self, position: usize, bytes: &[u8]) -> Result<(), EncodeError> {
+        let output = self
+            .0
+            .get_mut(position..)
+            .and_then(|tail| tail.get_mut(..bytes.len()))
+            .ok_or(EncodeError::UnexpectedEnd)?;
+        output.copy_from_slice(bytes);
+        Ok(())
+    }
 }
 
 fn encode_value_into(value: &impl Encode, buffer: &mut Vec<u8>) -> Result<(), EncodeError> {
@@ -85,11 +99,23 @@ impl Writer for DynWriter<'_> {
     fn write(&mut self, bytes: &[u8]) -> Result<(), EncodeError> {
         self.0.write(bytes)
     }
+
+    fn position(&self) -> Result<usize, EncodeError> {
+        self.0.position()
+    }
+
+    fn overwrite(&mut self, position: usize, bytes: &[u8]) -> Result<(), EncodeError> {
+        self.0.overwrite(position, bytes)
+    }
 }
 
 struct DynReader<'a>(&'a mut dyn Reader);
 
 impl Reader for DynReader<'_> {
+    fn read_some(&mut self, bytes: &mut [u8]) -> Result<usize, DecodeError> {
+        self.0.read_some(bytes)
+    }
+
     fn read(&mut self, bytes: &mut [u8]) -> Result<(), DecodeError> {
         self.0.read(bytes)
     }

--- a/core/cu29_runtime/src/curuntime.rs
+++ b/core/cu29_runtime/src/curuntime.rs
@@ -1256,6 +1256,20 @@ impl Writer for PreallocatedVecWriter<'_> {
         self.0.extend_from_slice(bytes);
         Ok(())
     }
+
+    fn position(&self) -> Result<usize, EncodeError> {
+        Ok(self.0.len())
+    }
+
+    fn overwrite(&mut self, position: usize, bytes: &[u8]) -> Result<(), EncodeError> {
+        let output = self
+            .0
+            .get_mut(position..)
+            .and_then(|tail| tail.get_mut(..bytes.len()))
+            .ok_or(EncodeError::UnexpectedEnd)?;
+        output.copy_from_slice(bytes);
+        Ok(())
+    }
 }
 
 impl KeyFramesManager {

--- a/core/cu29_runtime/src/logcodec.rs
+++ b/core/cu29_runtime/src/logcodec.rs
@@ -1,3 +1,5 @@
+//! Typed payload codecs with Copper-owned framing in the log stream.
+
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
@@ -9,9 +11,11 @@ use alloc::format;
 use alloc::string::{String, ToString};
 #[cfg(feature = "std")]
 use bincode::config::standard;
-use bincode::de::{Decode, Decoder};
+use bincode::de::read::Reader;
+use bincode::de::{Decode, Decoder, DecoderImpl};
 #[cfg(feature = "std")]
 use bincode::decode_from_std_read;
+use bincode::enc::write::Writer;
 use bincode::enc::{Encode, Encoder};
 use bincode::error::{DecodeError, EncodeError};
 use core::any::TypeId;
@@ -30,6 +34,13 @@ use crate::curuntime::{RuntimeLifecycleEvent, RuntimeLifecycleRecord};
 #[cfg(feature = "std")]
 use cu29_unifiedlog::{UnifiedLogger, UnifiedLoggerBuilder, UnifiedLoggerIOReader};
 
+/// Encodes a payload inside a boundary managed by Copper.
+///
+/// Copper prefixes each present codec payload with its encoded byte length (a
+/// fixed four-byte little-endian integer). Encoding writes directly to storage;
+/// decoding receives a reader restricted to that payload and must consume it fully.
+/// Codecs encode their own representation without adding Copper's frame header.
+/// The destination writer must support position queries and overwrites.
 pub trait CuLogCodec<P: CuMsgPayload>: 'static {
     type Config: DeserializeOwned + Default;
 
@@ -276,21 +287,7 @@ where
         }
         Some(payload) => {
             1u8.encode(encoder)?;
-            let encoded_start = observed_encode_bytes();
-            let handle_start = crate::monitoring::current_payload_handle_bytes();
-            let source_handle_bytes = codec.source_payload_handle_bytes(payload);
-            if source_handle_bytes > 0 {
-                crate::monitoring::record_payload_handle_bytes(source_handle_bytes);
-            }
-            codec.encode_payload(payload, encoder)?;
-            let encoded_bytes = observed_encode_bytes().saturating_sub(encoded_start);
-            let handle_bytes =
-                crate::monitoring::current_payload_handle_bytes().saturating_sub(handle_start);
-            crate::monitoring::record_current_slot_payload_io_stats(
-                core::mem::size_of::<T>(),
-                encoded_bytes,
-                handle_bytes,
-            );
+            encode_payload_with_codec(payload, codec, encoder)?;
         }
     }
     msg.tov.encode(encoder)?;
@@ -310,7 +307,7 @@ where
     let present: u8 = Decode::decode(decoder)?;
     let payload = match present {
         0 => None,
-        1 => Some(codec.decode_payload(decoder)?),
+        1 => Some(decode_framed_payload(decoder, codec)?),
         value => {
             return Err(DecodeError::OtherString(format!(
                 "Invalid CuMsg presence tag {value} for payload '{}'",
@@ -342,7 +339,7 @@ where
     if source_handle_bytes > 0 {
         crate::monitoring::record_payload_handle_bytes(source_handle_bytes);
     }
-    codec.encode_payload(payload, encoder)?;
+    encode_framed_payload(payload, codec, encoder)?;
     let encoded_bytes = observed_encode_bytes().saturating_sub(encoded_start);
     let handle_bytes =
         crate::monitoring::current_payload_handle_bytes().saturating_sub(handle_start);
@@ -363,7 +360,113 @@ where
     C: CuLogCodec<T>,
     D: Decoder<Context = ()>,
 {
-    codec.decode_payload(decoder)
+    decode_framed_payload(decoder, codec)
+}
+
+const CODEC_LENGTH_BYTES: usize = 4;
+
+fn encode_framed_payload<T, C, E>(
+    payload: &T,
+    codec: &mut C,
+    encoder: &mut E,
+) -> Result<(), EncodeError>
+where
+    T: CuMsgPayload,
+    C: CuLogCodec<T>,
+    E: Encoder,
+{
+    let header = encoder.writer().position()?;
+    encoder.writer().write(&[0; CODEC_LENGTH_BYTES])?;
+    let start = encoder.writer().position()?;
+    codec.encode_payload(payload, encoder)?;
+    let len = encoder
+        .writer()
+        .position()?
+        .checked_sub(start)
+        .and_then(|len| u32::try_from(len).ok())
+        .ok_or(EncodeError::Other(
+            "Logging codec payload exceeds its frame length",
+        ))?;
+    encoder.writer().overwrite(header, &len.to_le_bytes())
+}
+
+/// Restricts every reader operation, including lookahead, to one codec payload.
+struct PayloadReader<'a, R> {
+    inner: &'a mut R,
+    remaining: usize,
+    overconsumed: bool,
+}
+
+impl<R: Reader> Reader for PayloadReader<'_, R> {
+    fn read_some(&mut self, bytes: &mut [u8]) -> Result<usize, DecodeError> {
+        let len = bytes.len().min(self.remaining);
+        if len == 0 {
+            return Ok(0);
+        }
+        let read = self.inner.read_some(&mut bytes[..len])?;
+        self.remaining -= read;
+        Ok(read)
+    }
+
+    fn read(&mut self, bytes: &mut [u8]) -> Result<(), DecodeError> {
+        if bytes.len() > self.remaining {
+            return Err(DecodeError::UnexpectedEnd {
+                additional: bytes.len() - self.remaining,
+            });
+        }
+        self.inner.read(bytes)?;
+        self.remaining -= bytes.len();
+        Ok(())
+    }
+
+    fn peek_read(&mut self, len: usize) -> Option<&[u8]> {
+        if len > self.remaining {
+            return None;
+        }
+        self.inner.peek_read(len)
+    }
+
+    fn consume(&mut self, len: usize) {
+        if len > self.remaining {
+            self.overconsumed = true;
+        }
+        let len = len.min(self.remaining);
+        self.inner.consume(len);
+        self.remaining -= len;
+    }
+}
+
+fn decode_framed_payload<T, C, D>(decoder: &mut D, codec: &mut C) -> Result<T, DecodeError>
+where
+    T: CuMsgPayload,
+    C: CuLogCodec<T>,
+    D: Decoder<Context = ()>,
+{
+    let mut length = [0; CODEC_LENGTH_BYTES];
+    decoder.claim_bytes_read(CODEC_LENGTH_BYTES)?;
+    decoder.reader().read(&mut length)?;
+    let len =
+        usize::try_from(u32::from_le_bytes(length)).map_err(|_| DecodeError::LimitExceeded)?;
+    // Charge the enclosing decoder so successive frames share its byte limit.
+    decoder.claim_bytes_read(len)?;
+    let config = *decoder.config();
+    let mut reader = PayloadReader {
+        inner: decoder.reader(),
+        remaining: len,
+        overconsumed: false,
+    };
+    let payload = codec.decode_payload(&mut DecoderImpl::new(&mut reader, config, ()))?;
+    if reader.overconsumed {
+        return Err(DecodeError::Other(
+            "Logging codec consumed beyond its payload frame",
+        ));
+    }
+    if reader.remaining != 0 {
+        return Err(DecodeError::Other(
+            "Logging codec did not consume its entire payload frame",
+        ));
+    }
+    Ok(payload)
 }
 
 #[cfg(feature = "std")]
@@ -423,4 +526,214 @@ pub fn seed_effective_config_from_log<T: 'static>(log_base: &Path) -> CuResult<O
         set_effective_config_ron::<T>(ron);
     }
     Ok(effective_config_ron)
+}
+
+#[cfg(test)]
+mod framing_tests {
+    use super::*;
+    use bincode::config::standard;
+    use bincode::de::read::SliceReader;
+    use bincode::enc::EncoderImpl;
+    use bincode::enc::write::SliceWriter;
+    use cu29_traits::ObservedWriter;
+
+    #[derive(Default)]
+    struct BytesCodec {
+        encodes: usize,
+    }
+
+    impl CuLogCodec<u8> for BytesCodec {
+        type Config = ();
+
+        fn new(_: ()) -> CuResult<Self> {
+            Ok(Self::default())
+        }
+
+        fn source_payload_handle_bytes(&self, _: &u8) -> usize {
+            0
+        }
+
+        fn encode_payload<E: Encoder>(
+            &mut self,
+            payload: &u8,
+            encoder: &mut E,
+        ) -> Result<(), EncodeError> {
+            self.encodes += 1;
+            encoder.writer().write(&[*payload; 3])
+        }
+
+        fn decode_payload<D: Decoder<Context = ()>>(
+            &mut self,
+            decoder: &mut D,
+        ) -> Result<u8, DecodeError> {
+            // A codec may look ahead, but cannot see the adjacent payload.
+            assert!(decoder.reader().peek_read(4).is_none());
+            assert!(matches!(
+                decoder.reader().read(&mut [0; 4]),
+                Err(DecodeError::UnexpectedEnd { .. })
+            ));
+            let mut bytes = [0; 3];
+            decoder.reader().read(&mut bytes)?;
+            assert!(decoder.reader().peek_read(1).is_none());
+            Ok(bytes[0])
+        }
+    }
+
+    #[test]
+    fn codec_frames_encode_once_in_fixed_storage_and_count_header_once() {
+        let mut storage = [0; 15];
+        let mut codec = BytesCodec::default();
+        cu29_traits::begin_observed_encode();
+        let mut encoder = EncoderImpl::new(
+            ObservedWriter::new(SliceWriter::new(&mut storage)),
+            standard(),
+        );
+        encode_payload_with_codec(&7, &mut codec, &mut encoder).unwrap();
+        encode_payload_with_codec(&9, &mut codec, &mut encoder).unwrap();
+        42u8.encode(&mut encoder).unwrap();
+        assert_eq!(encoder.writer().position().unwrap(), 15);
+        assert_eq!(cu29_traits::finish_observed_encode(), 15);
+        assert_eq!(codec.encodes, 2);
+        assert_eq!(storage, [3, 0, 0, 0, 7, 7, 7, 3, 0, 0, 0, 9, 9, 9, 42]);
+        let mut decoder = DecoderImpl::new(SliceReader::new(&storage), standard(), ());
+        assert_eq!(
+            decode_payload_with_codec(&mut decoder, &mut codec).unwrap(),
+            7
+        );
+        assert_eq!(
+            decode_payload_with_codec(&mut decoder, &mut codec).unwrap(),
+            9
+        );
+        assert_eq!(u8::decode(&mut decoder).unwrap(), 42);
+    }
+
+    #[test]
+    fn codec_frames_preserve_message_metadata_and_absent_payloads() {
+        let mut storage = [0; 256];
+        let mut codec = BytesCodec::default();
+        let mut present = CuMsg::new(Some(7u8));
+        present.tov = Tov::Time(cu29_clock::CuTime::from_nanos(123));
+        let absent = CuMsg::<u8>::default();
+        let mut encoder = EncoderImpl::new(SliceWriter::new(&mut storage), standard());
+        encode_msg_with_codec(&present, &mut codec, &mut encoder).unwrap();
+        encode_msg_with_codec(&absent, &mut codec, &mut encoder).unwrap();
+        let len = encoder.writer().position().unwrap();
+        assert_eq!(codec.encodes, 1);
+        let mut decoder = DecoderImpl::new(SliceReader::new(&storage[..len]), standard(), ());
+        let decoded = decode_msg_with_codec(&mut decoder, &mut codec).unwrap();
+        assert_eq!(decoded.payload(), Some(&7));
+        assert_eq!(decoded.tov, present.tov);
+        assert!(
+            decode_msg_with_codec(&mut decoder, &mut codec)
+                .unwrap()
+                .payload()
+                .is_none()
+        );
+        assert!(decoder.reader().peek_read(1).is_none());
+    }
+
+    #[test]
+    fn codec_frame_limits_accumulate_in_outer_decoder() {
+        let bytes = [3, 0, 0, 0, 7, 7, 7, 3, 0, 0, 0, 9, 9, 9];
+        let mut codec = BytesCodec::default();
+        let mut decoder =
+            DecoderImpl::new(SliceReader::new(&bytes), standard().with_limit::<13>(), ());
+        assert_eq!(
+            decode_payload_with_codec(&mut decoder, &mut codec).unwrap(),
+            7
+        );
+        assert!(matches!(
+            decode_payload_with_codec(&mut decoder, &mut codec),
+            Err(DecodeError::LimitExceeded)
+        ));
+    }
+
+    #[test]
+    fn codec_frame_truncation_and_short_destination_are_errors() {
+        let bytes = [3, 0, 0, 0, 7, 7, 7];
+        let mut codec = BytesCodec::default();
+        for len in 0..bytes.len() {
+            let mut decoder = DecoderImpl::new(SliceReader::new(&bytes[..len]), standard(), ());
+            assert!(matches!(
+                decode_payload_with_codec(&mut decoder, &mut codec),
+                Err(DecodeError::UnexpectedEnd { .. })
+            ));
+        }
+        let mut storage = [0; 6];
+        let mut encoder = EncoderImpl::new(SliceWriter::new(&mut storage), standard());
+        assert!(matches!(
+            encode_payload_with_codec(&7, &mut codec, &mut encoder),
+            Err(EncodeError::UnexpectedEnd)
+        ));
+        assert_eq!(&storage[..4], &[0; 4]);
+    }
+
+    #[test]
+    fn payload_reader_caps_consume_and_preserves_following_bytes() {
+        let mut source = SliceReader::new(&[7, 8, 9]);
+        let mut reader = PayloadReader {
+            inner: &mut source,
+            remaining: 2,
+            overconsumed: false,
+        };
+        assert_eq!(reader.peek_read(2), Some(&[7, 8][..]));
+        reader.consume(usize::MAX);
+        assert!(reader.overconsumed);
+        assert_eq!(reader.remaining, 0);
+        assert_eq!(source.peek_read(1), Some(&[9][..]));
+    }
+
+    #[test]
+    fn codec_frame_rejects_unconsumed_payload_bytes() {
+        // BytesCodec consumes three bytes; the fourth belongs to this frame.
+        let mut source = SliceReader::new(&[4, 0, 0, 0, 7, 7, 7, 8, 9]);
+        struct ShortCodec;
+        impl CuLogCodec<u8> for ShortCodec {
+            type Config = ();
+            fn new(_: ()) -> CuResult<Self> {
+                Ok(Self)
+            }
+            fn source_payload_handle_bytes(&self, _: &u8) -> usize {
+                0
+            }
+            fn encode_payload<E: Encoder>(&mut self, _: &u8, _: &mut E) -> Result<(), EncodeError> {
+                Ok(())
+            }
+            fn decode_payload<D: Decoder<Context = ()>>(
+                &mut self,
+                decoder: &mut D,
+            ) -> Result<u8, DecodeError> {
+                let mut bytes = [0; 3];
+                decoder.reader().read(&mut bytes)?;
+                Ok(bytes[0])
+            }
+        }
+        let mut decoder = DecoderImpl::new(&mut source, standard(), ());
+        assert!(matches!(
+            decode_payload_with_codec(&mut decoder, &mut ShortCodec),
+            Err(DecodeError::Other(
+                "Logging codec did not consume its entire payload frame"
+            ))
+        ));
+        assert_eq!(source.peek_read(2), Some(&[8, 9][..]));
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn codec_frames_decode_from_non_peekable_reader() {
+        let bytes = [3, 0, 0, 0, 7, 7, 7, 42];
+        let mut source = &bytes[..];
+        struct Frame;
+        impl Decode<()> for Frame {
+            fn decode<D: Decoder<Context = ()>>(decoder: &mut D) -> Result<Self, DecodeError> {
+                assert_eq!(
+                    decode_payload_with_codec(decoder, &mut BytesCodec::default())?,
+                    7
+                );
+                Ok(Self)
+            }
+        }
+        bincode::decode_from_std_read::<Frame, _, _>(&mut source, standard()).unwrap();
+        assert_eq!(source, &[42]);
+    }
 }

--- a/core/cu29_traits/src/lib.rs
+++ b/core/cu29_traits/src/lib.rs
@@ -435,6 +435,15 @@ impl<W: Writer> Writer for ObservedWriter<W> {
         record_observed_encode_bytes(bytes.len());
         Ok(())
     }
+
+    fn position(&self) -> Result<usize, EncodeError> {
+        self.inner.position()
+    }
+
+    fn overwrite(&mut self, position: usize, bytes: &[u8]) -> Result<(), EncodeError> {
+        // These bytes were counted when the frame header was reserved.
+        self.inner.overwrite(position, bytes)
+    }
 }
 
 /// Defines a basic write, append only stream trait to be able to log or send serializable objects.

--- a/doc/v1-api-surface.md
+++ b/doc/v1-api-surface.md
@@ -106,6 +106,9 @@ This file defines the Copper V1 public contract. Anything not listed as stable i
   - `high-precision-limiter`
 - Low-level logging codec registry APIs in `cu29::logcodec`.
 - Low-level monitoring probes and allocation counters.
+- `cu29_traits::ObservedWriter` and its bincode writer operations, including
+  `position` and `overwrite` for filling reserved codec headers. Overwrites do
+  not increment appended-byte accounting.
 - Direct unified-log section/header structs.
 
 ## Internal

--- a/examples/cu_image_codec_demo/README.md
+++ b/examples/cu_image_codec_demo/README.md
@@ -31,3 +31,19 @@ just run-consolemon
 just fsck-consolemon
 just log-stats-consolemon
 ```
+
+## Payload framing
+
+Copper surrounds each present codec payload with a fixed four-byte little-endian
+encoded length. It reserves the header, encodes directly into log storage, then
+fills in the byte count. On decode, the codec receives a reader limited to that
+payload, keeping adjacent messages and metadata intact. Codecs must consume the
+complete frame. Writers used for codec logging must support bincode's `position`
+and `overwrite` operations; Copper's memory-mapped writer supports both.
+
+Read logs with the logreader built for the application version that recorded them.
+The codec payload framing changes the encoded content; the unified-log file and
+section header version remains unchanged.
+
+Run `just codec-framing-check` from the repository root to check codec boundaries,
+PNG pixel roundtrips, generated replay, and the shared `no_std` build.

--- a/examples/cu_rp2350_skeleton/Cargo.toml
+++ b/examples/cu_rp2350_skeleton/Cargo.toml
@@ -28,7 +28,7 @@ cu-sdlogger = { path = "../../components/libs/cu_sdlogger", default-features = f
   "eh1",
 ], optional = true, version = "1.2.0-dev" }
 cu29-export = { path = "../../core/cu29_export", version = "1.2.0-dev", optional = true, default-features = false }
-bincode = { package = "cu-bincode", version = "2.0", default-features = false, features = [
+bincode = { package = "cu-bincode", version = "2.2", git = "https://github.com/copper-project/cu-bincode", rev = "f10d7ac8b061cf63e9b69a0a13c76919a3a4599a", default-features = false, features = [
   "derive",
 ] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/justfile
+++ b/justfile
@@ -31,6 +31,16 @@ pr-check:
 	just logstream-udp-check
 	just logstream-pacing-check
 
+# Verify codec framing, generated replay, and fixed-storage serialization.
+codec-framing-check:
+	just fmt-check
+	cargo +stable test -p cu29-runtime --lib framing_tests
+	cargo +stable test -p cu29-runtime --test replay_primitives
+	cargo +stable test -p cu-png-codec -p cu-ffv1-codec
+	cargo +stable test -p cu29-unifiedlog -p cu29-traits --lib
+	cargo +stable clippy -p cu29-runtime -p cu29-traits -p cu29-unifiedlog -p cu-png-codec --all-targets -- -D warnings
+	cargo +stable check -p cu29-runtime -p cu29-traits -p cu29-unifiedlog --no-default-features
+
 # Reproduce the scheduled weekly audit and beta checks on the local host.
 weekly: weekly-audit
 	cargo +beta fmt --all -- --check


### PR DESCRIPTION
A codec decoder shares the CopperList stream with other payloads and metadata. Copper now gives every present codec payload its own byte boundary: reserve a fixed four-byte little-endian length, encode directly into the destination, measure the writer cursor, and fill in the reserved header. Decoding caps reads, short reads, peeks, and consumption at that boundary and rejects incomplete consumption.

The fixed-storage path invokes the codec once and adds no payload allocation or intermediate payload copy. Writer wrappers preserve backpatching and count the reserved header once. PNG retains direct encoding; its decoding adapter also supports the non-peekable reader used by log export through a fixed 1 KiB buffer.

This changes encoded codec payload content. Recordings require the matching application logreader; the unified-log encapsulation version remains unchanged. Custom codec writers need the new bincode position/overwrite operations. Both the workspace and standalone RP2350 example pin the tested cu-bincode commit pending its 2.2 release.

Validation:
- `just codec-framing-check`: framing regressions, adjacent PNGs with pixel checks through slice and streaming readers, generated replay, storage/accounting tests, clippy, and shared no_std checks.
- `just nostd-ci`: passes, including 596 tests and embedded/RP2350 firmware and host builds.
- `just api-check`: passes with the two intentional ObservedWriter trait methods reflected in the snapshot.
- Optional FFmpeg-enabled FFV1 tests are blocked in `ffmpeg-next` by API mismatches with the installed FFmpeg headers. Default FFV1 tests pass.

Replaces #1301. Supporting dependency: https://github.com/copper-project/cu-bincode/pull/9 (CI passes). Book documentation: https://github.com/copper-project/copper-rs-book/pull/69 (`just build` passes). The wiki source update is on its `docs/codec-payload-framing` review branch; GitHub wikis do not support pull requests.
