### PR TITLE
Scope logreader tools to recorded runs

### DIFF
--- a/api/v1/cu29-export.txt
+++ b/api/v1/cu29-export.txt
@@ -68,8 +68,9 @@ pub cu29_export::Command::ExtractTextLog::log_index: std::path::PathBuf
 pub cu29_export::Command::Fsck
 pub cu29_export::Command::Fsck::dump_runtime_lifecycle: bool
 pub cu29_export::Command::Fsck::verbose: u8
+pub cu29_export::Command::ListInstances
 pub cu29_export::Command::LogStats
-pub cu29_export::Command::LogStats::config: std::path::PathBuf
+pub cu29_export::Command::LogStats::config: core::option::Option<std::path::PathBuf>
 pub cu29_export::Command::LogStats::features: alloc::vec::Vec<alloc::string::String>
 pub cu29_export::Command::LogStats::mission: core::option::Option<alloc::string::String>
 pub cu29_export::Command::LogStats::output: std::path::PathBuf
@@ -80,6 +81,7 @@ impl core::fmt::Display for cu29_export::ExportFormat
 pub fn cu29_export::ExportFormat::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct cu29_export::LogReaderCli
 pub cu29_export::LogReaderCli::command: cu29_export::Command
+pub cu29_export::LogReaderCli::instance: core::option::Option<usize>
 pub cu29_export::LogReaderCli::unifiedlog_base: std::path::PathBuf
 pub fn cu29_export::assert_unified_log_mission(unifiedlog_base: &std::path::Path, expected_mission: &str) -> cu29_traits::CuResult<()>
 pub fn cu29_export::copperlists_reader<P: cu29_traits::CopperListTuple>(src: impl std::io::Read) -> impl core::iter::traits::iterator::Iterator<Item = cu29_runtime::copperlist::CopperList<P>>

--- a/api/v1/cu29-export.txt
+++ b/api/v1/cu29-export.txt
@@ -68,7 +68,7 @@ pub cu29_export::Command::ExtractTextLog::log_index: std::path::PathBuf
 pub cu29_export::Command::Fsck
 pub cu29_export::Command::Fsck::dump_runtime_lifecycle: bool
 pub cu29_export::Command::Fsck::verbose: u8
-pub cu29_export::Command::ListInstances
+pub cu29_export::Command::ListRuns
 pub cu29_export::Command::LogStats
 pub cu29_export::Command::LogStats::config: core::option::Option<std::path::PathBuf>
 pub cu29_export::Command::LogStats::features: alloc::vec::Vec<alloc::string::String>
@@ -81,7 +81,7 @@ impl core::fmt::Display for cu29_export::ExportFormat
 pub fn cu29_export::ExportFormat::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct cu29_export::LogReaderCli
 pub cu29_export::LogReaderCli::command: cu29_export::Command
-pub cu29_export::LogReaderCli::instance: core::option::Option<usize>
+pub cu29_export::LogReaderCli::run: core::option::Option<usize>
 pub cu29_export::LogReaderCli::unifiedlog_base: std::path::PathBuf
 pub fn cu29_export::assert_unified_log_mission(unifiedlog_base: &std::path::Path, expected_mission: &str) -> cu29_traits::CuResult<()>
 pub fn cu29_export::copperlists_reader<P: cu29_traits::CopperListTuple>(src: impl std::io::Read) -> impl core::iter::traits::iterator::Iterator<Item = cu29_runtime::copperlist::CopperList<P>>

--- a/core/cu29_export/README.md
+++ b/core/cu29_export/README.md
@@ -16,6 +16,47 @@ see
 - CopperList export helpers
 - optional Python bindings for iterating logs without going through JSON first
 
+## Selecting a Runtime Instance
+
+A unified log can contain multiple runtime instances after a mission change or an
+appended restart. Each `Instantiated` lifecycle record announces a fresh runtime.
+Its CopperList IDs and clock can start over independently of the previous instance.
+
+Use the application's logreader binary to list the instances and select one:
+
+```sh
+logreader logs/robot.copper list-instances
+logreader logs/robot.copper --instance 1 fsck --dump-runtime-lifecycle
+logreader logs/robot.copper --instance 1 extract-copperlists
+logreader logs/robot.copper --instance 1 extract-text-log target/debug/cu29_log_index
+logreader logs/robot.copper --instance 1 log-stats --output instance-1.json
+logreader logs/robot.copper --instance 1 export-mcap --output instance-1.mcap
+```
+
+Indices are zero-based and follow `Instantiated` record order. They are distinct
+from the recorded `instance_id`, which can repeat across process restarts.
+`list-instances` reads lifecycle metadata without decoding application payloads.
+It shows the mission, application, runtime instance ID, start time, and whether
+`ShutdownCompleted` was recorded.
+
+Single-instance logs select their instance automatically. Logs from standalone
+writers with no `Instantiated` record are treated as one implicit instance.
+Multi-instance logs require `--instance` for extraction, fsck, statistics, and MCAP
+export. The selection includes the runtime's initial stream reservations and all
+of its CL, keyframe, lifecycle, and structured-log sections. A multi-instance log
+whose startup section ordering cannot be recognized is listed but rejected for
+selection.
+
+The selected instance supplies the recorded configuration used by logging codecs.
+Statistics also default to that configuration and its recorded mission; `--config`
+and `--mission` provide explicit overrides. Without a recorded configuration,
+statistics use `copperconfig.ron`. Use a logreader and string index built for the
+application version that produced the selected instance.
+
+`fsck` checks CopperList IDs within the selected instance, reports decoding errors,
+and returns an error for repeated or decreasing IDs and an unclean final log close.
+An ID reset at the next `Instantiated` belongs to that next instance.
+
 ## Python Support
 
 Python support lives behind the `python` feature and is not supported on macOS in

--- a/core/cu29_export/README.md
+++ b/core/cu29_export/README.md
@@ -16,46 +16,46 @@ see
 - CopperList export helpers
 - optional Python bindings for iterating logs without going through JSON first
 
-## Selecting a Runtime Instance
+## Selecting a Recorded Run
 
-A unified log can contain multiple runtime instances after a mission change or an
-appended restart. Each `Instantiated` lifecycle record announces a fresh runtime.
-Its CopperList IDs and clock can start over independently of the previous instance.
+A unified log can contain multiple recorded runs after a mission change or an
+appended restart. Each `Instantiated` lifecycle record begins a recorded run.
+Its CopperList IDs and clock can start over independently of the previous run.
 
-Use the application's logreader binary to list the instances and select one:
+Use the application's logreader binary to list the runs and select one:
 
 ```sh
-logreader logs/robot.copper list-instances
-logreader logs/robot.copper --instance 1 fsck --dump-runtime-lifecycle
-logreader logs/robot.copper --instance 1 extract-copperlists
-logreader logs/robot.copper --instance 1 extract-text-log target/debug/cu29_log_index
-logreader logs/robot.copper --instance 1 log-stats --output instance-1.json
-logreader logs/robot.copper --instance 1 export-mcap --output instance-1.mcap
+logreader logs/robot.copper list-runs
+logreader logs/robot.copper --run 1 fsck --dump-runtime-lifecycle
+logreader logs/robot.copper --run 1 extract-copperlists
+logreader logs/robot.copper --run 1 extract-text-log target/debug/cu29_log_index
+logreader logs/robot.copper --run 1 log-stats --output run-1.json
+logreader logs/robot.copper --run 1 export-mcap --output run-1.mcap
 ```
 
 Indices are zero-based and follow `Instantiated` record order. They are distinct
 from the recorded `instance_id`, which can repeat across process restarts.
-`list-instances` reads lifecycle metadata without decoding application payloads.
+`list-runs` reads lifecycle metadata without decoding application payloads.
 It shows the mission, application, runtime instance ID, start time, and whether
 `ShutdownCompleted` was recorded.
 
-Single-instance logs select their instance automatically. Logs from standalone
-writers with no `Instantiated` record are treated as one implicit instance.
-Multi-instance logs require `--instance` for extraction, fsck, statistics, and MCAP
+Single-run logs select their run automatically. Logs from standalone
+writers with no `Instantiated` record are treated as one implicit run.
+Multi-run logs require `--run` for extraction, fsck, statistics, and MCAP
 export. The selection includes the runtime's initial stream reservations and all
-of its CL, keyframe, lifecycle, and structured-log sections. A multi-instance log
+of its CL, keyframe, lifecycle, and structured-log sections. A multi-run log
 whose startup section ordering cannot be recognized is listed but rejected for
 selection.
 
-The selected instance supplies the recorded configuration used by logging codecs.
+The selected run supplies the recorded configuration used by logging codecs.
 Statistics also default to that configuration and its recorded mission; `--config`
 and `--mission` provide explicit overrides. Without a recorded configuration,
 statistics use `copperconfig.ron`. Use a logreader and string index built for the
-application version that produced the selected instance.
+application version that produced the selected run.
 
-`fsck` checks CopperList IDs within the selected instance, reports decoding errors,
+`fsck` checks CopperList IDs within the selected run, reports decoding errors,
 and returns an error for repeated or decreasing IDs and an unclean final log close.
-An ID reset at the next `Instantiated` belongs to that next instance.
+An ID reset at the next `Instantiated` belongs to that next run.
 
 ## Python Support
 

--- a/core/cu29_export/src/fsck.rs
+++ b/core/cu29_export/src/fsck.rs
@@ -1,8 +1,7 @@
-use crate::{keyframes_reader, structlog_reader};
+use crate::instances::InstanceReader;
 use bincode::config::standard;
 use bincode::decode_from_std_read;
 use bincode::error::DecodeError;
-use cu29::prelude::UnifiedLoggerRead;
 use cu29::prelude::*;
 use cu29::{CopperListTuple, CuResult};
 use num_format::{Locale, ToFormattedString};
