### PR TITLE
feat(unifiedlog): add rollover(size) for fixed-size on-disk logging

### DIFF
--- a/components/libs/cu_sdlogger/src/logger.rs
+++ b/components/libs/cu_sdlogger/src/logger.rs
@@ -218,6 +218,10 @@ impl<BD: BlockDevice> EMMCLogger<BD> {
             format_version: UNIFIED_LOG_FORMAT_VERSION,
             first_section_offset: BLK as u16,
             page_size: BLK as u16,
+            head_slab_index: 0,
+            head_offset: BLK as u64,
+            max_slabs: 0,
+            slab_size: 0,
         };
         let mut block: Block = Block::new();
 

--- a/core/cu29_unifiedlog/src/lib.rs
+++ b/core/cu29_unifiedlog/src/lib.rs
@@ -50,8 +50,10 @@ pub const SECTION_MAGIC: [u8; 2] = [0xFA, 0x57]; // FAST
 /// to CopperLists, payload types, keyframes, or their serialization must not bump
 /// this value. Decode content with the logreader built for the exact application
 /// version that produced it; this header cannot establish content compatibility.
-/// The encapsulation remains version 1, unchanged since Copper's original format.
-pub const UNIFIED_LOG_FORMAT_VERSION: u8 = 1;
+/// Version 2 adds rollover support: the main header now carries the head pointer
+/// (first retained section) and the slab-ring geometry. Older readers reject this
+/// version and this reader rejects older versions.
+pub const UNIFIED_LOG_FORMAT_VERSION: u8 = 2;
 
 pub const SECTION_HEADER_COMPACT_SIZE: u16 = 512; // Usual minimum size for a disk sector.
 
@@ -65,6 +67,19 @@ pub struct MainHeader {
     pub format_version: u8,
     pub first_section_offset: u16, // This is to align with a page at write time.
     pub page_size: u16,
+    /// Index of the first retained slab when rollover is enabled; always 0 when
+    /// the log is unbounded (`max_slabs == 0`).
+    pub head_slab_index: u32,
+    /// Offset of the first retained section. For the slab-based (std) backend this
+    /// is the offset within [`MainHeader::head_slab_index`]; for block-device
+    /// (no_std) backends it is an absolute byte offset over the log. Always a
+    /// section boundary, never the middle of a section.
+    pub head_offset: u64,
+    /// Number of slabs in the rollover ring; 0 means unbounded (no rollover).
+    pub max_slabs: u32,
+    /// Size in bytes of each slab. Persisted so `append(true)` can fail loudly when
+    /// a restart requests a different ring geometry (rollover size or slab size).
+    pub slab_size: u64,
 }
 
 impl Display for MainHeader {
@@ -76,7 +91,11 @@ impl Display for MainHeader {
         )?;
         writeln!(f, "  format_version -> {}", self.format_version)?;
         writeln!(f, "  first_section_offset -> {}", self.first_section_offset)?;
-        writeln!(f, "  page_size -> {}", self.page_size)
+        writeln!(f, "  page_size -> {}", self.page_size)?;
+        writeln!(f, "  head_slab_index -> {}", self.head_slab_index)?;
+        writeln!(f, "  head_offset -> {}", self.head_offset)?;
+        writeln!(f, "  max_slabs -> {}", self.max_slabs)?;
+        writeln!(f, "  slab_size -> {}", self.slab_size)
     }
 }
 

--- a/core/cu29_unifiedlog/src/memmap.rs
+++ b/core/cu29_unifiedlog/src/memmap.rs
@@ -101,6 +101,7 @@ pub struct MmapUnifiedLoggerBuilder {
     write: bool,
     create: bool,
     append: bool,
+    rollover_size: Option<usize>,
 }
 
 impl Default for MmapUnifiedLoggerBuilder {
@@ -117,6 +118,7 @@ impl MmapUnifiedLoggerBuilder {
             write: false,
             create: false, // This is the safest default
             append: false,
+            rollover_size: None,
         }
     }
 
@@ -151,6 +153,15 @@ impl MmapUnifiedLoggerBuilder {
         self
     }
 
