### PR TITLE
Backport PNG decoding, RP2350 dependency, and watchdog test fixes to 1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ cu29-units = { path = "core/cu29_units", version = "1.1.1" }
 cu29-value = { path = "core/cu29_value", default-features = false, version = "1.1.1" }
 cu-ffv1-codec = { path = "components/codecs/cu_ffv1_codec", version = "1.1.1" }
 cu-linux-resources = { path = "components/res/cu_linux_resources", version = "1.1.1" }
-cu-png-codec = { path = "components/codecs/cu_png_codec", version = "1.1.1" }
+cu-png-codec = { path = "components/codecs/cu_png_codec", version = "1.1.2" }
 cu-rng = { path = "components/res/cu_rng", version = "1.1.1" }
 
 # Copper components

--- a/components/codecs/cu_png_codec/Cargo.toml
+++ b/components/codecs/cu_png_codec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cu-png-codec"
 description = "PNG log codec for Copper image payloads"
-version.workspace = true
+version = "1.1.2"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/components/codecs/cu_png_codec/src/lib.rs
+++ b/components/codecs/cu_png_codec/src/lib.rs
@@ -70,68 +70,74 @@ impl<W: BincodeWriter> Write for BincodeWriterAdapter<'_, W> {
 struct BincodeReaderAdapter<'a, R> {
     inner: &'a mut R,
     position: u64,
+    buffer: [u8; 1024],
+    buffered: std::ops::Range<usize>,
+    chunk_remaining: u64,
+    last_chunk: bool,
 }
 
-impl<'a, R> BincodeReaderAdapter<'a, R> {
+impl<'a, R: BincodeReader> BincodeReaderAdapter<'a, R> {
     fn new(inner: &'a mut R) -> Self {
-        Self { inner, position: 0 }
+        Self {
+            inner,
+            position: 0,
+            buffer: [0; 1024],
+            buffered: 0..0,
+            chunk_remaining: 8, // PNG signature, followed by length/type/data/CRC chunks.
+            last_chunk: false,
+        }
     }
 
-    fn peek_window_len(&mut self) -> usize
-    where
-        R: BincodeReader,
-    {
-        if self.inner.peek_read(8192).is_some() {
-            8192
-        } else if self.inner.peek_read(4096).is_some() {
-            4096
-        } else if self.inner.peek_read(2048).is_some() {
-            2048
-        } else if self.inner.peek_read(1024).is_some() {
-            1024
-        } else if self.inner.peek_read(512).is_some() {
-            512
-        } else if self.inner.peek_read(256).is_some() {
-            256
-        } else if self.inner.peek_read(128).is_some() {
-            128
-        } else if self.inner.peek_read(64).is_some() {
-            64
-        } else if self.inner.peek_read(32).is_some() {
-            32
-        } else if self.inner.peek_read(16).is_some() {
-            16
-        } else if self.inner.peek_read(8).is_some() {
+    // Bound each read to the PNG signature, a chunk header, or its data/CRC.
+    // This lets stream readers use fixed storage without reading past IEND.
+    // The PNG decoder validates the signature, contents, and checksums.
+    fn fill_png(&mut self) -> io::Result<&[u8]> {
+        if !self.buffered.is_empty() {
+            return Ok(&self.buffer[self.buffered.clone()]);
+        }
+        let header = self.chunk_remaining == 0;
+        if header && self.last_chunk {
+            return Ok(&[]);
+        }
+        if !header {
+            // Borrow available input directly, including from partially buffered
+            // readers. Fall back to an exact read when peeking is unavailable.
+            for length in [
+                8192, 4096, 2048, 1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1,
+            ] {
+                if length as u64 <= self.chunk_remaining && self.inner.peek_read(length).is_some() {
+                    return self
+                        .inner
+                        .peek_read(length)
+                        .ok_or(io::ErrorKind::UnexpectedEof.into());
+                }
+            }
+        }
+        let length = if header {
             8
-        } else if self.inner.peek_read(4).is_some() {
-            4
-        } else if self.inner.peek_read(2).is_some() {
-            2
-        } else if self.inner.peek_read(1).is_some() {
-            1
         } else {
-            0
+            self.chunk_remaining.min(self.buffer.len() as u64) as usize
+        };
+        self.inner
+            .read(&mut self.buffer[..length])
+            .map_err(|err| match err {
+                DecodeError::UnexpectedEnd { .. } => io::ErrorKind::UnexpectedEof.into(),
+                DecodeError::Io { inner, .. } => inner,
+                _ => io::ErrorKind::InvalidData.into(),
+            })?;
+        if header {
+            self.chunk_remaining = u64::from(u32::from_be_bytes([
+                self.buffer[0],
+                self.buffer[1],
+                self.buffer[2],
+                self.buffer[3],
+            ])) + 4; // Include the CRC.
+            self.last_chunk = &self.buffer[4..8] == b"IEND";
+        } else {
+            self.chunk_remaining -= length as u64;
         }
-    }
-
-    fn fill_from_peek(&mut self) -> io::Result<&[u8]>
-    where
-        R: BincodeReader,
-    {
-        let peek_len = self.peek_window_len();
-        if peek_len == 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "PNG codec expected more bytes from the bincode decoder",
-            ));
-        }
-
-        self.inner.peek_read(peek_len).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "PNG codec expected more bytes from the bincode decoder",
-            )
-        })
+        self.buffered = 0..length;
+        Ok(&self.buffer[..length])
     }
 }
 