@@ -243,10 +242,10 @@ fn print_runtime_lifecycle_record(index: usize, entry: &RuntimeLifecycleRecord) 
 }
 
 pub(crate) fn check<P>(
-    dl: &mut UnifiedLoggerRead,
+    dl: &mut InstanceReader,
     verbose: u8,
     dump_runtime_lifecycle: bool,
-) -> Option<CuResult<()>>
+) -> CuResult<()>
 where
     P: CopperListTuple,
 {
@@ -283,13 +282,17 @@ where
                 match header.entry_type {
                     UnifiedLogType::StructuredLogLine => {
                         structured_log_size += content.len();
-                        let mut reader: Cursor<Vec<u8>> = Cursor::new(content);
-                        let iter = structlog_reader(&mut reader);
-                        for entry in iter {
-                            sl_entries += 1;
-                            if entry.is_err() {
-                                println!("Struct log #{sl_entries} is corrupted: {entry:?}");
+                        let mut reader = Cursor::new(content.as_slice());
+                        while reader.position() < content.len() as u64 {
+                            if let Err(error) =
+                                decode_from_std_read::<CuLogEntry, _, _>(&mut reader, standard())
+                            {
+                                break 'scan Err(CuError::new_with_cause(
+                                    "Corrupted structured log entry",
+                                    error,
+                                ));
                             }
+                            sl_entries += 1;
                         }
                     }
                     UnifiedLogType::CopperList => {
@@ -317,23 +320,28 @@ where
                             };
                             let entry_end = reader.position() as usize;
                             cl_entropy_samples.observe(&content[entry_start..entry_end]);
+                            if let Some(last) = copperlist_sequence.last_id
+                                && entry.id <= last
+                            {
+                                break 'scan Err(CuError::from(format!(
+                                    "CopperList IDs must increase within a runtime instance: {} after {}",
+                                    entry.id, last,
+                                )));
+                            }
                             copperlist_sequence.observe(entry.id);
                             section_last_cl = Some(entry.id);
                             if first_ts.is_none() {
                                 first_cl = Some(entry.id);
-                                first_ts = entry
-                                    .cumsgs()
-                                    .first()
-                                    .expect("Empty copperlist")
-                                    .metadata()
-                                    .process_time()
-                                    .start;
+                                if let Some(first) = entry.cumsgs().first() {
+                                    first_ts = first.metadata().process_time().start;
+                                }
                                 if overall_first_ts.is_none() {
                                     overall_first_ts = first_ts;
                                 }
                             }
-                            let last_msg = *entry.cumsgs().last().expect("Empty copperlist");
-                            last_ts = last_msg.metadata().process_time().end;
+                            if let Some(last_msg) = entry.cumsgs().last() {
+                                last_ts = last_msg.metadata().process_time().end;
+                            }
                         }
                         if verbose > 0 {
                             match (first_cl, section_last_cl) {
@@ -346,9 +354,20 @@ where
                     }
                     UnifiedLogType::FrozenTasks => {
                         kfs_size += content.len();
-                        let mut reader: Cursor<Vec<u8>> = Cursor::new(content);
-                        let iter = keyframes_reader(&mut reader);
-                        for entry in iter {
+                        let mut reader = Cursor::new(content.as_slice());
+                        while reader.position() < content.len() as u64 {
+                            let entry = match decode_from_std_read::<KeyFrame, _, _>(
+                                &mut reader,
+                                standard(),
+                            ) {
+                                Ok(entry) => entry,
+                                Err(error) => {
+                                    break 'scan Err(CuError::new_with_cause(
+                                        "Corrupted keyframe",
+                                        error,
+                                    ));
+                                }
+                            };
                             keyframes += 1;
                             if verbose > 0 {
                                 println!(
@@ -424,6 +443,11 @@ where
                         }
                     }
                     UnifiedLogType::LastEntry => {
+                        if header.is_open {
+                            break Err(CuError::from(
+                                "The log has a temporary end marker; its writer has not closed it cleanly",
+                            ));
+                        }
                         if verbose > 0 {
                             println!("Last Entry / EOF.");
                             println!();
@@ -585,7 +609,7 @@ where
         runtime_lifecycle_size.to_formatted_string(l)
     );
 
-    None
+    result
 }
 
 #[cfg(test)]

--- a/core/cu29_export/src/fsck.rs
+++ b/core/cu29_export/src/fsck.rs
@@ -1,4 +1,4 @@
-use crate::instances::InstanceReader;
+use crate::runs::RunReader;
 use bincode::config::standard;
 use bincode::decode_from_std_read;
 use bincode::error::DecodeError;
@@ -242,7 +242,7 @@ fn print_runtime_lifecycle_record(index: usize, entry: &RuntimeLifecycleRecord) 
 }
 
 pub(crate) fn check<P>(
-    dl: &mut InstanceReader,
+    dl: &mut RunReader,
     verbose: u8,
     dump_runtime_lifecycle: bool,
 ) -> CuResult<()>
@@ -324,7 +324,7 @@ where
                                 && entry.id <= last
                             {
                                 break 'scan Err(CuError::from(format!(
-                                    "CopperList IDs must increase within a runtime instance: {} after {}",
+                                    "CopperList IDs must increase within a recorded run: {} after {}",
                                     entry.id, last,
                                 )));
                             }