+    /// When `write` and `create` are both set, keep the log bounded on disk:
+    /// slabs form a ring of `max(1, size / slab_size)` files and, once the ring
+    /// is full, the oldest slab is overwritten so only the most recent logs are
+    /// retained.
+    pub fn rollover(mut self, size: usize) -> Self {
+        self.rollover_size = Some(size);
+        self
+    }
+
     pub fn build(self) -> io::Result<MmapUnifiedLogger> {
         let page_size = page_size::get();
 
@@ -167,10 +178,14 @@ impl MmapUnifiedLoggerBuilder {
                     "Preallocated size is required for write mode",
                 )
             })?;
+            let max_slabs = match self.rollover_size {
+                Some(size) => (size / preallocated_size).max(1),
+                None => 0,
+            };
             let ulw = if self.append {
-                MmapUnifiedLoggerWrite::append(&file_path, preallocated_size)?
+                MmapUnifiedLoggerWrite::append(&file_path, preallocated_size, max_slabs)?
             } else {
-                MmapUnifiedLoggerWrite::new(&file_path, preallocated_size, page_size)?
+                MmapUnifiedLoggerWrite::new(&file_path, preallocated_size, page_size, max_slabs)?
             };
             Ok(MmapUnifiedLogger::Write(ulw))
         } else {
@@ -501,6 +516,12 @@ pub struct MmapUnifiedLoggerWrite {
     slab_size: usize,
     /// current suffix for the backing files.
     front_slab_suffix: usize,
+    /// number of slabs in the rollover ring; 0 means unbounded (no rollover).
+    max_slabs: usize,
+    /// index of the oldest retained slab (the first retained section).
+    head_slab_index: usize,
+    /// byte offset of the first retained section within its slab.
+    head_offset: u64,
 }
 
 fn build_slab_path(base_file_path: &Path, slab_index: usize) -> io::Result<PathBuf> {
@@ -717,14 +738,20 @@ impl UnifiedLogWrite<MmapSectionStorage> for MmapUnifiedLoggerWrite {
 }
 
 impl MmapUnifiedLoggerWrite {
-    fn next_slab(&mut self) -> io::Result<File> {
-        let next_suffix = self.front_slab_suffix + 1;
-        let file = make_slab_file(&self.base_file_path, self.slab_size, next_suffix)?;
-        self.front_slab_suffix = next_suffix;
-        Ok(file)
+    fn next_suffix(&self) -> usize {
+        if self.max_slabs > 0 {
+            (self.front_slab_suffix + 1) % self.max_slabs
+        } else {
+            self.front_slab_suffix + 1
+        }
     }
 
-    fn new(base_file_path: &Path, slab_size: usize, page_size: usize) -> io::Result<Self> {
+    fn new(
+        base_file_path: &Path,
+        slab_size: usize,
+        page_size: usize,
+        max_slabs: usize,
+    ) -> io::Result<Self> {
         let file = make_slab_file(base_file_path, slab_size, 0)?;
         create_base_alias_link(base_file_path)?;
         let mut front_slab = SlabEntry::new(file, page_size)?;
@@ -735,6 +762,10 @@ impl MmapUnifiedLoggerWrite {
             format_version: UNIFIED_LOG_FORMAT_VERSION,
             first_section_offset: page_size as u16,
             page_size: page_size as u16,
+            head_slab_index: 0,
+            head_offset: page_size as u64,
+            max_slabs: max_slabs as u32,
+            slab_size: slab_size as u64,
         };
         let nb_bytes = encode_into_slice(&main_header, &mut front_slab.mmap_buffer[..], standard())
             .map_err(|e| io::Error::other(format!("Failed to encode main header: {e}")))?;
@@ -747,6 +778,9 @@ impl MmapUnifiedLoggerWrite {
             base_file_path: base_file_path.to_path_buf(),
             slab_size,
             front_slab_suffix: 0,
+            max_slabs,
+            head_slab_index: 0,
+            head_offset: page_size as u64,
         })
     }
 
@@ -756,14 +790,26 @@ impl MmapUnifiedLoggerWrite {
     /// last slab for writing (re-extending it to `slab_size`, since it is trimmed
     /// on clean shutdown), and positions the cursor right after that marker so new
     /// sections overwrite it. The main header and earlier slabs are left untouched.
-    fn append(base_file_path: &Path, slab_size: usize) -> io::Result<Self> {
+    fn append(base_file_path: &Path, slab_size: usize, max_slabs: usize) -> io::Result<Self> {
         // Locate the end-of-log marker using the read side.
         let mut reader = MmapUnifiedLoggerRead::new(base_file_path)?;
+        let existing_slab_size = reader.raw_main_header().slab_size as usize;
+        let existing_max_slabs = reader.raw_main_header().max_slabs as usize;
+        if existing_slab_size != slab_size || existing_max_slabs != max_slabs {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "append(true) ring geometry mismatch: log has slab_size={existing_slab_size} max_slabs={existing_max_slabs}; requested slab_size={slab_size} max_slabs={max_slabs}"
+                ),
+            ));
+        }
         let end = reader.end_of_log().map_err(io::Error::other)?;
         let last_slab_index = end.slab_index;
         let resume_offset = end.offset;
         // Preserve the original page alignment recorded in the main header.
         let original_page_size = reader.raw_main_header().page_size as usize;
+        let head_slab_index = reader.raw_main_header().head_slab_index as usize;
+        let head_offset = reader.raw_main_header().head_offset;
         drop(reader);
 
         let slab_path = build_slab_path(base_file_path, last_slab_index)?;
@@ -814,6 +860,9 @@ impl MmapUnifiedLoggerWrite {
             base_file_path: base_file_path.to_path_buf(),
             slab_size,
             front_slab_suffix: last_slab_index,
+            max_slabs,
+            head_slab_index,
+            head_offset,
         })
     }
 
@@ -844,11 +893,82 @@ impl MmapUnifiedLoggerWrite {
     }
 
     fn create_slab(&mut self) -> CuResult<SlabEntry> {
-        let file = self
-            .next_slab()
+        let next_suffix = self.next_suffix();
+        let wrapping = self.max_slabs > 0 && next_suffix == self.head_slab_index;
+        let file = make_slab_file(&self.base_file_path, self.slab_size, next_suffix)
             .map_err(|e| CuError::new_with_cause("Failed to create slab file", e))?;
-        SlabEntry::new(file, self.front_slab.page_size)
-            .map_err(|e| CuError::new_with_cause("Failed to create slab memory map", e))
+        self.front_slab_suffix = next_suffix;
+
+        if wrapping {
+            // The ring wrapped: the slab being overwritten is the head, so the
+            // head advances to the next slab in the ring.
+            self.head_slab_index = (next_suffix + 1) % self.max_slabs;
+            self.head_offset = if self.head_slab_index == 0 {
+                self.front_slab.page_size as u64
+            } else {
+                0
+            };
+        }
+
+        let mut slab = SlabEntry::new(file, self.front_slab.page_size)
+            .map_err(|e| CuError::new_with_cause("Failed to create slab memory map", e))?;
+
+        if next_suffix == 0 {
+            // Slab 0 always carries the main header.
+            self.write_main_header(&mut slab)
+                .map_err(|e| CuError::new_with_cause("Failed to write main header", e))?;
+        } else if wrapping {
+            // Wrapped onto a non-zero slab: persist the new head pointer in slab 0.
+            self.persist_head()
+                .map_err(|e| CuError::new_with_cause("Failed to persist head pointer", e))?;
+        }
+
+        Ok(slab)
+    }
+
+    fn page_size(&self) -> usize {
+        self.front_slab.page_size
+    }
+
+    fn main_header(&self) -> MainHeader {
+        MainHeader {
+            magic: MAIN_MAGIC,
+            format_version: UNIFIED_LOG_FORMAT_VERSION,
+            first_section_offset: self.page_size() as u16,
+            page_size: self.page_size() as u16,
+            head_slab_index: self.head_slab_index as u32,
+            head_offset: self.head_offset,
+            max_slabs: self.max_slabs as u32,
+            slab_size: self.slab_size as u64,
+        }
+    }
+
+    fn write_main_header(&self, slab: &mut SlabEntry) -> io::Result<()> {
+        let header = self.main_header();
+        let nb_bytes = encode_into_slice(&header, &mut slab.mmap_buffer[..], standard())
+            .map_err(|e| io::Error::other(format!("Failed to encode main header: {e}")))?;
+        debug_assert!(nb_bytes < self.page_size());
+        slab.current_global_position = self.page_size();
+        Ok(())
+    }
+
+    fn persist_head(&self) -> io::Result<()> {
+        let slab0_path = build_slab_path(&self.base_file_path, 0)?;
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&slab0_path)?;
+        let mut mmap = unsafe { MmapMut::map_mut(&file) }.map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!("Failed to map slab 0 for header update: {e}"),
+            )
+        })?;
+        let header = self.main_header();
+        encode_into_slice(&header, &mut mmap[..], standard())
+            .map_err(|e| io::Error::other(format!("Failed to encode main header: {e}")))?;
+        mmap.flush()
+            .map_err(|e| io::Error::new(e.kind(), format!("Failed to flush main header: {e}")))
     }
 }
 