@@ -141,7 +147,7 @@ impl<R: BincodeReader> Read for BincodeReaderAdapter<'_, R> {
             return Ok(0);
         }
 
-        let available = self.fill_from_peek()?;
+        let available = self.fill_buf()?;
         let count = available.len().min(buf.len());
         buf[..count].copy_from_slice(&available[..count]);
         self.consume(count);
@@ -151,11 +157,16 @@ impl<R: BincodeReader> Read for BincodeReaderAdapter<'_, R> {
 
 impl<R: BincodeReader> BufRead for BincodeReaderAdapter<'_, R> {
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
-        self.fill_from_peek()
+        self.fill_png()
     }
 
     fn consume(&mut self, amt: usize) {
-        self.inner.consume(amt);
+        if self.buffered.is_empty() {
+            self.inner.consume(amt);
+            self.chunk_remaining -= amt as u64;
+        } else {
+            self.buffered.start += amt.min(self.buffered.len());
+        }
         self.position = self.position.saturating_add(amt as u64);
     }
 }
@@ -409,8 +420,10 @@ mod tests {
     }
 
     fn sample_image() -> CuImage<Vec<u8>> {
-        let width = 16;
-        let height = 12;
+        sample_image_with_size(16, 12)
+    }
+
+    fn sample_image_with_size(width: u32, height: u32) -> CuImage<Vec<u8>> {
         let stride = width * 3;
         let mut buffer = vec![0u8; (stride * height) as usize];
         for y in 0..height as usize {
@@ -430,6 +443,146 @@ mod tests {
                 pixel_format: *b"RGB3",
             },
             buffer_handle: CuHandle::new_detached(buffer),
+        }
+    }
+
+    fn encoded_image(image: &CuImage<Vec<u8>>) -> EncodedWithCodec<'_> {
+        EncodedWithCodec {
+            image,
+            codec: std::cell::RefCell::new(
+                CuPngCodec::new(CuPngCodecConfig {
+                    compression: CuPngCompression::Uncompressed,
+                    ..Default::default()
+                })
+                .expect("codec"),
+            ),
+        }
+    }
+
+    fn assert_image_eq(expected: &CuImage<Vec<u8>>, actual: &CuImage<Vec<u8>>) {
+        assert_eq!(actual.seq, expected.seq);
+        assert_eq!(actual.format.width, expected.format.width);
+        assert_eq!(actual.format.height, expected.format.height);
+        assert_eq!(actual.format.stride, expected.format.stride);
+        assert_eq!(actual.format.pixel_format, expected.format.pixel_format);
+        expected.buffer_handle.with_inner(|expected| {
+            actual.buffer_handle.with_inner(|actual| {
+                let actual: &[u8] = actual;
+                let expected: &[u8] = expected;
+                assert_eq!(actual, expected);
+            });
+        });
+    }
+
+    struct ShortReads<R>(R);
+
+    impl<R: Read> Read for ShortReads<R> {
+        fn read(&mut self, bytes: &mut [u8]) -> io::Result<usize> {
+            let length = bytes.len().min(3);
+            self.0.read(&mut bytes[..length])
+        }
+    }
+
+    #[test]
+    fn png_stream_decode_preserves_following_images_and_fields() {
+        let first = sample_image_with_size(64, 48);
+        let mut second = sample_image();
+        second.seq = 42;
+        let marker = 0x0123_4567_89ab_cdefu64;
+        let encoded = encode_to_vec(
+            (encoded_image(&first), encoded_image(&second), marker),
+            standard(),
+        )
+        .expect("encode images and trailing field");
+        assert!(encoded.len() > 1024);
+
+        type Images = (DecodedWithCodec, DecodedWithCodec, u64);
+        let ((a, b, trailing), used): (Images, usize) =
+            decode_from_slice(&encoded, standard()).expect("slice decode");
+        assert_eq!(used, encoded.len());
+        assert_image_eq(&first, &a.0);
+        assert_image_eq(&second, &b.0);
+        assert_eq!(trailing, marker);
+
+        let directory = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../target/png-stream-reader");
+        std::fs::create_dir_all(&directory).expect("test directory");
+        let path = directory.join(format!("images-{}.bin", std::process::id()));
+        let mut file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .expect("test file");
+        file.write_all(&encoded).expect("write file");
+        file.rewind().expect("rewind file");
+        let (a, b, trailing): Images =
+            bincode::decode_from_std_read(&mut file, standard()).expect("file decode");
+        assert_image_eq(&first, &a.0);
+        assert_image_eq(&second, &b.0);
+        assert_eq!(trailing, marker);
+        assert_eq!(
+            file.stream_position().expect("file position"),
+            encoded.len() as u64
+        );
+        drop(file);
+        std::fs::remove_file(path).expect("remove test file");
+
+        let mut short = ShortReads(std::io::Cursor::new(&encoded));
+        let (a, b, trailing): Images = bincode::decode_from_std_read(&mut short, standard())
+            .expect("short-read stream decode");
+        assert_image_eq(&first, &a.0);
+        assert_image_eq(&second, &b.0);
+        assert_eq!(trailing, marker);
+        assert_eq!(short.0.position(), encoded.len() as u64);
+
+        let mut buffered = std::io::BufReader::with_capacity(17, std::io::Cursor::new(&encoded));
+        buffered.fill_buf().expect("prime partial peek window");
+        let (a, b, trailing): Images = bincode::decode_from_reader(&mut buffered, standard())
+            .expect("partially buffered reader decode");
+        assert_image_eq(&first, &a.0);
+        assert_image_eq(&second, &b.0);
+        assert_eq!(trailing, marker);
+        assert_eq!(
+            buffered.stream_position().expect("buffered position"),
+            encoded.len() as u64
+        );
+    }
+
+    #[test]
+    fn png_stream_decode_rejects_truncation_and_bad_crc() {
+        let image = sample_image();
+        let encoded = encode_to_vec(encoded_image(&image), standard()).expect("encode");
+        let signature = encoded
+            .windows(8)
+            .position(|bytes| bytes == b"\x89PNG\r\n\x1a\n")
+            .expect("PNG signature");
+        let iend = encoded
+            .windows(8)
+            .rposition(|bytes| bytes == b"\0\0\0\0IEND")
+            .expect("IEND header");
+        for end in [signature + 3, signature + 11, signature + 20, iend + 10] {
+            let mut input = std::io::Cursor::new(&encoded[..end]);
+            let error =
+                bincode::decode_from_std_read::<DecodedWithCodec, _, _>(&mut input, standard())
+                    .expect_err("truncated PNG");
+            assert!(
+                matches!(error, DecodeError::UnexpectedEnd { .. }),
+                "{error:?}"
+            );
+        }
+        for crc in [signature + 8 + 8 + 13, iend + 8] {
+            let mut corrupt = encoded.clone();
+            corrupt[crc] ^= 1;
+            let error = bincode::decode_from_std_read::<DecodedWithCodec, _, _>(
+                &mut std::io::Cursor::new(corrupt),
+                standard(),
+            )
+            .expect_err("bad PNG CRC");
+            assert!(
+                !matches!(error, DecodeError::UnexpectedEnd { .. }),
+                "{error:?}"
+            );
         }
     }
 