--- a/core/cu29_export/src/instances.rs
+++ b/core/cu29_export/src/instances.rs
@@ -1,0 +1,744 @@
+//! Runtime instance discovery and bounded access to a selected instance's sections.
+
+use crate::build_read_logger;
+use bincode::config::standard;
+use bincode::decode_from_slice;
+use cu29::prelude::CuError;
+use cu29::prelude::CuResult;
+use cu29::prelude::CuTime;
+use cu29::prelude::MainHeader;
+use cu29::prelude::RuntimeLifecycleEvent;
+use cu29::prelude::RuntimeLifecycleRecord;
+use cu29::prelude::RuntimeLifecycleStackInfo;
+use cu29::prelude::SectionHeader;
+use cu29::prelude::UnifiedLogRead;
+use cu29::prelude::UnifiedLogType;
+use cu29::prelude::UnifiedLoggerRead;
+use cu29::prelude::memmap::LogPosition;
+use std::io::{self, Read};
+use std::path::Path;
+
+#[derive(Debug)]
+pub(crate) struct RuntimeInstance {
+    pub index: usize,
+    pub started_at: Option<CuTime>,
+    pub stack: Option<RuntimeLifecycleStackInfo>,
+    pub config: Option<String>,
+    pub missions: Vec<String>,
+    pub shutdown_completed: bool,
+    start: LogPosition,
+    end: Option<LogPosition>,
+    pub copperlist_bytes: u64,
+    boundary_known: bool,
+}
+
+impl RuntimeInstance {
+    fn new(index: usize, start: LogPosition) -> Self {
+        Self {
+            index,
+            started_at: None,
+            stack: None,
+            config: None,
+            missions: Vec::new(),
+            shutdown_completed: false,
+            start,
+            end: None,
+            copperlist_bytes: 0,
+            boundary_known: true,
+        }
+    }
+
+    pub fn reader(&self, path: &Path) -> CuResult<InstanceReader> {
+        let mut inner = build_read_logger(path)?;
+        inner.seek(self.start)?;
+        Ok(InstanceReader {
+            inner,
+            end: self.end,
+        })
+    }
+}
+
+/// Inspect lifecycle records without decoding application-specific payloads.
+pub(crate) fn discover(path: &Path) -> CuResult<Vec<RuntimeInstance>> {
+    let mut reader = build_read_logger(path)?;
+    let beginning = reader.position();
+    let mut instances = Vec::<RuntimeInstance>::new();
+    let mut sections = Vec::new();
+    let mut startup_prefix = None;
+    let mut previous_marker = 0;
+    loop {
+        let position = reader.position();
+        let header = reader.raw_skip_section()?;
+        if header.entry_type == UnifiedLogType::LastEntry {
+            break;
+        }
+        if header.entry_type == UnifiedLogType::Empty
+            || header.offset_to_next_section < u32::from(header.block_size)
+            || header.used > header.offset_to_next_section - u32::from(header.block_size)
+            || reader.position() == position
+        {
+            return Err(CuError::from(format!(
+                "Invalid section at slab {} offset {}",
+                position.slab_index, position.offset,
+            )));
+        }
+        if header.entry_type == UnifiedLogType::RuntimeLifecycle {
+            reader.seek(position)?;
+            let (_, content) = reader.raw_read_section()?;
+            let mut remaining = content.as_slice();
+            while !remaining.is_empty() {
+                let (record, used) =
+                    decode_from_slice::<RuntimeLifecycleRecord, _>(remaining, standard()).map_err(
+                        |e| CuError::new_with_cause("Invalid runtime lifecycle record", e),
+                    )?;
+                match record.event {
+                    RuntimeLifecycleEvent::Instantiated {
+                        effective_config_ron,
+                        stack,
+                        ..
+                    } => {
+                        if remaining.len() != content.len() {
+                            return Err(CuError::from(
+                                "Instantiated must start its runtime lifecycle section",
+                            ));
+                        }
+                        // Generated runtimes reserve their streams before the lifecycle
+                        // stream. Instantiated still identifies the new instance; include
+                        // those initial reservations in its physical section range.
+                        let prefix = startup_reservations(&sections[previous_marker..]);
+                        let has_prefix = *startup_prefix.get_or_insert(!sections.is_empty());
+                        let start = if has_prefix {
+                            prefix.unwrap_or(position)
+                        } else {
+                            position
+                        };
+                        let mut instance = RuntimeInstance::new(instances.len(), start);
+                        instance.boundary_known = !has_prefix || prefix.is_some();
+                        previous_marker = sections.len();
+                        instance.started_at = Some(record.timestamp);
+                        instance.config = Some(effective_config_ron);
+                        instance.stack = Some(stack);
+                        instances.push(instance);
+                    }
+                    RuntimeLifecycleEvent::MissionStarted { mission } => {
+                        if let Some(instance) = instances.last_mut()
+                            && !instance.missions.contains(&mission)
+                        {
+                            instance.missions.push(mission);
+                        }
+                    }
+                    RuntimeLifecycleEvent::ShutdownCompleted => {
+                        if let Some(instance) = instances.last_mut() {
+                            instance.shutdown_completed = true;
+                        }
+                    }
+                    _ => {}
+                }
+                remaining = &remaining[used..];
+            }
+        }
+        sections.push((position, header.entry_type, header.used));
+    }
+
+    if instances.is_empty() {
+        // Logs from standalone writers can have no runtime lifecycle stream.
+        instances.push(RuntimeInstance::new(0, beginning));
+    } else if instances.len() == 1 {
+        // Include streams reserved before Instantiated by older runtime builders.
+        instances[0].start = beginning;
+        instances[0].boundary_known = true;
+    }
+
+    // An unresolved boundary also makes the preceding instance's end ambiguous.
+    if instances.iter().any(|instance| !instance.boundary_known) {
+        for instance in &mut instances {
+            instance.boundary_known = false;
+        }
+    }
+
+    for index in 0..instances.len().saturating_sub(1) {
+        instances[index].end = Some(instances[index + 1].start);
+    }
+    for instance in &mut instances {
+        instance.copperlist_bytes = sections
+            .iter()
+            .filter(|(position, kind, _)| {
+                *kind == UnifiedLogType::CopperList
+                    && position_key(*position) >= position_key(instance.start)
+                    && instance
+                        .end
+                        .is_none_or(|end| position_key(*position) < position_key(end))
+            })
+            .map(|(_, _, used)| u64::from(*used))
+            .sum();
+    }
+    Ok(instances)
+}
+
+fn startup_reservations(sections: &[(LogPosition, UnifiedLogType, u32)]) -> Option<LogPosition> {
+    use UnifiedLogType::{CopperList, FrozenTasks, StructuredLogLine};
+    // cu29_derive::build_with_resources allocates text first for local logging,
+    // and after CL/keyframes when logstream fanout is enabled. Keyframes are optional.
+    for types in [
+        &[StructuredLogLine, CopperList, FrozenTasks][..],
+        &[CopperList, FrozenTasks, StructuredLogLine][..],
+        &[StructuredLogLine, CopperList][..],
+        &[CopperList, StructuredLogLine][..],
+    ] {
+        if sections.len() >= types.len() {
+            let tail = &sections[sections.len() - types.len()..];
+            if tail
+                .iter()
+                .zip(types)
+                .all(|((_, kind, _), expected)| kind == expected)
+            {
+                return Some(tail[0].0);
+            }
+        }
+    }
+    None
+}
+
+fn position_key(position: LogPosition) -> (usize, usize) {
+    (position.slab_index, position.offset)
+}
+
+pub(crate) fn select(
+    instances: &[RuntimeInstance],
+    requested: Option<usize>,
+) -> CuResult<&RuntimeInstance> {
+    let index = match requested {
+        Some(index) => index,
+        None if instances.len() == 1 => 0,
+        None => {
+            return Err(CuError::from(format!(
+                "Log contains {} runtime instances; use list-instances and select --instance <index>",
+                instances.len()
+            )));
+        }
+    };
+    let instance = instances.get(index).ok_or_else(|| {
+        CuError::from(format!(
+            "Runtime instance {index} does not exist; use list-instances to see available instances"
+        ))
+    })?;
+    if !instance.boundary_known {
+        return Err(CuError::from(
+            "Cannot isolate runtime instances: startup sections do not match the recorded runtime layout",
+        ));
+    }
+    Ok(instance)
+}
+
+pub(crate) struct InstanceReader {
+    inner: UnifiedLoggerRead,
+    end: Option<LogPosition>,
+}
+
+impl InstanceReader {
+    pub fn raw_main_header(&self) -> &MainHeader {
+        self.inner.raw_main_header()
+    }
+
+    fn at_end(&self) -> bool {
+        self.end
+            .is_some_and(|end| position_key(self.inner.position()) >= position_key(end))
+    }
+
+    pub fn raw_read_section(&mut self) -> CuResult<(SectionHeader, Vec<u8>)> {
+        if self.at_end() {
+            return Ok((
+                SectionHeader {
+                    entry_type: UnifiedLogType::LastEntry,
+                    is_open: false,
+                    ..SectionHeader::default()
+                },
+                Vec::new(),
+            ));
+        }
+        self.inner.raw_read_section()
+    }
+
+    fn read_next_section_type(&mut self, kind: UnifiedLogType) -> CuResult<Option<Vec<u8>>> {
+        while !self.at_end() {
+            let position = self.inner.position();
+            let header = self.inner.raw_skip_section()?;
+            if header.entry_type == UnifiedLogType::LastEntry {
+                return Ok(None);
+            }
+            if header.entry_type == kind {
+                self.inner.seek(position)?;
+                return self
+                    .inner
+                    .raw_read_section()
+                    .map(|(_, content)| Some(content));
+            }
+        }
+        Ok(None)
+    }
+
+    pub fn stream(self, kind: UnifiedLogType) -> InstanceStream {
+        InstanceStream {
+            reader: self,
+            kind,
+            buffer: Vec::new(),
+            offset: 0,
+            finished: false,
+        }
+    }
+}
+
+pub(crate) struct InstanceStream {
+    reader: InstanceReader,
+    kind: UnifiedLogType,
+    buffer: Vec<u8>,
+    offset: usize,
+    finished: bool,
+}
+
+impl Read for InstanceStream {
+    fn read(&mut self, destination: &mut [u8]) -> io::Result<usize> {
+        if destination.is_empty() || self.finished {
+            return Ok(0);
+        }
+        while self.offset == self.buffer.len() {
+            let content = self
+                .reader
+                .read_next_section_type(self.kind)
+                .map_err(|e| io::Error::other(e.to_string()))?;
+            let Some(content) = content else {
+                self.finished = true;
+                return Ok(0);
+            };
+            self.buffer = content;
+            self.offset = 0;
+        }
+        let count = destination.len().min(self.buffer.len() - self.offset);
+        destination[..count].copy_from_slice(&self.buffer[self.offset..self.offset + count]);
+        self.offset += count;
+        Ok(count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::copperlists_reader;
+    use bincode::{Decode, Encode};
+    use cu29::prelude::memmap::MmapSectionStorage;
+    use cu29::prelude::*;
+    use std::sync::{Arc, Mutex};
+    use tempfile::TempDir;
+
+    #[derive(Debug, Default, Encode, Decode, serde::Serialize)]
+    struct Messages(u32);
+
+    impl ErasedCuStampedDataSet for Messages {
+        fn cumsgs(&self) -> Vec<&dyn ErasedCuStampedData> {
+            Vec::new()
+        }
+    }
+
+    impl MatchingTasks for Messages {
+        fn get_all_task_ids() -> &'static [&'static str] {
+            &[]
+        }
+    }
+
+    impl CuPayloadRawBytes for Messages {
+        fn payload_raw_bytes(&self) -> Vec<Option<u64>> {
+            Vec::new()
+        }
+    }
+
+    fn writer(path: &Path, append: bool) -> Arc<Mutex<UnifiedLoggerWrite>> {
+        let UnifiedLogger::Write(writer) = UnifiedLoggerBuilder::new()
+            .file_base_name(path)
+            .write(true)
+            .create(true)
+            .append(append)
+            .preallocated_size(64 * 1024)
+            .build()
+            .unwrap()
+        else {
+            panic!("Expected a writer");
+        };
+        Arc::new(Mutex::new(writer))
+    }
+
+    fn write_instance(logger: &Arc<Mutex<UnifiedLoggerWrite>>, value: u32, mission: &str) {
+        write_instance_with_options(logger, value, mission, false, true, 3);
+    }
+
+    fn write_instance_with_options(
+        logger: &Arc<Mutex<UnifiedLoggerWrite>>,
+        value: u32,
+        mission: &str,
+        logstream: bool,
+        capture_keyframes: bool,
+        entries: u64,
+    ) {
+        let make_text = || {
+            stream_write::<CuLogEntry, MmapSectionStorage>(
+                logger.clone(),
+                UnifiedLogType::StructuredLogLine,
+                1024,
+            )
+            .unwrap()
+        };
+        let early_text = (!logstream).then(make_text);
+        let mut cls = stream_write::<CopperList<Messages>, MmapSectionStorage>(
+            logger.clone(),
+            UnifiedLogType::CopperList,
+            1024,
+        )
+        .unwrap();
+        let mut keyframes = capture_keyframes.then(|| {
+            stream_write::<KeyFrame, MmapSectionStorage>(
+                logger.clone(),
+                UnifiedLogType::FrozenTasks,
+                1024,
+            )
+            .unwrap()
+        });
+        let mut text = early_text.unwrap_or_else(make_text);
+        let mut lifecycle = stream_write::<RuntimeLifecycleRecord, MmapSectionStorage>(
+            logger.clone(),
+            UnifiedLogType::RuntimeLifecycle,
+            1024,
+        )
+        .unwrap();
+        lifecycle
+            .log(&RuntimeLifecycleRecord {
+                timestamp: CuTime::from_nanos(0),
+                event: RuntimeLifecycleEvent::Instantiated {
+                    config_source: RuntimeLifecycleConfigSource::BundledDefault,
+                    effective_config_ron: format!("(missions: [(id: \"drive\"), (id: \"park\")], tasks: [], cnx: [], // {value}\n)"),
+                    stack: RuntimeLifecycleStackInfo {
+                        app_name: "instance-test".to_string(),
+                        app_version: "1".to_string(),
+                        git_commit: None,
+                        git_dirty: None,
+                        subsystem_id: None,
+                        subsystem_code: 0,
+                        instance_id: 0,
+                    },
+                },
+            })
+            .unwrap();
+        lifecycle
+            .log(&RuntimeLifecycleRecord {
+                timestamp: CuTime::from_nanos(1),
+                event: RuntimeLifecycleEvent::MissionStarted {
+                    mission: mission.to_string(),
+                },
+            })
+            .unwrap();
+        for id in 0..entries {
+            cls.log(&CopperList::new(id, Messages(value))).unwrap();
+        }
+        text.log(&CuLogEntry::new(value, CuLogLevel::Info)).unwrap();
+        if let Some(keyframes) = &mut keyframes {
+            keyframes
+                .log(&KeyFrame {
+                    culistid: 0,
+                    timestamp: CuTime::from_nanos(u64::from(value)),
+                    serialized_tasks: Vec::new(),
+                })
+                .unwrap();
+        }
+        lifecycle
+            .log(&RuntimeLifecycleRecord {
+                timestamp: CuTime::from_nanos(10),
+                event: RuntimeLifecycleEvent::ShutdownCompleted,
+            })
+            .unwrap();
+    }
+
+    fn assert_instances(path: &Path) {
+        let catalog = discover(path).unwrap();
+        assert_eq!(catalog.len(), 2);
+        assert!(select(&catalog, None).is_err());
+        assert!(select(&catalog, Some(2)).is_err());
+        for (index, expected) in [17, 29].into_iter().enumerate() {
+            let instance = select(&catalog, Some(index)).unwrap();
+            assert_eq!(instance.stack.as_ref().unwrap().instance_id, 0);
+            assert_eq!(
+                instance.missions,
+                [if index == 0 { "drive" } else { "park" }]
+            );
+            assert!(instance.shutdown_completed);
+            let entries = copperlists_reader::<Messages>(
+                instance
+                    .reader(path)
+                    .unwrap()
+                    .stream(UnifiedLogType::CopperList),
+            )
+            .collect::<Vec<_>>();
+            assert_eq!(
+                entries.iter().map(|entry| entry.id).collect::<Vec<_>>(),
+                [0, 1, 2]
+            );
+            assert!(entries.iter().all(|entry| entry.msgs.0 == expected));
+            crate::fsck::check::<Messages>(&mut instance.reader(path).unwrap(), 0, false).unwrap();
+            for kind in [
+                UnifiedLogType::StructuredLogLine,
+                UnifiedLogType::FrozenTasks,
+            ] {
+                let mut bytes = Vec::new();
+                instance
+                    .reader(path)
+                    .unwrap()
+                    .stream(kind)
+                    .read_to_end(&mut bytes)
+                    .unwrap();
+                match kind {
+                    UnifiedLogType::StructuredLogLine => {
+                        let (entry, used) =
+                            decode_from_slice::<CuLogEntry, _>(&bytes, standard()).unwrap();
+                        assert_eq!(entry.msg_index, expected);
+                        assert_eq!(used, bytes.len());
+                    }
+                    UnifiedLogType::FrozenTasks => {
+                        let (entry, used) =
+                            decode_from_slice::<KeyFrame, _>(&bytes, standard()).unwrap();
+                        assert_eq!(entry.culistid, 0);
+                        assert_eq!(entry.timestamp.as_nanos(), u64::from(expected));
+                        assert_eq!(used, bytes.len());
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_mission_change_with_repeated_ids_selects_all_streams() {
+        let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
+        let path = dir.path().join("missions.copper");
+        let logger = writer(&path, false);
+        write_instance(&logger, 17, "drive");
+        write_instance(&logger, 29, "park");
+        drop(logger);
+        assert_instances(&path);
+    }
+
+    #[test]
+    fn test_appended_restart_with_repeated_ids_selects_all_streams() {
+        let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
+        let path = dir.path().join("restart.copper");
+        let logger = writer(&path, false);
+        write_instance(&logger, 17, "drive");
+        drop(logger);
+        let logger = writer(&path, true);
+        write_instance(&logger, 29, "park");
+        drop(logger);
+        assert_instances(&path);
+    }
+
+    #[test]
+    fn test_log_without_lifecycle_has_one_implicit_instance() {
+        let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
+        let path = dir.path().join("standalone.copper");
+        drop(writer(&path, false));
+        let catalog = discover(&path).unwrap();
+        assert!(select(&catalog, None).unwrap().stack.is_none());
+    }
+
+    #[test]
+    fn test_logstream_order_and_optional_keyframes_across_slabs() {
+        let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
+        let path = dir.path().join("slabs.copper");
+        let logger = writer(&path, false);
+        write_instance_with_options(&logger, 17, "drive", true, false, 10_000);
+        write_instance_with_options(&logger, 29, "park", false, true, 10_000);
+        drop(logger);
+        let catalog = discover(&path).unwrap();
+        assert_eq!(catalog.len(), 2);
+        assert!(catalog[1].start.slab_index > 0);
+        for (index, expected) in [17, 29].into_iter().enumerate() {
+            let instance = select(&catalog, Some(index)).unwrap();
+            let entries = copperlists_reader::<Messages>(
+                instance
+                    .reader(&path)
+                    .unwrap()
+                    .stream(UnifiedLogType::CopperList),
+            )
+            .collect::<Vec<_>>();
+            assert_eq!(entries.len(), 10_000);
+            for (id, entry) in entries.iter().enumerate() {
+                assert_eq!(entry.id, id as u64);
+                assert_eq!(entry.msgs.0, expected);
+            }
+            crate::fsck::check::<Messages>(&mut instance.reader(&path).unwrap(), 0, false).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_selection_does_not_decode_other_instances_payloads() {
+        let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
+        let path = dir.path().join("schemas.copper");
+        let logger = writer(&path, false);
+        write_instance(&logger, 17, "drive");
+        {
+            let mut different_schema = stream_write::<String, MmapSectionStorage>(
+                logger.clone(),
+                UnifiedLogType::CopperList,
+                1024,
+            )
+            .unwrap();
+            different_schema
+                .log(&"a different application payload".to_string())
+                .unwrap();
+        }
+        write_instance(&logger, 29, "park");
+        drop(logger);
+        let catalog = discover(&path).unwrap();
+        let selected = select(&catalog, Some(1)).unwrap();
+        crate::fsck::check::<Messages>(&mut selected.reader(&path).unwrap(), 0, false).unwrap();
+    }
+
+    #[test]
+    fn test_fsck_rejects_cl_reset_without_instantiated() {
+        let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
+        let path = dir.path().join("reset.copper");
+        let logger = writer(&path, false);
+        write_instance(&logger, 17, "drive");
+        {
+            let mut stream = stream_write::<CopperList<Messages>, MmapSectionStorage>(
+                logger.clone(),
+                UnifiedLogType::CopperList,
+                1024,
+            )
+            .unwrap();
+            stream.log(&CopperList::new(0, Messages(29))).unwrap();
+        }
+        drop(logger);
+        let catalog = discover(&path).unwrap();
+        let selected = select(&catalog, None).unwrap();
+        let error = crate::fsck::check::<Messages>(&mut selected.reader(&path).unwrap(), 0, false)
+            .unwrap_err();
+        assert!(error.to_string().contains("IDs must increase"));
+    }
+
+    #[test]
+    fn test_fsck_reports_corrupted_keyframe_and_unclean_close() {
+        let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
+        let path = dir.path().join("incomplete.copper");
+        let logger = writer(&path, false);
+        write_instance(&logger, 17, "drive");
+        let catalog = discover(&path).unwrap();
+        let selected = select(&catalog, None).unwrap();
+        let error = crate::fsck::check::<Messages>(&mut selected.reader(&path).unwrap(), 0, false)
+            .unwrap_err();
+        assert!(error.to_string().contains("temporary end marker"));
+        {
+            let mut stream = stream_write::<u8, MmapSectionStorage>(
+                logger.clone(),
+                UnifiedLogType::FrozenTasks,
+                1024,
+            )
+            .unwrap();
+            stream.log(&255).unwrap();
+        }
+        drop(logger);
+        let catalog = discover(&path).unwrap();
+        let selected = select(&catalog, None).unwrap();
+        let error = crate::fsck::check::<Messages>(&mut selected.reader(&path).unwrap(), 0, false)
+            .unwrap_err();
+        assert!(error.to_string().contains("Corrupted keyframe"));
+    }
+
+    #[test]
+    fn test_unknown_startup_boundary_is_listed_but_cannot_be_selected() {
+        let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
+        let path = dir.path().join("unknown.copper");
+        let logger = writer(&path, false);
+        write_instance(&logger, 17, "drive");
+        let catalog = discover(&path).unwrap();
+        let mut lifecycle = crate::runtime_lifecycle_reader(
+            catalog[0]
+                .reader(&path)
+                .unwrap()
+                .stream(UnifiedLogType::RuntimeLifecycle),
+        );
+        let instantiated = lifecycle.next().unwrap();
+        drop(lifecycle);
+        {
+            let mut unrelated = stream_write::<u32, MmapSectionStorage>(
+                logger.clone(),
+                UnifiedLogType::CopperList,
+                1024,
+            )
+            .unwrap();
+            unrelated.log(&7).unwrap();
+            let mut lifecycle = stream_write::<RuntimeLifecycleRecord, MmapSectionStorage>(
+                logger.clone(),
+                UnifiedLogType::RuntimeLifecycle,
+                1024,
+            )
+            .unwrap();
+            lifecycle.log(&instantiated).unwrap();
+        }
+        drop(logger);
+        let catalog = discover(&path).unwrap();
+        assert_eq!(catalog.len(), 2);
+        assert!(select(&catalog, Some(0)).is_err());
+        assert!(select(&catalog, Some(1)).is_err());
+    }
+
+    #[test]
+    fn test_cli_selects_recorded_config_and_mission_for_stats() {
+        use clap::Parser;
+        let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
+        let path = dir.path().join("cli.copper");
+        let logger = writer(&path, false);
+        write_instance(&logger, 17, "drive");
+        write_instance(&logger, 29, "park");
+        drop(logger);
+        let path = path.to_str().unwrap();
+        let args =
+            crate::LogReaderCli::try_parse_from(["logreader", path, "list-instances"]).unwrap();
+        crate::run_cli_with_args::<Messages>(args).unwrap();
+        let args = crate::LogReaderCli::try_parse_from(["logreader", path, "fsck"]).unwrap();
+        assert!(
+            crate::run_cli_with_args::<Messages>(args)
+                .unwrap_err()
+                .to_string()
+                .contains("--instance")
+        );
+        let args =
+            crate::LogReaderCli::try_parse_from(["logreader", path, "fsck", "--instance", "1"])
+                .unwrap();
+        crate::run_cli_with_args::<Messages>(args).unwrap();
+        let args = crate::LogReaderCli::try_parse_from([
+            "logreader",
+            path,
+            "--instance",
+            "1",
+            "extract-copperlists",
+        ])
+        .unwrap();
+        crate::run_cli_with_args::<Messages>(args).unwrap();
+        let output = dir.path().join("stats.json");
+        let args = crate::LogReaderCli::try_parse_from([
+            "logreader",
+            path,
+            "--instance",
+            "1",
+            "log-stats",
+            "--output",
+            output.to_str().unwrap(),
+        ])
+        .unwrap();
+        crate::run_cli_with_args::<Messages>(args).unwrap();
+        let stats: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(output).unwrap()).unwrap();
+        assert_eq!(stats["mission"], "park");
+        assert!(
+            cu29::logcodec::effective_config_entry::<Messages>("")
+                .ron()
+                .contains("// 29")
+        );
+    }
+}

--- a/core/cu29_export/src/lib.rs
+++ b/core/cu29_export/src/lib.rs
@@ -14,6 +14,7 @@
 //! For runtime Python task prototyping, see `cu-python-task` instead.
 
 mod fsck;
+mod instances;
 pub mod logstats;
 
 #[cfg(feature = "mcap")]
@@ -115,12 +116,18 @@ pub struct LogReaderCli {
     /// for example for toto_0.copper, toto_1.copper ... the base name is toto.copper
     pub unifiedlog_base: PathBuf,
 
+    /// Select the runtime instance by its zero-based index from list-instances.
+    #[arg(long, global = true)]
+    pub instance: Option<usize>,
+
     #[command(subcommand)]
     pub command: Command,
 }
 
 #[derive(Subcommand)]
 pub enum Command {
+    /// List runtime instances announced by Instantiated lifecycle records.
+    ListInstances,
     /// Extract logs
     ExtractTextLog { log_index: PathBuf },
     /// Extract copperlists
@@ -141,9 +148,9 @@ pub enum Command {
         /// Output JSON file path
         #[arg(short, long, default_value = "cu29_logstats.json")]
         output: PathBuf,
-        /// Config file used to map outputs to edges
-        #[arg(long, default_value = "copperconfig.ron")]
-        config: PathBuf,
+        /// Config override; defaults to the selected instance's recorded configuration.
+        #[arg(long)]
+        config: Option<PathBuf>,
         /// Mission id override; defaults to the mission recorded in the log
         #[arg(long)]
         mission: Option<String>,
@@ -228,25 +235,66 @@ where
     run_cli_inner::<P>()
 }
 
-#[cfg(feature = "mcap")]
 fn run_cli_inner<P>() -> CuResult<()>
 where
     P: CopperListTuple + CuPayloadRawBytes + 'static,
 {
-    let args = LogReaderCli::parse();
-    let unifiedlog_base = args.unifiedlog_base;
-    let _ = cu29::logcodec::seed_effective_config_from_log::<P>(&unifiedlog_base)?;
+    run_cli_with_args::<P>(LogReaderCli::parse())
+}
 
-    let mut dl = build_read_logger(&unifiedlog_base)?;
+fn run_cli_with_args<P>(args: LogReaderCli) -> CuResult<()>
+where
+    P: CopperListTuple + CuPayloadRawBytes + 'static,
+{
+    let unifiedlog_base = args.unifiedlog_base;
+    #[cfg(feature = "mcap")]
+    if let Command::McapInfo {
+        mcap_file,
+        schemas,
+        sample_messages,
+    } = &args.command
+    {
+        return mcap_info(mcap_file, *schemas, *sample_messages);
+    }
+
+    let instances = instances::discover(&unifiedlog_base)?;
+    if matches!(args.command, Command::ListInstances) {
+        for instance in &instances {
+            println!(
+                "Instance {}: mission={} app={} instance_id={} started={} shutdown={}",
+                instance.index,
+                instance.missions.join(","),
+                instance
+                    .stack
+                    .as_ref()
+                    .map_or("unknown", |stack| stack.app_name.as_str()),
+                instance.stack.as_ref().map_or_else(
+                    || "unknown".to_string(),
+                    |stack| stack.instance_id.to_string()
+                ),
+                instance
+                    .started_at
+                    .map_or_else(|| "unknown".to_string(), |time| time.to_string()),
+                instance.shutdown_completed,
+            );
+        }
+        return Ok(());
+    }
+    let instance = instances::select(&instances, args.instance)?;
+    if let Some(config) = &instance.config {
+        cu29::logcodec::set_effective_config_ron::<P>(config);
+    }
+    let mut dl = instance.reader(&unifiedlog_base)?;
 
     match args.command {
+        Command::ListInstances => unreachable!("instance listing handled before selection"),
         Command::ExtractTextLog { log_index } => {
-            let reader = UnifiedLoggerIOReader::new(dl, UnifiedLogType::StructuredLogLine);
+            let reader = dl.stream(UnifiedLogType::StructuredLogLine);
             textlog_dump(reader, &log_index)?;
         }
         Command::ExtractCopperlists { export_format } => {
             println!("Extracting copperlists with format: {export_format}");
-            let mut reader = UnifiedLoggerIOReader::new(dl, UnifiedLogType::CopperList);
+            let mut reader = dl.stream(UnifiedLogType::CopperList);
             let iter = copperlists_reader::<P>(&mut reader);
 
             match export_format {
@@ -291,9 +339,7 @@ where
             verbose,
             dump_runtime_lifecycle,
         } => {
-            if let Some(value) = check::<P>(&mut dl, verbose, dump_runtime_lifecycle) {
-                return value;
-            }
+            check::<P>(&mut dl, verbose, dump_runtime_lifecycle)?;
         }
         Command::LogStats {
             output,
@@ -301,7 +347,7 @@ where
             mission,
             features,
         } => {
-            run_logstats::<P>(&unifiedlog_base, dl, output, config, mission, &features)?;
+            run_logstats::<P>(instance, dl, output, config, mission, &features)?;
         }
         #[cfg(feature = "mcap")]
         Command::ExportMcap {
@@ -313,12 +359,12 @@ where
 
             let show_progress = should_show_progress(progress, quiet);
             let total_bytes = if show_progress {
-                Some(copperlist_total_bytes(&unifiedlog_base)?)
+                Some(instance.copperlist_bytes)
             } else {
                 None
             };
 
-            let reader = UnifiedLoggerIOReader::new(dl, UnifiedLogType::CopperList);
+            let reader = dl.stream(UnifiedLogType::CopperList);
 
             // Export to MCAP with schemas derived from generated output metadata.
             let stats = if let Some(total_bytes) = total_bytes {
@@ -345,111 +391,32 @@ where
     Ok(())
 }
 
-#[cfg(not(feature = "mcap"))]
-fn run_cli_inner<P>() -> CuResult<()>
-where
-    P: CopperListTuple + CuPayloadRawBytes + 'static,
-{
-    let args = LogReaderCli::parse();
-    let unifiedlog_base = args.unifiedlog_base;
-    let _ = cu29::logcodec::seed_effective_config_from_log::<P>(&unifiedlog_base)?;
-
-    let mut dl = build_read_logger(&unifiedlog_base)?;
-
-    match args.command {
-        Command::ExtractTextLog { log_index } => {
-            let reader = UnifiedLoggerIOReader::new(dl, UnifiedLogType::StructuredLogLine);
-            textlog_dump(reader, &log_index)?;
-        }
-        Command::ExtractCopperlists { export_format } => {
-            println!("Extracting copperlists with format: {export_format}");
-            let mut reader = UnifiedLoggerIOReader::new(dl, UnifiedLogType::CopperList);
-            let iter = copperlists_reader::<P>(&mut reader);
-
-            match export_format {
-                ExportFormat::Json => {
-                    for entry in iter {
-                        write_json_pretty(&entry)?;
-                    }
-                }
-                ExportFormat::Csv => {
-                    let mut first = true;
-                    for origin in P::get_all_task_ids() {
-                        if !first {
-                            print!(", ");
-                        } else {
-                            print!("id, ");
-                        }
-                        print!("{origin}_time, {origin}_tov, {origin},");
-                        first = false;
-                    }
-                    println!();
-                    for entry in iter {
-                        let mut first = true;
-                        for msg in entry.cumsgs() {
-                            if let Some(payload) = msg.payload() {
-                                if !first {
-                                    print!(", ");
-                                } else {
-                                    print!("{}, ", entry.id);
-                                }
-                                let metadata = msg.metadata();
-                                print!("{}, {}, ", metadata.process_time(), msg.tov());
-                                write_json(payload)?;
-                                first = false;
-                            }
-                        }
-                        println!();
-                    }
-                }
-            }
-        }
-        Command::Fsck {
-            verbose,
-            dump_runtime_lifecycle,
-        } => {
-            if let Some(value) = check::<P>(&mut dl, verbose, dump_runtime_lifecycle) {
-                return value;
-            }
-        }
-        Command::LogStats {
-            output,
-            config,
-            mission,
-            features,
-        } => {
-            run_logstats::<P>(&unifiedlog_base, dl, output, config, mission, &features)?;
-        }
-    }
-
-    Ok(())
-}
-
 fn run_logstats<P>(
-    unifiedlog_base: &Path,
-    dl: UnifiedLoggerRead,
+    instance: &instances::RuntimeInstance,
+    dl: instances::InstanceReader,
     output: PathBuf,
-    config: PathBuf,
+    config: Option<PathBuf>,
     mission: Option<String>,
     features: &[String],
 ) -> CuResult<()>
 where
     P: CopperListTuple + CuPayloadRawBytes,
 {
-    let config_path = config
-        .to_str()
-        .ok_or_else(|| CuError::from("Config path is not valid UTF-8"))?;
-    let feature_refs = features.iter().map(String::as_str).collect::<Vec<_>>();
-    let cfg = cu29::config::read_configuration_with_features(config_path, &feature_refs)
-        .map_err(|e| CuError::new_with_cause("Failed to read configuration", e))?;
-    let logged_mission =
-        if mission.is_none() && matches!(&cfg.graphs, cu29::config::ConfigGraphs::Missions(_)) {
-            unified_log_mission(unifiedlog_base)?
-        } else {
-            None
-        };
-    let mission = resolve_logstats_mission(&cfg, mission, logged_mission);
-    let reader = UnifiedLoggerIOReader::new(dl, UnifiedLogType::CopperList);
+    let cfg = if config.is_none() && instance.config.is_some() {
+        CuConfig::deserialize_ron(instance.config.as_deref().unwrap()).map_err(|e| {
+            CuError::new_with_cause("Failed to read the selected instance's configuration", e)
+        })?
+    } else {
+        let config = config.unwrap_or_else(|| PathBuf::from("copperconfig.ron"));
+        let config_path = config
+            .to_str()
+            .ok_or_else(|| CuError::from("Config path is not valid UTF-8"))?;
+        let feature_refs = features.iter().map(String::as_str).collect::<Vec<_>>();
+        cu29::config::read_configuration_with_features(config_path, &feature_refs)
+            .map_err(|e| CuError::new_with_cause("Failed to read configuration", e))?
+    };
+    let mission = resolve_logstats_mission(&cfg, mission, instance.missions.first().cloned())?;
+    let reader = dl.stream(UnifiedLogType::CopperList);
     let stats = compute_logstats::<P>(reader, &cfg, mission.as_deref())?;
     write_logstats(&stats, &output)
 }
@@ -458,22 +425,23 @@ fn resolve_logstats_mission(
     config: &CuConfig,
     requested: Option<String>,
     logged: Option<String>,
-) -> Option<String> {
-    if requested.is_some() {
-        return requested;
-    }
+) -> CuResult<Option<String>> {
+    let mission = requested.or(logged);
     let cu29::config::ConfigGraphs::Missions(graphs) = &config.graphs else {
-        return None;
+        return Ok(None);
     };
-    if let Some(logged) = logged
-        && graphs.contains_key(&logged)
-    {
-        return Some(logged);
+    if let Some(mission) = mission {
+        if !graphs.contains_key(&mission) {
+            return Err(CuError::from(format!(
+                "Mission '{mission}' is absent from the statistics configuration"
+            )));
+        }
+        return Ok(Some(mission));
     }
     if graphs.contains_key("default") {
-        return Some("default".to_string());
+        return Ok(Some("default".to_string()));
     }
-    graphs.keys().min().cloned()
+    Ok(graphs.keys().min().cloned())
 }
 
 /// Helper function for MCAP export.
@@ -528,15 +496,6 @@ fn make_progress_bar(total_bytes: u64) -> ProgressBar {
 #[cfg(feature = "mcap")]
 fn should_show_progress(force_progress: bool, quiet: bool) -> bool {
     !quiet && (force_progress || std::io::stderr().is_terminal())
-}
-
-#[cfg(feature = "mcap")]
-fn copperlist_total_bytes(log_base: &Path) -> CuResult<u64> {
-    let mut reader = UnifiedLoggerRead::new(log_base)
-        .map_err(|e| CuError::new_with_cause("Failed to open log for progress estimation", e))?;
-    reader
-        .scan_section_bytes(UnifiedLogType::CopperList)
-        .map_err(|e| CuError::new_with_cause("Failed to scan log for progress estimation", e))
 }
 
 fn read_next_entry<T: Decode<()>>(src: &mut impl Read) -> Option<T> {
@@ -1627,15 +1586,16 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            resolve_logstats_mission(&config, None, Some("zeta".to_string())).as_deref(),
+            resolve_logstats_mission(&config, None, Some("zeta".to_string()))
+                .unwrap()
+                .as_deref(),
             Some("zeta")
         );
+        assert!(resolve_logstats_mission(&config, None, Some("missing".to_string())).is_err());
         assert_eq!(
-            resolve_logstats_mission(&config, None, Some("missing".to_string())).as_deref(),
-            Some("default")
-        );
-        assert_eq!(
-            resolve_logstats_mission(&config, Some("alpha".to_string()), None).as_deref(),
+            resolve_logstats_mission(&config, Some("alpha".to_string()), None)
+                .unwrap()
+                .as_deref(),
             Some("alpha")
         );
 
@@ -1648,7 +1608,9 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            resolve_logstats_mission(&config, None, None).as_deref(),
+            resolve_logstats_mission(&config, None, None)
+                .unwrap()
+                .as_deref(),
             Some("alpha")
         );
     }

--- a/core/cu29_export/src/lib.rs
+++ b/core/cu29_export/src/lib.rs
@@ -14,8 +14,8 @@
 //! For runtime Python task prototyping, see `cu-python-task` instead.
 
 mod fsck;
-mod instances;
 pub mod logstats;
+mod runs;
 
 #[cfg(feature = "mcap")]
 pub mod mcap_export;
@@ -116,9 +116,9 @@ pub struct LogReaderCli {
     /// for example for toto_0.copper, toto_1.copper ... the base name is toto.copper
     pub unifiedlog_base: PathBuf,
 
-    /// Select the runtime instance by its zero-based index from list-instances.
+    /// Select the recorded run by its zero-based index from list-runs.
     #[arg(long, global = true)]
-    pub instance: Option<usize>,
+    pub run: Option<usize>,
 
     #[command(subcommand)]
     pub command: Command,
@@ -126,8 +126,8 @@ pub struct LogReaderCli {
 
 #[derive(Subcommand)]
 pub enum Command {
-    /// List runtime instances announced by Instantiated lifecycle records.
-    ListInstances,
+    /// List recorded runs announced by Instantiated lifecycle records.
+    ListRuns,
     /// Extract logs
     ExtractTextLog { log_index: PathBuf },
     /// Extract copperlists
@@ -148,7 +148,7 @@ pub enum Command {
         /// Output JSON file path
         #[arg(short, long, default_value = "cu29_logstats.json")]
         output: PathBuf,
-        /// Config override; defaults to the selected instance's recorded configuration.
+        /// Config override; defaults to the selected run's recorded configuration.
         #[arg(long)]
         config: Option<PathBuf>,
         /// Mission id override; defaults to the mission recorded in the log
@@ -257,37 +257,35 @@ where
         return mcap_info(mcap_file, *schemas, *sample_messages);
     }
 
-    let instances = instances::discover(&unifiedlog_base)?;
-    if matches!(args.command, Command::ListInstances) {
-        for instance in &instances {
+    let runs = runs::discover(&unifiedlog_base)?;
+    if matches!(args.command, Command::ListRuns) {
+        for run in &runs {
             println!(
-                "Instance {}: mission={} app={} instance_id={} started={} shutdown={}",
-                instance.index,
-                instance.missions.join(","),
-                instance
-                    .stack
+                "Run {}: mission={} app={} instance_id={} started={} shutdown={}",
+                run.index,
+                run.missions.join(","),
+                run.stack
                     .as_ref()
                     .map_or("unknown", |stack| stack.app_name.as_str()),
-                instance.stack.as_ref().map_or_else(
+                run.stack.as_ref().map_or_else(
                     || "unknown".to_string(),
                     |stack| stack.instance_id.to_string()
                 ),
-                instance
-                    .started_at
+                run.started_at
                     .map_or_else(|| "unknown".to_string(), |time| time.to_string()),
-                instance.shutdown_completed,
+                run.shutdown_completed,
             );
         }
         return Ok(());
     }
-    let instance = instances::select(&instances, args.instance)?;
-    if let Some(config) = &instance.config {
+    let run = runs::select(&runs, args.run)?;
+    if let Some(config) = &run.config {
         cu29::logcodec::set_effective_config_ron::<P>(config);
     }
-    let mut dl = instance.reader(&unifiedlog_base)?;
+    let mut dl = run.reader(&unifiedlog_base)?;
 
     match args.command {
-        Command::ListInstances => unreachable!("instance listing handled before selection"),
+        Command::ListRuns => unreachable!("run listing handled before selection"),
         Command::ExtractTextLog { log_index } => {
             let reader = dl.stream(UnifiedLogType::StructuredLogLine);
             textlog_dump(reader, &log_index)?;
@@ -347,7 +345,7 @@ where
             mission,
             features,
         } => {
-            run_logstats::<P>(instance, dl, output, config, mission, &features)?;
+            run_logstats::<P>(run, dl, output, config, mission, &features)?;
         }
         #[cfg(feature = "mcap")]
         Command::ExportMcap {
@@ -359,7 +357,7 @@ where
 
             let show_progress = should_show_progress(progress, quiet);
             let total_bytes = if show_progress {
-                Some(instance.copperlist_bytes)
+                Some(run.copperlist_bytes)
             } else {
                 None
             };
@@ -392,8 +390,8 @@ where
 }
 
 fn run_logstats<P>(
-    instance: &instances::RuntimeInstance,
-    dl: instances::InstanceReader,
+    run: &runs::RecordedRun,
+    dl: runs::RunReader,
     output: PathBuf,
     config: Option<PathBuf>,
     mission: Option<String>,
@@ -402,9 +400,9 @@ fn run_logstats<P>(
 where
     P: CopperListTuple + CuPayloadRawBytes,
 {
-    let cfg = if config.is_none() && instance.config.is_some() {
-        CuConfig::deserialize_ron(instance.config.as_deref().unwrap()).map_err(|e| {
-            CuError::new_with_cause("Failed to read the selected instance's configuration", e)
+    let cfg = if config.is_none() && run.config.is_some() {
+        CuConfig::deserialize_ron(run.config.as_deref().unwrap()).map_err(|e| {
+            CuError::new_with_cause("Failed to read the selected run's configuration", e)
         })?
     } else {
         let config = config.unwrap_or_else(|| PathBuf::from("copperconfig.ron"));
@@ -415,7 +413,7 @@ where
         cu29::config::read_configuration_with_features(config_path, &feature_refs)
             .map_err(|e| CuError::new_with_cause("Failed to read configuration", e))?
     };
-    let mission = resolve_logstats_mission(&cfg, mission, instance.missions.first().cloned())?;
+    let mission = resolve_logstats_mission(&cfg, mission, run.missions.first().cloned())?;
     let reader = dl.stream(UnifiedLogType::CopperList);
     let stats = compute_logstats::<P>(reader, &cfg, mission.as_deref())?;
     write_logstats(&stats, &output)

--- a/core/cu29_export/src/runs.rs
+++ b/core/cu29_export/src/runs.rs
@@ -1,4 +1,4 @@
-//! Runtime instance discovery and bounded access to a selected instance's sections.
+//! Recorded run discovery and bounded access to a selected run's sections.
 
 use crate::build_read_logger;
 use bincode::config::standard;
@@ -19,7 +19,7 @@ use std::io::{self, Read};
 use std::path::Path;
 
 #[derive(Debug)]
-pub(crate) struct RuntimeInstance {
+pub(crate) struct RecordedRun {
     pub index: usize,
     pub started_at: Option<CuTime>,
     pub stack: Option<RuntimeLifecycleStackInfo>,
@@ -32,7 +32,7 @@ pub(crate) struct RuntimeInstance {
     boundary_known: bool,
 }
 
-impl RuntimeInstance {
+impl RecordedRun {
     fn new(index: usize, start: LogPosition) -> Self {
         Self {
             index,
@@ -48,10 +48,10 @@ impl RuntimeInstance {
         }
     }
 
-    pub fn reader(&self, path: &Path) -> CuResult<InstanceReader> {
+    pub fn reader(&self, path: &Path) -> CuResult<RunReader> {
         let mut inner = build_read_logger(path)?;
         inner.seek(self.start)?;
-        Ok(InstanceReader {
+        Ok(RunReader {
             inner,
             end: self.end,
         })
@@ -59,10 +59,10 @@ impl RuntimeInstance {
 }
 
 /// Inspect lifecycle records without decoding application-specific payloads.
-pub(crate) fn discover(path: &Path) -> CuResult<Vec<RuntimeInstance>> {
+pub(crate) fn discover(path: &Path) -> CuResult<Vec<RecordedRun>> {
     let mut reader = build_read_logger(path)?;
     let beginning = reader.position();
-    let mut instances = Vec::<RuntimeInstance>::new();
+    let mut runs = Vec::<RecordedRun>::new();
     let mut sections = Vec::new();
     let mut startup_prefix = None;
     let mut previous_marker = 0;
@@ -103,7 +103,7 @@ pub(crate) fn discover(path: &Path) -> CuResult<Vec<RuntimeInstance>> {
                             ));
                         }
                         // Generated runtimes reserve their streams before the lifecycle
-                        // stream. Instantiated still identifies the new instance; include
+                        // stream. Instantiated still identifies the new run; include
                         // those initial reservations in its physical section range.
                         let prefix = startup_reservations(&sections[previous_marker..]);
                         let has_prefix = *startup_prefix.get_or_insert(!sections.is_empty());
@@ -112,24 +112,24 @@ pub(crate) fn discover(path: &Path) -> CuResult<Vec<RuntimeInstance>> {
                         } else {
                             position
                         };
-                        let mut instance = RuntimeInstance::new(instances.len(), start);
-                        instance.boundary_known = !has_prefix || prefix.is_some();
+                        let mut run = RecordedRun::new(runs.len(), start);
+                        run.boundary_known = !has_prefix || prefix.is_some();
                         previous_marker = sections.len();
-                        instance.started_at = Some(record.timestamp);
-                        instance.config = Some(effective_config_ron);
-                        instance.stack = Some(stack);
-                        instances.push(instance);
+                        run.started_at = Some(record.timestamp);
+                        run.config = Some(effective_config_ron);
+                        run.stack = Some(stack);
+                        runs.push(run);
                     }
                     RuntimeLifecycleEvent::MissionStarted { mission } => {
-                        if let Some(instance) = instances.last_mut()
-                            && !instance.missions.contains(&mission)
+                        if let Some(run) = runs.last_mut()
+                            && !run.missions.contains(&mission)
                         {
-                            instance.missions.push(mission);
+                            run.missions.push(mission);
                         }
                     }
                     RuntimeLifecycleEvent::ShutdownCompleted => {
-                        if let Some(instance) = instances.last_mut() {
-                            instance.shutdown_completed = true;
+                        if let Some(run) = runs.last_mut() {
+                            run.shutdown_completed = true;
                         }
                     }
                     _ => {}
@@ -140,39 +140,39 @@ pub(crate) fn discover(path: &Path) -> CuResult<Vec<RuntimeInstance>> {
         sections.push((position, header.entry_type, header.used));
     }
 
-    if instances.is_empty() {
+    if runs.is_empty() {
         // Logs from standalone writers can have no runtime lifecycle stream.
-        instances.push(RuntimeInstance::new(0, beginning));
-    } else if instances.len() == 1 {
+        runs.push(RecordedRun::new(0, beginning));
+    } else if runs.len() == 1 {
         // Include streams reserved before Instantiated by older runtime builders.
-        instances[0].start = beginning;
-        instances[0].boundary_known = true;
+        runs[0].start = beginning;
+        runs[0].boundary_known = true;
     }
 
-    // An unresolved boundary also makes the preceding instance's end ambiguous.
-    if instances.iter().any(|instance| !instance.boundary_known) {
-        for instance in &mut instances {
-            instance.boundary_known = false;
+    // An unresolved boundary also makes the preceding run's end ambiguous.
+    if runs.iter().any(|run| !run.boundary_known) {
+        for run in &mut runs {
+            run.boundary_known = false;
         }
     }
 
-    for index in 0..instances.len().saturating_sub(1) {
-        instances[index].end = Some(instances[index + 1].start);
+    for index in 0..runs.len().saturating_sub(1) {
+        runs[index].end = Some(runs[index + 1].start);
     }
-    for instance in &mut instances {
-        instance.copperlist_bytes = sections
+    for run in &mut runs {
+        run.copperlist_bytes = sections
             .iter()
             .filter(|(position, kind, _)| {
                 *kind == UnifiedLogType::CopperList
-                    && position_key(*position) >= position_key(instance.start)
-                    && instance
+                    && position_key(*position) >= position_key(run.start)
+                    && run
                         .end
                         .is_none_or(|end| position_key(*position) < position_key(end))
             })
             .map(|(_, _, used)| u64::from(*used))
             .sum();
     }
-    Ok(instances)
+    Ok(runs)
 }
 
 fn startup_reservations(sections: &[(LogPosition, UnifiedLogType, u32)]) -> Option<LogPosition> {
@@ -203,39 +203,36 @@ fn position_key(position: LogPosition) -> (usize, usize) {
     (position.slab_index, position.offset)
 }
 
-pub(crate) fn select(
-    instances: &[RuntimeInstance],
-    requested: Option<usize>,
-) -> CuResult<&RuntimeInstance> {
+pub(crate) fn select(runs: &[RecordedRun], requested: Option<usize>) -> CuResult<&RecordedRun> {
     let index = match requested {
         Some(index) => index,
-        None if instances.len() == 1 => 0,
+        None if runs.len() == 1 => 0,
         None => {
             return Err(CuError::from(format!(
-                "Log contains {} runtime instances; use list-instances and select --instance <index>",
-                instances.len()
+                "Log contains {} recorded runs; use list-runs and select --run <index>",
+                runs.len()
             )));
         }
     };
-    let instance = instances.get(index).ok_or_else(|| {
+    let run = runs.get(index).ok_or_else(|| {
         CuError::from(format!(
-            "Runtime instance {index} does not exist; use list-instances to see available instances"
+            "Recorded run {index} does not exist; use list-runs to see available runs"
         ))
     })?;
-    if !instance.boundary_known {
+    if !run.boundary_known {
         return Err(CuError::from(
-            "Cannot isolate runtime instances: startup sections do not match the recorded runtime layout",
+            "Cannot isolate recorded runs: startup sections do not match the recorded runtime layout",
         ));
     }
-    Ok(instance)
+    Ok(run)
 }
 
-pub(crate) struct InstanceReader {
+pub(crate) struct RunReader {
     inner: UnifiedLoggerRead,
     end: Option<LogPosition>,
 }
 
-impl InstanceReader {
+impl RunReader {
     pub fn raw_main_header(&self) -> &MainHeader {
         self.inner.raw_main_header()
     }
@@ -277,8 +274,8 @@ impl InstanceReader {
         Ok(None)
     }
 
-    pub fn stream(self, kind: UnifiedLogType) -> InstanceStream {
-        InstanceStream {
+    pub fn stream(self, kind: UnifiedLogType) -> RunStream {
+        RunStream {
             reader: self,
             kind,
             buffer: Vec::new(),
@@ -288,15 +285,15 @@ impl InstanceReader {
     }
 }
 
-pub(crate) struct InstanceStream {
-    reader: InstanceReader,
+pub(crate) struct RunStream {
+    reader: RunReader,
     kind: UnifiedLogType,
     buffer: Vec<u8>,
     offset: usize,
     finished: bool,
 }
 
-impl Read for InstanceStream {
+impl Read for RunStream {
     fn read(&mut self, destination: &mut [u8]) -> io::Result<usize> {
         if destination.is_empty() || self.finished {
             return Ok(0);
@@ -366,11 +363,11 @@ mod tests {
         Arc::new(Mutex::new(writer))
     }
 
-    fn write_instance(logger: &Arc<Mutex<UnifiedLoggerWrite>>, value: u32, mission: &str) {
-        write_instance_with_options(logger, value, mission, false, true, 3);
+    fn write_run(logger: &Arc<Mutex<UnifiedLoggerWrite>>, value: u32, mission: &str) {
+        write_run_with_options(logger, value, mission, false, true, 3);
     }
 
-    fn write_instance_with_options(
+    fn write_run_with_options(
         logger: &Arc<Mutex<UnifiedLoggerWrite>>,
         value: u32,
         mission: &str,
@@ -415,7 +412,7 @@ mod tests {
                     config_source: RuntimeLifecycleConfigSource::BundledDefault,
                     effective_config_ron: format!("(missions: [(id: \"drive\"), (id: \"park\")], tasks: [], cnx: [], // {value}\n)"),
                     stack: RuntimeLifecycleStackInfo {
-                        app_name: "instance-test".to_string(),
+                        app_name: "run-test".to_string(),
                         app_version: "1".to_string(),
                         git_commit: None,
                         git_dirty: None,
@@ -455,24 +452,18 @@ mod tests {
             .unwrap();
     }
 
-    fn assert_instances(path: &Path) {
+    fn assert_runs(path: &Path) {
         let catalog = discover(path).unwrap();
         assert_eq!(catalog.len(), 2);
         assert!(select(&catalog, None).is_err());
         assert!(select(&catalog, Some(2)).is_err());
         for (index, expected) in [17, 29].into_iter().enumerate() {
-            let instance = select(&catalog, Some(index)).unwrap();
-            assert_eq!(instance.stack.as_ref().unwrap().instance_id, 0);
-            assert_eq!(
-                instance.missions,
-                [if index == 0 { "drive" } else { "park" }]
-            );
-            assert!(instance.shutdown_completed);
+            let run = select(&catalog, Some(index)).unwrap();
+            assert_eq!(run.stack.as_ref().unwrap().instance_id, 0);
+            assert_eq!(run.missions, [if index == 0 { "drive" } else { "park" }]);
+            assert!(run.shutdown_completed);
             let entries = copperlists_reader::<Messages>(
-                instance
-                    .reader(path)
-                    .unwrap()
-                    .stream(UnifiedLogType::CopperList),
+                run.reader(path).unwrap().stream(UnifiedLogType::CopperList),
             )
             .collect::<Vec<_>>();
             assert_eq!(
@@ -480,14 +471,13 @@ mod tests {
                 [0, 1, 2]
             );
             assert!(entries.iter().all(|entry| entry.msgs.0 == expected));
-            crate::fsck::check::<Messages>(&mut instance.reader(path).unwrap(), 0, false).unwrap();
+            crate::fsck::check::<Messages>(&mut run.reader(path).unwrap(), 0, false).unwrap();
             for kind in [
                 UnifiedLogType::StructuredLogLine,
                 UnifiedLogType::FrozenTasks,
             ] {
                 let mut bytes = Vec::new();
-                instance
-                    .reader(path)
+                run.reader(path)
                     .unwrap()
                     .stream(kind)
                     .read_to_end(&mut bytes)
@@ -517,10 +507,10 @@ mod tests {
         let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
         let path = dir.path().join("missions.copper");
         let logger = writer(&path, false);
-        write_instance(&logger, 17, "drive");
-        write_instance(&logger, 29, "park");
+        write_run(&logger, 17, "drive");
+        write_run(&logger, 29, "park");
         drop(logger);
-        assert_instances(&path);
+        assert_runs(&path);
     }
 
     #[test]
@@ -528,16 +518,16 @@ mod tests {
         let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
         let path = dir.path().join("restart.copper");
         let logger = writer(&path, false);
-        write_instance(&logger, 17, "drive");
+        write_run(&logger, 17, "drive");
         drop(logger);
         let logger = writer(&path, true);
-        write_instance(&logger, 29, "park");
+        write_run(&logger, 29, "park");
         drop(logger);
-        assert_instances(&path);
+        assert_runs(&path);
     }
 
     #[test]
-    fn test_log_without_lifecycle_has_one_implicit_instance() {
+    fn test_log_without_lifecycle_has_one_implicit_run() {
         let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
         let path = dir.path().join("standalone.copper");
         drop(writer(&path, false));
@@ -550,17 +540,16 @@ mod tests {
         let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
         let path = dir.path().join("slabs.copper");
         let logger = writer(&path, false);
-        write_instance_with_options(&logger, 17, "drive", true, false, 10_000);
-        write_instance_with_options(&logger, 29, "park", false, true, 10_000);
+        write_run_with_options(&logger, 17, "drive", true, false, 10_000);
+        write_run_with_options(&logger, 29, "park", false, true, 10_000);
         drop(logger);
         let catalog = discover(&path).unwrap();
         assert_eq!(catalog.len(), 2);
         assert!(catalog[1].start.slab_index > 0);
         for (index, expected) in [17, 29].into_iter().enumerate() {
-            let instance = select(&catalog, Some(index)).unwrap();
+            let run = select(&catalog, Some(index)).unwrap();
             let entries = copperlists_reader::<Messages>(
-                instance
-                    .reader(&path)
+                run.reader(&path)
                     .unwrap()
                     .stream(UnifiedLogType::CopperList),
             )
@@ -570,16 +559,16 @@ mod tests {
                 assert_eq!(entry.id, id as u64);
                 assert_eq!(entry.msgs.0, expected);
             }
-            crate::fsck::check::<Messages>(&mut instance.reader(&path).unwrap(), 0, false).unwrap();
+            crate::fsck::check::<Messages>(&mut run.reader(&path).unwrap(), 0, false).unwrap();
         }
     }
 
     #[test]
-    fn test_selection_does_not_decode_other_instances_payloads() {
+    fn test_selection_does_not_decode_other_runs_payloads() {
         let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
         let path = dir.path().join("schemas.copper");
         let logger = writer(&path, false);
-        write_instance(&logger, 17, "drive");
+        write_run(&logger, 17, "drive");
         {
             let mut different_schema = stream_write::<String, MmapSectionStorage>(
                 logger.clone(),
@@ -591,7 +580,7 @@ mod tests {
                 .log(&"a different application payload".to_string())
                 .unwrap();
         }
-        write_instance(&logger, 29, "park");
+        write_run(&logger, 29, "park");
         drop(logger);
         let catalog = discover(&path).unwrap();
         let selected = select(&catalog, Some(1)).unwrap();
@@ -603,7 +592,7 @@ mod tests {
         let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
         let path = dir.path().join("reset.copper");
         let logger = writer(&path, false);
-        write_instance(&logger, 17, "drive");
+        write_run(&logger, 17, "drive");
         {
             let mut stream = stream_write::<CopperList<Messages>, MmapSectionStorage>(
                 logger.clone(),
@@ -626,7 +615,7 @@ mod tests {
         let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
         let path = dir.path().join("incomplete.copper");
         let logger = writer(&path, false);
-        write_instance(&logger, 17, "drive");
+        write_run(&logger, 17, "drive");
         let catalog = discover(&path).unwrap();
         let selected = select(&catalog, None).unwrap();
         let error = crate::fsck::check::<Messages>(&mut selected.reader(&path).unwrap(), 0, false)
@@ -654,7 +643,7 @@ mod tests {
         let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
         let path = dir.path().join("unknown.copper");
         let logger = writer(&path, false);
-        write_instance(&logger, 17, "drive");
+        write_run(&logger, 17, "drive");
         let catalog = discover(&path).unwrap();
         let mut lifecycle = crate::runtime_lifecycle_reader(
             catalog[0]
@@ -693,28 +682,26 @@ mod tests {
         let dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
         let path = dir.path().join("cli.copper");
         let logger = writer(&path, false);
-        write_instance(&logger, 17, "drive");
-        write_instance(&logger, 29, "park");
+        write_run(&logger, 17, "drive");
+        write_run(&logger, 29, "park");
         drop(logger);
         let path = path.to_str().unwrap();
-        let args =
-            crate::LogReaderCli::try_parse_from(["logreader", path, "list-instances"]).unwrap();
+        let args = crate::LogReaderCli::try_parse_from(["logreader", path, "list-runs"]).unwrap();
         crate::run_cli_with_args::<Messages>(args).unwrap();
         let args = crate::LogReaderCli::try_parse_from(["logreader", path, "fsck"]).unwrap();
         assert!(
             crate::run_cli_with_args::<Messages>(args)
                 .unwrap_err()
                 .to_string()
-                .contains("--instance")
+                .contains("--run")
         );
         let args =
-            crate::LogReaderCli::try_parse_from(["logreader", path, "fsck", "--instance", "1"])
-                .unwrap();
+            crate::LogReaderCli::try_parse_from(["logreader", path, "fsck", "--run", "1"]).unwrap();
         crate::run_cli_with_args::<Messages>(args).unwrap();
         let args = crate::LogReaderCli::try_parse_from([
             "logreader",
             path,
-            "--instance",
+            "--run",
             "1",
             "extract-copperlists",
         ])
@@ -724,7 +711,7 @@ mod tests {
         let args = crate::LogReaderCli::try_parse_from([
             "logreader",
             path,
-            "--instance",
+            "--run",
             "1",
             "log-stats",
             "--output",

--- a/doc/v1-api-surface.md
+++ b/doc/v1-api-surface.md
@@ -9,6 +9,10 @@ This file defines the Copper V1 public contract. Anything not listed as stable i
 - `internal`: public only because proc macros, generated code, tests, or rustdoc need a path.
 - `deprecated`: still callable, but not part of new V1 design.
 
+The logreader CLI parser types (`cu29_export::LogReaderCli`, `Command`, and
+`ExportFormat`) are experimental. `list-instances` and the global `--instance`
+option select runtime instances identified by `Instantiated` lifecycle records.
+
 ## Stable
 
 - `cu29::prelude`: canonical import surface for application crates.

--- a/doc/v1-api-surface.md
+++ b/doc/v1-api-surface.md
@@ -10,8 +10,8 @@ This file defines the Copper V1 public contract. Anything not listed as stable i
 - `deprecated`: still callable, but not part of new V1 design.
 
 The logreader CLI parser types (`cu29_export::LogReaderCli`, `Command`, and
-`ExportFormat`) are experimental. `list-instances` and the global `--instance`
-option select runtime instances identified by `Instantiated` lifecycle records.
+`ExportFormat`) are experimental. `list-runs` and the global `--run`
+option select recorded runs identified by `Instantiated` lifecycle records.
 
 ## Stable
 


### PR DESCRIPTION
## Summary

A mission change or appended restart can put multiple fresh runtimes in one unified log, each starting its CopperList IDs at zero. Each `Instantiated` lifecycle record begins a recorded run. The logreader lists these runs and requires an explicit selection before processing a log containing multiple runs. The zero-based run index is separate from deployment `instance_id`, which remains recorded metadata.

```sh
logreader logs/robot.copper list-runs
logreader logs/robot.copper --run 1 fsck
logreader logs/robot.copper --run 1 extract-copperlists
```

## Related issues

Follow-up to #1385 and #1386.

## Changes

- Share run discovery and bounded section readers across CL/text extraction, fsck, statistics, and MCAP export. Include the streams the generated runtime reserves before its `Instantiated` record, including optional keyframes and logstream startup ordering.
- Select the run's recorded codec configuration; statistics also use its recorded configuration and mission by default.
- Keep single-run and standalone logs automatic. Reject selection when a multi-run startup layout cannot be resolved.
- Make fsck return errors for corrupt records, repeated/decreasing CL IDs within an run, and temporary final end markers.
- Update CLI documentation and API snapshots.

## Validation

Terminology follow-up: `just fmt` and all 49 `cu29-export` library tests with `mcap,python` passed. The full PR checks below were run before this naming-only follow-up.

- `just pr-check`: passed, including 1,109 workspace tests, 598 no-default-feature tests, and logstream checks.
- Export tests and Clippy with `mcap,python`: passed.
- Regression coverage includes appended restarts, mission changes, repeated deployment instance IDs and CL IDs, different payload layouts, slab rollover, optional keyframes, malformed records, and CLI selection of recorded mission/configuration.

## Reminder

- [x] I ran `just pr-check` from the repo root.
- [x] I updated the README and companion book/wiki documentation; the book builds with `just build`.

Companion book PR: https://github.com/copper-project/copper-rs-book/pull/70. The wiki update is committed and pushed on `docs/logreader-runtime-instances` (GitHub wikis do not support pull requests).