@@ -926,6 +1046,8 @@ pub struct MmapUnifiedLoggerRead {
     current_file: File,
     current_slab_index: usize,
     current_reading_position: usize,
+    max_slabs: usize,
+    slabs_read: usize,
 }
 
 /// Absolute position inside a unified log (slab index + byte offset).
@@ -1029,18 +1151,24 @@ impl MmapUnifiedLoggerRead {
     }
 
     pub fn new(base_file_path: &Path) -> io::Result<Self> {
-        let (file, mmap, prolog, header) = open_slab_index(base_file_path, 0)?;
+        let (_, _, _, header) = open_slab_index(base_file_path, 0)?;
         let main_header = header.ok_or_else(|| {
             io::Error::new(io::ErrorKind::InvalidData, "Missing main header in slab 0")
         })?;
+        let head_slab = main_header.head_slab_index as usize;
+        let head_offset = main_header.head_offset as usize;
+        let max_slabs = main_header.max_slabs as usize;
+        let (file, mmap, _prolog, _) = open_slab_index(base_file_path, head_slab)?;
 
         Ok(Self {
             base_file_path: base_file_path.to_path_buf(),
             main_header,
             current_file: file,
             current_mmap_buffer: mmap,
-            current_slab_index: 0,
-            current_reading_position: prolog as usize,
+            current_slab_index: head_slab,
+            current_reading_position: head_offset,
+            max_slabs,
+            slabs_read: 1,
         })
     }
 