--- a/components/monitors/cu_safetymon/tests/safety_monitoring.rs
+++ b/components/monitors/cu_safetymon/tests/safety_monitoring.rs
@@ -215,26 +215,28 @@ fn panic_fault_exits_with_configured_code_and_marker_context() {
 #[test]
 fn lock_fault_exits_with_configured_code_and_last_marker() {
     if std::env::var(CHILD_MODE_ENV).ok().as_deref() == Some("lock") {
-        let cfg = safetymon_test_config(79, 80);
+        // Allow the child to finish publishing progress on a busy CI runner.
+        let cfg = safetymon_test_config_with_timing(1_000, 10, 79, 80);
         let probe = Arc::new(RuntimeExecutionProbe::default());
         let (metadata, runtime) = monitor_metadata(&cfg, Some(probe.clone()));
         let layout = metadata.layout();
         let mut monitor = CuSafetyMon::new(metadata, runtime).expect("safetymon new");
         let (ctx, _clock_control) = CuContext::new_mock_clock();
-        monitor.start(&ctx).expect("safetymon start");
         let cl_ctx = CuContext::builder(ctx.clock.clone()).cl_id(9).build();
         let metadata = CuMsgMetadata::default();
         let msgs: [&CuMsgMetadata; 1] = [&metadata];
-        monitor
-            .process_copperlist(&cl_ctx, layout.view(&msgs))
-            .expect("safetymon process_copperlist");
+        // Publish the marker before arming the watchdog.
         probe.record(ExecutionMarker {
             component_id: ComponentId::new(1),
             step: CuComponentState::Process,
             culistid: Some(9),
         });
+        monitor.start(&ctx).expect("safetymon start");
+        monitor
+            .process_copperlist(&cl_ctx, layout.view(&msgs))
+            .expect("safetymon process_copperlist");
 
-        thread::sleep(Duration::from_millis(300));
+        thread::sleep(Duration::from_secs(10));
         std::process::exit(254);
     }
 
@@ -245,13 +247,14 @@ fn lock_fault_exits_with_configured_code_and_last_marker() {
     assert_eq!(
         output.status.code(),
         Some(79),
-        "unexpected lock child exit status: {:?}",
-        output.status
+        "unexpected lock child exit status: {:?}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("cu_safetymon lock fault:"));
-    assert!(stderr.contains("component='driver'"));
-    assert!(stderr.contains("last_culist=9"));
+    assert!(stderr.contains("cu_safetymon lock fault:"), "{stderr}");
+    assert!(stderr.contains("component='driver'"), "{stderr}");
+    assert!(stderr.contains("last_culist=9"), "{stderr}");
     let _ = fs::remove_dir_all(&child_dir);
 }
 

--- a/examples/cu_rp2350_skeleton/Cargo.toml
+++ b/examples/cu_rp2350_skeleton/Cargo.toml
@@ -28,7 +28,9 @@ cu-sdlogger = { path = "../../components/libs/cu_sdlogger", default-features = f
   "eh1",
 ], optional = true, version = "1.1.1" }
 cu29-export = { path = "../../core/cu29_export", version = "1.1.1", optional = true, default-features = false }
-bincode = { version = "2.0", default-features = false, features = ["derive"] }
+bincode = { package = "cu-bincode", version = "2.0", default-features = false, features = [
+  "derive",
+] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 # embedded stuff


### PR DESCRIPTION
Backport three fixes to `release/1.1`. PNG decoding now stops at the PNG boundary, preserving subsequent images and fields, and supports bincode readers without peek support. The RP2350 skeleton uses `cu-bincode`, matching Copper's serialization traits. The safety-monitor watchdog regression test publishes its marker before arming the watchdog and allows startup time on busy CI runners.

Backports: #1381, #1325, and #1367.

Only `cu-png-codec` moves to **1.1.2**, with its workspace dependency reference updated. The workspace and all other crate versions remain at 1.1.1. The safety-monitor change is test-only and the RP2350 example is unpublished.

Validation:

- PNG and safety-monitor tests: 15 passed.
- Clippy on all targets of both crates: passed.
- `just fmt-check` and typo checks on changed files: passed.
- `just clippy-nostd`, including RP2350 firmware and host targets: passed.
- `cargo +stable publish -p cu-png-codec --dry-run --allow-dirty`: passed, including compilation against published dependencies; no upload.
- Cargo metadata confirms `cu-png-codec` is the only package at 1.1.2.

The full `just fmt` typo hook could not complete locally because it scans an unrelated, untracked 104 GB Autoware benchmark log left by another branch. The file was preserved; formatting and focused typo validation passed separately.

The channel-routing, transform-layout, and logging-runtime changes remain in 1.2.