@@ -1071,12 +1199,23 @@ impl MmapUnifiedLoggerRead {
     }
 
     fn next_slab(&mut self) -> io::Result<()> {
-        self.current_slab_index += 1;
+        if self.max_slabs > 0 && self.slabs_read >= self.max_slabs {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Reached the start of the ring without finding the end-of-log marker",
+            ));
+        }
+        self.current_slab_index = if self.max_slabs > 0 {
+            (self.current_slab_index + 1) % self.max_slabs
+        } else {
+            self.current_slab_index + 1
+        };
         let (file, mmap, prolog, _) =
             open_slab_index(&self.base_file_path, self.current_slab_index)?;
         self.current_file = file;
         self.current_mmap_buffer = mmap;
         self.current_reading_position = prolog as usize;
+        self.slabs_read += 1;
         Ok(())
     }
 
@@ -1910,5 +2049,112 @@ mod tests {
             }
         }
         assert_eq!(total_readback, 10000);
+    }
+
+    #[test]
+    fn test_rollover_keeps_only_last_slabs() {
+        let tmp_dir = TempDir::new().expect("could not create a tmp dir");
+        let file_path = tmp_dir.path().join("test.bin");
+        // Ring of 2 slabs.
+        let rollover_size = SMALL_SLAB * 2;
+        {
+            let MmapUnifiedLogger::Write(logger) = MmapUnifiedLoggerBuilder::new()
+                .write(true)
+                .create(true)
+                .file_base_name(&file_path)
+                .preallocated_size(SMALL_SLAB)
+                .rollover(rollover_size)
+                .build()
+                .expect("Failed to create logger")
+            else {
+                panic!("Failed to create logger")
+            };
+            let logger = Arc::new(Mutex::new(logger));
+            {
+                let mut stream =
+                    stream_write(logger.clone(), UnifiedLogType::CopperList, 1024).unwrap();
+                let cl0 = CopperList {
+                    state: CopperListStateMock::Free,
+                    payload: (1u32, 2u32, 3u32),
+                };
+                // Enough entries to span many slabs and wrap the ring.
+                for _ in 0..10000 {
+                    stream.log(&cl0).unwrap();
+                }
+            }
+        } // logger drops -> clean close
+
+        // The ring must not have grown past max_slabs (2) files.
+        assert!(build_slab_path(&file_path, 0).unwrap().exists());
+        assert!(build_slab_path(&file_path, 1).unwrap().exists());
+        assert!(!build_slab_path(&file_path, 2).unwrap().exists());
+
+        let MmapUnifiedLogger::Read(mut dl) = MmapUnifiedLoggerBuilder::new()
+            .file_base_name(&file_path)
+            .build()
+            .expect("Failed to build reader")
+        else {
+            panic!("Failed to build reader")
+        };
+
+        let mut total_readback = 0;
+        loop {
+            let section = dl.read_next_section_type(UnifiedLogType::CopperList);
+            if section.is_err() {
+                break;
+            }
+            let section = section.unwrap();
+            if section.is_none() {
+                break;
+            }
+            let section = section.unwrap();
+            let mut reader = SliceReader::new(&section[..]);
+            loop {
+                let maybe_cl: Result<CopperList<(u32, u32, u32)>, _> =
+                    decode_from_reader(&mut reader, standard());
+                if maybe_cl.is_ok() {
+                    total_readback += 1;
+                } else {
+                    break;
+                }
+            }
+        }
+        // Rollover must have dropped the oldest entries, but retained some.
+        assert!(total_readback > 0);
+        assert!(total_readback < 10000);
+    }
+
+    #[test]
+    fn test_append_rollover_geometry_mismatch_fails() {
+        let tmp_dir = TempDir::new().expect("could not create a tmp dir");
+        let file_path = tmp_dir.path().join("test.bin");
+        {
+            let MmapUnifiedLogger::Write(_logger) = MmapUnifiedLoggerBuilder::new()
+                .write(true)
+                .create(true)
+                .file_base_name(&file_path)
+                .preallocated_size(SMALL_SLAB)
+                .rollover(SMALL_SLAB * 2)
+                .build()
+                .expect("Failed to create logger")
+            else {
+                panic!("Failed to create logger")
+            };
+        }
+
+        // Append with a different slab size must fail loudly (geometry mismatch).
+        let err = match MmapUnifiedLoggerBuilder::new()
+            .write(true)
+            .create(true)
+            .append(true)
+            .file_base_name(&file_path)
+            .preallocated_size(LARGE_SLAB)
+            .rollover(LARGE_SLAB * 2)
+            .build()
+        {
+            Ok(_) => panic!("append(true) should have failed on geometry mismatch"),
+            Err(e) => e,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
 }


### PR DESCRIPTION
Implements #1377 — a retention policy for the unified log, starting with the simplest one: a maximum size on disk, keeping only the last logs.

## What it does

The `MmapUnifiedLoggerBuilder` gains a `rollover(size)` option (requires `write` + `create`). It turns the slab files into a ring of `max(1, size / slab_size)` slabs; once the ring is full, the oldest slab is overwritten so only the most recent logs are retained.

## Design (aligned with @gbin in #1377)

- **`MainHeader` extended + `UNIFIED_LOG_FORMAT_VERSION` bumped to 2.** The header now carries:
  - `head_slab_index` — first retained slab (0 for `no_std`),
  - `head_offset` — byte offset of the first retained section (within-slab for `std`; absolute bytes for `no_std`),
  - `max_slabs` — ring size (0 = unbounded),
  - `slab_size` — bytes per slab (so `append(true)` can detect geometry mismatch).
- **Reader starts at the head pointer** and wraps around the ring (`next_slab` modulo `max_slabs`), stopping at the end-of-log marker. A safety guard errors out if a full ring is traversed without finding the marker.
- **`append(true)` fails loudly** when the requested ring geometry (slab size or rollover size) does not match the existing log.
- The `no_std` backend (`cu_sdlogger`) writes the v2 header with the head pointer in absolute bytes (`head_offset = BLK`), no ring yet (`max_slabs = 0`).

## Tests

- `test_rollover_keeps_only_last_slabs` — writes enough to wrap a 2-slab ring, asserts only 2 slab files exist and that readback returns a non-empty, strictly smaller history.
- `test_append_rollover_geometry_mismatch_fails` — asserts `append(true)` errors with `InvalidInput` on mismatched slab size.

`cargo test -p cu29-unifiedlog` → 16 passed; `cargo clippy -p cu29-unifiedlog --all-features` clean.

Closes #1377.